### PR TITLE
Ensure compatibility from 14.0 to 2016.1

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -31,7 +31,7 @@
     <ConfirmationsSetting value="0" id="Add" />
     <ConfirmationsSetting value="0" id="Remove" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_6" default="false" assert-keyword="true" jdk-15="true" project-jdk-name="IntelliJ IDEA Community Edition IC-143.382.35" project-jdk-type="IDEA JDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_6" default="false" assert-keyword="true" jdk-15="true" project-jdk-name="IntelliJ IDEA Community Edition IC-145.258.11" project-jdk-type="IDEA JDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/.idea/runConfigurations/Elixir.xml
+++ b/.idea/runConfigurations/Elixir.xml
@@ -3,6 +3,7 @@
     <module name="intellij-elixir" />
     <option name="VM_PARAMETERS" value="-Xmx512m -Xms256m -XX:MaxPermSize=250m -ea" />
     <option name="PROGRAM_PARAMETERS" value="" />
+    <log_file path="$USER_HOME$/Library/Caches/IntelliJIdea2016.1/plugins-sandbox/system/log/idea.log" checked="false" skipped="true" show_all="false" alias="IDEA LOG" />
     <method />
   </configuration>
 </component>

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,15 +2,34 @@ cache:
   directories:
   - cache
   - dependencies
-language: elixir
-elixir:
-- 1.1.1
-- 1.2.0
-otp_release:
-- 18.2
+language: java
+matrix:
+  include:
+    - env: ELIXIR_VERSION="1.2.3" IDEA_TARBALL_ROOT_BASENAME="idea-IC-145.258.11" IDEA_VERSION="2016.1"
+      jdk: oraclejdk8
+    - env: ELIXIR_VERSION="1.1.1" IDEA_TARBALL_ROOT_BASENAME="idea-IC-145.258.11" IDEA_VERSION="2016.1"
+      jdk: oraclejdk8
+
+    - env: ELIXIR_VERSION="1.2.3" IDEA_TARBALL_ROOT_BASENAME="idea-IC-143.2287.1" IDEA_VERSION="15.0.4"
+      jdk: oraclejdk8
+    - env: ELIXIR_VERSION="1.1.1" IDEA_TARBALL_ROOT_BASENAME="idea-IC-143.2287.1" IDEA_VERSION="15.0.4"
+      jdk: oraclejdk8
+
+    - env: ELIXIR_VERSION="1.2.3" IDEA_TARBALL_ROOT_BASENAME="idea-IC-141.3056.4" IDEA_VERSION="14.1.6"
+      jdk: openjdk6
+    - env: ELIXIR_VERSION="1.1.1" IDEA_TARBALL_ROOT_BASENAME="idea-IC-141.3056.4" IDEA_VERSION="14.1.6"
+      jdk: openjdk6
+
+    - env: ELIXIR_VERSION="1.2.3" IDEA_TARBALL_ROOT_BASENAME="idea-IC-139.1603.1" IDEA_VERSION="14.0.4"
+      jdk: openjdk6
+    - env: ELIXIR_VERSION="1.1.1" IDEA_TARBALL_ROOT_BASENAME="idea-IC-139.1603.1" IDEA_VERSION="14.0.4"
+      jdk: openjdk6
 before_install:
 - "export DISPLAY=:99.0"
 - "sh -e /etc/init.d/xvfb start"
-install: ant -logger org.apache.tools.ant.listener.AnsiColorLogger -f intellij-elixir.xml get.idea get.intellij-erlang release.intellij_elixir
+install:
+  - if [ ! -f cache/erlang/18.3/activate ]; then curl -O https://raw.githubusercontent.com/yrashk/kerl/master/kerl && chmod a+x kerl && ./kerl update releases && ./kerl build 18.3 18.3 && ./kerl install 18.3 cache/erlang/18.3; fi
+  - source cache/erlang/18.3/activate
+  - ant -logger org.apache.tools.ant.listener.AnsiColorLogger -f intellij-elixir.xml get.idea get.intellij-erlang release.intellij_elixir
 script:  ant -logger org.apache.tools.ant.listener.AnsiColorLogger -f intellij-elixir.xml test.modules
 sudo: false

--- a/elixir.xml
+++ b/elixir.xml
@@ -2,11 +2,13 @@
 <project default="get.elixir" name="elixir">
     <dirname property="elixir.basedir" file="${ant.file.elixir}"/>
 
+    <property environment="env"/>
+    <property name="elixir.version" value="${env.ELIXIR_VERSION}"/>
     <property name="elixir.output.dir" value="${elixir.basedir}/dependencies/elixir"/>
-    <property name="elixir.sha1" value="v${env.TRAVIS_ELIXIR_VERSION}"/>
+    <property name="elixir.sha1" value="v${elixir.version}"/>
     <property name="elixir.zip" value="${elixir.sha1}.zip"/>
     <property name="elixir.cache" value="${elixir.basedir}/cache/elixir"/>
