### PR TITLE
Eliminate the AssertionError reported when typing infix operations

### DIFF
--- a/src/org/elixir_lang/psi/impl/ElixirPsiImplUtil.java
+++ b/src/org/elixir_lang/psi/impl/ElixirPsiImplUtil.java
@@ -913,9 +913,24 @@ public class ElixirPsiImplUtil {
     public static Operator operator(Infix infix) {
         PsiElement[] children = infix.getChildren();
 
-        assert children.length == 3;
+        /* 1. When the error is in the rightOperand, then the operator is the last of 2 elements ({@code children[1]}).
+         * 2. When there is no error, then the operator is the middle ({@code children[1]}) element.
+         * 3. When the error is in the leftOperand, then the leftOperand can actually be multiple elements, so it is
+         *    not possible determine which index to use.
+         *
+         * With all that in mind, it is simplest just detect by {@code instanceof}.
+         */
 
-        return (Operator) children[1];
+        Operator operator = null;
+
+        for (PsiElement child : children) {
+          if (child instanceof Operator) {
+              operator = (Operator) child;
+          }
+        }
+
+        //noinspection ConstantConditions
+        return operator;
     }
 
     @Contract(pure = true)

--- a/testData/org/elixir_lang/parser_definition/infix_parsing_test_case/Issue251.ex
+++ b/testData/org/elixir_lang/parser_definition/infix_parsing_test_case/Issue251.ex
@@ -1,0 +1,5 @@
+defmodule Sensor do
+  defp start_sensor(sensor, master_pid, sup) do
+    id = [sensor["id"]
+  end
+end

--- a/testData/org/elixir_lang/parser_definition/infix_parsing_test_case/Issue251WithNoLeftOperand.ex
+++ b/testData/org/elixir_lang/parser_definition/infix_parsing_test_case/Issue251WithNoLeftOperand.ex
@@ -1,0 +1,7 @@
+defmodule Sensor do
+  defp start_sensor(sensor, master_pid, sup) do
+    = [sensor["id"]]
+    {:ok, pid} = Supervisor.start_child sup, worker(SensorNode, [id, master_pid], id: "sensor_#{id}")
+    pid
+  end
+end

--- a/testData/org/elixir_lang/parser_definition/infix_parsing_test_case/WellFormed.ex
+++ b/testData/org/elixir_lang/parser_definition/infix_parsing_test_case/WellFormed.ex
@@ -1,0 +1,7 @@
+defmodule Sensor do
+  defp start_sensor(sensor, master_pid, sup) do
+    id = [sensor["id"]]
+    {:ok, pid} = Supervisor.start_child sup, worker(SensorNode, [id, master_pid], id: "sensor_#{id}")
+    pid
+  end
+end

--- a/tests/org/elixir_lang/parser_definition/InfixParsingTestCase.java
+++ b/tests/org/elixir_lang/parser_definition/InfixParsingTestCase.java
@@ -1,0 +1,96 @@
+package org.elixir_lang.parser_definition;
+
+import com.intellij.openapi.fileEditor.impl.LoadTextUtil;
+import com.intellij.psi.*;
+import com.intellij.psi.impl.source.tree.LeafPsiElement;
+import com.intellij.psi.util.PsiTreeUtil;
+import com.intellij.testFramework.LightVirtualFile;
+import org.elixir_lang.ElixirLanguage;
+import org.elixir_lang.psi.Operator;
+import org.elixir_lang.psi.operation.Operation;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.IOException;
+import java.util.Collection;
+
+public class InfixParsingTestCase extends ParsingTestCase {
+    /*
+     * Static Methods
+     */
+
+    private static void assertOperator(Operation operation, @NotNull String operatorText) {
+        assertEquals(operatorText, operation.operator().getText());
+    }
+
+    /*
+     * Tests
+     */
+
+    public void testIssue251() {
+        Operation[] operations = operations();
+
+        assertEquals(1, operations.length);
+        assertOperator(operations[0], "=");
+    }
+
+    public void testIssue251WithNoLeftOperand() {
+        Operation[] operations = operations();
+
+        assertEquals(2, operations.length);
+        assertOperator(operations[0], "=");
+        assertOperator(operations[1], "=");
+    }
+
+    public void testWellFormed() {
+        Operation[] operations = operations();
+
+        assertEquals(2, operations.length);
+
+        assertOperator(operations[0], "=");
+        assertOperator(operations[1], "=");
+    }
+
+    /*
+     *
+     * Instance Methods
+     *   *
+     */
+
+    @Override
+    protected String getTestDataPath() {
+        return super.getTestDataPath() + "/infix_parsing_test_case";
+    }
+
+    @NotNull
+    private Operation[] operations() {
+        PsiFile root = root();
+        Collection<Operation> operationCollection = PsiTreeUtil.findChildrenOfType(root, Operation.class);
+
+        return operationCollection.toArray(new Operation[operationCollection.size()]);
+    }
+
+    @NotNull
+    private PsiFile root() {
+        String name = getTestName(false);
+        PsiFile root;
+
+        try {
+            String text = loadFile(name + "." + myFileExt);
+            myFile = createPsiFile(name, text);
+            ensureParsed(myFile);
+            assertEquals("light virtual file text mismatch", text, ((LightVirtualFile) myFile.getVirtualFile()).getContent().toString());
+            assertEquals("virtual file text mismatch", text, LoadTextUtil.loadText(myFile.getVirtualFile()));
+            assertEquals("doc text mismatch", text, myFile.getViewProvider().getDocument().getText());
+            assertEquals("psi text mismatch", text, myFile.getText());
+            ensureCorrectReparse(myFile);
+            FileViewProvider fileViewProvider = myFile.getViewProvider();
+            root = fileViewProvider.getPsi(ElixirLanguage.INSTANCE);
+
+            assertNotNull(root);
+        } catch (IOException exception) {
+            throw new RuntimeException(exception);
+        }
+
+        return root;
+    }
+}

--- a/tests/org/elixir_lang/parser_definition/InfixParsingTestCase.java
+++ b/tests/org/elixir_lang/parser_definition/InfixParsingTestCase.java
@@ -82,7 +82,6 @@ public class InfixParsingTestCase extends ParsingTestCase {
             assertEquals("virtual file text mismatch", text, LoadTextUtil.loadText(myFile.getVirtualFile()));
             assertEquals("doc text mismatch", text, myFile.getViewProvider().getDocument().getText());
             assertEquals("psi text mismatch", text, myFile.getText());
-            ensureCorrectReparse(myFile);
             FileViewProvider fileViewProvider = myFile.getViewProvider();
             root = fileViewProvider.getPsi(ElixirLanguage.INSTANCE);
 


### PR DESCRIPTION
Fixes #251

# Changelog
* Bug Fixes
  * Allow `Infix#operator` to work on operations with errors, which eliminates the `AssertionError` reported when typing infix operation and they are incomplete.