### PR TITLE
Annotate Erlang Elixir.* Atoms as Modules

### DIFF
--- a/.idea/libraries/JInterface.xml
+++ b/.idea/libraries/JInterface.xml
@@ -1,9 +1,11 @@
 <component name="libraryTable">
   <library name="JInterface">
     <CLASSES>
-      <root url="jar:///usr/local/Cellar/erlang/17.4/lib/erlang/lib/jinterface-1.5.12/priv/OtpErlang.jar!/" />
+      <root url="jar:///usr/local/Cellar/erlang/17.5/lib/erlang/lib/jinterface-1.5.12/priv/OtpErlang.jar!/" />
     </CLASSES>
     <JAVADOC />
-    <SOURCES />
+    <SOURCES>
+      <root url="file:///usr/local/Cellar/erlang/17.5/lib/erlang/lib/jinterface-1.5.12/java_src" />
+    </SOURCES>
   </library>
 </component>

--- a/.idea/libraries/erlang.xml
+++ b/.idea/libraries/erlang.xml
@@ -1,0 +1,9 @@
+<component name="libraryTable">
+  <library name="erlang">
+    <CLASSES>
+      <root url="jar://$PROJECT_DIR$/cache/intellij-erlang/lib/erlang.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES />
+  </library>
+</component>

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,6 @@ language: elixir
 before_install:
 - "export DISPLAY=:99.0"
 - "sh -e /etc/init.d/xvfb start"
-install: ant -logger org.apache.tools.ant.listener.AnsiColorLogger -f intellij-elixir.xml get.idea release.intellij_elixir
+install: ant -logger org.apache.tools.ant.listener.AnsiColorLogger -f intellij-elixir.xml get.idea get.intellij-erlang release.intellij_elixir
 script:  ant -logger org.apache.tools.ant.listener.AnsiColorLogger -f intellij-elixir.xml test.modules
 sudo: false

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ TARGET_XML=intellij-elixir.xml
 all: install test build
 
 install:
-	${ANT} -logger org.apache.tools.ant.listener.AnsiColorLogger -f ${TARGET_XML} get.idea release.intellij_elixir 
+	${ANT} -logger org.apache.tools.ant.listener.AnsiColorLogger -f ${TARGET_XML} get.idea get.intellij-erlang release.intellij_elixir
 
 build:
 	${ANT} -logger org.apache.tools.ant.listener.AnsiColorLogger -f ${TARGET_XML} build.modules

--- a/intellij-elixir.iml
+++ b/intellij-elixir.iml
@@ -5,10 +5,10 @@
     <exclude-output />
     <content url="file://$MODULE_DIR$">
       <sourceFolder url="file://$MODULE_DIR$/src" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/gen" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/tests" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/testData" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/res" type="java-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/gen" isTestSource="false" />
       <excludeFolder url="file://$MODULE_DIR$/bin" />
       <excludeFolder url="file://$MODULE_DIR$/cache" />
       <excludeFolder url="file://$MODULE_DIR$/dependencies" />
@@ -33,5 +33,6 @@
     <orderEntry type="library" name="junit-4.11" level="project" />
     <orderEntry type="module" module-name="jps-shared" />
     <orderEntry type="module" module-name="jps-builder" />
+    <orderEntry type="library" scope="PROVIDED" name="erlang" level="project" />
   </component>
 </module>

--- a/intellij-elixir.xml
+++ b/intellij-elixir.xml
@@ -57,6 +57,7 @@
   </patternset>
 
   <import file="${basedir}/idea.xml"/>
+  <import file="${basedir}/intellij-erlang.xml"/>
 
   <!-- JDK definitions -->
   <exec executable="elixir" outputproperty="elixir.code.lib.dir">
@@ -170,6 +171,9 @@
       <include name="lib/xmlrpc-2.0.jar"/>
       <include name="lib/xpp3-1.1.4-min.jar"/>
       <include name="lib/xstream-1.4.3.jar"/>
+    </fileset>
+    <fileset dir="${intellij-erlang.cache}">
+      <include name="lib/erlang.jar"/>
     </fileset>
     <fileset dir="${basedir}/tests">
       <include name="mockito-core-2.0.7-beta.jar"/>