-    <property name="elixir.zip.root.basename" value="elixir-${env.TRAVIS_ELIXIR_VERSION}"/>
+    <property name="elixir.zip.root.basename" value="elixir-${elixir.version}"/>
 
     <property name="elixir.output.zip.root.dir" value="${elixir.output.dir}/${elixir.zip.root.basename}"/>
     <available file="${elixir.output.zip.root.dir}" property="elixir.output.zip.root.available"/>
@@ -26,6 +28,13 @@
         </copy>
     </target>
 
+    <target name="set.elixir.code.lib.dir" depends="make.elixir" description="Set elixir.code.lib.dir to :code.lib_dir">
+        <exec executable="${elixir.output.zip.root.dir}/bin/elixir" outputproperty="elixir.code.lib.dir">
+            <arg value="-e"/>
+            <arg value="IO.puts :code.lib_dir"/>
+        </exec>
+    </target>
+
     <target name="get.elixir.zip" description="Get Elixir ${elixir.sha1} zip from Github" unless="elixir.zip.available">
         <mkdir dir="${elixir.output.dir}"/>
         <get dest="${elixir.output.dir}"
@@ -34,7 +43,17 @@
              verbose="true"/>
     </target>
 
+    <target name="make.elixir" depends="unpack.elixir.zip" description="Build Elixir">
+        <exec dir="${elixir.output.zip.root.dir}" executable="make" />
+    </target>
+
     <target name="unpack.elixir.zip" depends="get.elixir.zip" description="unzip ${elixir.zip}" unless="elixir.output.zip.root.available">
         <unzip src="${elixir.output.dir}/${elixir.zip}" dest="${elixir.output.dir}"/>
+        <chmod perm="u+x">
+            <file file="${elixir.output.zip.root.dir}/rebar"/>
+            <fileset dir="${elixir.output.zip.root.dir}/bin">
+                <exclude name="*.bat"/>
+            </fileset>
+        </chmod>
     </target>
 </project>

--- a/idea.xml
+++ b/idea.xml
@@ -2,11 +2,12 @@
 <project default="get.idea" name="idea">
     <dirname property="idea.basedir" file="${ant.file.idea}"/>
 
-    <property name="idea.output.dir" value="${idea.basedir}/dependencies/idea"/>
-    <property name="idea.version" value="14.1.6"/>
+    <property environment="env"/>
+    <property name="idea.version" value="${env.IDEA_VERSION}"/>
+    <property name="idea.output.dir" value="${idea.basedir}/dependencies/idea/${idea.version}"/>
     <property name="idea.tarball" value="ideaIC-${idea.version}.tar.gz"/>
-    <property name="idea.cache" value="${idea.basedir}/cache/idea"/>
-    <property name="idea.tarball.root.basename" value="idea-IC-141.3056.4"/>
+    <property name="idea.cache" value="${idea.basedir}/cache/idea/${idea.version}"/>
+    <property name="idea.tarball.root.basename" value="${env.IDEA_TARBALL_ROOT_BASENAME}"/>
 
     <property name="idea.output.tarball.root.dir" value="${idea.output.dir}/${idea.tarball.root.basename}"/>
     <available file="${idea.output.tarball.root.dir}" property="idea.output.tarball.root.available"/>

--- a/intellij-elixir.xml
+++ b/intellij-elixir.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project name="intellij-elixir" default="all">
-  
-  
+
+
   <property file="intellij-elixir.properties"/>
   <!-- Uncomment the following property if no tests compilation is needed -->
-  <!-- 
+  <!--
   <property name="skip.tests" value="true"/>
    -->
-  
+
   <!-- Compiler options -->
-  
+
   <property name="compiler.debug" value="on"/>
   <property name="compiler.generate.no.warnings" value="off"/>
   <property name="compiler.args" value=""/>
@@ -60,11 +60,6 @@
   <import file="${basedir}/intellij-erlang.xml"/>
 
   <!-- JDK definitions -->
-  <exec executable="elixir" outputproperty="elixir.code.lib.dir">
-    <arg value="-e"/>
-    <arg value="IO.puts :code.lib_dir"/>
-  </exec>
-
   <property environment="env"/>
   <property name="jdk.home" value="${env.JAVA_HOME}"/>
   <property name="jdk.bin" value="${jdk.home}/bin"/>
@@ -73,9 +68,6 @@
   <property name="project.jdk.home" value="${jdk.home}"/>
 
   <path id="jdk.classpath">
-    <fileset dir="${elixir.code.lib.dir}">
-      <include name="jinterface-*/priv/OtpErlang.jar"/>
-    </fileset>
     <fileset dir="${idea.cache}">
       <include name="lib/annotations.jar"/>
       <include name="lib/asm-all.jar"/>
