### PR TITLE
Error handler

### DIFF
--- a/src/META-INF/plugin.xml
+++ b/src/META-INF/plugin.xml
@@ -770,6 +770,8 @@
   <depends config-file="rich-platform-plugin.xml" optional="true">com.intellij.modules.java</depends>
 
   <extensions defaultExtensionNs="com.intellij">
+    <errorHandler implementation="org.elixir_lang.errorreport.Submitter"/>
+
     <!-- Elixir Module Structure -->
     <sdkType implementation="org.elixir_lang.sdk.ElixirSdkType"/>
 

--- a/src/org/elixir_lang/annonator/ModuleAttribute.java
+++ b/src/org/elixir_lang/annonator/ModuleAttribute.java
@@ -11,8 +11,8 @@ import com.intellij.openapi.util.TextRange;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiRecursiveElementVisitor;
 import com.intellij.psi.tree.TokenSet;
-import org.apache.commons.lang.NotImplementedException;
 import org.elixir_lang.ElixirSyntaxHighlighter;
+import org.elixir_lang.errorreport.Logger;
 import org.elixir_lang.psi.*;
 import org.elixir_lang.psi.call.Call;
 import org.elixir_lang.psi.impl.ElixirPsiImplUtil;
@@ -110,6 +110,14 @@ public class ModuleAttribute implements Annotator, DumbAware {
     /*
      * Private Instance Methods
      */
+
+    private void cannotHighlightTypes(PsiElement element) {
+        error("Cannot highlight types", element);
+    }
+
+    private void error(@NotNull String userMessage, PsiElement element) {
+        Logger.error(this.getClass(), userMessage, element);
+    }
 
     /**
      * Highlights `textRange` with the given `textAttributesKey`.
@@ -296,20 +304,10 @@ public class ModuleAttribute implements Annotator, DumbAware {
                             );
                         }
                     } else {
-                        throw new NotImplementedException(
-                                "Highlighting types for " + call.getClass().getCanonicalName() + " PsiElements is " +
-                                        "not implemented yet.  Please open an issue " +
-                                        "(https://github.com/KronicDeth/intellij-elixir/issues/new) with the class " +
-                                        "name of the sample text:\n" + ((PsiElement) call).getText()
-                        );
+                        cannotHighlightTypes(call);
                     }
                 } else {
-                    throw new NotImplementedException(
-                            "Highlighting types for " + leftOperand.getClass().getCanonicalName() + " PsiElements is " +
-                                    "not implemented yet.  Please open an issue " +
-                                    "(https://github.com/KronicDeth/intellij-elixir/issues/new) with the class name of " +
-                                    "the sample text:\n" + leftOperand.getText()
-                    );
+                    cannotHighlightTypes(leftOperand);
                 }
 
                 PsiElement rightOperand = infix.rightOperand();
@@ -338,21 +336,10 @@ public class ModuleAttribute implements Annotator, DumbAware {
                         );
                     }
                 } else {
-                    throw new NotImplementedException(
-                            "Highlighting types for " +
-                                    matchedUnqualifiedParenthesesCall.getClass().getCanonicalName() + " PsiElements " +
-                                    "is not implemented yet.  Please open an issue " +
-                                    "(https://github.com/KronicDeth/intellij-elixir/issues/new) with the class name " +
-                                    "of the sample text:\n" + grandChild.getText()
-                    );
+                    cannotHighlightTypes(matchedUnqualifiedParenthesesCall);
                 }
             } else {
-                throw new NotImplementedException(
-                        "Highlighting types for " + grandChild.getClass().getCanonicalName() + " PsiElements is not " +
-                                "implemented yet.  Please open an issue " +
-                                "(https://github.com/KronicDeth/intellij-elixir/issues/new) with the class name of " +
-                                "the sample text:\n" + grandChild.getText()
-                );
+                cannotHighlightTypes(grandChild);
             }
         }
     }
@@ -385,12 +372,7 @@ public class ModuleAttribute implements Annotator, DumbAware {
                     typeTextAttributesKey
             );
         } else {
-            throw new NotImplementedException(
-                    "Highlighting types and type type parameter declarations for " +
-                            psiElement.getClass().getCanonicalName() + " PsiElements is not implemented yet.  Please " +
-                            "open an issue (https://github.com/KronicDeth/intellij-elixir/issues/new) with the class " +
-                            "name of the sample text:\n" + psiElement.getText()
-            );
+            error("Cannot highlight types and type parameter declarations", psiElement);
         }
     }
 
@@ -520,15 +502,7 @@ public class ModuleAttribute implements Annotator, DumbAware {
                             );
                         }
                     } else {
-                        throw new NotImplementedException(
-                                "Highlighting types for " +
-                                        matchedTypeOperationLeftOperand.getClass().getCanonicalName() +
-                                        " PsiElements that are the left operand of " +
-                                        matchedTypeOperation.getClass().getCanonicalName() + " is not implemented " +
-                                        "yet.  Please open an issue " +
-                                        "(https://github.com/KronicDeth/intellij-elixir/issues/new) with the class " +
-                                        "name of the sample text:\n" + matchedWhenOperation.getText()
-                        );
+                        cannotHighlightTypes(matchedTypeOperationLeftOperand);
                     }
 
                     PsiElement matchedTypeOperationRightOperand = matchedTypeOperation.rightOperand();
@@ -540,13 +514,7 @@ public class ModuleAttribute implements Annotator, DumbAware {
                             ElixirSyntaxHighlighter.TYPE
                     );
                 } else {
-                    throw new NotImplementedException(
-                            "Highlighting types for " + leftOperand.getClass().getCanonicalName() + " PsiElements " +
-                                    "that are the left operand of " +
-                                    matchedWhenOperation.getClass().getCanonicalName() + " is not implemented yet.  " +
-                                    "Please open an issue (https://github.com/KronicDeth/intellij-elixir/issues/new) " +
-                                    "with the class name of the sample text:\n" + matchedWhenOperation.getText()
-                    );
+                    cannotHighlightTypes(leftOperand);
                 }
 
                 highlightTypesAndSpecificationTypeParameterDeclarations(
@@ -613,27 +581,7 @@ public class ModuleAttribute implements Annotator, DumbAware {
                     typeTextAttributesKey
             );
         } else {
-            throw new NotImplementedException(
-                    "Highlighting types and type parameter declarations not implemented for your use case. Please " +
-                            "open an issue (https://github.com/KronicDeth/intellij-elixir/issues/new) using the " +
-                            "following:\n" +
-                            "\n" +
-                            "# Class\n" +
-                            "\n" +
-                            "`" + psiElement.getClass().getCanonicalName() + "`\n" +
-                            "\n" +
-                            "# Excerpt\n" +
-                            "\n" +
-                            "```\n" +
-                            psiElement.getText() + "\n" +
-                            "```\n" +
-                            "\n" +
-                            "# Full Text\n" +
-                            "\n" +
-                            "```\n" +
-                            psiElement.getContainingFile().getText() + "\n" +
-                            "```"
-            );
+            error("Cannot highlight types and specification type parameter declarations", psiElement);
         }
     }
 
@@ -658,8 +606,6 @@ public class ModuleAttribute implements Annotator, DumbAware {
             @SuppressWarnings("unused") TextAttributesKey textAttributesKey) {
         if (typeParameterNameSet.contains(unqualifiedNoArgumentsCall.functionName())) {
             PsiElement functionNameElement = unqualifiedNoArgumentsCall.functionNameElement();
-
-            assert functionNameElement != null;
 
             highlight(
                     functionNameElement.getTextRange(),
@@ -754,12 +700,7 @@ public class ModuleAttribute implements Annotator, DumbAware {
                     typeTextAttributesKey
             );
         } else {
-            throw new NotImplementedException(
-                    "Highlighting types for " + stabParenthesesSignature.getClass().getCanonicalName() +
-                            " PsiElements with neither 1 nor 3 children is not implemented yet.  Please open an " +
-                            "issue (https://github.com/KronicDeth/intellij-elixir/issues/new) with the class name " +
-                            "of the sample text:\n" + stabParenthesesSignature.getText()
-            );
+            error("Cannot highlight types and type parameter usages", stabParenthesesSignature);
         }
     }
 
@@ -929,12 +870,7 @@ public class ModuleAttribute implements Annotator, DumbAware {
                     typeTextAttributesKey
             );
         } else {
-            throw new NotImplementedException(
-                    "Highlighting types for " + psiElement.getClass().getCanonicalName() +
-                            " PsiElements is not implemented yet.  Please open an issue " +
-                            "(https://github.com/KronicDeth/intellij-elixir/issues/new) with the class name of the " +
-                            "sample text:\n" + psiElement.getText()
-            );
+            cannotHighlightTypes(psiElement);
         }
     }
 
@@ -1032,15 +968,19 @@ public class ModuleAttribute implements Annotator, DumbAware {
             AnnotationHolder annotationHolder,
             TextAttributesKey typeTextAttributesKey) {
         PsiElement functionNameElement = unqualifiedNoParenthesesCall.functionNameElement();
-        assert functionNameElement != null;
-        highlight(functionNameElement.getTextRange(), annotationHolder, typeTextAttributesKey);
 
-        highlightTypesAndTypeParameterUsages(
-                unqualifiedNoParenthesesCall.primaryArguments(),
-                typeParameterNameSet,
-                annotationHolder,
-                typeTextAttributesKey
-        );
+        if (functionNameElement != null) {
+            highlight(functionNameElement.getTextRange(), annotationHolder, typeTextAttributesKey);
+
+            highlightTypesAndTypeParameterUsages(
+                    unqualifiedNoParenthesesCall.primaryArguments(),
+                    typeParameterNameSet,
+                    annotationHolder,
+                    typeTextAttributesKey
+            );
+        } else {
+            error("Cannot highlight types and type parameter usages", unqualifiedNoParenthesesCall);
+        }
     }
 
     private void highlightTypesAndTypeParameterUsages(
@@ -1050,26 +990,29 @@ public class ModuleAttribute implements Annotator, DumbAware {
             TextAttributesKey typeTextAttributesKey) {
         PsiElement functionNameElement = unqualifiedParenthesesCall.functionNameElement();
 
-        assert functionNameElement != null;
+        if (functionNameElement != null) {
 
-        highlight(functionNameElement.getTextRange(), annotationHolder, typeTextAttributesKey);
+            highlight(functionNameElement.getTextRange(), annotationHolder, typeTextAttributesKey);
 
-        highlightTypesAndTypeParameterUsages(
-                unqualifiedParenthesesCall.primaryArguments(),
-                typeParameterNameSet,
-                annotationHolder,
-                typeTextAttributesKey
-        );
-
-        PsiElement[] secondaryArguments = unqualifiedParenthesesCall.secondaryArguments();
-
-        if (secondaryArguments != null) {
             highlightTypesAndTypeParameterUsages(
-                    secondaryArguments,
+                    unqualifiedParenthesesCall.primaryArguments(),
                     typeParameterNameSet,
                     annotationHolder,
                     typeTextAttributesKey
             );
+
+            PsiElement[] secondaryArguments = unqualifiedParenthesesCall.secondaryArguments();
+
+            if (secondaryArguments != null) {
+                highlightTypesAndTypeParameterUsages(
+                        secondaryArguments,
+                        typeParameterNameSet,
+                        annotationHolder,
+                        typeTextAttributesKey
+                );
+            }
+        } else {
+            error("Cannot highlight types and type parameter usages", unqualifiedParenthesesCall);
         }
     }
 
@@ -1116,40 +1059,25 @@ public class ModuleAttribute implements Annotator, DumbAware {
     }
 
     private Set<String> specificationTypeParameterNameSet(PsiElement psiElement) {
+        Set<String> parameterNameSet;
+
         if (psiElement instanceof ElixirAccessExpression ||
                 psiElement instanceof ElixirKeywords ||
                 psiElement instanceof ElixirList ||
                 psiElement instanceof ElixirNoParenthesesKeywords) {
-            return specificationTypeParameterNameSet(psiElement.getChildren());
+            parameterNameSet = specificationTypeParameterNameSet(psiElement.getChildren());
         } else if (psiElement instanceof ElixirKeywordPair) {
-            return specificationTypeParameterNameSet((ElixirKeywordPair) psiElement);
+            parameterNameSet = specificationTypeParameterNameSet((ElixirKeywordPair) psiElement);
         } else if (psiElement instanceof ElixirNoParenthesesKeywordPair) {
-            return specificationTypeParameterNameSet((ElixirNoParenthesesKeywordPair) psiElement);
+            parameterNameSet = specificationTypeParameterNameSet((ElixirNoParenthesesKeywordPair) psiElement);
         } else if (psiElement instanceof UnqualifiedNoArgumentsCall) {
-            return specificationTypeParameterNameSet((UnqualifiedNoArgumentsCall) psiElement);
+            parameterNameSet = specificationTypeParameterNameSet((UnqualifiedNoArgumentsCall) psiElement);
         } else {
-            throw new NotImplementedException(
-                    "Extracting specification type parameter name set not implemented for your use case. Please open " +
-                            "an issue (https://github.com/KronicDeth/intellij-elixir/issues/new) using the " +
-                            "following:\n" +
-                            "\n" +
-                            "# Class\n" +
-                            "\n" +
-                            "`" + psiElement.getClass().getCanonicalName() + "`\n" +
-                            "\n" +
-                            "# Excerpt\n" +
-                            "\n" +
-                            "```\n" +
-                            psiElement.getText() + "\n" +
-                            "```\n" +
-                            "\n" +
-                            "# Full Text\n" +
-                            "\n" +
-                            "```\n" +
-                            psiElement.getContainingFile().getText() + "\n" +
-                            "```"
-            );
+            error("Cannot extract specification type parameter name set", psiElement);
+            parameterNameSet = Collections.emptySet();
         }
+
+        return parameterNameSet;
     }
 
     private Set<String> specificationTypeParameterNameSet(PsiElement[] psiElements) {
@@ -1191,16 +1119,16 @@ public class ModuleAttribute implements Annotator, DumbAware {
     }
 
     private Set<String> typeTypeParameterNameSet(PsiElement psiElement) {
+        Set<String> typeParameterNameSet;
+
         if (psiElement instanceof ElixirUnmatchedUnqualifiedNoArgumentsCall) {
-            return Collections.singleton(psiElement.getText());
+            typeParameterNameSet = Collections.singleton(psiElement.getText());
         } else {
-            throw new NotImplementedException(
-                    "Extracting type type parameter name set for " + psiElement.getClass().getCanonicalName() +
-                            " PsiElements is not implemented yet.  Please open an issue " +
-                            "(https://github.com/KronicDeth/intellij-elixir/issues/new) with the class name of the " +
-                            "sample text:\n" + psiElement.getText()
-            );
+            error("Cannot extract type type parameter name set", psiElement);
+            typeParameterNameSet = Collections.emptySet();
         }
+
+        return typeParameterNameSet;
     }
 
     private Set<String> typeTypeParameterNameSet(PsiElement[] psiElements) {

--- a/src/org/elixir_lang/errorreport/Logger.java
+++ b/src/org/elixir_lang/errorreport/Logger.java
@@ -1,0 +1,96 @@
+package org.elixir_lang.errorreport;
+
+import com.google.common.base.Joiner;
+import com.intellij.diagnostic.AttachmentFactory;
+import com.intellij.diagnostic.LogMessageEx;
+import com.intellij.openapi.diagnostic.Attachment;
+import com.intellij.openapi.editor.Document;
+import com.intellij.openapi.util.TextRange;
+import com.intellij.psi.FileViewProvider;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
+import org.elixir_lang.psi.impl.ElixirPsiImplUtil;
+import org.jetbrains.annotations.NotNull;
+
+public class Logger {
+    /*
+     * Public Static Methods
+     */
+
+    /**
+     * Logs error to the {@code klass}'s {@link com.intellij.openapi.diagnostic.Logger} instance with the given
+     * {@code userMessage} and the text of {@code element} as the details and containing file of {@code element} as an
+     * attachment
+     *
+     * @param klass       Class whose logger to use
+     * @param userMessage User message for
+     *                    {@link com.intellij.diagnostic.LogMessageEx#createEvent(String, String, Attachment...)}
+     * @param element     element responsible for the error
+     */
+    public static void error(@NotNull Class klass, @NotNull String userMessage, PsiElement element) {
+        error(com.intellij.openapi.diagnostic.Logger.getInstance(klass), userMessage, element);
+    }
+
+    /**
+     * Logs error {@link com.intellij.openapi.diagnostic.Logger} instance with the given {@code userMessage} and the
+     * text of {@code element} as the details and containing file of {@code element} as an * attachment
+     *
+     * @param logger      logger to which to log an error.
+     * @param userMessage User message for
+     *                    {@link com.intellij.diagnostic.LogMessageEx#createEvent(String, String, Attachment...)}
+     * @param element     element responsible for the error
+     */
+    public static void error(@NotNull com.intellij.openapi.diagnostic.Logger logger,
+                             @NotNull String userMessage,
+                             @NotNull PsiElement element) {
+        PsiFile containingFile = element.getContainingFile();
+
+        logger.error(
+                LogMessageEx.createEvent(
+                        fullUserMessage(userMessage, containingFile, element),
+                        Joiner.on("\n").join(new Throwable().getStackTrace()),
+                        AttachmentFactory.createAttachment(containingFile.getVirtualFile())
+                )
+        );
+    }
+
+    /*
+     * Private Static Methods
+     */
+
+    private static String excerpt(@NotNull PsiFile containingFile, @NotNull PsiElement element) {
+        StringBuilder excerptBuilder = new StringBuilder();
+        excerptBuilder.append('\n');
+        excerptBuilder.append("### Excerpt\n");
+        excerptBuilder.append('\n');
+
+        excerptBuilder.append("```\n");
+        excerptBuilder.append(element.getText());
+        excerptBuilder.append('\n');
+        excerptBuilder.append("```\n");
+
+        FileViewProvider fileViewProvider = containingFile.getViewProvider();
+        Document document = fileViewProvider.getDocument();
+
+        if (document != null) {
+            TextRange textRange = element.getTextRange();
+            int startingLine = document.getLineNumber(textRange.getStartOffset());
+            int endingLine = document.getLineNumber(textRange.getEndOffset());
+
+            excerptBuilder.append(" Line(s) ");
+            excerptBuilder.append(startingLine);
+            excerptBuilder.append('-');
+            excerptBuilder.append(endingLine);
+            excerptBuilder.append("\n");
+        }
+
+        return excerptBuilder.toString();
+    }
+
+    private static String fullUserMessage(@NotNull String userMessage,
+                                          @NotNull PsiFile containingFile,
+                                          @NotNull PsiElement element) {
+        return userMessage + "\n" +
+                excerpt(containingFile, element);
+    }
+}

