### PR TITLE
intellij-erlang dependency link change

### DIFF
--- a/intellij-erlang.xml
+++ b/intellij-erlang.xml
@@ -28,13 +28,13 @@
 
     <target name="get.intellij-erlang.zip" description="Get intellij-erlang ${intellij-erlang.release} zip from Github" unless="intellij-erlang.zip.available">
         <mkdir dir="${intellij-erlang.output.dir}"/>
-        <get dest="${intellij-erlang.output.dir}"
-             src="https://github.com/ignatov/intellij-erlang/releases/download/%23${intellij-erlang.release}/Erlang.${intellij-erlang.release}.zip"
+        <get dest="${intellij-erlang.output.dir}/Erlang.${intellij-erlang.release}.zip"
+             src="https://github.com/ignatov/intellij-erlang/archive/%23${intellij-erlang.release}.zip"
              usetimestamp="true"
              verbose="true"/>
     </target>
 
     <target name="unpack.intellij-erlang.zip" depends="get.intellij-erlang.zip" description="unzip ${intellij-erlang.zip}" unless="intellij-erlang.output.zip.root.available">
-        <unzip src="${intellij-erlang.output.dir}/${intellij-erlang.zip}" dest="${intellij-erlang.output.dir}"/>
+        <unzip src="${intellij-erlang.output.dir}/${intellij-erlang.zip}" dest="${intellij-erlang.output.dir}/Erlang"/>
     </target>
 </project>


### PR DESCRIPTION
Changed intellij-erlang dependency release endpoints (archive link does not change, unlike the release one).