@@ -87,23 +79,65 @@
       <include name="lib/bootstrap.jar"/>
       <include name="lib/cglib-2.2.2.jar"/>
       <include name="lib/cli-parser-1.1.jar"/>
+
+      <!-- 14.X -->
       <include name="lib/commons-codec-1.8.jar"/>
+      <!-- 2016.1 -->
+      <include name="lib/commons-codec-1.9.jar"/>
+
       <include name="lib/commons-httpclient-3.1-patched.jar"/>
+
+      <!-- 14.X -->
       <include name="lib/commons-logging-1.1.3.jar"/>
+      <!-- 2016.1 -->
+      <include name="lib/commons-logging-1.2.jar"/>
+
       <include name="lib/commons-net-3.1.jar"/>
+
+      <!-- 14.X -->
       <include name="lib/ecj-4.4.jar"/>
+      <!-- 2016.1 -->
+      <include name="lib/ecj-4.4.2.jar"/>
+
       <include name="lib/extensions.jar"/>
+
+      <!-- 14.X -->
       <include name="lib/fluent-hc-4.3.2.jar"/>
+      <!-- 2016.1 -->
+      <include name="lib/fluent-hc-4.4.1.jar"/>
+
       <include name="lib/forms_rt.jar"/>
       <include name="lib/freemarker.jar"/>
+
+      <!-- 14.X -->
       <include name="lib/groovy-all-2.2.1.jar"/>
+      <!-- 2016.1 -->
+      <include name="lib/groovy-all-2.4.6.jar"/>
+
+      <!-- 14.X -->
       <include name="lib/gson-2.2.4.jar"/>
+      <!-- 2016.1 -->
+      <include name="lib/gson-2.5.jar"/>
+
       <include name="lib/guava-17.0.jar"/>
       <include name="lib/hamcrest-core-1.3.jar"/>
       <include name="lib/hamcrest-library-1.3.jar"/>
+
+      <!-- 14.X -->
       <include name="lib/httpclient-4.3.2.jar"/>
+      <!-- 2016.1 -->
+      <include name="lib/httpclient-4.4.1.jar"/>
+
+      <!-- 14.X -->
       <include name="lib/httpcore-4.3.1.jar"/>
+      <!-- 2016.1 -->
+      <include name="lib/httpcore-4.4.1.jar"/>
+
+      <!-- 14.X -->
       <include name="lib/httpmime-4.3.2.jar"/>
+      <!-- 2016.1 -->
+      <include name="lib/httpmime-4.4.1.jar"/>
+
       <include name="lib/icons.jar"/>
       <include name="lib/idea.jar"/>
       <include name="lib/idea_rt.jar"/>
@@ -121,10 +155,16 @@
       <include name="lib/jing.jar"/>
       <include name="lib/jna-utils.jar"/>
       <include name="lib/jna.jar"/>
+      <include name="lib/jps-builders.jar"/>
       <include name="lib/jps-launcher.jar"/>
       <include name="lib/jps-model.jar"/>
       <include name="lib/jps-server.jar"/>
+
+      <!-- 14.X -->
       <include name="lib/jsch-0.1.51.jar"/>
+      <!-- 2016.1 -->
+      <include name="lib/jsch-0.1.52.jar"/>
+
       <include name="lib/jsch.agentproxy.connector-factory.jar"/>
       <include name="lib/jsch.agentproxy.core.jar"/>
       <include name="lib/jsch.agentproxy.pageant.jar"/>
@@ -133,22 +173,45 @@
       <include name="lib/jsch.agentproxy.usocket-nc.jar"/>
       <include name="lib/jsr166e.jar"/>
       <include name="lib/jsr173_1.0_api.jar"/>
+
+      <!-- 14.X -->
       <include name="lib/junit-4.11.jar"/>
+      <!-- 2016.1 -->
+      <include name="lib/junit-4.12.jar"/>
+
       <include name="lib/jzlib-1.1.1.jar"/>
       <include name="lib/log4j.jar"/>
+
+      <!-- 2016.1 -->
+      <include name="lib/kotlin-runtime.jar"/>
+
       <include name="lib/markdownj-core-0.4.2-SNAPSHOT.jar"/>
       <include name="lib/microba.jar"/>
       <include name="lib/miglayout-swing.jar"/>
       <include name="lib/nanoxml-2.2.3.jar"/>
       <include name="lib/nekohtml-1.9.14.jar"/>
+
+      <!-- 14.X -->
       <include name="lib/netty-all-4.1.0.Beta3.jar"/>