--- a/intellij-erlang.xml
+++ b/intellij-erlang.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project default="get.intellij-erlang" name="intellij-erlang">
+    <dirname property="intellij-erlang.basedir" file="${ant.file.intellij-erlang}"/>
+
+    <property name="intellij-erlang.output.dir" value="${intellij-erlang.basedir}/dependencies/intellij-erlang"/>
+    <property name="intellij-erlang.release" value="778"/>
+    <property name="intellij-erlang.zip" value="Erlang.${intellij-erlang.release}.zip"/>
+    <property name="intellij-erlang.cache" value="${intellij-erlang.basedir}/cache/intellij-erlang"/>
+    <property name="intellij-erlang.zip.root.basename" value="Erlang"/>
+
+    <property name="intellij-erlang.output.zip.root.dir" value="${intellij-erlang.output.dir}/${intellij-erlang.zip.root.basename}"/>
+    <available file="${intellij-erlang.output.zip.root.dir}" property="intellij-erlang.output.zip.root.available"/>
+
+    <available file="${intellij-erlang.output.dir}/${intellij-erlang.zip}" property="intellij-erlang.zip.available"/>
+
+    <target name="clean.intellij-erlang">
+        <delete quiet="true">
+            <fileset dir="${intellij-erlang.output.dir}"/>
+            <fileset dir="${intellij-erlang.cache}"/>
+        </delete>
+    </target>
+
+    <target name="get.intellij-erlang" depends="unpack.intellij-erlang.zip" description="Get intellij-erlang ${intellij-erlang.release} from Github">
+        <copy todir="${intellij-erlang.cache}">
+            <fileset dir="${intellij-erlang.output.zip.root.dir}"/>
+        </copy>
+    </target>
+
+    <target name="get.intellij-erlang.zip" description="Get intellij-erlang ${intellij-erlang.release} zip from Github" unless="intellij-erlang.zip.available">
+        <mkdir dir="${intellij-erlang.output.dir}"/>
+        <get dest="${intellij-erlang.output.dir}"
+             src="https://github.com/ignatov/intellij-erlang/releases/download/%23${intellij-erlang.release}/Erlang.${intellij-erlang.release}.zip"
+             usetimestamp="true"
+             verbose="true"/>
+    </target>
+
+    <target name="unpack.intellij-erlang.zip" depends="get.intellij-erlang.zip" description="unzip ${intellij-erlang.zip}" unless="intellij-erlang.output.zip.root.available">
+        <unzip src="${intellij-erlang.output.dir}/${intellij-erlang.zip}" dest="${intellij-erlang.output.dir}"/>
+    </target>
+</project>

--- a/src/META-INF/intellij-erlang-plugin.xml
+++ b/src/META-INF/intellij-erlang-plugin.xml
@@ -1,0 +1,6 @@
+<!-- Extensions that use classes only available when the intellij-erlang plugin is installed. -->
+<idea-plugin version="2">
+  <extensions defaultExtensionNs="com.intellij">
+    <annotator language="Erlang" implementationClass="org.elixir_lang.annonator.Module"/>
+  </extensions>
+</idea-plugin>

--- a/src/META-INF/plugin.xml
+++ b/src/META-INF/plugin.xml
@@ -372,6 +372,7 @@
   <!-- please see http://confluence.jetbrains.com/display/IDEADEV/Plugin+Compatibility+with+IntelliJ+Platform+Products
        on how to target different products -->
   <depends>com.intellij.modules.lang</depends>
+  <depends config-file="intellij-erlang-plugin.xml" optional="true">org.jetbrains.erlang</depends>
   <depends config-file="rich-platform-plugin.xml" optional="true">com.intellij.modules.java</depends>
 
   <extensions defaultExtensionNs="com.intellij">

--- a/src/org/elixir_lang/Macro.java
+++ b/src/org/elixir_lang/Macro.java
@@ -1,7 +1,11 @@
 package org.elixir_lang;
 
 import com.ericsson.otp.erlang.*;
