### PR TITLE
Strip for comprehensions surrounding definitions when finding Modular

### DIFF
--- a/src/org/elixir_lang/structure_view/element/CallDefinitionClause.java
+++ b/src/org/elixir_lang/structure_view/element/CallDefinitionClause.java
@@ -48,8 +48,18 @@ public class CallDefinitionClause extends Element<Call> implements Presentable, 
     @Nullable
     public static Modular enclosingModular(@NotNull Call call) {
         Modular modular = null;
+        Call enclosedCall = call;
+        Call enclosingMacroCall;
 
-        Call enclosingMacroCall = enclosingMacroCall(call);
+        while(true) {
+            enclosingMacroCall = enclosingMacroCall(enclosedCall);
+
+            if (enclosingMacroCall != null && enclosingMacroCall.isCallingMacro("Elixir.Kernel", "for", 2)) {
+                enclosedCall = enclosingMacroCall;
+            } else {
+                break;
+            }
+        }
 
         if (enclosingMacroCall != null) {
             modular = modular(enclosingMacroCall);


### PR DESCRIPTION
# Changelog
* Bug Fixes
  * Fix (one cause) of `AssertionError` in `GoToSymbolContributor` when the `Modular` (`defimpl`, `demodule`, `defprotocol`, and `quote`) could not be resolved due a `def` being surrounded by a `for` comprehension, which is common in Elixir libraries as was the case for `Postgrex`: any enclosing `for` comprehension(s) will now be ignored and the next enclosing macro will be checked to see if it is a `Modular`.