+      <!-- 2016.1 -->
+      <include name="lib/netty-all-4.1.0.Beta8.jar"/>
+
       <include name="lib/openapi.jar"/>
       <include name="lib/optimizedFileManager.jar"/>
       <include name="lib/oromatcher.jar"/>
       <include name="lib/picocontainer.jar"/>
       <include name="lib/protobuf-2.5.0.jar"/>
+
+      <!-- 14.X -->
       <include name="lib/proxy-vole_20120920.jar"/>
+      <!-- 2016.1 -->
+      <include name="lib/proxy-vole_20131209.jar"/>
+
+      <!-- 14.X -->
       <include name="lib/pty4j-0.3.jar"/>
+      <!-- 2016.1 -->
+      <include name="lib/pty4j-0.6.jar"/>
+
       <include name="lib/purejavacomm.jar"/>
       <include name="lib/resolver.jar"/>
       <include name="lib/resources.jar"/>
@@ -158,19 +221,33 @@
       <include name="lib/rt/jps-plugin-system.jar"/>
       <include name="lib/sanselan-0.98-snapshot.jar"/>
       <include name="lib/serviceMessages.jar"/>
+
+      <!-- 14.X -->
       <include name="lib/snappy-in-java-0.3.jar"/>
+      <!-- 2016.1 -->
+      <include name="lib/snappy-in-java-0.3.1.jar"/>
+
       <include name="lib/swingx-core-1.6.2.jar"/>
       <include name="lib/trang-core.jar"/>
       <include name="lib/trove4j.jar"/>
       <include name="lib/trove4j_src.jar"/>
       <include name="lib/util.jar"/>
       <include name="lib/velocity.jar"/>
+
+      <!-- 14.X -->
       <include name="lib/winp-1.21-patched.jar"/>
+      <!-- 2016.1 -->
+      <include name="lib/winp-1.23-patched.jar"/>
+
       <include name="lib/xbean.jar"/>
       <include name="lib/xerces.jar"/>
       <include name="lib/xmlrpc-2.0.jar"/>
       <include name="lib/xpp3-1.1.4-min.jar"/>
+
+      <!-- 14.X -->
       <include name="lib/xstream-1.4.3.jar"/>
+      <!-- 2016.1 -->
+      <include name="lib/xstream-1.4.8.jar"/>
     </fileset>
     <fileset dir="${intellij-erlang.cache}">
       <include name="lib/erlang.jar"/>
@@ -185,12 +262,12 @@
   </path>
 
   <!-- Project Libraries -->
-  
+
   <path id="library.junit.classpath">
     <pathelement location="${idea.cache}/lib/junit.jar"/>
   </path>
-  
-  
+
+
   <!-- Global Libraries -->
   <!-- Register Custom Compiler Taskdefs -->
   <target name="register.custom.compilers" depends="get.idea">
@@ -204,18 +281,18 @@
     <taskdef name="javac2" classname="com.intellij.ant.Javac2" classpathref="javac2.classpath"/>
     <taskdef name="instrumentIdeaExtensions" classname="com.intellij.ant.InstrumentIdeaExtensions" classpathref="javac2.classpath"/>
   </target>
-  
+
   <!-- Modules -->
 
   <import file="${basedir}/intellij_elixir.xml"/>
   <import file="${basedir}/module_intellij-elixir.xml"/>
-  
+
   <target name="init" description="Build initialization">
     <!-- Perform any build initialization in this target -->
   </target>
-  
+
   <target name="clean" depends="clean.module.intellij-elixir" description="cleanup all"/>
-  
+
   <target name="build.modules" depends="init, clean, plugin.build.jar.intellij-elixir" description="build all modules"/>
   <target name="test.modules" depends="test.module.intellij-elixir" description="test all modules"/>
 

--- a/intellij_elixir.xml
+++ b/intellij_elixir.xml
@@ -26,9 +26,12 @@
         </exec>
     </target>
 
-    <target name="deps.get.intellij_elixir" depends="local.hex.intellij_elixir">
-        <exec dir="${intellij_elixir.output.repo.dir}" executable="mix">
+    <import file="${intellij_elixir.basedir}/elixir.xml"/>
+
+    <target name="deps.get.intellij_elixir" depends="local.hex.intellij_elixir,make.elixir">
+        <exec dir="${intellij_elixir.output.repo.dir}" executable="${elixir.output.zip.root.dir}/bin/mix">
             <arg value="deps.get"/>
+            <env key="PATH" value="${env.PATH}:${elixir.output.zip.root.dir}/bin"/>
         </exec>
     </target>
 
@@ -38,28 +41,41 @@
         </exec>
     </target>
 
-    <target name="local.hex.intellij_elixir" depends="checkout.intellij_elixir">
-        <exec dir="${intellij_elixir.output.repo.dir}" executable="mix">
+    <target name="local.hex.intellij_elixir" depends="checkout.intellij_elixir,make.elixir">
+        <property environment="env"/>
+        <exec dir="${intellij_elixir.output.repo.dir}" executable="${elixir.output.zip.root.dir}/bin/mix">
             <arg value="local.hex"/>
             <arg value="--force"/>