--- a/src/org/elixir_lang/errorreport/Submitter.java
+++ b/src/org/elixir_lang/errorreport/Submitter.java
@@ -12,6 +12,7 @@ import com.intellij.notification.NotificationListener;
 import com.intellij.notification.NotificationType;
 import com.intellij.openapi.actionSystem.CommonDataKeys;
 import com.intellij.openapi.actionSystem.DataContext;
+import com.intellij.openapi.diagnostic.Attachment;
 import com.intellij.openapi.diagnostic.IdeaLoggingEvent;
 import com.intellij.openapi.diagnostic.SubmittedReportInfo;
 import com.intellij.openapi.extensions.PluginId;
@@ -24,6 +25,10 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.awt.*;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.*;
+import java.util.List;
 
 /**
  * @see <a href="https://github.com/JesusFreke/smali/blob/87d10dac2773cd35b7d5825d7957206e26c1727b/smalidea/src/main/java/org/jf/smalidea/errorReporting/ErrorReporter.java">{@code org.jf.smalidea.errorReporting.ErrorReporter}</a>
@@ -89,9 +94,51 @@ public class Submitter extends com.intellij.openapi.diagnostic.ErrorReportSubmit
         Object data = event.getData();
 
         if (data instanceof LogMessageEx) {
-            bean.setAttachments(((LogMessageEx) data).getIncludedAttachments());
+            bean.setAttachments(includedAttachments((LogMessageEx) data));
         }
         return bean;
+    }
+
+    /**
+     * Gets the attachment the user has marked to be included.  Tries to use
+     * {@link LogMessageEx#getIncludedAttachments()}, and then {@link LogMessageEx#getAttachments()}.
+     *
+     * @param logMessageEx with attachments
+     * @return the attachments
+     */
+    private static List<Attachment> includedAttachments(LogMessageEx logMessageEx) {
+        Class<LogMessageEx> klass = LogMessageEx.class;
+
+        List<Attachment> attachmentList = Collections.emptyList();
+
+        try {
+            Method getIncludedAttachments = klass.getDeclaredMethod("getIncludedAttachments", LogMessageEx.class);
+
+            try {
+                attachmentList = (List<Attachment>) getIncludedAttachments.invoke(logMessageEx);
+            } catch (IllegalAccessException e) {
+                e.printStackTrace();
+            } catch (InvocationTargetException e) {
+                e.printStackTrace();
+            }
+        } catch (NoSuchMethodException noSuchGetIncludedAttachmentsMethod) {
+            try {
+                Method getAttachments = klass.getDeclaredMethod("getAttachments", LogMessageEx.class);
+
+                try {
+                    attachmentList = (List<Attachment>) getAttachments.invoke(logMessageEx);
+                } catch (IllegalAccessException e) {
+                    e.printStackTrace();
+                } catch (InvocationTargetException e) {
+                    e.printStackTrace();
+                }
+            } catch (NoSuchMethodException noSuchGetAttachmentsMethod) {
+                noSuchGetAttachmentsMethod.printStackTrace();
+            }
+        }
+
+
+        return attachmentList;
     }
 
     @Nullable

