### PR TITLE
Use elixir -e instead of --version

### DIFF
--- a/src/org/elixir_lang/sdk/ElixirSdkRelease.java
+++ b/src/org/elixir_lang/sdk/ElixirSdkRelease.java
@@ -6,39 +6,92 @@ import org.jetbrains.annotations.Nullable;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-/**
- * Created by zyuyou on 2015/5/27.
- *
- */
 public final class ElixirSdkRelease {
-  public static final ElixirSdkRelease V_1_0_0 = new ElixirSdkRelease("1", "0", "0");
-  public static final ElixirSdkRelease V_1_0_1 = new ElixirSdkRelease("1", "0", "1");
-  public static final ElixirSdkRelease V_1_0_2 = new ElixirSdkRelease("1", "0", "2");
-  public static final ElixirSdkRelease V_1_0_3 = new ElixirSdkRelease("1", "0", "3");
-  public static final ElixirSdkRelease V_1_0_4 = new ElixirSdkRelease("1", "0", "4");
-  public static final ElixirSdkRelease V_1_0_5 = new ElixirSdkRelease("1", "0", "5");
+  /*
+   * CONSTANTS
+   */
 
-  private static final Pattern VERSION_PATTERN = Pattern.compile("Elixir (\\d+)\\.(\\d+)\\.(\\d+)");
+  public static final ElixirSdkRelease V_1_0_4 = new ElixirSdkRelease("1", "0", "4", null, null);
 
-  private final String myRelease;
+  private static final Pattern VERSION_PATTERN = Pattern.compile(
+          // @version_regex from Version in elixir itself
+          "(\\d+)(?:\\.(\\d+))?(?:\\.(\\d+))?(?:\\-([\\d\\w\\.\\-]+))?(?:\\+([\\d\\w\\-]+))?"
+  );
 
-  public ElixirSdkRelease(@NotNull String release, @NotNull String version, @NotNull String fix){
-    myRelease = release + "." + version + "." + fix;
-  }
-
-  @NotNull
-  public String getRelease(){
-    return myRelease;
-  }
-
-  @Override
-  public String toString() {
-    return "Elixir " + getRelease();
-  }
+  /*
+   * Static Methods
+   */
 
   @Nullable
   public static ElixirSdkRelease fromString(@Nullable String versionString){
     Matcher m = versionString != null ? VERSION_PATTERN.matcher(versionString) : null;
-    return m != null && m.matches() ? new ElixirSdkRelease(m.group(1), m.group(2), m.group(3)) : null;
+    return m != null && m.matches() ? new ElixirSdkRelease(m.group(1), m.group(2), m.group(3), m.group(4), m.group(5)) : null;
+  }
+
+  /*
+   * Fields
+   */
+
+  @Nullable
+  private final String build;
+  @NotNull
+  private final String major;
+  @Nullable
+  private final String minor;
+  @Nullable
+  private final String patch;
+  @Nullable
+  private final String pre;
+
+  /*
+   * Constructors
+   */
+
+  public ElixirSdkRelease(@NotNull String major,
+                          @Nullable String minor,
+                          @Nullable String patch,
+                          @Nullable String pre,
+                          @Nullable String build) {
+    this.major = major;
+    this.minor = minor;
+    this.patch = patch;
+    this.pre = pre;
+    this.build = build;
+
+    if (minor == null && patch != null) {
+      throw new IllegalArgumentException("patch MUST be null if minor is null");
+    }
+  }
+
+  /*
+   * Instance Methods
+   */
+
+  @Override
+  public String toString() {
+    return "Elixir " + version();
+  }
+
+  @NotNull
+  public String version(){
+    StringBuilder version = new StringBuilder(major);
+
+    if (minor != null) {
+      version.append('.').append(minor);
+    }
+
+    if (patch != null) {
+      version.append('.').append(patch);
+    }
+
+    if (pre != null) {
+      version.append('-').append(pre);
+    }
+
+    if (build != null) {
+      version.append('+').append(build);
+    }
+
+    return version.toString();
   }
 }

--- a/src/org/elixir_lang/sdk/ElixirSdkType.java
+++ b/src/org/elixir_lang/sdk/ElixirSdkType.java
@@ -163,8 +163,8 @@ public class ElixirSdkType extends SdkType {
 
 
   @NotNull
-  private static String getDefaultSdkName(@NotNull String sdkHome, @Nullable ElixirSdkRelease version){
-    return version != null ? "Elixir " + version.getRelease() : "Unknown Elixir version at " + sdkHome ;
+  private static String getDefaultSdkName(@NotNull String sdkHome, @Nullable ElixirSdkRelease release){
+    return release != null ? release.toString() : "Unknown Elixir version at " + sdkHome ;
   }
 
   @Nullable
@@ -184,13 +184,14 @@ public class ElixirSdkType extends SdkType {
     }
 
     try{
-      ProcessOutput output = ElixirSystemUtil.getProcessOutput(sdkHome, elixir.getAbsolutePath(), "-v");
+      ProcessOutput output = ElixirSystemUtil.getProcessOutput(sdkHome, elixir.getAbsolutePath(), "-e", "IO.puts System.build_info[:version]");
       List<String> lines = output.getExitCode() != 0 || output.isTimeout() || output.isCancelled() ?
           ContainerUtil.<String>emptyList() : output.getStdoutLines();
 
       for (String line : lines) {
-        if (line.startsWith("Elixir")) {
-          ElixirSdkRelease release = ElixirSdkRelease.fromString(line);
+        ElixirSdkRelease release = ElixirSdkRelease.fromString(line);
+
+        if (release != null) {
           mySdkHomeToReleaseCache.put(getVersionCacheKey(sdkHome), release);
           return release;
         }


### PR DESCRIPTION
Fixes #238

# Changelog
* Enhancements
  * Get the Elixir version directly from `System.build_info[:version]` instead of processing the formatted output of `elixir --version` as the build info version is more stable.
* Bug Fixes
  * Elixir version parsing handles both pre and build numbers if present by using the same regular expression as Elixir itself uses for the `Version` module.