+            <env key="PATH" value="${env.PATH}:${elixir.output.zip.root.dir}/bin"/>
         </exec>
     </target>
 
-    <target name="release.intellij_elixir" depends="deps.get.intellij_elixir">
-        <exec dir="${intellij_elixir.output.repo.dir}" executable="mix">
+    <target name="release.intellij_elixir" depends="deps.get.intellij_elixir,make.elixir">
+        <!-- Removing these files prevents `Application metadata file exists but is malformed` when doing `mix release`
+             for intellij_elixir -->
+        <delete file="${elixir.output.zip.root.dir}/lib/mix/test/fixtures/deps_status/_build/dev/lib/invalidapp/ebin/invalidapp.app"/>
+        <delete file="${elixir.output.zip.root.dir}/lib/mix/test/fixtures/deps_status/_build/dev/lib/invalidvsn/ebin/invalidvsn.app"/>
+        <delete file="${elixir.output.zip.root.dir}/lib/mix/test/fixtures/deps_status/_build/dev/lib/nosemver/ebin/nosemver.app"/>
+        <delete file="${elixir.output.zip.root.dir}/lib/mix/test/fixtures/deps_status/_build/dev/lib/ok/ebin/ok.app"/>
+        <delete dir="${elixir.output.zip.root.dir}/lib/mix/test/fixtures/archive"/>
+
+        <exec dir="${intellij_elixir.output.repo.dir}" executable="${elixir.output.zip.root.dir}/bin/mix">
             <arg value="release"/>
+            <env key="PATH" value="${env.PATH}:${elixir.output.zip.root.dir}/bin"/>
         </exec>
     </target>
 
-    <target name="start.intellij_elixir" depends="release.intellij_elixir">
+    <target name="start.intellij_elixir" depends="release.intellij_elixir,make.elixir">
         <exec executable="${intellij_elixir.executable}">
             <arg value="start"/>
+            <env key="PATH" value="${env.PATH}:${elixir.output.zip.root.dir}/bin"/>
         </exec>
     </target>
 
-     <target name="stop.intellij_elixir" depends="release.intellij_elixir">
+     <target name="stop.intellij_elixir" depends="release.intellij_elixir,make.elixir">
         <exec executable="${intellij_elixir.executable}">
             <arg value="stop"/>
+            <env key="PATH" value="${env.PATH}:${elixir.output.zip.root.dir}/bin"/>
         </exec>
     </target>
 </project>

--- a/module_intellij-elixir.xml
+++ b/module_intellij-elixir.xml
@@ -4,6 +4,7 @@
   <dirname property="module.intellij-elixir.basedir" file="${ant.file.module_intellij-elixir}"/>
 
   <import file="${module.intellij-elixir.basedir}/idea.xml"/>
+  <import file="${module.intellij-elixir.basedir}/elixir.xml"/>
 
   <property name="module.jdk.home.intellij-elixir" value="${project.jdk.home}"/>
   <property name="module.jdk.bin.intellij-elixir" value="${project.jdk.bin}"/>
@@ -16,11 +17,11 @@
   <property name="intellij-elixir.jps-builder.output.dir" value="${module.intellij-elixir.basedir}/out/production/jps-builder" />
   <property name="intellij-elixir.output.dir" value="${module.intellij-elixir.basedir}/out/production/intellij-elixir"/>
   <property name="intellij-elixir.testoutput.dir" value="${module.intellij-elixir.basedir}/out/test/intellij-elixir"/>
-  
+
   <path id="intellij-elixir.module.bootclasspath">
     <!-- Paths to be included in compilation bootclasspath -->
   </path>
-  
+
   <path id="intellij-elixir.module.production.classpath">
     <path refid="${module.jdk.classpath.intellij-elixir}"/>
     <path refid="library.junit.classpath"/>
@@ -28,7 +29,7 @@
     <pathelement location="${idea.cache}/lib/hamcrest-library-1.3.jar"/>
     <pathelement location="${idea.cache}/lib/junit-4.11.jar"/>
   </path>
-  
+
   <path id="intellij-elixir.runtime.production.module.classpath">
     <pathelement location="${intellij-elixir.output.dir}"/>
     <path refid="library.junit.classpath"/>
@@ -36,7 +37,7 @@
     <pathelement location="${idea.cache}/lib/hamcrest-library-1.3.jar"/>
     <pathelement location="${idea.cache}/lib/junit-4.11.jar"/>
   </path>
-  
+
   <path id="intellij-elixir.module.classpath">
     <path refid="${module.jdk.classpath.intellij-elixir}"/>
     <pathelement location="${intellij-elixir.output.dir}"/>
