### PR TITLE
Better error handling in Structure

### DIFF
--- a/src/org/elixir_lang/structure_view/element/CallDefinition.java
+++ b/src/org/elixir_lang/structure_view/element/CallDefinition.java
@@ -75,6 +75,7 @@ public class CallDefinition implements StructureViewTreeElement, Timed, Visible 
     public void clause(Call clause) {
         Pair<String, IntRange> nameArityRange = CallDefinitionClause.nameArityRange(clause);
 
+        assert nameArityRange != null;
         assert nameArityRange.first.equals(name);
         assert nameArityRange.second.getMinimumInteger() <= arity && nameArityRange.second.getMaximumInteger() >= arity;
 

--- a/src/org/elixir_lang/structure_view/element/call_definition_by_name_arity/TreeElementList.java
+++ b/src/org/elixir_lang/structure_view/element/call_definition_by_name_arity/TreeElementList.java
@@ -53,10 +53,13 @@ public class TreeElementList
 
     public void addClausesToCallDefinition(@NotNull Call call) {
         Pair<String, IntRange> nameArityRange = CallDefinitionClause.nameArityRange(call);
-        String name = nameArityRange.first;
-        IntRange arityRange = nameArityRange.second;
 
-        addClausesToCallDefinition(call, name, arityRange);
+        if (nameArityRange != null) {
+            String name = nameArityRange.first;
+            IntRange arityRange = nameArityRange.second;
+
+            addClausesToCallDefinition(call, name, arityRange);
+        }
     }
 
     public void addClausesToCallDefinition(@NotNull Call call, @NotNull String name, @NotNull IntRange arityRange) {

--- a/src/org/elixir_lang/structure_view/element/modular/Module.java
+++ b/src/org/elixir_lang/structure_view/element/modular/Module.java
@@ -47,18 +47,21 @@ public class Module extends Element<Call> implements Modular {
             @NotNull Inserter<CallDefinition> callDefinitionInserter
     ) {
         Pair<String, IntRange> nameArityRange = CallDefinitionClause.nameArityRange(call);
-        String name = nameArityRange.first;
-        IntRange arityRange = nameArityRange.second;
 
-        addClausesToCallDefinition(
-                call,
-                name,
-                arityRange,
-                callDefinitionByNameArity,
-                modular,
-                time,
-                callDefinitionInserter
-        );
+        if (nameArityRange != null) {
+            String name = nameArityRange.first;
+            IntRange arityRange = nameArityRange.second;
+
+            addClausesToCallDefinition(
+                    call,
+                    name,
+                    arityRange,
+                    callDefinitionByNameArity,
+                    modular,
+                    time,
+                    callDefinitionInserter
+            );
+        }
     }
 
     public static void addClausesToCallDefinition(
@@ -166,7 +169,10 @@ public class Module extends Element<Call> implements Modular {
                         String name = callReference.name();
 
                         CallDefinition function = functionByNameArity.get(pair(name, arity));
-                        function.setOverridable(true);
+
+                        if (function != null) {
+                            function.setOverridable(true);
+                        }
                     }
                 }
             }

--- a/src/org/elixir_lang/structure_view/node_provider/Used.java
+++ b/src/org/elixir_lang/structure_view/node_provider/Used.java
@@ -11,7 +11,6 @@ import com.intellij.openapi.util.Pair;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
 import com.intellij.psi.PsiReference;
-import com.intellij.psi.util.PsiUtil;
 import com.intellij.util.IncorrectOperationException;
 import org.apache.commons.lang.math.IntRange;
 import org.elixir_lang.psi.ElixirAccessExpression;
@@ -28,7 +27,6 @@ import java.util.*;
 
 import static com.intellij.openapi.util.Pair.pair;
 import static org.elixir_lang.structure_view.element.modular.Module.addClausesToCallDefinition;
-import static org.elixir_lang.structure_view.element.modular.Module.is;
 
 public class Used implements FileStructureNodeProvider<TreeElement>, ActionShortcutProvider {
     /*
@@ -127,23 +125,26 @@ public class Used implements FileStructureNodeProvider<TreeElement>, ActionShort
                                                        dealing with macros, restricted to __using__/1 */
                                                     if (CallDefinitionClause.isMacro(childCall)) {
                                                         Pair<String, IntRange> nameArityRange = CallDefinitionClause.nameArityRange(childCall);
-                                                        String name = nameArityRange.first;
-                                                        IntRange arityRange = nameArityRange.second;
 
-                                                        if (name.equals(USING) && arityRange.containsInteger(1)) {
-                                                            addClausesToCallDefinition(
-                                                                    childCall,
-                                                                    name,
-                                                                    arityRange,
-                                                                    macroByNameArity,
-                                                                    module,
-                                                                    Timed.Time.COMPILE,
-                                                                    new Inserter<CallDefinition>() {
-                                                                        @Override
-                                                                        public void insert(CallDefinition element) {
+                                                        if (nameArityRange != null) {
+                                                            String name = nameArityRange.first;
+                                                            IntRange arityRange = nameArityRange.second;
+
+                                                            if (name.equals(USING) && arityRange.containsInteger(1)) {
+                                                                addClausesToCallDefinition(
+                                                                        childCall,
+                                                                        name,
+                                                                        arityRange,
+                                                                        macroByNameArity,
+                                                                        module,
+                                                                        Timed.Time.COMPILE,
+                                                                        new Inserter<CallDefinition>() {
+                                                                            @Override
+                                                                            public void insert(CallDefinition element) {
+                                                                            }
                                                                         }
-                                                                    }
-                                                            );
+                                                                );
+                                                            }
                                                         }
                                                     }
                                                 }


### PR DESCRIPTION
# Changelog
* Bug Fixes
  * Handle there being no primary arguments for call definitions as can be the case when the function name hasn't been typed yet, which previously caused a failing assert.