--- a/src/org/elixir_lang/errorreport/Submitter.java
+++ b/src/org/elixir_lang/errorreport/Submitter.java
@@ -1,0 +1,193 @@
+package org.elixir_lang.errorreport;
+
+import com.intellij.diagnostic.IdeErrorsDialog;
+import com.intellij.diagnostic.LogMessageEx;
+import com.intellij.diagnostic.ReportMessages;
+import com.intellij.errorreport.bean.ErrorBean;
+import com.intellij.ide.DataManager;
+import com.intellij.ide.plugins.IdeaPluginDescriptor;
+import com.intellij.ide.plugins.PluginManager;
+import com.intellij.idea.IdeaLogger;
+import com.intellij.notification.NotificationListener;
+import com.intellij.notification.NotificationType;
+import com.intellij.openapi.actionSystem.CommonDataKeys;
+import com.intellij.openapi.actionSystem.DataContext;
+import com.intellij.openapi.diagnostic.IdeaLoggingEvent;
+import com.intellij.openapi.diagnostic.SubmittedReportInfo;
+import com.intellij.openapi.extensions.PluginId;
+import com.intellij.openapi.progress.EmptyProgressIndicator;
+import com.intellij.openapi.progress.ProgressIndicator;
+import com.intellij.openapi.progress.ProgressManager;
+import com.intellij.openapi.project.Project;
+import com.intellij.util.Consumer;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.awt.*;
+
+/**
+ * @see <a href="https://github.com/JesusFreke/smali/blob/87d10dac2773cd35b7d5825d7957206e26c1727b/smalidea/src/main/java/org/jf/smalidea/errorReporting/ErrorReporter.java">{@code org.jf.smalidea.errorReporting.ErrorReporter}</a>
+ */
+public class Submitter extends com.intellij.openapi.diagnostic.ErrorReportSubmitter {
+    /*
+     * CONSTANTS
+     */
+
+    private static final String ORGANIZATION = "KronicDeth";
+    private static final String REPOSITORY = "intellij-elixir";
+    private static final String REPOSITORY_URL = "https://github.com/" + ORGANIZATION + "/" + REPOSITORY;
+    static final String ISSUES_URL = REPOSITORY_URL + "/issues";
+
+    /*
+     * Static Methods
+     */
+
+    @NotNull
+    private static Consumer<Exception> errorCallback(@Nullable final Project project) {
+        return new Consumer<Exception>() {
+            @Override
+            public void consume(Exception e) {
+                String message = String.format(
+                        "<html>\n" +
+                                "  There was an error while creating a GitHub issue: %s\n" +
+                                "  <br>\n" +
+                                "  Please consider <a href=\"" + ISSUES_URL +
+                                "/new\">manually creating an issue</a>\n" +
+                                "</html>",
+                        e.getMessage()
+                );
+                ReportMessages.GROUP.createNotification(
+                        ReportMessages.ERROR_REPORT,
+                        message,
+                        NotificationType.ERROR,
+                        NotificationListener.URL_OPENING_LISTENER
+                ).setImportant(false).notify(project);
+            }
+        };
+    }
+
+    @NotNull
+    private static ErrorBean errorBean(@NotNull IdeaLoggingEvent[] events, String additionalInfo) {
+        IdeaLoggingEvent event = events[0];
+        ErrorBean bean = new ErrorBean(event.getThrowable(), IdeaLogger.ourLastActionId);
+
+        bean.setDescription(additionalInfo);
+        bean.setMessage(event.getMessage());
+
+        Throwable throwable = event.getThrowable();
+        if (throwable != null) {
+            final PluginId pluginId = IdeErrorsDialog.findPluginId(throwable);
+            if (pluginId != null) {
+                final IdeaPluginDescriptor ideaPluginDescriptor = PluginManager.getPlugin(pluginId);
+                if (ideaPluginDescriptor != null && !ideaPluginDescriptor.isBundled()) {
+                    bean.setPluginName(ideaPluginDescriptor.getName());
+                    bean.setPluginVersion(ideaPluginDescriptor.getVersion());
+                }
+            }
+        }
+
+        Object data = event.getData();
+
+        if (data instanceof LogMessageEx) {
+            bean.setAttachments(((LogMessageEx) data).getIncludedAttachments());
+        }
+        return bean;
+    }
+
+    @Nullable
+    private static Project project(@NotNull Component parentComponent) {
+        DataContext dataContext = DataManager.getInstance().getDataContext(parentComponent);
+        return CommonDataKeys.PROJECT.getData(dataContext);
+    }
+
+    /**
+     * Runs the task in the background if it can.
+     *
+     * @param task Task that will create an issue on Github
+     * @param direct {@code true} to run directly with {@link Task#run(ProgressIndicator)}; {@code false} to run with
+     *               the {@link com.intellij.openapi.project.ProjectManager}.
+     */
+    private static void run(Task task, boolean direct) {
+        if (direct) {
+            task.run(new EmptyProgressIndicator());
+        } else {
+            ProgressManager.getInstance().run(task);
+        }
+    }
+
+    @NotNull
+    private static Consumer<Boolean> successCallback(
+            @Nullable final Project project,
+            @NotNull final Consumer<SubmittedReportInfo> consumer
+    ) {
+        return new Consumer<Boolean>() {
+            @Override
+            public void consume(Boolean opened) {
+                String url = null;
+                String linkText = null;
+                //noinspection ConstantConditions
+                final SubmittedReportInfo reportInfo = new SubmittedReportInfo(
+                        url,
+                        linkText,
+                        SubmittedReportInfo.SubmissionStatus.NEW_ISSUE
+                );
+                consumer.consume(reportInfo);
+
+                // pseudo-named-arguments
+                NotificationListener notificationListener = null;
+
+                //noinspection ConstantConditions
+                ReportMessages.GROUP.createNotification(
+                        ReportMessages.ERROR_REPORT,
+                        "Submitted",
+                        NotificationType.INFORMATION,
+                        notificationListener
+                ).setImportant(false).notify(project);
+            }
+        };
+    }
+
+    /*
+     *
+     * Instance Methods
+     *
+     */
+
+    /*
+     * Public Instance Methods
+     */
+
+    /**
+     * @return an action text to be used in Error Reporter user interface, e.g. "Report to JetBrains".
+     */
+    @Override
+    public String getReportActionText() {
+        return "Open issue against " + REPOSITORY_URL;
+    }
+
+    /**
+     * This method is called whenever an exception in a plugin code had happened and a user decided to report a problem
+     * to the plugin vendor.
+     *
+     * @param events          a non-empty sequence of error descriptors.
+     * @param additionalInfo  additional information provided by a user.
+     * @param parentComponent UI component to use as a parent in any UI activity from a submitter.
+     * @param consumer        a callback to be called after sending is finished (or failed).
+     * @return {@code true} if reporting was started, {@code false} if a report can't be sent at the moment.
+     */
+    @Override
+    public boolean submit(@NotNull IdeaLoggingEvent[] events,
+                          String additionalInfo,
+                          @NotNull Component parentComponent,
+                          @NotNull final Consumer<SubmittedReportInfo> consumer) {
+        final Project project = project(parentComponent);
+        ErrorBean errorBean = errorBean(events, additionalInfo);
+        Consumer<Boolean> successCallback = successCallback(project, consumer);
+        Consumer<Exception> errorCallback = errorCallback(project);
+
+        Task task = new Task(project, errorBean, successCallback, errorCallback);
+        run(task, project == null);
+
+        return true;
+    }
+}