@@ -47,7 +48,7 @@
     <pathelement location="${idea.cache}/lib/hamcrest-library-1.3.jar"/>
     <pathelement location="${idea.cache}/lib/junit-4.11.jar"/>
   </path>
-  
+
   <path id="intellij-elixir.runtime.module.classpath">
     <pathelement location="${intellij-elixir.testoutput.dir}"/>
     <pathelement location="${intellij-elixir.output.dir}"/>
@@ -56,12 +57,12 @@
     <pathelement location="${idea.cache}/lib/hamcrest-library-1.3.jar"/>
     <pathelement location="${idea.cache}/lib/junit-4.11.jar"/>
   </path>
-  
-  
+
+
   <patternset id="excluded.from.module.intellij-elixir">
     <patternset refid="ignored.files"/>
   </patternset>
-  
+
   <patternset id="excluded.from.compilation.intellij-elixir">
     <patternset refid="excluded.from.module.intellij-elixir"/>
   </patternset>
@@ -85,23 +86,29 @@
       <include name="res"/>
     </dirset>
   </path>
-  
+
   <path id="intellij-elixir.module.test.sourcepath">
     <dirset dir="${module.intellij-elixir.basedir}">
       <include name="tests"/>
       <include name="testData"/>
     </dirset>
   </path>
-  
-  
+
   <target name="compile.module.intellij-elixir" depends="compile.module.intellij-elixir.production,compile.module.intellij-elixir.tests" description="Compile module intellij-elixir"/>
 
-  <target name="compile.module.jps-shared.production" depends="register.custom.compilers" description="Compile module jps-shared; production classes">
+  <target name="compile.module.jps-shared.production" depends="register.custom.compilers,set.elixir.code.lib.dir" description="Compile module jps-shared; production classes">
     <mkdir dir="${intellij-elixir.jps-shared.output.dir}"/>
     <javac2 destdir="${intellij-elixir.jps-shared.output.dir}" debug="${compiler.debug}" nowarn="${compiler.generate.no.warnings}" memorymaximumsize="${compiler.max.memory}" fork="true" executable="${module.jdk.bin.intellij-elixir}/javac">
       <compilerarg line="${compiler.args.intellij-elixir}"/>
       <bootclasspath refid="intellij-elixir.module.bootclasspath"/>
-      <classpath refid="intellij-elixir.module.production.classpath"/>
+      <classpath>
+        <path refid="intellij-elixir.module.production.classpath"/>
+        <path>
+          <fileset dir="${elixir.code.lib.dir}">
+            <include name="jinterface-*/priv/OtpErlang.jar"/>
+          </fileset>
+        </path>
+      </classpath>
       <src refid="intellij-elixir.module.jps-shared.sourcepath"/>
       <patternset refid="excluded.from.compilation.intellij-elixir"/>
     </javac2>
@@ -115,7 +122,7 @@
 
   </target>
 
-  <target name="compile.module.jps-builder.production" depends="register.custom.compilers,compile.module.jps-shared.production" description="Compile module jps-builder; production classes">
+  <target name="compile.module.jps-builder.production" depends="register.custom.compilers,compile.module.jps-shared.production,set.elixir.code.lib.dir" description="Compile module jps-builder; production classes">
     <mkdir dir="${intellij-elixir.jps-builder.output.dir}"/>
     <javac2 destdir="${intellij-elixir.jps-builder.output.dir}" debug="${compiler.debug}" nowarn="${compiler.generate.no.warnings}" memorymaximumsize="${compiler.max.memory}" fork="true" executable="${module.jdk.bin.intellij-elixir}/javac">
       <compilerarg line="${compiler.args.intellij-elixir}"/>
@@ -135,7 +142,7 @@
 
   </target>
 
-  <target name="compile.module.intellij-elixir.production" depends="register.custom.compilers,compile.module.jps-shared.production,compile.module.jps-builder.production" description="Compile module intellij-elixir; production classes">
+  <target name="compile.module.intellij-elixir.production" depends="register.custom.compilers,compile.module.jps-shared.production,compile.module.jps-builder.production,set.elixir.code.lib.dir" description="Compile module intellij-elixir; production classes">
     <mkdir dir="${intellij-elixir.output.dir}"/>
     <javac2 destdir="${intellij-elixir.output.dir}" debug="${compiler.debug}" nowarn="${compiler.generate.no.warnings}" memorymaximumsize="${compiler.max.memory}" fork="true" executable="${module.jdk.bin.intellij-elixir}/javac">
       <compilerarg line="${compiler.args.intellij-elixir}"/>
@@ -143,6 +150,13 @@
       <classpath refid="intellij-elixir.module.production.classpath"/>
       <classpath path="${intellij-elixir.jps-shared.output.dir}"/>
       <classpath path="${intellij-elixir.jps-builder.output.dir}"/>
