### PR TITLE
Support associations (=>) in types

### DIFF
--- a/gen/org/elixir_lang/psi/ElixirContainerAssociationOperation.java
+++ b/gen/org/elixir_lang/psi/ElixirContainerAssociationOperation.java
@@ -15,15 +15,6 @@ public interface ElixirContainerAssociationOperation extends AssociationOperatio
   List<ElixirUnmatchedExpression> getUnmatchedExpressionList();
 
   @NotNull
-  Quotable leftOperand();
-
-  @NotNull
-  Operator operator();
-
-  @NotNull
   OtpErlangObject quote();
-
-  @NotNull
-  Quotable rightOperand();
 
 }

--- a/gen/org/elixir_lang/psi/impl/ElixirContainerAssociationOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirContainerAssociationOperationImpl.java
@@ -6,7 +6,10 @@ import com.intellij.extapi.psi.ASTWrapperPsiElement;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import org.elixir_lang.psi.*;
+import org.elixir_lang.psi.ElixirContainerAssociationOperation;
+import org.elixir_lang.psi.ElixirEmptyParentheses;
+import org.elixir_lang.psi.ElixirUnmatchedExpression;
+import org.elixir_lang.psi.ElixirVisitor;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
@@ -35,23 +38,8 @@ public class ElixirContainerAssociationOperationImpl extends ASTWrapperPsiElemen
   }
 
   @NotNull
-  public Quotable leftOperand() {
-    return ElixirPsiImplUtil.leftOperand(this);
-  }
-
-  @NotNull
-  public Operator operator() {
-    return ElixirPsiImplUtil.operator(this);
-  }
-
-  @NotNull
   public OtpErlangObject quote() {
     return ElixirPsiImplUtil.quote(this);
-  }
-
-  @NotNull
-  public Quotable rightOperand() {
-    return ElixirPsiImplUtil.rightOperand(this);
   }
 
 }

--- a/src/org/elixir_lang/Elixir.bnf
+++ b/src/org/elixir_lang/Elixir.bnf
@@ -2007,15 +2007,7 @@ private associationInfixOperator ::= EOL* ASSOCIATION_OPERATOR EOL*
 
 // @see https://github.com/elixir-lang/elixir/blob/de39bbaca277002797e52ffbde617ace06233a2b/lib/elixir/src/elixir_parser.yrl#L505
 containerAssociationOperation ::= containerExpression associationInfixOperator containerExpression
-                                  {
-                                    implements = "org.elixir_lang.psi.AssociationOperation"
-                                    methods = [
-                                      leftOperand
-                                      operator
-                                      quote
-                                      rightOperand
-                                    ]
-                                  }
+                                  { implements = "org.elixir_lang.psi.AssociationOperation" methods = [quote] }
 
 left maxDotCall ::= dotInfixOperator parenthesesArguments parenthesesArguments?
                     { elementType = matchedDotCall }

--- a/src/org/elixir_lang/annonator/ModuleAttribute.java
+++ b/src/org/elixir_lang/annonator/ModuleAttribute.java
@@ -756,6 +756,9 @@ public class ModuleAttribute implements Annotator, DumbAware {
                     typeTextAttributesKey
             );
         } else if (psiElement instanceof ElixirAccessExpression ||
+                psiElement instanceof ElixirAssociationsBase ||
+                psiElement instanceof ElixirAssociations ||
+                psiElement instanceof ElixirContainerAssociationOperation ||
                 psiElement instanceof ElixirKeywordPair ||
                 psiElement instanceof ElixirKeywords ||
                 psiElement instanceof ElixirList ||
@@ -783,7 +786,7 @@ public class ModuleAttribute implements Annotator, DumbAware {
                 psiElement instanceof ElixirStringLine ||
                 psiElement instanceof ElixirUnaryNumericOperation) {
             // leave normal highlighting
-        } else if (psiElement instanceof ElixirMapOperation) {
+        }  else if (psiElement instanceof ElixirMapOperation) {
             highlightTypesAndTypeParameterUsages(
                     (ElixirMapOperation) psiElement,
                     typeParameterNameSet,

--- a/src/org/elixir_lang/psi/AssociationOperation.java
+++ b/src/org/elixir_lang/psi/AssociationOperation.java
@@ -1,8 +1,10 @@
 package org.elixir_lang.psi;
 
-/**
- * A binary operator with a left operand, association operator, and right operand
- */
-public interface AssociationOperation extends InfixOperation {
+import com.intellij.psi.PsiElement;
 
+/**
+ * A binary operator with a left operand, association operator, and right operand, but the association operator is
+ * ignored for quoting, so not an {@link InfixOperation}.
+ */
+public interface AssociationOperation extends Quotable {
 }


### PR DESCRIPTION
Extends #223

# Changelog
* Enhancements
  * Annotate left and right types when `=>` is used in maps in types.