--- a/src/org/elixir_lang/errorreport/Task.java
+++ b/src/org/elixir_lang/errorreport/Task.java
@@ -1,0 +1,80 @@
+package org.elixir_lang.errorreport;
+
+import com.intellij.errorreport.bean.ErrorBean;
+import com.intellij.ide.BrowserUtil;
+import com.intellij.openapi.progress.ProgressIndicator;
+import com.intellij.openapi.project.Project;
+import com.intellij.util.Consumer;
+import org.elixir_lang.github.issues.create.Request;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.io.*;
+import java.net.URLEncoder;
+
+import static org.elixir_lang.errorreport.Submitter.ISSUES_URL;
+
+class Task extends com.intellij.openapi.progress.Task.Backgroundable {
+    /*
+     * CONSTANTS
+     */
+
+    private static final boolean CAN_BE_CANCELLED = true;
+    private static final String TITLE = "Opening GitHub Issue";
+
+    /*
+     * Static Methods
+     */
+
+    private static void create(@NotNull ErrorBean errorBean) throws IOException {
+        Request request = new Request(errorBean);
+        BrowserUtil.open(
+                ISSUES_URL + "/new?" +
+                        "title=" + URLEncoder.encode(request.title, "UTF-8") +
+                        "&" +
+                        "body=" + URLEncoder.encode(request.body, "UTF-8")
+        );
+    }
+
+    /*
+     * Fields
+     */
+
+    @NotNull
+    private final Consumer<Exception> errorCallback;
+    @NotNull
+    private final ErrorBean errorBean;
+    @NotNull
+    private final Consumer<Boolean> successCallback;
+
+    /*
+     * Constructors
+     */
+
+    Task(@Nullable Project project,
+         @NotNull ErrorBean errorBean,
+         @NotNull Consumer<Boolean> successCallback,
+         @NotNull Consumer<Exception> errorCallback) {
+        super(project, TITLE, CAN_BE_CANCELLED);
+
+        this.errorCallback = errorCallback;
+        this.errorBean = errorBean;
+        this.successCallback = successCallback;
+    }
+
+    /*
+     * Instance Methods
+     */
+
+    @Override
+    public void run(@NotNull ProgressIndicator indicator) {
+        indicator.setIndeterminate(true);
+        try {
+            create(errorBean);
+            successCallback.consume(true);
+        } catch (Exception exception) {
+            errorCallback.consume(exception);
+        }
+    }
+
+}

