### PR TITLE
Make the new elixir file type last in the NewFile menu

### DIFF
--- a/src/META-INF/plugin.xml
+++ b/src/META-INF/plugin.xml
@@ -328,7 +328,7 @@
   <actions>
     <action id="Elixir.NewFile" class="org.elixir_lang.action.CreateElixirModuleAction"
             text="Elixir File" description="Create new Elixir Module">
-      <add-to-group group-id="NewGroup" anchor="before" relative-to-action="NewFile"/>
+      <add-to-group group-id="NewGroup" anchor="last" />
     </action>
   </actions>
 


### PR DESCRIPTION
It is still unclear to me how to determine what the group names are in this menu.  Using the following config, at very least, it's not first on the list, leaving the generic 'new file' option first.

fixes KronicDeth/intellij-elixir#161

Other repos that do this in various ways: 
https://github.com/Vektah/idea-rust/blob/master/META-INF/plugin.xml
https://github.com/Atsky/haskell-idea-plugin/blob/07b40cd14fbd73a68ad9326f04d7c63f59d6ae09/plugin/META-INF/plugin.xml