### PR TITLE
Fix mix version detection on Windows

### DIFF
--- a/.idea/libraries/JInterface.xml
+++ b/.idea/libraries/JInterface.xml
@@ -2,10 +2,12 @@
   <library name="JInterface">
     <CLASSES>
       <root url="jar:///usr/local/Cellar/erlang/18.1/lib/erlang/lib/jinterface-1.6/priv/OtpErlang.jar!/" />
+      <root url="jar://C:/Program Files/erl7.2/lib/jinterface-1.6.1/priv/OtpErlang.jar!/" />
     </CLASSES>
     <JAVADOC />
     <SOURCES>
       <root url="file:///usr/local/Cellar/erlang/18.1/lib/erlang/lib/jinterface-1.6/java_src" />
+      <root url="file://C:/Program Files/erl7.2/lib/jinterface-1.6.1/java_src" />
     </SOURCES>
   </library>
 </component>

--- a/src/org/elixir_lang/mix/importWizard/MixProjectRootStep.java
+++ b/src/org/elixir_lang/mix/importWizard/MixProjectRootStep.java
@@ -122,17 +122,25 @@ public class MixProjectRootStep extends ProjectImportWizardStep {
       }
     }
 
-    boolean isPosix = SystemInfo.isMac || SystemInfo.isLinux || SystemInfo.isUnix;
-    if(!isPosix) return "";
-
     String output = "";
-    try{
-      GeneralCommandLine which = new GeneralCommandLine("which");
-      which.addParameter("mix");
-      output = ScriptRunnerUtil.getProcessOutput(which);
-    }catch (Exception ignored){
-      LOG.warn(ignored);
+    GeneralCommandLine generalCommandLine = null;
+
+    if (SystemInfo.isWindows) {
+      generalCommandLine = new GeneralCommandLine("where");
+      generalCommandLine.addParameter("mix.bat");
+    } else if (SystemInfo.isMac || SystemInfo.isLinux || SystemInfo.isUnix) {
+      generalCommandLine = new GeneralCommandLine("which");
+      generalCommandLine.addParameter("mix");
     }
+
+    if (generalCommandLine != null) {
+      try {
+        output = ScriptRunnerUtil.getProcessOutput(generalCommandLine);
+      } catch (Exception ignored) {
+        LOG.warn(ignored);
+      }
+    }
+
     return output.trim();
   }
 

--- a/src/org/elixir_lang/mix/runner/MixRunningStateUtil.java
+++ b/src/org/elixir_lang/mix/runner/MixRunningStateUtil.java
@@ -40,8 +40,15 @@ public class MixRunningStateUtil {
     GeneralCommandLine commandLine = new GeneralCommandLine();
 
     commandLine.withWorkDirectory(getWorkingDirectory(configuration));
-    commandLine.setExePath(elixirPath);
-    commandLine.addParameter(mixSettings.getMixPath());
+
+    String mixPath = mixSettings.getMixPath();
+
+    if (mixPath.endsWith(".bat")) {
+      commandLine.setExePath(mixPath);
+    } else {
+      commandLine.setExePath(elixirPath);
+      commandLine.addParameter(mixPath);
+    }
 
     List<String> split = ContainerUtil.list(configuration.getCommand().split("\\s+"));
     if(configuration.isSkipDependencies() && !split.contains("--no-deps-check")){

--- a/src/org/elixir_lang/mix/settings/MixConfigurationForm.java
+++ b/src/org/elixir_lang/mix/settings/MixConfigurationForm.java
@@ -72,9 +72,23 @@ public class MixConfigurationForm {
     String mixPath = myMixPathSelector.getText();
     if(!new File(mixPath).exists()) return false;
 
-    ExtProcessUtil.ExtProcessOutput output = ExtProcessUtil.execAndGetFirstLine(3000, myMixPathSelector.getText(), "--version");
+    ExtProcessUtil.ExtProcessOutput output = ExtProcessUtil.execAndGetFirstLine(3000, mixPath, "--version");
     String version = output.getStdOut();
-    if(version.startsWith("Mix")){
+
+    // Elixir X.Y.Z for mix.bat before 1.2
+    // Mix X.Y.Z for all others
+    if (version.startsWith("Mix")) {
+      myMixVersionText.setText(version);
+      return true;
+    }
+
+    // Elixir X.Y.Z for mix.bat before 1.2.  See https://github.com/elixir-lang/elixir/issues/4075
+    output = ExtProcessUtil.execAndGetFirstLine(3000, mixPath, "--", "--version");
+    version = output.getStdOut();
+
+    // Elixir X.Y.Z for mix.bat before 1.2
+    // Mix X.Y.Z for all others
+    if (version.startsWith("Mix")) {
       myMixVersionText.setText(version);
       return true;
     }


### PR DESCRIPTION
Fixes #224
Supersedes #220

When on Windows, use `mix.bat` instead of just `mix` as `mix` by itself won't run.

# Changelog
* Bug Fixes
  * Use `mix.bat` instead of `mix` on Windows and ensure that  the mix version is properly detected even with the Elixir versions < 1.2 where @f-lombardo fixed the mix output in https://github.com/elixir-lang/elixir/pull/4077