--- a/src/org/elixir_lang/github/issues/create/Request.java
+++ b/src/org/elixir_lang/github/issues/create/Request.java
@@ -1,0 +1,97 @@
+package org.elixir_lang.github.issues.create;
+
+import com.intellij.errorreport.bean.ErrorBean;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class Request {
+    /*
+     * CONSTANTS
+     */
+
+    private static final String TITLE = "[auto-generated]";
+
+    /*
+     * Static Methods
+     */
+
+    private static String body(ErrorBean errorBean) {
+        StringBuilder stringBuilder = new StringBuilder();
+
+        version(stringBuilder, errorBean.getPluginVersion());
+        description(stringBuilder, errorBean.getDescription());
+        message(stringBuilder, errorBean.getMessage());
+        stacktrace(stringBuilder, errorBean.getStackTrace());
+
+        return stringBuilder.toString();
+    }
+
+    private static void codeBlock(@NotNull StringBuilder stringBuilder, @NotNull String code) {
+        codeFence(stringBuilder);
+        stringBuilder.append(code);
+        codeFence(stringBuilder);
+    }
+
+    private static void codeBlockSection(@NotNull StringBuilder stringBuilder,
+                                         @NotNull String name,
+                                         @Nullable String code) {
+        if (code != null && !code.isEmpty()) {
+            header(stringBuilder, name);
+            codeBlock(stringBuilder, code);
+        }
+    }
+
+    private static void codeFence(@NotNull StringBuilder stringBuilder) {
+        stringBuilder.append("```\n");
+    }
+
+    private static void description(@NotNull StringBuilder stringBuilder, @Nullable String description) {
+        if (description != null && !description.isEmpty()) {
+            header(stringBuilder, "Description");
+            stringBuilder.append(description);
+            stringBuilder.append("\n\n");
+        }
+    }
+
+    private static void header(@NotNull StringBuilder stringBuilder, @NotNull String name) {
+        stringBuilder.append("\n");
+        stringBuilder.append("# ");
+        stringBuilder.append(name);
+        stringBuilder.append("\n\n");
+    }
+
+
+    private static void message(@NotNull StringBuilder stringBuilder, @Nullable String message) {
+        codeBlockSection(stringBuilder, "Message", message);
+    }
+
+    private static void stacktrace(@NotNull StringBuilder stringBuilder, @Nullable String stacktrace) {
+        codeBlockSection(stringBuilder, "Stacktrace", stacktrace);
+    }
+
+    private static void version(@NotNull StringBuilder stringBuilder, @Nullable String version) {
+        if (version != null) {
+            header(stringBuilder, "Version");
+            stringBuilder.append(version);
+            stringBuilder.append("\n\n");
+        }
+    }
+
+    /*
+     * Fields
+     */
+
+    @NotNull
+    public final String body;
+    @NotNull
+    public final String title;
+
+    public Request(@NotNull ErrorBean errorBean) {
+        this(TITLE, body(errorBean));
+    }
+
+    private Request(@NotNull String title, @NotNull String body) {
+        this.body = body;
+        this.title = title;
+    }
+}