+      <classpath>
+        <path>
+          <fileset dir="${elixir.code.lib.dir}">
+            <include name="jinterface-*/priv/OtpErlang.jar"/>
+          </fileset>
+        </path>
+      </classpath>
       <src refid="intellij-elixir.module.sourcepath"/>
       <patternset refid="excluded.from.compilation.intellij-elixir"/>
     </javac2>
@@ -163,16 +177,23 @@
     </copy>
   </target>
 
-  <target name="compile.module.intellij-elixir.tests" depends="register.custom.compilers,compile.module.intellij-elixir.production" description="compile module intellij-elixir; test classes" unless="skip.tests">
+  <target name="compile.module.intellij-elixir.tests" depends="register.custom.compilers,compile.module.intellij-elixir.production,set.elixir.code.lib.dir" description="compile module intellij-elixir; test classes" unless="skip.tests">
     <mkdir dir="${intellij-elixir.testoutput.dir}"/>
     <javac2 destdir="${intellij-elixir.testoutput.dir}" debug="${compiler.debug}" nowarn="${compiler.generate.no.warnings}" memorymaximumsize="${compiler.max.memory}" fork="true" executable="${module.jdk.bin.intellij-elixir}/javac">
       <compilerarg line="${compiler.args.intellij-elixir}"/>
       <bootclasspath refid="intellij-elixir.module.bootclasspath"/>
       <classpath refid="intellij-elixir.module.classpath"/>
+      <classpath>
+        <path>
+          <fileset dir="${elixir.code.lib.dir}">
+            <include name="jinterface-*/priv/OtpErlang.jar"/>
+          </fileset>
+        </path>
+      </classpath>
       <src refid="intellij-elixir.module.test.sourcepath"/>
       <patternset refid="excluded.from.compilation.intellij-elixir"/>
     </javac2>
-    
+
     <copy todir="${intellij-elixir.testoutput.dir}">
       <fileset dir="${module.intellij-elixir.basedir}/tests">
         <patternset refid="compiler.resources"/>
@@ -184,7 +205,7 @@
       </fileset>
     </copy>
   </target>
-  
+
   <target name="clean.module.intellij-elixir" description="cleanup module">
     <delete dir="${intellij-elixir.jps-shared.output.dir}"/>
     <delete dir="${intellij-elixir.jps-builder.output.dir}"/>
@@ -204,12 +225,14 @@
   <import file="${module.intellij-elixir.basedir}/elixir.xml"/>
   <import file="${module.intellij-elixir.basedir}/intellij_elixir.xml"/>
 
-  <target name="test.module.intellij-elixir" depends="compile.module.intellij-elixir,release.intellij_elixir,unpack.elixir.zip" description="test module">
+  <target name="test.module.intellij-elixir" depends="compile.module.intellij-elixir,release.intellij_elixir,set.elixir.code.lib.dir,unpack.elixir.zip" description="test module">
     <mkdir dir="tmp"/>
     <mkdir dir="tmp/results"/>
 
+    <property environment="env"/>
     <exec executable="${intellij_elixir.executable}">
       <arg value="start"/>
+      <env key="PATH" value="${env.PATH}:${elixir.output.zip.root.dir}/bin"/>
     </exec>
 
     <!-- must fork or env won't work -->
@@ -223,6 +246,11 @@
       <env key="INTELLIJ_ELIXIR_PATH" value="${module.intellij-elixir.basedir}"/>
       <classpath>
         <path refid="classpath.test" />
+        <path>
+          <fileset dir="${elixir.code.lib.dir}">
+            <include name="jinterface-*/priv/OtpErlang.jar"/>
+          </fileset>
+        </path>
         <pathelement location="${basedir}/tests/mockito-core-2.0.7-beta.jar"/>
         <pathelement location="${basedir}/tests/objenesis-2.1.jar"/>
         <pathelement location="${test.build}"/>