+import com.google.common.base.Joiner;
 import org.elixir_lang.psi.impl.ElixirPsiImplUtil;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.*;
 
 public class Macro {
     public static OtpErlangList callArguments(OtpErlangTuple callExpression) {
@@ -145,5 +149,28 @@ public class Macro {
 
     public static OtpErlangList metadata(OtpErlangTuple expression) {
         return (OtpErlangList) expression.elementAt(1);
+    }
+
+    /**
+     *
+     * @param macro
+     * @return
+     * @see <a href="https://github.com/elixir-lang/elixir/blob/a1b06e1e9067ae08826f91274fefcb68c2bbdd02/lib/elixir/lib/macro.ex#L461-L464">Macro.to_string</a>
+     */
+    @NotNull
+    public static String toString(OtpErlangObject macro) {
+        assert Macro.isAliases(macro);
+
+        OtpErlangTuple quotedAlias = (OtpErlangTuple) macro;
+        OtpErlangList refs = (OtpErlangList) quotedAlias.elementAt(2);
+        java.util.List<String> refStringList = new ArrayList<String>();
+
+        for (OtpErlangObject ref : refs) {
+            OtpErlangAtom refAtom = (OtpErlangAtom) ref;
+
+            refStringList.add(refAtom.atomValue());
+        }
+
+        return Joiner.on(".").join(refStringList);
     }
 }

--- a/src/org/elixir_lang/Util.java
+++ b/src/org/elixir_lang/Util.java
@@ -1,0 +1,173 @@
+package org.elixir_lang;
+
+import com.ericsson.otp.erlang.OtpErlangAtom;
+import com.ericsson.otp.erlang.OtpErlangObject;
+import com.ericsson.otp.erlang.OtpErlangTuple;
+import com.google.common.collect.AbstractIterator;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.PsiManager;
+import com.intellij.psi.search.FileTypeIndex;
+import com.intellij.psi.search.GlobalSearchScope;
+import com.intellij.psi.util.PsiTreeUtil;
+import com.intellij.util.indexing.FileBasedIndex;
+import org.elixir_lang.psi.*;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Collection;
+import java.util.Iterator;
+
+public class Util {
+    /**
+     * Iterator of calls in all Elixir file in project.
+     *
+     * @param project The project whose Elixir files to search for calls.
+     * @return Iterator of calls in all Elixir file in project.
+     */
+    public static Iterator<Quotable> callIterator(Project project) {
+        final Iterator<ElixirFile> elixirFileIterator = elixirFileIterator(project);
+
+        return new AbstractIterator<Quotable>() {
+            private Iterator<Quotable> quotableIterator = null;
+
+            @Override
+            protected Quotable computeNext() {
+                while (true) {
+                    if (quotableIterator == null || !quotableIterator.hasNext()) {
+                        if (elixirFileIterator.hasNext()) {
+                            nextQuotableIterator();
+                        } else {
+                            return endOfData();
+                        }
+                    } else {
+                        return quotableIterator.next();
+                    }
+                }
+            }
+
+            /**
+             * Private Instance Methods
+             */
+
+            private void nextQuotableIterator() {
+                ElixirFile elixirFile = elixirFileIterator.next();
+
+                Collection<Quotable> children = PsiTreeUtil.findChildrenOfAnyType(
+                        elixirFile,
+                        AtUnqualifiedNoParenthesesCall.class,
+                        Call.class,
+                        DotCall.class,
+                        QualifiedNoArgumentsCall.class,
+                        QualifiedNoParenthesesCall.class,
+                        QualifiedParenthesesCall.class,
+                        UnqualifiedNoArgumentsCall.class,
+                        UnqualifiedNoParenthesesCall.class,
+                        UnqualifiedParenthesesCall.class
+                );
+
+                quotableIterator = children.iterator();
+            }
+
+        };
+    }
+
+    /**
+     * Iterator of calls with the given, unqualified name
+     *
+     * @param project The project whose Elixir files to search for calls
+     * @param name name of function called without Module qualifier
+     */
+    public static Iterator<Quotable> callIterator(Project project, final String name) {
+        final Iterator<Quotable> callIterator = callIterator(project);
+
+        return new AbstractIterator<Quotable>() {
+            @Override
+            protected Quotable computeNext() {
+                while (callIterator.hasNext()) {
+                    Quotable call = callIterator.next();
+
+                    OtpErlangTuple quotedCall = (OtpErlangTuple) call.quote();
+                    OtpErlangObject quotedIdentifier = quotedCall.elementAt(0);
+
+                    // Can't handle other forms yet
+                    assert quotedIdentifier instanceof OtpErlangAtom;
+
+                    OtpErlangAtom identifierAtom = (OtpErlangAtom) quotedIdentifier;
+
+                    if (identifierAtom.atomValue().equals(name)) {
+                        return call;
+                    }
+                }
+
+                return endOfData();
+            }
+        };
+    }
+
+    /**
+     * Iterator of ElixirFiles in project.
+     *
+     * @param project
+     * @return
+     */
+    public static Iterator<ElixirFile> elixirFileIterator(final Project project) {
+        Collection<VirtualFile> virtualFileCollection = FileBasedIndex.getInstance().getContainingFiles(
+                FileTypeIndex.NAME,
+                ElixirFileType.INSTANCE,
+                GlobalSearchScope.allScope(project)
+        );
+        final Iterator<VirtualFile> virtualFileIterator = virtualFileCollection.iterator();
+
+        return new AbstractIterator<ElixirFile>() {
+            @Override
+            protected ElixirFile computeNext() {
+                while (virtualFileIterator.hasNext()) {
+                    VirtualFile virtualFile = virtualFileIterator.next();
+                    ElixirFile elixirFile = (ElixirFile) PsiManager.getInstance(project).findFile(virtualFile);
+
+                    if (elixirFile != null) {
+                        return elixirFile;
+                    }
+                }
+
+                return endOfData();
+            }
+        };
+    }
+
+    @Nullable
+    public static ModuleDefinition findModuleDefinition(Project project, String fullyQualifiedName) {
+        ModuleDefinition found = null;
+
+        for (Iterator<ModuleDefinition> moduleDefinitionIterator = moduleDefinitionIterator(project); moduleDefinitionIterator.hasNext();) {
+            ModuleDefinition moduleDefinition = moduleDefinitionIterator.next();
+            String moduleFullyQualifiedName = moduleDefinition.fullyQualifiedName();
+
+            if (moduleFullyQualifiedName.equals(fullyQualifiedName)) {
+                found = moduleDefinition;
+
+                break;
+            }
+        }
+
+        return found;
+    }
+
+    public static Iterator<ModuleDefinition> moduleDefinitionIterator(Project project) {
+        final Iterator<Quotable> defmoduleIterator = callIterator(project, "defmodule");
+
+        return new AbstractIterator<ModuleDefinition>() {
+            @Override
+            protected ModuleDefinition computeNext() {
+                while (defmoduleIterator.hasNext()) {
+                    Quotable defmodule = defmoduleIterator.next();
+
+                    return new ModuleDefinition(defmodule);
+                }
+
+                return endOfData();
+            }
+        };
+    }
+
+}

--- a/src/org/elixir_lang/annonator/Module.java
+++ b/src/org/elixir_lang/annonator/Module.java
@@ -1,0 +1,38 @@
+package org.elixir_lang.annonator;
+
+import com.intellij.lang.annotation.Annotation;
+import com.intellij.lang.annotation.Annotator;
+import com.intellij.openapi.editor.DefaultLanguageHighlighterColors;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.TextRange;
+import com.intellij.psi.PsiElement;
+import org.elixir_lang.Util;
+import org.intellij.erlang.psi.ErlangAtom;
+import org.jetbrains.annotations.NotNull;
+
+public class Module implements Annotator {
+
+    public static final String ELIXIR_ALIAS_PREFIX = "Elixir.";
+
+    @Override
+    public void annotate(@NotNull PsiElement psiElement, @NotNull com.intellij.lang.annotation.AnnotationHolder annotationHolder) {
+        if (psiElement instanceof ErlangAtom) {
+            ErlangAtom erlangAtom = (ErlangAtom) psiElement;
+            String name = erlangAtom.getName();
+
+            if (name.startsWith(ELIXIR_ALIAS_PREFIX)) {
+                Project project = psiElement.getProject();
+
+                if (Util.findModuleDefinition(project, name) != null) {
+                    TextRange textRange = psiElement.getTextRange();
+                    String unprefixedName = name.substring(ELIXIR_ALIAS_PREFIX.length(), name.length());
+                    Annotation annotation = annotationHolder.createInfoAnnotation(textRange, "Resolves to Elixir Module " + unprefixedName);
+                    annotation.setTextAttributes(DefaultLanguageHighlighterColors.LINE_COMMENT);
+                } else {
+                    TextRange textRange = psiElement.getTextRange();
+                    annotationHolder.createErrorAnnotation(textRange, "Unresolved Elixir Module");
+                }
+            }
+        }
+    }
+}

--- a/src/org/elixir_lang/psi/ModuleDefinition.java
+++ b/src/org/elixir_lang/psi/ModuleDefinition.java
@@ -1,0 +1,41 @@
+package org.elixir_lang.psi;
+
+import com.ericsson.otp.erlang.OtpErlangList;
+import com.ericsson.otp.erlang.OtpErlangObject;
+import com.ericsson.otp.erlang.OtpErlangTuple;
+import com.intellij.psi.PsiElement;
+import org.elixir_lang.Macro;
+
+/**
+ * Module definition wrapping a `defmodule` call PSIElement.
+ */
+public class ModuleDefinition {
+    /*
+     * Private Fields
+     */
+
+    private final Quotable defmodule;
+
+    /*
+     * Constructors
+     */
+
+    public ModuleDefinition(Quotable defmodule){
+        this.defmodule = defmodule;
+    }
+
+    public String fullyQualifiedName(){
+        OtpErlangTuple quotedDefmodule = (OtpErlangTuple) defmodule.quote();
+        OtpErlangList callArguments = Macro.callArguments(quotedDefmodule);
+
+        // Alias + block
+        assert callArguments.arity() == 2;
+
+        OtpErlangObject quotedName = callArguments.elementAt(0);
+
+        // TODO handle other forms for module names
+        assert Macro.isAliases(quotedName);
+
+        return "Elixir." + Macro.toString(quotedName);
+    }
+}


### PR DESCRIPTION
Resolves #84

# Changelog
* Enhancements
  * If (1) you have intellij-erlang installed and (2) you have an atom in
Erlang that starts with `Elixir.`, such as `'Elixir.Test'`, then
intellij-elixir will annotate whether it can resolve the name to a
`defmodule` call in Elixir files.