--- a/src/org/elixir_lang/navigation/GotoSymbolContributor.java
+++ b/src/org/elixir_lang/navigation/GotoSymbolContributor.java
@@ -4,11 +4,14 @@ import com.intellij.navigation.ChooseByNameContributor;
 import com.intellij.navigation.NavigationItem;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Pair;
+import com.intellij.psi.PsiAnchor;
+import com.intellij.psi.PsiElement;
 import com.intellij.psi.search.GlobalSearchScope;
 import com.intellij.psi.stubs.StubIndex;
 import com.intellij.util.ArrayUtil;
 import com.intellij.util.containers.ContainerUtil;
 import org.apache.commons.lang.math.IntRange;
+import org.elixir_lang.errorreport.Logger;
 import org.elixir_lang.psi.AtUnqualifiedNoParenthesesCall;
 import org.elixir_lang.psi.NamedElement;
 import org.elixir_lang.psi.call.Call;
@@ -87,82 +90,94 @@ public class GotoSymbolContributor implements ChooseByNameContributor {
                         Timed.Time time = CallDefinitionClause.time(call);
                         Modular modular = enclosingModularByCall.putNew(call);
 
-                        assert modular != null;
+                        if (modular == null) {
+                            error("Cannot find enclosing Modular", call);
+                        } else {
+                            for (int arity = arityRange.getMinimumInteger(); arity <= arityRange.getMaximumInteger(); arity++) {
+                                CallDefinition.Tuple tuple = new CallDefinition.Tuple(modular, time, callName, arity);
+                                CallDefinition callDefinition = callDefinitionByTuple.get(tuple);
 
-                        for (int arity = arityRange.getMinimumInteger(); arity <= arityRange.getMaximumInteger(); arity++) {
-                            CallDefinition.Tuple tuple = new CallDefinition.Tuple(modular, time, callName, arity);
-                            CallDefinition callDefinition = callDefinitionByTuple.get(tuple);
+                                if (callDefinition == null) {
+                                    callDefinition = new CallDefinition(tuple.modular, tuple.time, tuple.name, tuple.arity);
+                                    items.add(callDefinition);
+                                    callDefinitionByTuple.put(tuple, callDefinition);
+                                }
 
-                            if (callDefinition == null) {
-                                callDefinition = new CallDefinition(tuple.modular, tuple.time, tuple.name, tuple.arity);
-                                items.add(callDefinition);
-                                callDefinitionByTuple.put(tuple, callDefinition);
+                                CallDefinitionClause callDefinitionClause = callDefinition.clause(call);
+                                items.add(callDefinitionClause);
                             }
-
-                            CallDefinitionClause callDefinitionClause = callDefinition.clause(call);
-                            items.add(callDefinitionClause);
                         }
                     }
                 } else if (CallDefinitionHead.is(call)) {
                     Call delegationCall = CallDefinitionHead.enclosingDelegationCall(call);
 
-                    assert delegationCall != null;
+                    if (delegationCall != null) {
+                        Modular modular = enclosingModularByCall.putNew(delegationCall);
 
-                    Modular modular = enclosingModularByCall.putNew(delegationCall);
+                        if (modular != null) {
+                            String callDefinitionName = call.functionName();
 
-                    assert modular != null;
+                            if (callDefinitionName != null) {
+                                int callDefinitionArity = call.resolvedFinalArity();
 
-                    String callDefinitionName = call.functionName();
+                                CallDefinition.Tuple tuple = new CallDefinition.Tuple(
+                                        modular,
+                                        // Delegation can't delegate macros
+                                        Timed.Time.RUN,
+                                        callDefinitionName,
+                                        callDefinitionArity
+                                );
+                                CallDefinition callDefinition = callDefinitionByTuple.get(tuple);
 
-                    assert callDefinitionName != null;
+                                if (callDefinition == null) {
+                                    callDefinition = new CallDefinition(tuple.modular, tuple.time, tuple.name, tuple.arity);
+                                    items.add(callDefinition);
+                                    callDefinitionByTuple.put(tuple, callDefinition);
+                                }
 
-                    int callDefinitionArity = call.resolvedFinalArity();
+                                // Delegation is always public as import should be used for private
+                                Visible.Visibility visibility = Visible.Visibility.PUBLIC;
 
-                    CallDefinition.Tuple tuple = new CallDefinition.Tuple(
-                            modular,
-                            // Delegation can't delegate macros
-                            Timed.Time.RUN,
-                            callDefinitionName,
-                            callDefinitionArity
-                    );
-                    CallDefinition callDefinition = callDefinitionByTuple.get(tuple);
-
-                    if (callDefinition == null) {
-                        callDefinition = new CallDefinition(tuple.modular, tuple.time, tuple.name, tuple.arity);
-                        items.add(callDefinition);
-                        callDefinitionByTuple.put(tuple, callDefinition);
+                                //noinspection ConstantConditions
+                                CallDefinitionHead callDefinitionHead = new CallDefinitionHead(callDefinition, visibility, call);
+                                items.add(callDefinitionHead);
+                            } else {
+                                error("Call for CallDefinitionHead does not have function name", call);
+                            }
+                        } else {
+                            error("Cannot find enclosing Modular for Delegation call", delegationCall);
+                        }
+                    } else {
+                        error("Cannot find enclosing delegation call for CallDefinitionHead", call);
                     }
-
-                    // Delegation is always public as import should be used for private
-                    Visible.Visibility visibility = Visible.Visibility.PUBLIC;
-
-                    //noinspection ConstantConditions
-                    CallDefinitionHead callDefinitionHead = new CallDefinitionHead(callDefinition, visibility, call);
-                    items.add(callDefinitionHead);
                 } else if (CallDefinitionSpecification.is(call)) {
                     Modular modular = enclosingModularByCall.putNew(call);
 
-                    assert modular != null;
+                    if (modular != null) {
+                        // pseudo-named-arguments
+                        boolean callback = false;
+                        Timed.Time time = Timed.Time.RUN;
 
-                    // pseudo-named-arguments
-                    boolean callback = false;
-                    Timed.Time time = Timed.Time.RUN;
-
-                    //noinspection ConstantConditions
-                    CallDefinitionSpecification callDefinitionSpecification = new CallDefinitionSpecification(
-                            modular,
-                            (AtUnqualifiedNoParenthesesCall) call,
-                            callback,
-                            time
-                    );
-                    items.add(callDefinitionSpecification);
+                        //noinspection ConstantConditions
+                        CallDefinitionSpecification callDefinitionSpecification = new CallDefinitionSpecification(
+                                modular,
+                                (AtUnqualifiedNoParenthesesCall) call,
+                                callback,
+                                time
+                        );
+                        items.add(callDefinitionSpecification);
+                    } else {
+                        error("Cannot find enclosing Modular for CallDefinitionSpecification", call);
+                    }
                 } else if (Callback.is(call)) {
                     Modular modular = enclosingModularByCall.putNew(call);
 
-                    assert modular != null;
-
-                    Callback callback = new Callback(modular, call);
-                    items.add(callback);
+                    if (modular != null) {
+                        Callback callback = new Callback(modular, call);
+                        items.add(callback);
+                    } else {
+                        error("Cannot find enclosing Modular for Callback", call);
+                    }
                 } else if (Implementation.is(call)) {
                     Modular modular = enclosingModularByCall.putNew(call);
 
@@ -198,5 +213,13 @@ public class GotoSymbolContributor implements ChooseByNameContributor {
     @Override
     public String[] getNames(Project project, boolean includeNonProjectItems) {
         return ArrayUtil.toStringArray(StubIndex.getInstance().getAllKeys(AllName.KEY, project));
+    }
+
+    /*
+     * Private Instance Methods
+     */
+
+    private void error(@NotNull String userMessage, @NotNull PsiElement element) {
+        Logger.error(this.getClass(), userMessage, element);
     }
 }

--- a/src/org/elixir_lang/psi/UnqualifiedNoArgumentsCall.java
+++ b/src/org/elixir_lang/psi/UnqualifiedNoArgumentsCall.java
@@ -1,12 +1,17 @@
 package org.elixir_lang.psi;
 
+import com.intellij.psi.PsiElement;
 import org.elixir_lang.psi.call.StubBased;
 import org.elixir_lang.psi.call.arguments.None;
 import org.elixir_lang.psi.qualification.Unqualified;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * IDENTIFIER !KEYWORD_PAIR_COLON doBlock?
  */
 public interface UnqualifiedNoArgumentsCall<Stub extends org.elixir_lang.psi.stub.call.Stub>
         extends None, Quotable, StubBased<Stub>, Unqualified {
+    @NotNull
+    @Override
+    PsiElement functionNameElement();
 }

--- a/src/org/elixir_lang/psi/impl/ElixirPsiImplUtil.java
+++ b/src/org/elixir_lang/psi/impl/ElixirPsiImplUtil.java
@@ -43,6 +43,7 @@ import javax.swing.*;
 import java.math.BigInteger;
 import java.util.*;
 
+import static org.elixir_lang.errorreport.Logger.error;
 import static org.elixir_lang.intellij_elixir.Quoter.*;
 
 /**
@@ -755,7 +756,9 @@ public class ElixirPsiImplUtil {
     public static Quotable leftOperand(Infix infix) {
         PsiElement[] children = infix.getChildren();
 
-        assert children.length == 3;
+        if (children.length != 3) {
+            error(Infix.class, "Infix operation expected 3 children, but has " + children.length, infix);
+        }
 
         return (Quotable) children[0];
     }
@@ -903,7 +906,9 @@ public class ElixirPsiImplUtil {
     public static Quotable operand(Prefix prefix) {
         PsiElement[] children = prefix.getChildren();
 
-        assert children.length == 2;
+        if (children.length != 2) {
+            error(Prefix.class, "Prefix operation does not have 2 children, but " + children.length, prefix);
+        }
 
         return (Quotable) children[1];
     }
@@ -4241,7 +4246,9 @@ if (quoted == null) {
     public static Quotable rightOperand(Infix infix) {
         PsiElement[] children = infix.getChildren();
 
-        assert children.length == 3;
+        if (children.length != 3) {
+            error(Infix.class, "Excepted infix operations to have 3 children, but have " + children.length, infix);
+        }
 
         return (Quotable) children[2];
     }


### PR DESCRIPTION
# Changelog
* Enhancements
  * Custom error handling that will open an issue against https://github.com/KronicDeth/intellij-elixir with the exception messsage and stacktrace filled in.
  * Changed `NotImplementedExceptions` and (some) `assert`s to logging custom error message that include the `PsiElement` text and the containing file as an attachment.  The files make the URL too big for the error handler to put the file contents in when opening the browser with the error handler, so the issue body instead explains how to get the attachment text out of IntelliJ's "IDE Fatal Errors"