--- a/src/org/elixir_lang/ElixirSyntaxHighlighter.java
+++ b/src/org/elixir_lang/ElixirSyntaxHighlighter.java
@@ -100,8 +100,7 @@ public class ElixirSyntaxHighlighter extends SyntaxHighlighterBase {
 
     public static final TextAttributesKey MODULE_ATTRIBUTE = createTextAttributesKey(
             "ELIXIR_MODULE_ATTRIBUTE",
-            // Color used for "ERL_ATTRIBUTE" in intellij-erlang
-            CodeInsightColors.ANNOTATION_NAME_ATTRIBUTES
+            DefaultLanguageHighlighterColors.CONSTANT
     );
 
     public static final TextAttributesKey OBSOLETE_WHOLE_NUMBER_BASE = createTextAttributesKey(
@@ -122,7 +121,7 @@ public class ElixirSyntaxHighlighter extends SyntaxHighlighterBase {
 
     public static final TextAttributesKey SPECIFICATION = createTextAttributesKey(
             "ELIXIR_SPECIFICATION",
-            CodeInsightColors.METHOD_DECLARATION_ATTRIBUTES
+            DefaultLanguageHighlighterColors.FUNCTION_DECLARATION
     );
 
     public static final TextAttributesKey CALLBACK = createTextAttributesKey(
@@ -137,13 +136,12 @@ public class ElixirSyntaxHighlighter extends SyntaxHighlighterBase {
 
     public static final TextAttributesKey TYPE = createTextAttributesKey(
             "ELIXIR_TYPE",
-            // matches ERL_TYPE
-            CodeInsightColors.ANNOTATION_ATTRIBUTE_NAME_ATTRIBUTES
+            DefaultLanguageHighlighterColors.METADATA
     );
 
     public static final TextAttributesKey TYPE_PARAMETER = createTextAttributesKey(
             "ELIXIR_TYPE_PARAMETER",
-            CodeInsightColors.TYPE_PARAMETER_NAME_ATTRIBUTES
+            DefaultLanguageHighlighterColors.PARAMETER
     );
 
     public static final TextAttributesKey VALID_DIGIT = createTextAttributesKey(

--- a/src/org/elixir_lang/mix/settings/MixConfigurationForm.java
+++ b/src/org/elixir_lang/mix/settings/MixConfigurationForm.java
@@ -37,7 +37,7 @@ public class MixConfigurationForm {
 
   public MixConfigurationForm(){
     myMixPathSelector.addBrowseFolderListener("Select Mix executable", "", null,
-        FileChooserDescriptorFactory.createSingleFileDescriptor());
+        FileChooserDescriptorFactory.createSingleLocalFileDescriptor());
     myMixPathSelector.getTextField().getDocument().addDocumentListener(new DocumentAdapter() {
       @Override
       protected void textChanged(DocumentEvent documentEvent) {

--- a/tests/org/elixir_lang/parser_definition/ElixirLangElixirParsingTestCase.java
+++ b/tests/org/elixir_lang/parser_definition/ElixirLangElixirParsingTestCase.java
@@ -804,10 +804,6 @@ public class ElixirLangElixirParsingTestCase extends ParsingTestCase {
         assertParsed("lib/mix/lib/mix/utils.ex", Parse.CORRECT);
     }
 
-    public void testArchiveLibLocalSample() {
-        assertParsed("lib/mix/test/fixtures/archive/lib/local.sample.ex", Parse.CORRECT);
-    }
-
     public void testDepsStatusCustomRawRepoLibRawRepo() {
         assertParsed("lib/mix/test/fixtures/deps_status/custom/raw_repo/lib/raw_repo.ex", Parse.CORRECT);
     }


### PR DESCRIPTION
Fixes #230
Fixes #250
Fixes #258

# Changelog
* Enhancements
  * Build against 14.0, 14.1, 15.0, and 2016.1 on travis-ci to ensure continued compatibility.
* Bug Fixes
  * Use `TextAttributesKey`s that aren't deprecated in 2016.1 and work back to 14.1
     
    All of `CodeInsightColors` is deprecated, so all constants from there had to be replaced.  Unfortunately, the recommended replacements don't have the same color as the original, so I used different `DefaultLanguageHighlighterColors` constants for some.

    "Module Attribute" is now based on `DefaultLanguageHighlighterColors.CONSTANT` (which is purplish in Darcula) instead of the recommended `METADATA`, which is yellow.  Although module attributes don't have to be constant since they can be set to accumulate, often they are used as constants and not really as metadata, since they are just data then.  All the `metadata` uses of module attributes have a separate color.

    "Specification" is now based on `DefaultLanguageHighlighterColors.FUNCTION_DECLARATION`, which maintains the golden color that `CodeInsightColors.METHOD_DECLARATION_ATTRIBUTES` had.

    "Type" is now based on `DefaultLanguageHighlighterColors.METADATA`, which is bright yellow unlike `CodeInsightColors.ANNOTATION_ATTRIBUTE_NAME_ATTRIBUTES`, which was a bright white.

    "Type Parameter" is now based on `DefaultLanguageHighlighterColors.PARAMETER`, which unfortunately has no attributes associated with it, but the constant name was too good a fit not to use, so if you want the old color, you'll need to customize it yourself.
  * Restore compatibility with the IntelliJ IDEA 14.0 release line
    * By using reflection to call `FileTemplateManager#getInstance` if `FileTemplateManager#getDefaultInstance` is not available
    * By calling `FileChooserDescriptorFactory#createSingleLocalFileDescriptor` (which works in 14.0 through 2016.1) instead of `FileChooserDescriptorFactory#createSingleFileDescriptor` (which only works in 14.1 through 2016.1)