### PR TITLE
Infix error recovery recovery

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,11 +19,6 @@ matrix:
       jdk: openjdk6
     - env: ELIXIR_VERSION="1.1.1" IDEA_TARBALL_ROOT_BASENAME="idea-IC-141.3056.4" IDEA_VERSION="14.1.6"
       jdk: openjdk6
-
-    - env: ELIXIR_VERSION="1.2.3" IDEA_TARBALL_ROOT_BASENAME="idea-IC-139.1603.1" IDEA_VERSION="14.0.4"
-      jdk: openjdk6
-    - env: ELIXIR_VERSION="1.1.1" IDEA_TARBALL_ROOT_BASENAME="idea-IC-139.1603.1" IDEA_VERSION="14.0.4"
-      jdk: openjdk6
 before_install:
 - "export DISPLAY=:99.0"
 - "sh -e /etc/init.d/xvfb start"

--- a/gen/org/elixir_lang/parser/ElixirParser.java
+++ b/gen/org/elixir_lang/parser/ElixirParser.java
@@ -709,7 +709,7 @@ public class ElixirParser implements PsiParser, LightPsiParser {
   public static boolean accessExpression(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "accessExpression")) return false;
     boolean r;
-    Marker m = enter_section_(b, l, _NONE_, "<access expression>");
+    Marker m = enter_section_(b, l, _NONE_, ACCESS_EXPRESSION, "<access expression>");
     r = atNumericOperation(b, l + 1);
     if (!r) r = captureNumericOperation(b, l + 1);
     if (!r) r = unaryNumericOperation(b, l + 1);
@@ -747,7 +747,7 @@ public class ElixirParser implements PsiParser, LightPsiParser {
     if (!r) r = atomKeyword(b, l + 1);
     if (!r) r = atom(b, l + 1);
     if (!r) r = alias(b, l + 1);
-    exit_section_(b, l, m, ACCESS_EXPRESSION, r, false, null);
+    exit_section_(b, l, m, r, false, null);
     return r;
   }
 
@@ -766,9 +766,9 @@ public class ElixirParser implements PsiParser, LightPsiParser {
   private static boolean accessExpression_10_1(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "accessExpression_10_1")) return false;
     boolean r;
-    Marker m = enter_section_(b, l, _NOT_, null);
+    Marker m = enter_section_(b, l, _NOT_);
     r = !consumeToken(b, KEYWORD_PAIR_COLON);
-    exit_section_(b, l, m, null, r, false, null);
+    exit_section_(b, l, m, r, false, null);
     return r;
   }
 
@@ -787,9 +787,9 @@ public class ElixirParser implements PsiParser, LightPsiParser {
   private static boolean accessExpression_12_1(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "accessExpression_12_1")) return false;
     boolean r;
-    Marker m = enter_section_(b, l, _NOT_, null);
+    Marker m = enter_section_(b, l, _NOT_);
     r = !consumeToken(b, KEYWORD_PAIR_COLON);
-    exit_section_(b, l, m, null, r, false, null);
+    exit_section_(b, l, m, r, false, null);
     return r;
   }
 
@@ -800,10 +800,10 @@ public class ElixirParser implements PsiParser, LightPsiParser {
     if (!recursion_guard_(b, l, "additionInfixOperator")) return false;
     if (!nextTokenIs(b, "<+, ->", DUAL_OPERATOR, SIGNIFICANT_WHITE_SPACE)) return false;
     boolean r;
-    Marker m = enter_section_(b, l, _NONE_, "<+, ->");
+    Marker m = enter_section_(b, l, _NONE_, ADDITION_INFIX_OPERATOR, "<+, ->");
     r = additionInfixOperator_0(b, l + 1);
     r = r && additionInfixOperator_1(b, l + 1);
-    exit_section_(b, l, m, ADDITION_INFIX_OPERATOR, r, false, null);
+    exit_section_(b, l, m, r, false, null);
     return r;
   }
 
@@ -845,9 +845,9 @@ public class ElixirParser implements PsiParser, LightPsiParser {
   private static boolean additionInfixOperator_0_0_2_1(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "additionInfixOperator_0_0_2_1")) return false;
     boolean r;
-    Marker m = enter_section_(b, l, _AND_, null);
+    Marker m = enter_section_(b, l, _AND_);
     r = consumeToken(b, EOL);
-    exit_section_(b, l, m, null, r, false, null);
+    exit_section_(b, l, m, r, false, null);
     return r;
   }
 
@@ -951,9 +951,9 @@ public class ElixirParser implements PsiParser, LightPsiParser {
   private static boolean alias_1(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "alias_1")) return false;
     boolean r;
-    Marker m = enter_section_(b, l, _NOT_, null);
+    Marker m = enter_section_(b, l, _NOT_);
     r = !consumeToken(b, KEYWORD_PAIR_COLON);
-    exit_section_(b, l, m, null, r, false, null);
+    exit_section_(b, l, m, r, false, null);
     return r;
   }
 
@@ -963,11 +963,11 @@ public class ElixirParser implements PsiParser, LightPsiParser {
     if (!recursion_guard_(b, l, "andInfixOperator")) return false;
     if (!nextTokenIs(b, "<&&, &&&, and>", AND_OPERATOR, EOL)) return false;
     boolean r;
-    Marker m = enter_section_(b, l, _NONE_, "<&&, &&&, and>");
+    Marker m = enter_section_(b, l, _NONE_, AND_INFIX_OPERATOR, "<&&, &&&, and>");
     r = andInfixOperator_0(b, l + 1);
     r = r && consumeToken(b, AND_OPERATOR);
     r = r && andInfixOperator_2(b, l + 1);
-    exit_section_(b, l, m, AND_INFIX_OPERATOR, r, false, null);
+    exit_section_(b, l, m, r, false, null);
     return r;
   }
 
@@ -1033,11 +1033,11 @@ public class ElixirParser implements PsiParser, LightPsiParser {
     if (!recursion_guard_(b, l, "arrowInfixOperator")) return false;
     if (!nextTokenIs(b, "<<~, |>, ~>, <<<, <<~, <|>, <~>, >>>, ~>>, ^^^>", ARROW_OPERATOR, EOL)) return false;
     boolean r;
-    Marker m = enter_section_(b, l, _NONE_, "<<~, |>, ~>, <<<, <<~, <|>, <~>, >>>, ~>>, ^^^>");
+    Marker m = enter_section_(b, l, _NONE_, ARROW_INFIX_OPERATOR, "<<~, |>, ~>, <<<, <<~, <|>, <~>, >>>, ~>>, ^^^>");
     r = arrowInfixOperator_0(b, l + 1);
     r = r && consumeToken(b, ARROW_OPERATOR);
     r = r && arrowInfixOperator_2(b, l + 1);
-    exit_section_(b, l, m, ARROW_INFIX_OPERATOR, r, false, null);
+    exit_section_(b, l, m, r, false, null);
     return r;
   }
 
@@ -1108,10 +1108,10 @@ public class ElixirParser implements PsiParser, LightPsiParser {
   public static boolean associations(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "associations")) return false;
     boolean r;
-    Marker m = enter_section_(b, l, _NONE_, "<associations>");
+    Marker m = enter_section_(b, l, _NONE_, ASSOCIATIONS, "<associations>");
     r = associationsBase(b, l + 1);
     r = r && associations_1(b, l + 1);
-    exit_section_(b, l, m, ASSOCIATIONS, r, false, null);
+    exit_section_(b, l, m, r, false, null);
     return r;
   }
 
@@ -1127,10 +1127,10 @@ public class ElixirParser implements PsiParser, LightPsiParser {
   public static boolean associationsBase(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "associationsBase")) return false;
     boolean r;
-    Marker m = enter_section_(b, l, _NONE_, "<associations base>");
+    Marker m = enter_section_(b, l, _NONE_, ASSOCIATIONS_BASE, "<associations base>");
     r = associationsExpression(b, l + 1);
     r = r && associationsBase_1(b, l + 1);
-    exit_section_(b, l, m, ASSOCIATIONS_BASE, r, false, null);
+    exit_section_(b, l, m, r, false, null);
     return r;
   }
 
@@ -1215,10 +1215,10 @@ public class ElixirParser implements PsiParser, LightPsiParser {
     if (!recursion_guard_(b, l, "atPrefixOperator")) return false;
     if (!nextTokenIs(b, AT_OPERATOR)) return false;
     boolean r;
-    Marker m = enter_section_(b);
+    Marker m = enter_section_(b, l, _NONE_, AT_PREFIX_OPERATOR, "<@>");
     r = consumeToken(b, AT_OPERATOR);
     r = r && atPrefixOperator_1(b, l + 1);
-    exit_section_(b, m, AT_PREFIX_OPERATOR, r);
+    exit_section_(b, l, m, r, false, null);
     return r;
   }
 
@@ -1263,11 +1263,11 @@ public class ElixirParser implements PsiParser, LightPsiParser {
   public static boolean atomKeyword(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "atomKeyword")) return false;
     boolean r;
-    Marker m = enter_section_(b, l, _NONE_, "<false, nil, true>");
+    Marker m = enter_section_(b, l, _NONE_, ATOM_KEYWORD, "<false, nil, true>");
     r = consumeToken(b, FALSE);
     if (!r) r = consumeToken(b, NIL);
     if (!r) r = consumeToken(b, TRUE);
-    exit_section_(b, l, m, ATOM_KEYWORD, r, false, null);
+    exit_section_(b, l, m, r, false, null);
     return r;
   }
 
@@ -1277,10 +1277,10 @@ public class ElixirParser implements PsiParser, LightPsiParser {
     if (!recursion_guard_(b, l, "binaryDigits")) return false;
     if (!nextTokenIs(b, "<binary digits>", INVALID_BINARY_DIGITS, VALID_BINARY_DIGITS)) return false;
     boolean r;
-    Marker m = enter_section_(b, l, _NONE_, "<binary digits>");
+    Marker m = enter_section_(b, l, _NONE_, BINARY_DIGITS, "<binary digits>");
     r = consumeToken(b, INVALID_BINARY_DIGITS);
     if (!r) r = consumeToken(b, VALID_BINARY_DIGITS);
-    exit_section_(b, l, m, BINARY_DIGITS, r, false, null);
+    exit_section_(b, l, m, r, false, null);
     return r;
   }
 
@@ -1290,12 +1290,12 @@ public class ElixirParser implements PsiParser, LightPsiParser {
     if (!recursion_guard_(b, l, "binaryWholeNumber")) return false;
     if (!nextTokenIs(b, BASE_WHOLE_NUMBER_PREFIX)) return false;
     boolean r, p;
-    Marker m = enter_section_(b, l, _NONE_, null);
+    Marker m = enter_section_(b, l, _NONE_, BINARY_WHOLE_NUMBER, null);
     r = consumeToken(b, BASE_WHOLE_NUMBER_PREFIX);
     r = r && binaryWholeNumber_1(b, l + 1);
     p = r; // pin = 2
     r = r && binaryWholeNumber_2(b, l + 1);
-    exit_section_(b, l, m, BINARY_WHOLE_NUMBER, r, p, null);
+    exit_section_(b, l, m, r, p, null);
     return r || p;
   }
 
@@ -1390,12 +1390,12 @@ public class ElixirParser implements PsiParser, LightPsiParser {
   public static boolean blockIdentifier(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "blockIdentifier")) return false;
     boolean r;
-    Marker m = enter_section_(b, l, _NONE_, "<block identifier>");
+    Marker m = enter_section_(b, l, _NONE_, BLOCK_IDENTIFIER, "<block identifier>");
     r = consumeToken(b, AFTER);
     if (!r) r = consumeToken(b, CATCH);
     if (!r) r = consumeToken(b, ELSE);
     if (!r) r = consumeToken(b, RESCUE);
-    exit_section_(b, l, m, BLOCK_IDENTIFIER, r, false, null);
+    exit_section_(b, l, m, r, false, null);
     return r;
   }
 
@@ -1405,11 +1405,11 @@ public class ElixirParser implements PsiParser, LightPsiParser {
   public static boolean blockItem(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "blockItem")) return false;
     boolean r;
-    Marker m = enter_section_(b, l, _NONE_, "<block item>");
+    Marker m = enter_section_(b, l, _NONE_, BLOCK_ITEM, "<block item>");
     r = blockIdentifier(b, l + 1);
     r = r && blockItem_1(b, l + 1);
     r = r && blockItem_2(b, l + 1);
-    exit_section_(b, l, m, BLOCK_ITEM, r, false, null);
+    exit_section_(b, l, m, r, false, null);
     return r;
   }
 
@@ -1450,7 +1450,7 @@ public class ElixirParser implements PsiParser, LightPsiParser {
   public static boolean blockList(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "blockList")) return false;
     boolean r;
-    Marker m = enter_section_(b, l, _NONE_, "<block list>");
+    Marker m = enter_section_(b, l, _NONE_, BLOCK_LIST, "<block list>");
     r = blockItem(b, l + 1);
     int c = current_position_(b);
     while (r) {
@@ -1458,7 +1458,7 @@ public class ElixirParser implements PsiParser, LightPsiParser {
       if (!empty_element_parsed_guard_(b, "blockList", c)) break;
       c = current_position_(b);
     }
-    exit_section_(b, l, m, BLOCK_LIST, r, false, null);
+    exit_section_(b, l, m, r, false, null);
     return r;
   }
 
@@ -1543,10 +1543,10 @@ public class ElixirParser implements PsiParser, LightPsiParser {
     if (!recursion_guard_(b, l, "capturePrefixOperator")) return false;
     if (!nextTokenIs(b, CAPTURE_OPERATOR)) return false;
     boolean r;
-    Marker m = enter_section_(b);
+    Marker m = enter_section_(b, l, _NONE_, CAPTURE_PREFIX_OPERATOR, "<&>");
     r = consumeToken(b, CAPTURE_OPERATOR);
     r = r && capturePrefixOperator_1(b, l + 1);
-    exit_section_(b, m, CAPTURE_PREFIX_OPERATOR, r);
+    exit_section_(b, l, m, r, false, null);
     return r;
   }
 
@@ -1570,13 +1570,13 @@ public class ElixirParser implements PsiParser, LightPsiParser {
     if (!recursion_guard_(b, l, "charListHeredoc")) return false;
     if (!nextTokenIs(b, CHAR_LIST_HEREDOC_PROMOTER)) return false;
     boolean r, p;
-    Marker m = enter_section_(b, l, _NONE_, null);
+    Marker m = enter_section_(b, l, _NONE_, CHAR_LIST_HEREDOC, null);
     r = consumeTokens(b, 1, CHAR_LIST_HEREDOC_PROMOTER, EOL);
     p = r; // pin = 1
     r = r && report_error_(b, charListHeredoc_2(b, l + 1));
     r = p && report_error_(b, heredocPrefix(b, l + 1)) && r;
     r = p && consumeToken(b, CHAR_LIST_HEREDOC_TERMINATOR) && r;
-    exit_section_(b, l, m, CHAR_LIST_HEREDOC, r, p, null);
+    exit_section_(b, l, m, r, p, null);
     return r || p;
   }
 
@@ -1597,11 +1597,11 @@ public class ElixirParser implements PsiParser, LightPsiParser {
   public static boolean charListHeredocLine(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "charListHeredocLine")) return false;
     boolean r;
-    Marker m = enter_section_(b, l, _NONE_, "<char list heredoc line>");
+    Marker m = enter_section_(b, l, _NONE_, CHAR_LIST_HEREDOC_LINE, "<char list heredoc line>");
     r = heredocLinePrefix(b, l + 1);
     r = r && quoteCharListBody(b, l + 1);
     r = r && consumeToken(b, EOL);
-    exit_section_(b, l, m, CHAR_LIST_HEREDOC_LINE, r, false, null);
+    exit_section_(b, l, m, r, false, null);
     return r;
   }
 
@@ -1649,11 +1649,11 @@ public class ElixirParser implements PsiParser, LightPsiParser {
     if (!recursion_guard_(b, l, "comparisonInfixOperator")) return false;
     if (!nextTokenIs(b, "<!=, ==, =~, !==, ===>", COMPARISON_OPERATOR, EOL)) return false;
     boolean r;
-    Marker m = enter_section_(b, l, _NONE_, "<!=, ==, =~, !==, ===>");
+    Marker m = enter_section_(b, l, _NONE_, COMPARISON_INFIX_OPERATOR, "<!=, ==, =~, !==, ===>");
     r = comparisonInfixOperator_0(b, l + 1);
     r = r && consumeToken(b, COMPARISON_OPERATOR);
     r = r && comparisonInfixOperator_2(b, l + 1);
-    exit_section_(b, l, m, COMPARISON_INFIX_OPERATOR, r, false, null);
+    exit_section_(b, l, m, r, false, null);
     return r;
   }
 
@@ -1762,11 +1762,11 @@ public class ElixirParser implements PsiParser, LightPsiParser {
   public static boolean containerAssociationOperation(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "containerAssociationOperation")) return false;
     boolean r;
-    Marker m = enter_section_(b, l, _NONE_, "<container association operation>");
+    Marker m = enter_section_(b, l, _NONE_, CONTAINER_ASSOCIATION_OPERATION, "<container association operation>");
     r = containerExpression(b, l + 1);
     r = r && associationInfixOperator(b, l + 1);
     r = r && containerExpression(b, l + 1);
-    exit_section_(b, l, m, CONTAINER_ASSOCIATION_OPERATION, r, false, null);
+    exit_section_(b, l, m, r, false, null);
     return r;
   }
 
@@ -1789,10 +1789,10 @@ public class ElixirParser implements PsiParser, LightPsiParser {
     if (!recursion_guard_(b, l, "decimalDigits")) return false;
     if (!nextTokenIs(b, "<decimal digits>", INVALID_DECIMAL_DIGITS, VALID_DECIMAL_DIGITS)) return false;
     boolean r;
-    Marker m = enter_section_(b, l, _NONE_, "<decimal digits>");
+    Marker m = enter_section_(b, l, _NONE_, DECIMAL_DIGITS, "<decimal digits>");
     r = consumeToken(b, INVALID_DECIMAL_DIGITS);
     if (!r) r = consumeToken(b, VALID_DECIMAL_DIGITS);
-    exit_section_(b, l, m, DECIMAL_DIGITS, r, false, null);
+    exit_section_(b, l, m, r, false, null);
     return r;
   }
 
@@ -1802,12 +1802,12 @@ public class ElixirParser implements PsiParser, LightPsiParser {
     if (!recursion_guard_(b, l, "decimalFloat")) return false;
     if (!nextTokenIs(b, "<decimal float>", INVALID_DECIMAL_DIGITS, VALID_DECIMAL_DIGITS)) return false;
     boolean r;
-    Marker m = enter_section_(b, l, _NONE_, "<decimal float>");
+    Marker m = enter_section_(b, l, _NONE_, DECIMAL_FLOAT, "<decimal float>");
     r = decimalFloatIntegral(b, l + 1);
     r = r && consumeToken(b, DECIMAL_MARK);
     r = r && decimalFloatFractional(b, l + 1);
     r = r && decimalFloat_3(b, l + 1);
-    exit_section_(b, l, m, DECIMAL_FLOAT, r, false, null);
+    exit_section_(b, l, m, r, false, null);
     return r;
   }
 
@@ -1834,10 +1834,10 @@ public class ElixirParser implements PsiParser, LightPsiParser {
   public static boolean decimalFloatExponent(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "decimalFloatExponent")) return false;
     boolean r;
-    Marker m = enter_section_(b, l, _NONE_, "<decimal float exponent>");
+    Marker m = enter_section_(b, l, _NONE_, DECIMAL_FLOAT_EXPONENT, "<decimal float exponent>");
     r = decimalFloatExponentSign(b, l + 1);
     r = r && decimalWholeNumber(b, l + 1);
-    exit_section_(b, l, m, DECIMAL_FLOAT_EXPONENT, r, false, null);
+    exit_section_(b, l, m, r, false, null);
     return r;
   }
 
@@ -1845,9 +1845,9 @@ public class ElixirParser implements PsiParser, LightPsiParser {
   // DUAL_OPERATOR?
   public static boolean decimalFloatExponentSign(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "decimalFloatExponentSign")) return false;
-    Marker m = enter_section_(b, l, _NONE_, "<decimal float exponent sign>");
+    Marker m = enter_section_(b, l, _NONE_, DECIMAL_FLOAT_EXPONENT_SIGN, "<decimal float exponent sign>");
     consumeToken(b, DUAL_OPERATOR);
-    exit_section_(b, l, m, DECIMAL_FLOAT_EXPONENT_SIGN, true, false, null);
+    exit_section_(b, l, m, true, false, null);
     return true;
   }
 
@@ -1857,9 +1857,9 @@ public class ElixirParser implements PsiParser, LightPsiParser {
     if (!recursion_guard_(b, l, "decimalFloatFractional")) return false;
     if (!nextTokenIs(b, "<decimal float fractional>", INVALID_DECIMAL_DIGITS, VALID_DECIMAL_DIGITS)) return false;
     boolean r;
-    Marker m = enter_section_(b, l, _NONE_, "<decimal float fractional>");
+    Marker m = enter_section_(b, l, _NONE_, DECIMAL_FLOAT_FRACTIONAL, "<decimal float fractional>");
     r = decimalWholeNumber(b, l + 1);
-    exit_section_(b, l, m, DECIMAL_FLOAT_FRACTIONAL, r, false, null);
+    exit_section_(b, l, m, r, false, null);
     return r;
   }
 
@@ -1869,9 +1869,9 @@ public class ElixirParser implements PsiParser, LightPsiParser {
     if (!recursion_guard_(b, l, "decimalFloatIntegral")) return false;
     if (!nextTokenIs(b, "<decimal float integral>", INVALID_DECIMAL_DIGITS, VALID_DECIMAL_DIGITS)) return false;
     boolean r;
-    Marker m = enter_section_(b, l, _NONE_, "<decimal float integral>");
+    Marker m = enter_section_(b, l, _NONE_, DECIMAL_FLOAT_INTEGRAL, "<decimal float integral>");
     r = decimalWholeNumber(b, l + 1);
-    exit_section_(b, l, m, DECIMAL_FLOAT_INTEGRAL, r, false, null);
+    exit_section_(b, l, m, r, false, null);
     return r;
   }
 
@@ -1881,10 +1881,10 @@ public class ElixirParser implements PsiParser, LightPsiParser {
     if (!recursion_guard_(b, l, "decimalWholeNumber")) return false;
     if (!nextTokenIs(b, "<decimal whole number>", INVALID_DECIMAL_DIGITS, VALID_DECIMAL_DIGITS)) return false;
     boolean r;
-    Marker m = enter_section_(b, l, _NONE_, "<decimal whole number>");
+    Marker m = enter_section_(b, l, _NONE_, DECIMAL_WHOLE_NUMBER, "<decimal whole number>");
     r = decimalDigits(b, l + 1);
     r = r && decimalWholeNumber_1(b, l + 1);
-    exit_section_(b, l, m, DECIMAL_WHOLE_NUMBER, r, false, null);
+    exit_section_(b, l, m, r, false, null);
     return r;
   }
 
@@ -1927,7 +1927,7 @@ public class ElixirParser implements PsiParser, LightPsiParser {
     if (!recursion_guard_(b, l, "doBlock")) return false;
     if (!nextTokenIs(b, DO)) return false;
     boolean r, p;
-    Marker m = enter_section_(b, l, _NONE_, null);
+    Marker m = enter_section_(b, l, _NONE_, DO_BLOCK, null);
     r = consumeToken(b, DO);
     p = r; // pin = DO
     r = r && report_error_(b, doBlock_1(b, l + 1));
@@ -1936,7 +1936,7 @@ public class ElixirParser implements PsiParser, LightPsiParser {
     r = p && report_error_(b, doBlock_4(b, l + 1)) && r;
     r = p && report_error_(b, doBlock_5(b, l + 1)) && r;
     r = p && consumeToken(b, END) && r;
-    exit_section_(b, l, m, DO_BLOCK, r, p, null);
+    exit_section_(b, l, m, r, p, null);
     return r || p;
   }
 
@@ -1981,11 +1981,11 @@ public class ElixirParser implements PsiParser, LightPsiParser {
     if (!recursion_guard_(b, l, "dotInfixOperator")) return false;
     if (!nextTokenIs(b, "<.>", DOT_OPERATOR, EOL)) return false;
     boolean r;
-    Marker m = enter_section_(b, l, _NONE_, "<.>");
+    Marker m = enter_section_(b, l, _NONE_, DOT_INFIX_OPERATOR, "<.>");
     r = dotInfixOperator_0(b, l + 1);
     r = r && consumeToken(b, DOT_OPERATOR);
     r = r && dotInfixOperator_2(b, l + 1);
-    exit_section_(b, l, m, DOT_INFIX_OPERATOR, r, false, null);
+    exit_section_(b, l, m, r, false, null);
     return r;
   }
 
@@ -2089,10 +2089,10 @@ public class ElixirParser implements PsiParser, LightPsiParser {
     if (!recursion_guard_(b, l, "enclosedHexadecimalEscapeSequence")) return false;
     if (!nextTokenIs(b, OPENING_CURLY)) return false;
     boolean r, p;
-    Marker m = enter_section_(b, l, _NONE_, null);
+    Marker m = enter_section_(b, l, _NONE_, ENCLOSED_HEXADECIMAL_ESCAPE_SEQUENCE, null);
     r = consumeTokens(b, 1, OPENING_CURLY, VALID_HEXADECIMAL_DIGITS, CLOSING_CURLY);
     p = r; // pin = 1
-    exit_section_(b, l, m, ENCLOSED_HEXADECIMAL_ESCAPE_SEQUENCE, r, p, null);
+    exit_section_(b, l, m, r, p, null);
     return r || p;
   }
 
@@ -2102,10 +2102,10 @@ public class ElixirParser implements PsiParser, LightPsiParser {
     if (!recursion_guard_(b, l, "endOfExpression")) return false;
     if (!nextTokenIs(b, "<end of expression>", EOL, SEMICOLON)) return false;
     boolean r;
-    Marker m = enter_section_(b, l, _NONE_, "<end of expression>");
+    Marker m = enter_section_(b, l, _NONE_, END_OF_EXPRESSION, "<end of expression>");
     r = infixSemicolon(b, l + 1);
     if (!r) r = endOfExpression_1(b, l + 1);
-    exit_section_(b, l, m, END_OF_EXPRESSION, r, false, null);
+    exit_section_(b, l, m, r, false, null);
     return r;
   }
 
@@ -2131,10 +2131,10 @@ public class ElixirParser implements PsiParser, LightPsiParser {
     if (!recursion_guard_(b, l, "escapedCharacter")) return false;
     if (!nextTokenIs(b, ESCAPE)) return false;
     boolean r, p;
-    Marker m = enter_section_(b, l, _NONE_, null);
+    Marker m = enter_section_(b, l, _NONE_, ESCAPED_CHARACTER, null);
     r = consumeTokens(b, 1, ESCAPE, ESCAPED_CHARACTER_TOKEN);
     p = r; // pin = 1
-    exit_section_(b, l, m, ESCAPED_CHARACTER, r, p, null);
+    exit_section_(b, l, m, r, p, null);
     return r || p;
   }
 
@@ -2204,9 +2204,9 @@ public class ElixirParser implements PsiParser, LightPsiParser {
   // HEREDOC_LINE_WHITE_SPACE_TOKEN?
   public static boolean heredocLinePrefix(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "heredocLinePrefix")) return false;
-    Marker m = enter_section_(b, l, _NONE_, "<heredoc line prefix>");
+    Marker m = enter_section_(b, l, _NONE_, HEREDOC_LINE_PREFIX, "<heredoc line prefix>");
     consumeToken(b, HEREDOC_LINE_WHITE_SPACE_TOKEN);
-    exit_section_(b, l, m, HEREDOC_LINE_PREFIX, true, false, null);
+    exit_section_(b, l, m, true, false, null);
     return true;
   }
 
@@ -2214,9 +2214,9 @@ public class ElixirParser implements PsiParser, LightPsiParser {
   // HEREDOC_PREFIX_WHITE_SPACE?
   public static boolean heredocPrefix(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "heredocPrefix")) return false;
-    Marker m = enter_section_(b, l, _NONE_, "<heredoc prefix>");
+    Marker m = enter_section_(b, l, _NONE_, HEREDOC_PREFIX, "<heredoc prefix>");
     consumeToken(b, HEREDOC_PREFIX_WHITE_SPACE);
-    exit_section_(b, l, m, HEREDOC_PREFIX, true, false, null);
+    exit_section_(b, l, m, true, false, null);
     return true;
   }
 
@@ -2226,10 +2226,10 @@ public class ElixirParser implements PsiParser, LightPsiParser {
     if (!recursion_guard_(b, l, "hexadecimalDigits")) return false;
     if (!nextTokenIs(b, "<hexadecimal digits>", INVALID_HEXADECIMAL_DIGITS, VALID_HEXADECIMAL_DIGITS)) return false;
     boolean r;
-    Marker m = enter_section_(b, l, _NONE_, "<hexadecimal digits>");
+    Marker m = enter_section_(b, l, _NONE_, HEXADECIMAL_DIGITS, "<hexadecimal digits>");
     r = consumeToken(b, INVALID_HEXADECIMAL_DIGITS);
     if (!r) r = consumeToken(b, VALID_HEXADECIMAL_DIGITS);
-    exit_section_(b, l, m, HEXADECIMAL_DIGITS, r, false, null);
+    exit_section_(b, l, m, r, false, null);
     return r;
   }
 
@@ -2263,12 +2263,12 @@ public class ElixirParser implements PsiParser, LightPsiParser {
     if (!recursion_guard_(b, l, "hexadecimalWholeNumber")) return false;
     if (!nextTokenIs(b, BASE_WHOLE_NUMBER_PREFIX)) return false;
     boolean r, p;
-    Marker m = enter_section_(b, l, _NONE_, null);
+    Marker m = enter_section_(b, l, _NONE_, HEXADECIMAL_WHOLE_NUMBER, null);
     r = consumeToken(b, BASE_WHOLE_NUMBER_PREFIX);
     r = r && hexadecimalWholeNumber_1(b, l + 1);
     p = r; // pin = 2
     r = r && hexadecimalWholeNumber_2(b, l + 1);
-    exit_section_(b, l, m, HEXADECIMAL_WHOLE_NUMBER, r, p, null);
+    exit_section_(b, l, m, r, p, null);
     return r || p;
   }
 
@@ -2317,11 +2317,11 @@ public class ElixirParser implements PsiParser, LightPsiParser {
     if (!recursion_guard_(b, l, "inInfixOperator")) return false;
     if (!nextTokenIs(b, "<in>", EOL, IN_OPERATOR)) return false;
     boolean r;
-    Marker m = enter_section_(b, l, _NONE_, "<in>");
+    Marker m = enter_section_(b, l, _NONE_, IN_INFIX_OPERATOR, "<in>");
     r = inInfixOperator_0(b, l + 1);
     r = r && consumeToken(b, IN_OPERATOR);
     r = r && inInfixOperator_2(b, l + 1);
-    exit_section_(b, l, m, IN_INFIX_OPERATOR, r, false, null);
+    exit_section_(b, l, m, r, false, null);
     return r;
   }
 
@@ -2355,11 +2355,11 @@ public class ElixirParser implements PsiParser, LightPsiParser {
     if (!recursion_guard_(b, l, "inMatchInfixOperator")) return false;
     if (!nextTokenIs(b, "<<-, \\\\>", EOL, IN_MATCH_OPERATOR)) return false;
     boolean r;
-    Marker m = enter_section_(b, l, _NONE_, "<<-, \\\\>");
+    Marker m = enter_section_(b, l, _NONE_, IN_MATCH_INFIX_OPERATOR, "<<-, \\\\>");
     r = inMatchInfixOperator_0(b, l + 1);
     r = r && consumeToken(b, IN_MATCH_OPERATOR);
     r = r && inMatchInfixOperator_2(b, l + 1);
-    exit_section_(b, l, m, IN_MATCH_INFIX_OPERATOR, r, false, null);
+    exit_section_(b, l, m, r, false, null);
     return r;
   }
 
@@ -2454,14 +2454,14 @@ public class ElixirParser implements PsiParser, LightPsiParser {
   // (interpolation | CHAR_LIST_FRAGMENT | sigilEscapeSequence)*
   public static boolean interpolatedCharListBody(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "interpolatedCharListBody")) return false;
-    Marker m = enter_section_(b, l, _NONE_, "<interpolated char list body>");
+    Marker m = enter_section_(b, l, _NONE_, INTERPOLATED_CHAR_LIST_BODY, "<interpolated char list body>");
     int c = current_position_(b);
     while (true) {
       if (!interpolatedCharListBody_0(b, l + 1)) break;
       if (!empty_element_parsed_guard_(b, "interpolatedCharListBody", c)) break;
       c = current_position_(b);
     }
-    exit_section_(b, l, m, INTERPOLATED_CHAR_LIST_BODY, true, false, null);
+    exit_section_(b, l, m, true, false, null);
     return true;
   }
 
@@ -2482,11 +2482,11 @@ public class ElixirParser implements PsiParser, LightPsiParser {
   public static boolean interpolatedCharListHeredocLine(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "interpolatedCharListHeredocLine")) return false;
     boolean r;
-    Marker m = enter_section_(b, l, _NONE_, "<interpolated char list heredoc line>");
+    Marker m = enter_section_(b, l, _NONE_, INTERPOLATED_CHAR_LIST_HEREDOC_LINE, "<interpolated char list heredoc line>");
     r = heredocLinePrefix(b, l + 1);
     r = r && interpolatedCharListBody(b, l + 1);
     r = r && consumeToken(b, EOL);
-    exit_section_(b, l, m, INTERPOLATED_CHAR_LIST_HEREDOC_LINE, r, false, null);
+    exit_section_(b, l, m, r, false, null);
     return r;
   }
 
@@ -2498,14 +2498,14 @@ public class ElixirParser implements PsiParser, LightPsiParser {
     if (!recursion_guard_(b, l, "interpolatedCharListSigilHeredoc")) return false;
     if (!nextTokenIs(b, TILDE)) return false;
     boolean r, p;
-    Marker m = enter_section_(b, l, _NONE_, null);
+    Marker m = enter_section_(b, l, _NONE_, INTERPOLATED_CHAR_LIST_SIGIL_HEREDOC, null);
     r = consumeTokens(b, 3, TILDE, INTERPOLATING_CHAR_LIST_SIGIL_NAME, CHAR_LIST_SIGIL_HEREDOC_PROMOTER, EOL);
     p = r; // pin = 3
     r = r && report_error_(b, interpolatedCharListSigilHeredoc_4(b, l + 1));
     r = p && report_error_(b, heredocPrefix(b, l + 1)) && r;
     r = p && report_error_(b, consumeToken(b, CHAR_LIST_SIGIL_HEREDOC_TERMINATOR)) && r;
     r = p && sigilModifiers(b, l + 1) && r;
-    exit_section_(b, l, m, INTERPOLATED_CHAR_LIST_SIGIL_HEREDOC, r, p, null);
+    exit_section_(b, l, m, r, p, null);
     return r || p;
   }
 
@@ -2540,14 +2540,14 @@ public class ElixirParser implements PsiParser, LightPsiParser {
   // (interpolation | REGEX_FRAGMENT | sigilEscapeSequence)*
   public static boolean interpolatedRegexBody(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "interpolatedRegexBody")) return false;
-    Marker m = enter_section_(b, l, _NONE_, "<interpolated regex body>");
+    Marker m = enter_section_(b, l, _NONE_, INTERPOLATED_REGEX_BODY, "<interpolated regex body>");
     int c = current_position_(b);
     while (true) {
       if (!interpolatedRegexBody_0(b, l + 1)) break;
       if (!empty_element_parsed_guard_(b, "interpolatedRegexBody", c)) break;
       c = current_position_(b);
     }
-    exit_section_(b, l, m, INTERPOLATED_REGEX_BODY, true, false, null);
+    exit_section_(b, l, m, true, false, null);
     return true;
   }
 
@@ -2571,14 +2571,14 @@ public class ElixirParser implements PsiParser, LightPsiParser {
     if (!recursion_guard_(b, l, "interpolatedRegexHeredoc")) return false;
     if (!nextTokenIs(b, TILDE)) return false;
     boolean r, p;
-    Marker m = enter_section_(b, l, _NONE_, null);
+    Marker m = enter_section_(b, l, _NONE_, INTERPOLATED_REGEX_HEREDOC, null);
     r = consumeTokens(b, 3, TILDE, INTERPOLATING_REGEX_SIGIL_NAME, REGEX_HEREDOC_PROMOTER, EOL);
     p = r; // pin = 3
     r = r && report_error_(b, interpolatedRegexHeredoc_4(b, l + 1));
     r = p && report_error_(b, heredocPrefix(b, l + 1)) && r;
     r = p && report_error_(b, consumeToken(b, REGEX_HEREDOC_TERMINATOR)) && r;
     r = p && sigilModifiers(b, l + 1) && r;
-    exit_section_(b, l, m, INTERPOLATED_REGEX_HEREDOC, r, p, null);
+    exit_section_(b, l, m, r, p, null);
     return r || p;
   }
 
@@ -2599,11 +2599,11 @@ public class ElixirParser implements PsiParser, LightPsiParser {
   public static boolean interpolatedRegexHeredocLine(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "interpolatedRegexHeredocLine")) return false;
     boolean r;
-    Marker m = enter_section_(b, l, _NONE_, "<interpolated regex heredoc line>");
+    Marker m = enter_section_(b, l, _NONE_, INTERPOLATED_REGEX_HEREDOC_LINE, "<interpolated regex heredoc line>");
     r = heredocLinePrefix(b, l + 1);
     r = r && interpolatedRegexBody(b, l + 1);
     r = r && consumeToken(b, EOL);
-    exit_section_(b, l, m, INTERPOLATED_REGEX_HEREDOC_LINE, r, false, null);
+    exit_section_(b, l, m, r, false, null);
     return r;
   }
 
@@ -2626,14 +2626,14 @@ public class ElixirParser implements PsiParser, LightPsiParser {
   // (interpolation | SIGIL_FRAGMENT | sigilEscapeSequence)*
   public static boolean interpolatedSigilBody(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "interpolatedSigilBody")) return false;
-    Marker m = enter_section_(b, l, _NONE_, "<interpolated sigil body>");
+    Marker m = enter_section_(b, l, _NONE_, INTERPOLATED_SIGIL_BODY, "<interpolated sigil body>");
     int c = current_position_(b);
     while (true) {
       if (!interpolatedSigilBody_0(b, l + 1)) break;
       if (!empty_element_parsed_guard_(b, "interpolatedSigilBody", c)) break;
       c = current_position_(b);
     }
-    exit_section_(b, l, m, INTERPOLATED_SIGIL_BODY, true, false, null);
+    exit_section_(b, l, m, true, false, null);
     return true;
   }
 
@@ -2657,14 +2657,14 @@ public class ElixirParser implements PsiParser, LightPsiParser {
     if (!recursion_guard_(b, l, "interpolatedSigilHeredoc")) return false;
     if (!nextTokenIs(b, TILDE)) return false;
     boolean r, p;
-    Marker m = enter_section_(b, l, _NONE_, null);
+    Marker m = enter_section_(b, l, _NONE_, INTERPOLATED_SIGIL_HEREDOC, null);
     r = consumeTokens(b, 3, TILDE, INTERPOLATING_SIGIL_NAME, SIGIL_HEREDOC_PROMOTER, EOL);
     p = r; // pin = 3
     r = r && report_error_(b, interpolatedSigilHeredoc_4(b, l + 1));
     r = p && report_error_(b, heredocPrefix(b, l + 1)) && r;
     r = p && report_error_(b, consumeToken(b, SIGIL_HEREDOC_TERMINATOR)) && r;
     r = p && sigilModifiers(b, l + 1) && r;
-    exit_section_(b, l, m, INTERPOLATED_SIGIL_HEREDOC, r, p, null);
+    exit_section_(b, l, m, r, p, null);
     return r || p;
   }
 
@@ -2685,11 +2685,11 @@ public class ElixirParser implements PsiParser, LightPsiParser {
   public static boolean interpolatedSigilHeredocLine(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "interpolatedSigilHeredocLine")) return false;
     boolean r;
-    Marker m = enter_section_(b, l, _NONE_, "<interpolated sigil heredoc line>");
+    Marker m = enter_section_(b, l, _NONE_, INTERPOLATED_SIGIL_HEREDOC_LINE, "<interpolated sigil heredoc line>");
     r = heredocLinePrefix(b, l + 1);
     r = r && interpolatedSigilBody(b, l + 1);
     r = r && consumeToken(b, EOL);
-    exit_section_(b, l, m, INTERPOLATED_SIGIL_HEREDOC_LINE, r, false, null);
+    exit_section_(b, l, m, r, false, null);
     return r;
   }
 
@@ -2712,14 +2712,14 @@ public class ElixirParser implements PsiParser, LightPsiParser {
   // (interpolation | STRING_FRAGMENT | sigilEscapeSequence)*
   public static boolean interpolatedStringBody(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "interpolatedStringBody")) return false;
-    Marker m = enter_section_(b, l, _NONE_, "<interpolated string body>");
+    Marker m = enter_section_(b, l, _NONE_, INTERPOLATED_STRING_BODY, "<interpolated string body>");
     int c = current_position_(b);
     while (true) {
       if (!interpolatedStringBody_0(b, l + 1)) break;
       if (!empty_element_parsed_guard_(b, "interpolatedStringBody", c)) break;
       c = current_position_(b);
     }
-    exit_section_(b, l, m, INTERPOLATED_STRING_BODY, true, false, null);
+    exit_section_(b, l, m, true, false, null);
     return true;
   }
 
@@ -2740,11 +2740,11 @@ public class ElixirParser implements PsiParser, LightPsiParser {
   public static boolean interpolatedStringHeredocLine(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "interpolatedStringHeredocLine")) return false;
     boolean r;
-    Marker m = enter_section_(b, l, _NONE_, "<interpolated string heredoc line>");
+    Marker m = enter_section_(b, l, _NONE_, INTERPOLATED_STRING_HEREDOC_LINE, "<interpolated string heredoc line>");
     r = heredocLinePrefix(b, l + 1);
     r = r && interpolatedStringBody(b, l + 1);
     r = r && consumeToken(b, EOL);
-    exit_section_(b, l, m, INTERPOLATED_STRING_HEREDOC_LINE, r, false, null);
+    exit_section_(b, l, m, r, false, null);
     return r;
   }
 
@@ -2756,14 +2756,14 @@ public class ElixirParser implements PsiParser, LightPsiParser {
     if (!recursion_guard_(b, l, "interpolatedStringSigilHeredoc")) return false;
     if (!nextTokenIs(b, TILDE)) return false;
     boolean r, p;
-    Marker m = enter_section_(b, l, _NONE_, null);
+    Marker m = enter_section_(b, l, _NONE_, INTERPOLATED_STRING_SIGIL_HEREDOC, null);
     r = consumeTokens(b, 3, TILDE, INTERPOLATING_STRING_SIGIL_NAME, STRING_SIGIL_HEREDOC_PROMOTER, EOL);
     p = r; // pin = 3
     r = r && report_error_(b, interpolatedStringSigilHeredoc_4(b, l + 1));
     r = p && report_error_(b, heredocPrefix(b, l + 1)) && r;
     r = p && report_error_(b, consumeToken(b, STRING_SIGIL_HEREDOC_TERMINATOR)) && r;
     r = p && sigilModifiers(b, l + 1) && r;
-    exit_section_(b, l, m, INTERPOLATED_STRING_SIGIL_HEREDOC, r, p, null);
+    exit_section_(b, l, m, r, p, null);
     return r || p;
   }
 
@@ -2798,14 +2798,14 @@ public class ElixirParser implements PsiParser, LightPsiParser {
   // (interpolation | WORDS_FRAGMENT | sigilEscapeSequence)*
   public static boolean interpolatedWordsBody(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "interpolatedWordsBody")) return false;
-    Marker m = enter_section_(b, l, _NONE_, "<interpolated words body>");
+    Marker m = enter_section_(b, l, _NONE_, INTERPOLATED_WORDS_BODY, "<interpolated words body>");
     int c = current_position_(b);
     while (true) {
       if (!interpolatedWordsBody_0(b, l + 1)) break;
       if (!empty_element_parsed_guard_(b, "interpolatedWordsBody", c)) break;
       c = current_position_(b);
     }
-    exit_section_(b, l, m, INTERPOLATED_WORDS_BODY, true, false, null);
+    exit_section_(b, l, m, true, false, null);
     return true;
   }
 
@@ -2829,14 +2829,14 @@ public class ElixirParser implements PsiParser, LightPsiParser {
     if (!recursion_guard_(b, l, "interpolatedWordsHeredoc")) return false;
     if (!nextTokenIs(b, TILDE)) return false;
     boolean r, p;
-    Marker m = enter_section_(b, l, _NONE_, null);
+    Marker m = enter_section_(b, l, _NONE_, INTERPOLATED_WORDS_HEREDOC, null);
     r = consumeTokens(b, 3, TILDE, INTERPOLATING_WORDS_SIGIL_NAME, WORDS_HEREDOC_PROMOTER, EOL);
     p = r; // pin = 3
     r = r && report_error_(b, interpolatedWordsHeredoc_4(b, l + 1));
     r = p && report_error_(b, heredocPrefix(b, l + 1)) && r;
     r = p && report_error_(b, consumeToken(b, WORDS_HEREDOC_TERMINATOR)) && r;
     r = p && sigilModifiers(b, l + 1) && r;
-    exit_section_(b, l, m, INTERPOLATED_WORDS_HEREDOC, r, p, null);
+    exit_section_(b, l, m, r, p, null);
     return r || p;
   }
 
@@ -2857,11 +2857,11 @@ public class ElixirParser implements PsiParser, LightPsiParser {
   public static boolean interpolatedWordsHeredocLine(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "interpolatedWordsHeredocLine")) return false;
     boolean r;
-    Marker m = enter_section_(b, l, _NONE_, "<interpolated words heredoc line>");
+    Marker m = enter_section_(b, l, _NONE_, INTERPOLATED_WORDS_HEREDOC_LINE, "<interpolated words heredoc line>");
     r = heredocLinePrefix(b, l + 1);
     r = r && interpolatedWordsBody(b, l + 1);
     r = r && consumeToken(b, EOL);
-    exit_section_(b, l, m, INTERPOLATED_WORDS_HEREDOC_LINE, r, false, null);
+    exit_section_(b, l, m, r, false, null);
     return r;
   }
 
@@ -2928,7 +2928,7 @@ public class ElixirParser implements PsiParser, LightPsiParser {
   public static boolean keywordKey(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "keywordKey")) return false;
     boolean r;
-    Marker m = enter_section_(b, l, _NONE_, "<keyword key>");
+    Marker m = enter_section_(b, l, _NONE_, KEYWORD_KEY, "<keyword key>");
     r = consumeToken(b, AFTER);
     if (!r) r = consumeToken(b, ALIAS_TOKEN);
     if (!r) r = consumeToken(b, AND_OPERATOR);
@@ -2959,7 +2959,7 @@ public class ElixirParser implements PsiParser, LightPsiParser {
     if (!r) r = consumeToken(b, UNARY_OPERATOR);
     if (!r) r = consumeToken(b, WHEN_OPERATOR);
     if (!r) r = quote(b, l + 1);
-    exit_section_(b, l, m, KEYWORD_KEY, r, false, null);
+    exit_section_(b, l, m, r, false, null);
     return r;
   }
 
@@ -2993,10 +2993,10 @@ public class ElixirParser implements PsiParser, LightPsiParser {
   public static boolean keywordPair(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "keywordPair")) return false;
     boolean r;
-    Marker m = enter_section_(b, l, _NONE_, "<keyword pair>");
+    Marker m = enter_section_(b, l, _NONE_, KEYWORD_PAIR, "<keyword pair>");
     r = keywordKeyColonEOL(b, l + 1);
     r = r && containerExpression(b, l + 1);
-    exit_section_(b, l, m, KEYWORD_PAIR, r, false, null);
+    exit_section_(b, l, m, r, false, null);
     return r;
   }
 
@@ -3005,11 +3005,11 @@ public class ElixirParser implements PsiParser, LightPsiParser {
   public static boolean keywords(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "keywords")) return false;
     boolean r;
-    Marker m = enter_section_(b, l, _NONE_, "<keywords>");
+    Marker m = enter_section_(b, l, _NONE_, KEYWORDS, "<keywords>");
     r = keywordPair(b, l + 1);
     r = r && keywords_1(b, l + 1);
     r = r && keywords_2(b, l + 1);
-    exit_section_(b, l, m, KEYWORDS, r, false, null);
+    exit_section_(b, l, m, r, false, null);
     return r;
   }
 
@@ -3109,14 +3109,14 @@ public class ElixirParser implements PsiParser, LightPsiParser {
   // (CHAR_LIST_FRAGMENT | sigilEscapeSequence)*
   public static boolean literalCharListBody(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "literalCharListBody")) return false;
-    Marker m = enter_section_(b, l, _NONE_, "<literal char list body>");
+    Marker m = enter_section_(b, l, _NONE_, LITERAL_CHAR_LIST_BODY, "<literal char list body>");
     int c = current_position_(b);
     while (true) {
       if (!literalCharListBody_0(b, l + 1)) break;
       if (!empty_element_parsed_guard_(b, "literalCharListBody", c)) break;
       c = current_position_(b);
     }
-    exit_section_(b, l, m, LITERAL_CHAR_LIST_BODY, true, false, null);
+    exit_section_(b, l, m, true, false, null);
     return true;
   }
 
@@ -3136,11 +3136,11 @@ public class ElixirParser implements PsiParser, LightPsiParser {
   public static boolean literalCharListHeredocLine(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "literalCharListHeredocLine")) return false;
     boolean r;
-    Marker m = enter_section_(b, l, _NONE_, "<literal char list heredoc line>");
+    Marker m = enter_section_(b, l, _NONE_, LITERAL_CHAR_LIST_HEREDOC_LINE, "<literal char list heredoc line>");
     r = heredocLinePrefix(b, l + 1);
     r = r && literalCharListBody(b, l + 1);
     r = r && consumeToken(b, EOL);
-    exit_section_(b, l, m, LITERAL_CHAR_LIST_HEREDOC_LINE, r, false, null);
+    exit_section_(b, l, m, r, false, null);
     return r;
   }
 
@@ -3152,14 +3152,14 @@ public class ElixirParser implements PsiParser, LightPsiParser {
     if (!recursion_guard_(b, l, "literalCharListSigilHeredoc")) return false;
     if (!nextTokenIs(b, TILDE)) return false;
     boolean r, p;
-    Marker m = enter_section_(b, l, _NONE_, null);
+    Marker m = enter_section_(b, l, _NONE_, LITERAL_CHAR_LIST_SIGIL_HEREDOC, null);
     r = consumeTokens(b, 3, TILDE, LITERAL_CHAR_LIST_SIGIL_NAME, CHAR_LIST_SIGIL_HEREDOC_PROMOTER, EOL);
     p = r; // pin = 3
     r = r && report_error_(b, literalCharListSigilHeredoc_4(b, l + 1));
     r = p && report_error_(b, heredocPrefix(b, l + 1)) && r;
     r = p && report_error_(b, consumeToken(b, CHAR_LIST_SIGIL_HEREDOC_TERMINATOR)) && r;
     r = p && sigilModifiers(b, l + 1) && r;
-    exit_section_(b, l, m, LITERAL_CHAR_LIST_SIGIL_HEREDOC, r, p, null);
+    exit_section_(b, l, m, r, p, null);
     return r || p;
   }
 
@@ -3194,14 +3194,14 @@ public class ElixirParser implements PsiParser, LightPsiParser {
   // (REGEX_FRAGMENT | sigilEscapeSequence)*
   public static boolean literalRegexBody(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "literalRegexBody")) return false;
-    Marker m = enter_section_(b, l, _NONE_, "<literal regex body>");
+    Marker m = enter_section_(b, l, _NONE_, LITERAL_REGEX_BODY, "<literal regex body>");
     int c = current_position_(b);
     while (true) {
       if (!literalRegexBody_0(b, l + 1)) break;
       if (!empty_element_parsed_guard_(b, "literalRegexBody", c)) break;
       c = current_position_(b);
     }
-    exit_section_(b, l, m, LITERAL_REGEX_BODY, true, false, null);
+    exit_section_(b, l, m, true, false, null);
     return true;
   }
 
@@ -3224,14 +3224,14 @@ public class ElixirParser implements PsiParser, LightPsiParser {
     if (!recursion_guard_(b, l, "literalRegexHeredoc")) return false;
     if (!nextTokenIs(b, TILDE)) return false;
     boolean r, p;
-    Marker m = enter_section_(b, l, _NONE_, null);
+    Marker m = enter_section_(b, l, _NONE_, LITERAL_REGEX_HEREDOC, null);
     r = consumeTokens(b, 3, TILDE, LITERAL_REGEX_SIGIL_NAME, REGEX_HEREDOC_PROMOTER, EOL);
     p = r; // pin = 3
     r = r && report_error_(b, literalRegexHeredoc_4(b, l + 1));
     r = p && report_error_(b, heredocPrefix(b, l + 1)) && r;
     r = p && report_error_(b, consumeToken(b, REGEX_HEREDOC_TERMINATOR)) && r;
     r = p && sigilModifiers(b, l + 1) && r;
-    exit_section_(b, l, m, LITERAL_REGEX_HEREDOC, r, p, null);
+    exit_section_(b, l, m, r, p, null);
     return r || p;
   }
 
@@ -3252,11 +3252,11 @@ public class ElixirParser implements PsiParser, LightPsiParser {
   public static boolean literalRegexHeredocLine(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "literalRegexHeredocLine")) return false;
     boolean r;
-    Marker m = enter_section_(b, l, _NONE_, "<literal regex heredoc line>");
+    Marker m = enter_section_(b, l, _NONE_, LITERAL_REGEX_HEREDOC_LINE, "<literal regex heredoc line>");
     r = heredocLinePrefix(b, l + 1);
     r = r && literalRegexBody(b, l + 1);
     r = r && consumeToken(b, EOL);
-    exit_section_(b, l, m, LITERAL_REGEX_HEREDOC_LINE, r, false, null);
+    exit_section_(b, l, m, r, false, null);
     return r;
   }
 
@@ -3279,14 +3279,14 @@ public class ElixirParser implements PsiParser, LightPsiParser {
   // (SIGIL_FRAGMENT | sigilEscapeSequence)*
   public static boolean literalSigilBody(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "literalSigilBody")) return false;
-    Marker m = enter_section_(b, l, _NONE_, "<literal sigil body>");
+    Marker m = enter_section_(b, l, _NONE_, LITERAL_SIGIL_BODY, "<literal sigil body>");
     int c = current_position_(b);
     while (true) {
       if (!literalSigilBody_0(b, l + 1)) break;
       if (!empty_element_parsed_guard_(b, "literalSigilBody", c)) break;
       c = current_position_(b);
     }
-    exit_section_(b, l, m, LITERAL_SIGIL_BODY, true, false, null);
+    exit_section_(b, l, m, true, false, null);
     return true;
   }
 
@@ -3309,14 +3309,14 @@ public class ElixirParser implements PsiParser, LightPsiParser {
     if (!recursion_guard_(b, l, "literalSigilHeredoc")) return false;
     if (!nextTokenIs(b, TILDE)) return false;
     boolean r, p;
-    Marker m = enter_section_(b, l, _NONE_, null);
+    Marker m = enter_section_(b, l, _NONE_, LITERAL_SIGIL_HEREDOC, null);
     r = consumeTokens(b, 3, TILDE, LITERAL_SIGIL_NAME, SIGIL_HEREDOC_PROMOTER, EOL);
     p = r; // pin = 3
     r = r && report_error_(b, literalSigilHeredoc_4(b, l + 1));
     r = p && report_error_(b, heredocPrefix(b, l + 1)) && r;
     r = p && report_error_(b, consumeToken(b, SIGIL_HEREDOC_TERMINATOR)) && r;
     r = p && sigilModifiers(b, l + 1) && r;
-    exit_section_(b, l, m, LITERAL_SIGIL_HEREDOC, r, p, null);
+    exit_section_(b, l, m, r, p, null);
     return r || p;
   }
 
@@ -3337,11 +3337,11 @@ public class ElixirParser implements PsiParser, LightPsiParser {
   public static boolean literalSigilHeredocLine(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "literalSigilHeredocLine")) return false;
     boolean r;
-    Marker m = enter_section_(b, l, _NONE_, "<literal sigil heredoc line>");
+    Marker m = enter_section_(b, l, _NONE_, LITERAL_SIGIL_HEREDOC_LINE, "<literal sigil heredoc line>");
     r = heredocLinePrefix(b, l + 1);
     r = r && literalSigilBody(b, l + 1);
     r = r && consumeToken(b, EOL);
-    exit_section_(b, l, m, LITERAL_SIGIL_HEREDOC_LINE, r, false, null);
+    exit_section_(b, l, m, r, false, null);
     return r;
   }
 
@@ -3364,14 +3364,14 @@ public class ElixirParser implements PsiParser, LightPsiParser {
   // (STRING_FRAGMENT | sigilEscapeSequence)*
   public static boolean literalStringBody(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "literalStringBody")) return false;
-    Marker m = enter_section_(b, l, _NONE_, "<literal string body>");
+    Marker m = enter_section_(b, l, _NONE_, LITERAL_STRING_BODY, "<literal string body>");
     int c = current_position_(b);
     while (true) {
       if (!literalStringBody_0(b, l + 1)) break;
       if (!empty_element_parsed_guard_(b, "literalStringBody", c)) break;
       c = current_position_(b);
     }
-    exit_section_(b, l, m, LITERAL_STRING_BODY, true, false, null);
+    exit_section_(b, l, m, true, false, null);
     return true;
   }
 
@@ -3391,11 +3391,11 @@ public class ElixirParser implements PsiParser, LightPsiParser {
   public static boolean literalStringHeredocLine(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "literalStringHeredocLine")) return false;
     boolean r;
-    Marker m = enter_section_(b, l, _NONE_, "<literal string heredoc line>");
+    Marker m = enter_section_(b, l, _NONE_, LITERAL_STRING_HEREDOC_LINE, "<literal string heredoc line>");
     r = heredocLinePrefix(b, l + 1);
     r = r && literalStringBody(b, l + 1);
     r = r && consumeToken(b, EOL);
-    exit_section_(b, l, m, LITERAL_STRING_HEREDOC_LINE, r, false, null);
+    exit_section_(b, l, m, r, false, null);
     return r;
   }
 
@@ -3407,14 +3407,14 @@ public class ElixirParser implements PsiParser, LightPsiParser {
     if (!recursion_guard_(b, l, "literalStringSigilHeredoc")) return false;
     if (!nextTokenIs(b, TILDE)) return false;
     boolean r, p;
-    Marker m = enter_section_(b, l, _NONE_, null);
+    Marker m = enter_section_(b, l, _NONE_, LITERAL_STRING_SIGIL_HEREDOC, null);
     r = consumeTokens(b, 3, TILDE, LITERAL_STRING_SIGIL_NAME, STRING_SIGIL_HEREDOC_PROMOTER, EOL);
     p = r; // pin = 3
     r = r && report_error_(b, literalStringSigilHeredoc_4(b, l + 1));
     r = p && report_error_(b, heredocPrefix(b, l + 1)) && r;
     r = p && report_error_(b, consumeToken(b, STRING_SIGIL_HEREDOC_TERMINATOR)) && r;
     r = p && sigilModifiers(b, l + 1) && r;
-    exit_section_(b, l, m, LITERAL_STRING_SIGIL_HEREDOC, r, p, null);
+    exit_section_(b, l, m, r, p, null);
     return r || p;
   }
 
@@ -3449,14 +3449,14 @@ public class ElixirParser implements PsiParser, LightPsiParser {
   // (WORDS_FRAGMENT | sigilEscapeSequence)*
   public static boolean literalWordsBody(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "literalWordsBody")) return false;
-    Marker m = enter_section_(b, l, _NONE_, "<literal words body>");
+    Marker m = enter_section_(b, l, _NONE_, LITERAL_WORDS_BODY, "<literal words body>");
     int c = current_position_(b);
     while (true) {
       if (!literalWordsBody_0(b, l + 1)) break;
       if (!empty_element_parsed_guard_(b, "literalWordsBody", c)) break;
       c = current_position_(b);
     }
-    exit_section_(b, l, m, LITERAL_WORDS_BODY, true, false, null);
+    exit_section_(b, l, m, true, false, null);
     return true;
   }
 
@@ -3479,14 +3479,14 @@ public class ElixirParser implements PsiParser, LightPsiParser {
     if (!recursion_guard_(b, l, "literalWordsHeredoc")) return false;
     if (!nextTokenIs(b, TILDE)) return false;
     boolean r, p;
-    Marker m = enter_section_(b, l, _NONE_, null);
+    Marker m = enter_section_(b, l, _NONE_, LITERAL_WORDS_HEREDOC, null);
     r = consumeTokens(b, 3, TILDE, LITERAL_WORDS_SIGIL_NAME, WORDS_HEREDOC_PROMOTER, EOL);
     p = r; // pin = 3
     r = r && report_error_(b, literalWordsHeredoc_4(b, l + 1));
     r = p && report_error_(b, heredocPrefix(b, l + 1)) && r;
     r = p && report_error_(b, consumeToken(b, WORDS_HEREDOC_TERMINATOR)) && r;
     r = p && sigilModifiers(b, l + 1) && r;
-    exit_section_(b, l, m, LITERAL_WORDS_HEREDOC, r, p, null);
+    exit_section_(b, l, m, r, p, null);
     return r || p;
   }
 
@@ -3507,11 +3507,11 @@ public class ElixirParser implements PsiParser, LightPsiParser {
   public static boolean literalWordsHeredocLine(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "literalWordsHeredocLine")) return false;
     boolean r;
-    Marker m = enter_section_(b, l, _NONE_, "<literal words heredoc line>");
+    Marker m = enter_section_(b, l, _NONE_, LITERAL_WORDS_HEREDOC_LINE, "<literal words heredoc line>");
     r = heredocLinePrefix(b, l + 1);
     r = r && literalWordsBody(b, l + 1);
     r = r && consumeToken(b, EOL);
-    exit_section_(b, l, m, LITERAL_WORDS_HEREDOC_LINE, r, false, null);
+    exit_section_(b, l, m, r, false, null);
     return r;
   }
 
@@ -3618,9 +3618,9 @@ public class ElixirParser implements PsiParser, LightPsiParser {
   public static boolean mapConstructionArguments(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "mapConstructionArguments")) return false;
     boolean r;
-    Marker m = enter_section_(b, l, _NONE_, "<map construction arguments>");
+    Marker m = enter_section_(b, l, _NONE_, MAP_CONSTRUCTION_ARGUMENTS, "<map construction arguments>");
     r = mapTailArguments(b, l + 1);
-    exit_section_(b, l, m, MAP_CONSTRUCTION_ARGUMENTS, r, false, null);
+    exit_section_(b, l, m, r, false, null);
     return r;
   }
 
@@ -3656,10 +3656,10 @@ public class ElixirParser implements PsiParser, LightPsiParser {
     if (!recursion_guard_(b, l, "mapPrefixOperator")) return false;
     if (!nextTokenIs(b, STRUCT_OPERATOR)) return false;
     boolean r;
-    Marker m = enter_section_(b);
+    Marker m = enter_section_(b, l, _NONE_, MAP_PREFIX_OPERATOR, "<%>");
     r = consumeToken(b, STRUCT_OPERATOR);
     r = r && mapPrefixOperator_1(b, l + 1);
-    exit_section_(b, m, MAP_PREFIX_OPERATOR, r);
+    exit_section_(b, l, m, r, false, null);
     return r;
   }
 
@@ -3707,11 +3707,11 @@ public class ElixirParser implements PsiParser, LightPsiParser {
   public static boolean mapUpdateArguments(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "mapUpdateArguments")) return false;
     boolean r;
-    Marker m = enter_section_(b, l, _NONE_, "<map update arguments>");
+    Marker m = enter_section_(b, l, _NONE_, MAP_UPDATE_ARGUMENTS, "<map update arguments>");
     r = matchedExpression(b, l + 1, 5);
     r = r && pipeInfixOperator(b, l + 1);
     r = r && mapTailArguments(b, l + 1);
-    exit_section_(b, l, m, MAP_UPDATE_ARGUMENTS, r, false, null);
+    exit_section_(b, l, m, r, false, null);
     return r;
   }
 
@@ -3721,11 +3721,11 @@ public class ElixirParser implements PsiParser, LightPsiParser {
     if (!recursion_guard_(b, l, "matchInfixOperator")) return false;
     if (!nextTokenIs(b, "<=>", EOL, MATCH_OPERATOR)) return false;
     boolean r;
-    Marker m = enter_section_(b, l, _NONE_, "<=>");
+    Marker m = enter_section_(b, l, _NONE_, MATCH_INFIX_OPERATOR, "<=>");
     r = matchInfixOperator_0(b, l + 1);
     r = r && consumeToken(b, MATCH_OPERATOR);
     r = r && matchInfixOperator_2(b, l + 1);
-    exit_section_(b, l, m, MATCH_INFIX_OPERATOR, r, false, null);
+    exit_section_(b, l, m, r, false, null);
     return r;
   }
 
@@ -3780,11 +3780,11 @@ public class ElixirParser implements PsiParser, LightPsiParser {
     if (!recursion_guard_(b, l, "maxDotCall")) return false;
     if (!nextTokenIs(b, "<max dot call>", DOT_OPERATOR, EOL)) return false;
     boolean r;
-    Marker m = enter_section_(b, l, _LEFT_, "<max dot call>");
+    Marker m = enter_section_(b, l, _LEFT_, MATCHED_DOT_CALL, "<max dot call>");
     r = dotInfixOperator(b, l + 1);
     r = r && parenthesesArguments(b, l + 1);
     r = r && maxDotCall_2(b, l + 1);
-    exit_section_(b, l, m, MATCHED_DOT_CALL, r, false, null);
+    exit_section_(b, l, m, r, false, null);
     return r;
   }
 
@@ -3931,10 +3931,10 @@ public class ElixirParser implements PsiParser, LightPsiParser {
     if (!recursion_guard_(b, l, "maxQualifiedAlias")) return false;
     if (!nextTokenIs(b, "<max qualified alias>", DOT_OPERATOR, EOL)) return false;
     boolean r;
-    Marker m = enter_section_(b, l, _LEFT_, "<max qualified alias>");
+    Marker m = enter_section_(b, l, _LEFT_, MATCHED_QUALIFIED_ALIAS, "<max qualified alias>");
     r = dotInfixOperator(b, l + 1);
     r = r && alias(b, l + 1);
-    exit_section_(b, l, m, MATCHED_QUALIFIED_ALIAS, r, false, null);
+    exit_section_(b, l, m, r, false, null);
     return r;
   }
 
@@ -3944,11 +3944,11 @@ public class ElixirParser implements PsiParser, LightPsiParser {
     if (!recursion_guard_(b, l, "maxQualifiedNoArgumentsCall")) return false;
     if (!nextTokenIs(b, "<max qualified no arguments call>", DOT_OPERATOR, EOL)) return false;
     boolean r;
-    Marker m = enter_section_(b, l, _LEFT_, "<max qualified no arguments call>");
+    Marker m = enter_section_(b, l, _LEFT_, MATCHED_QUALIFIED_NO_ARGUMENTS_CALL, "<max qualified no arguments call>");
     r = dotInfixOperator(b, l + 1);
     r = r && relativeIdentifier(b, l + 1);
     r = r && maxQualifiedNoArgumentsCall_2(b, l + 1);
-    exit_section_(b, l, m, MATCHED_QUALIFIED_NO_ARGUMENTS_CALL, r, false, null);
+    exit_section_(b, l, m, r, false, null);
     return r;
   }
 
@@ -3956,9 +3956,9 @@ public class ElixirParser implements PsiParser, LightPsiParser {
   private static boolean maxQualifiedNoArgumentsCall_2(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "maxQualifiedNoArgumentsCall_2")) return false;
     boolean r;
-    Marker m = enter_section_(b, l, _NOT_, null);
+    Marker m = enter_section_(b, l, _NOT_);
     r = !consumeToken(b, CALL);
-    exit_section_(b, l, m, null, r, false, null);
+    exit_section_(b, l, m, r, false, null);
     return r;
   }
 
@@ -3968,11 +3968,11 @@ public class ElixirParser implements PsiParser, LightPsiParser {
     if (!recursion_guard_(b, l, "maxQualifiedParenthesesCall")) return false;
     if (!nextTokenIs(b, "<max qualified parentheses call>", DOT_OPERATOR, EOL)) return false;
     boolean r;
-    Marker m = enter_section_(b, l, _LEFT_, "<max qualified parentheses call>");
+    Marker m = enter_section_(b, l, _LEFT_, MATCHED_QUALIFIED_PARENTHESES_CALL, "<max qualified parentheses call>");
     r = dotInfixOperator(b, l + 1);
     r = r && relativeIdentifier(b, l + 1);
     r = r && matchedParenthesesArguments(b, l + 1);
-    exit_section_(b, l, m, MATCHED_QUALIFIED_PARENTHESES_CALL, r, false, null);
+    exit_section_(b, l, m, r, false, null);
     return r;
   }
 
@@ -3982,11 +3982,11 @@ public class ElixirParser implements PsiParser, LightPsiParser {
     if (!recursion_guard_(b, l, "multiplicationInfixOperator")) return false;
     if (!nextTokenIs(b, "<*, />", EOL, MULTIPLICATION_OPERATOR)) return false;
     boolean r;
-    Marker m = enter_section_(b, l, _NONE_, "<*, />");
+    Marker m = enter_section_(b, l, _NONE_, MULTIPLICATION_INFIX_OPERATOR, "<*, />");
     r = multiplicationInfixOperator_0(b, l + 1);
     r = r && consumeToken(b, MULTIPLICATION_OPERATOR);
     r = r && multiplicationInfixOperator_2(b, l + 1);
-    exit_section_(b, l, m, MULTIPLICATION_INFIX_OPERATOR, r, false, null);
+    exit_section_(b, l, m, r, false, null);
     return r;
   }
 
@@ -4020,10 +4020,10 @@ public class ElixirParser implements PsiParser, LightPsiParser {
   public static boolean noParenthesesArguments(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "noParenthesesArguments")) return false;
     boolean r;
-    Marker m = enter_section_(b, l, _NONE_, "<no parentheses arguments>");
+    Marker m = enter_section_(b, l, _NONE_, NO_PARENTHESES_ARGUMENTS, "<no parentheses arguments>");
     r = noParenthesesOneArgument(b, l + 1);
     if (!r) r = noParenthesesManyArguments(b, l + 1);
-    exit_section_(b, l, m, NO_PARENTHESES_ARGUMENTS, r, false, null);
+    exit_section_(b, l, m, r, false, null);
     return r;
   }
 
@@ -4052,10 +4052,10 @@ public class ElixirParser implements PsiParser, LightPsiParser {
   public static boolean noParenthesesKeywordPair(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "noParenthesesKeywordPair")) return false;
     boolean r;
-    Marker m = enter_section_(b, l, _NONE_, "<no parentheses keyword pair>");
+    Marker m = enter_section_(b, l, _NONE_, NO_PARENTHESES_KEYWORD_PAIR, "<no parentheses keyword pair>");
     r = keywordKeyColonEOL(b, l + 1);
     r = r && noParenthesesExpression(b, l + 1);
-    exit_section_(b, l, m, NO_PARENTHESES_KEYWORD_PAIR, r, false, null);
+    exit_section_(b, l, m, r, false, null);
     return r;
   }
 
@@ -4064,10 +4064,10 @@ public class ElixirParser implements PsiParser, LightPsiParser {
   public static boolean noParenthesesKeywords(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "noParenthesesKeywords")) return false;
     boolean r;
-    Marker m = enter_section_(b, l, _NONE_, "<no parentheses keywords>");
+    Marker m = enter_section_(b, l, _NONE_, NO_PARENTHESES_KEYWORDS, "<no parentheses keywords>");
     r = noParenthesesKeywordPair(b, l + 1);
     r = r && noParenthesesKeywords_1(b, l + 1);
-    exit_section_(b, l, m, NO_PARENTHESES_KEYWORDS, r, false, null);
+    exit_section_(b, l, m, r, false, null);
     return r;
   }
 
@@ -4136,9 +4136,9 @@ public class ElixirParser implements PsiParser, LightPsiParser {
   private static boolean noParenthesesManyArguments_1_0(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "noParenthesesManyArguments_1_0")) return false;
     boolean r;
-    Marker m = enter_section_(b, l, _NOT_, null);
+    Marker m = enter_section_(b, l, _NOT_);
     r = !additionTail(b, l + 1);
-    exit_section_(b, l, m, null, r, false, null);
+    exit_section_(b, l, m, r, false, null);
     return r;
   }
 
@@ -4230,12 +4230,12 @@ public class ElixirParser implements PsiParser, LightPsiParser {
   public static boolean noParenthesesOneArgument(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "noParenthesesOneArgument")) return false;
     boolean r;
-    Marker m = enter_section_(b, l, _NONE_, "<no parentheses one argument>");
+    Marker m = enter_section_(b, l, _NONE_, NO_PARENTHESES_ONE_ARGUMENT, "<no parentheses one argument>");
     r = noParenthesesKeywords(b, l + 1);
     if (!r) r = unqualifiedNoParenthesesManyArgumentsCall(b, l + 1);
     if (!r) r = noParenthesesManyArgumentsStrict(b, l + 1);
     if (!r) r = noParenthesesOneArgument_3(b, l + 1);
-    exit_section_(b, l, m, NO_PARENTHESES_ONE_ARGUMENT, r, false, null);
+    exit_section_(b, l, m, r, false, null);
     return r;
   }
 
@@ -4254,9 +4254,9 @@ public class ElixirParser implements PsiParser, LightPsiParser {
   private static boolean noParenthesesOneArgument_3_0(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "noParenthesesOneArgument_3_0")) return false;
     boolean r;
-    Marker m = enter_section_(b, l, _NOT_, null);
+    Marker m = enter_section_(b, l, _NOT_);
     r = !additionTail(b, l + 1);
-    exit_section_(b, l, m, null, r, false, null);
+    exit_section_(b, l, m, r, false, null);
     return r;
   }
 
@@ -4334,10 +4334,10 @@ public class ElixirParser implements PsiParser, LightPsiParser {
     if (!recursion_guard_(b, l, "octalDigits")) return false;
     if (!nextTokenIs(b, "<octal digits>", INVALID_OCTAL_DIGITS, VALID_OCTAL_DIGITS)) return false;
     boolean r;
-    Marker m = enter_section_(b, l, _NONE_, "<octal digits>");
+    Marker m = enter_section_(b, l, _NONE_, OCTAL_DIGITS, "<octal digits>");
     r = consumeToken(b, INVALID_OCTAL_DIGITS);
     if (!r) r = consumeToken(b, VALID_OCTAL_DIGITS);
-    exit_section_(b, l, m, OCTAL_DIGITS, r, false, null);
+    exit_section_(b, l, m, r, false, null);
     return r;
   }
 
@@ -4347,11 +4347,11 @@ public class ElixirParser implements PsiParser, LightPsiParser {
     if (!recursion_guard_(b, l, "octalWholeNumber")) return false;
     if (!nextTokenIs(b, BASE_WHOLE_NUMBER_PREFIX)) return false;
     boolean r, p;
-    Marker m = enter_section_(b, l, _NONE_, null);
+    Marker m = enter_section_(b, l, _NONE_, OCTAL_WHOLE_NUMBER, null);
     r = consumeTokens(b, 2, BASE_WHOLE_NUMBER_PREFIX, OCTAL_WHOLE_NUMBER_BASE);
     p = r; // pin = 2
     r = r && octalWholeNumber_2(b, l + 1);
-    exit_section_(b, l, m, OCTAL_WHOLE_NUMBER, r, p, null);
+    exit_section_(b, l, m, r, p, null);
     return r || p;
   }
 
@@ -4389,11 +4389,11 @@ public class ElixirParser implements PsiParser, LightPsiParser {
     if (!recursion_guard_(b, l, "orInfixOperator")) return false;
     if (!nextTokenIs(b, "<||, |||, or>", EOL, OR_OPERATOR)) return false;
     boolean r;
-    Marker m = enter_section_(b, l, _NONE_, "<||, |||, or>");
+    Marker m = enter_section_(b, l, _NONE_, OR_INFIX_OPERATOR, "<||, |||, or>");
     r = orInfixOperator_0(b, l + 1);
     r = r && consumeToken(b, OR_OPERATOR);
     r = r && orInfixOperator_2(b, l + 1);
-    exit_section_(b, l, m, OR_INFIX_OPERATOR, r, false, null);
+    exit_section_(b, l, m, r, false, null);
     return r;
   }
 
@@ -4610,11 +4610,11 @@ public class ElixirParser implements PsiParser, LightPsiParser {
     if (!recursion_guard_(b, l, "pipeInfixOperator")) return false;
     if (!nextTokenIs(b, "<|>", EOL, PIPE_OPERATOR)) return false;
     boolean r;
-    Marker m = enter_section_(b, l, _NONE_, "<|>");
+    Marker m = enter_section_(b, l, _NONE_, PIPE_INFIX_OPERATOR, "<|>");
     r = pipeInfixOperator_0(b, l + 1);
     r = r && consumeToken(b, PIPE_OPERATOR);
     r = r && pipeInfixOperator_2(b, l + 1);
-    exit_section_(b, l, m, PIPE_INFIX_OPERATOR, r, false, null);
+    exit_section_(b, l, m, r, false, null);
     return r;
   }
 
@@ -4659,14 +4659,14 @@ public class ElixirParser implements PsiParser, LightPsiParser {
   // (interpolation | CHAR_LIST_FRAGMENT | quoteEscapeSequence)*
   public static boolean quoteCharListBody(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "quoteCharListBody")) return false;
-    Marker m = enter_section_(b, l, _NONE_, "<quote char list body>");
+    Marker m = enter_section_(b, l, _NONE_, QUOTE_CHAR_LIST_BODY, "<quote char list body>");
     int c = current_position_(b);
     while (true) {
       if (!quoteCharListBody_0(b, l + 1)) break;
       if (!empty_element_parsed_guard_(b, "quoteCharListBody", c)) break;
       c = current_position_(b);
     }
-    exit_section_(b, l, m, QUOTE_CHAR_LIST_BODY, true, false, null);
+    exit_section_(b, l, m, true, false, null);
     return true;
   }
 
@@ -4706,11 +4706,11 @@ public class ElixirParser implements PsiParser, LightPsiParser {
     if (!recursion_guard_(b, l, "quoteHexadecimalEscapeSequence")) return false;
     if (!nextTokenIs(b, ESCAPE)) return false;
     boolean r, p;
-    Marker m = enter_section_(b, l, _NONE_, null);
+    Marker m = enter_section_(b, l, _NONE_, QUOTE_HEXADECIMAL_ESCAPE_SEQUENCE, null);
     r = hexadecimalEscapePrefix(b, l + 1);
     p = r; // pin = 1
     r = r && quoteHexadecimalEscapeSequence_1(b, l + 1);
-    exit_section_(b, l, m, QUOTE_HEXADECIMAL_ESCAPE_SEQUENCE, r, p, null);
+    exit_section_(b, l, m, r, p, null);
     return r || p;
   }
 
@@ -4729,14 +4729,14 @@ public class ElixirParser implements PsiParser, LightPsiParser {
   // (interpolation | STRING_FRAGMENT | quoteEscapeSequence)*
   public static boolean quoteStringBody(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "quoteStringBody")) return false;
-    Marker m = enter_section_(b, l, _NONE_, "<quote string body>");
+    Marker m = enter_section_(b, l, _NONE_, QUOTE_STRING_BODY, "<quote string body>");
     int c = current_position_(b);
     while (true) {
       if (!quoteStringBody_0(b, l + 1)) break;
       if (!empty_element_parsed_guard_(b, "quoteStringBody", c)) break;
       c = current_position_(b);
     }
-    exit_section_(b, l, m, QUOTE_STRING_BODY, true, false, null);
+    exit_section_(b, l, m, true, false, null);
     return true;
   }
 
@@ -4758,11 +4758,11 @@ public class ElixirParser implements PsiParser, LightPsiParser {
     if (!recursion_guard_(b, l, "relationalInfixOperator")) return false;
     if (!nextTokenIs(b, "<<, >, <=, >=>", EOL, RELATIONAL_OPERATOR)) return false;
     boolean r;
-    Marker m = enter_section_(b, l, _NONE_, "<<, >, <=, >=>");
+    Marker m = enter_section_(b, l, _NONE_, RELATIONAL_INFIX_OPERATOR, "<<, >, <=, >=>");
     r = relationalInfixOperator_0(b, l + 1);
     r = r && consumeToken(b, RELATIONAL_OPERATOR);
     r = r && relationalInfixOperator_2(b, l + 1);
-    exit_section_(b, l, m, RELATIONAL_INFIX_OPERATOR, r, false, null);
+    exit_section_(b, l, m, r, false, null);
     return r;
   }
 
@@ -4826,7 +4826,7 @@ public class ElixirParser implements PsiParser, LightPsiParser {
   public static boolean relativeIdentifier(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "relativeIdentifier")) return false;
     boolean r;
-    Marker m = enter_section_(b, l, _NONE_, "<relative identifier>");
+    Marker m = enter_section_(b, l, _NONE_, RELATIVE_IDENTIFIER, "<relative identifier>");
     r = consumeToken(b, IDENTIFIER_TOKEN);
     if (!r) r = consumeToken(b, AFTER);
     if (!r) r = consumeToken(b, AND_OPERATOR);
@@ -4855,7 +4855,7 @@ public class ElixirParser implements PsiParser, LightPsiParser {
     if (!r) r = atomKeyword(b, l + 1);
     if (!r) r = charListLine(b, l + 1);
     if (!r) r = stringLine(b, l + 1);
-    exit_section_(b, l, m, RELATIVE_IDENTIFIER, r, false, null);
+    exit_section_(b, l, m, r, false, null);
     return r;
   }
 
@@ -4925,14 +4925,14 @@ public class ElixirParser implements PsiParser, LightPsiParser {
   // SIGIL_MODIFIER*
   public static boolean sigilModifiers(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "sigilModifiers")) return false;
-    Marker m = enter_section_(b, l, _NONE_, "<sigil modifiers>");
+    Marker m = enter_section_(b, l, _NONE_, SIGIL_MODIFIERS, "<sigil modifiers>");
     int c = current_position_(b);
     while (true) {
       if (!consumeToken(b, SIGIL_MODIFIER)) break;
       if (!empty_element_parsed_guard_(b, "sigilModifiers", c)) break;
       c = current_position_(b);
     }
-    exit_section_(b, l, m, SIGIL_MODIFIERS, true, false, null);
+    exit_section_(b, l, m, true, false, null);
     return true;
   }
 
@@ -4942,10 +4942,10 @@ public class ElixirParser implements PsiParser, LightPsiParser {
   public static boolean stab(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "stab")) return false;
     boolean r;
-    Marker m = enter_section_(b, l, _NONE_, "<stab>");
+    Marker m = enter_section_(b, l, _NONE_, STAB, "<stab>");
     r = stab_0(b, l + 1);
     if (!r) r = stabBody(b, l + 1);
-    exit_section_(b, l, m, STAB, r, false, null);
+    exit_section_(b, l, m, r, false, null);
     return r;
   }
 
@@ -4988,10 +4988,10 @@ public class ElixirParser implements PsiParser, LightPsiParser {
   public static boolean stabBody(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "stabBody")) return false;
     boolean r;
-    Marker m = enter_section_(b, l, _NONE_, "<stab body>");
+    Marker m = enter_section_(b, l, _NONE_, STAB_BODY, "<stab body>");
     r = stabBodyExpression(b, l + 1);
     r = r && stabBody_1(b, l + 1);
-    exit_section_(b, l, m, STAB_BODY, r, false, null);
+    exit_section_(b, l, m, r, false, null);
     return r;
   }
 
@@ -5034,9 +5034,9 @@ public class ElixirParser implements PsiParser, LightPsiParser {
   private static boolean stabBodyExpression_0(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "stabBodyExpression_0")) return false;
     boolean r;
-    Marker m = enter_section_(b, l, _NOT_, null);
+    Marker m = enter_section_(b, l, _NOT_);
     r = !stabOperationPrefix(b, l + 1);
-    exit_section_(b, l, m, null, r, false, null);
+    exit_section_(b, l, m, r, false, null);
     return r;
   }
 
@@ -5046,11 +5046,11 @@ public class ElixirParser implements PsiParser, LightPsiParser {
     if (!recursion_guard_(b, l, "stabInfixOperator")) return false;
     if (!nextTokenIs(b, "<->>", EOL, STAB_OPERATOR)) return false;
     boolean r;
-    Marker m = enter_section_(b, l, _NONE_, "<->>");
+    Marker m = enter_section_(b, l, _NONE_, STAB_INFIX_OPERATOR, "<->>");
     r = stabInfixOperator_0(b, l + 1);
     r = r && consumeToken(b, STAB_OPERATOR);
     r = r && stabInfixOperator_2(b, l + 1);
-    exit_section_(b, l, m, STAB_INFIX_OPERATOR, r, false, null);
+    exit_section_(b, l, m, r, false, null);
     return r;
   }
 
@@ -5083,9 +5083,9 @@ public class ElixirParser implements PsiParser, LightPsiParser {
   public static boolean stabNoParenthesesSignature(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "stabNoParenthesesSignature")) return false;
     boolean r;
-    Marker m = enter_section_(b, l, _NONE_, "<stab no parentheses signature>");
+    Marker m = enter_section_(b, l, _NONE_, STAB_NO_PARENTHESES_SIGNATURE, "<stab no parentheses signature>");
     r = noParenthesesArguments(b, l + 1);
-    exit_section_(b, l, m, STAB_NO_PARENTHESES_SIGNATURE, r, false, null);
+    exit_section_(b, l, m, r, false, null);
     return r;
   }
 
@@ -5094,10 +5094,10 @@ public class ElixirParser implements PsiParser, LightPsiParser {
   public static boolean stabOperation(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "stabOperation")) return false;
     boolean r;
-    Marker m = enter_section_(b, l, _NONE_, "<stab operation>");
+    Marker m = enter_section_(b, l, _NONE_, STAB_OPERATION, "<stab operation>");
     r = stabOperationPrefix(b, l + 1);
     r = r && stabOperation_1(b, l + 1);
-    exit_section_(b, l, m, STAB_OPERATION, r, false, null);
+    exit_section_(b, l, m, r, false, null);
     return r;
   }
 
@@ -5184,13 +5184,13 @@ public class ElixirParser implements PsiParser, LightPsiParser {
     if (!recursion_guard_(b, l, "stringHeredoc")) return false;
     if (!nextTokenIs(b, STRING_HEREDOC_PROMOTER)) return false;
     boolean r, p;
-    Marker m = enter_section_(b, l, _NONE_, null);
+    Marker m = enter_section_(b, l, _NONE_, STRING_HEREDOC, null);
     r = consumeTokens(b, 1, STRING_HEREDOC_PROMOTER, EOL);
     p = r; // pin = 1
     r = r && report_error_(b, stringHeredoc_2(b, l + 1));
     r = p && report_error_(b, heredocPrefix(b, l + 1)) && r;
     r = p && consumeToken(b, STRING_HEREDOC_TERMINATOR) && r;
-    exit_section_(b, l, m, STRING_HEREDOC, r, p, null);
+    exit_section_(b, l, m, r, p, null);
     return r || p;
   }
 
@@ -5211,11 +5211,11 @@ public class ElixirParser implements PsiParser, LightPsiParser {
   public static boolean stringHeredocLine(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "stringHeredocLine")) return false;
     boolean r;
-    Marker m = enter_section_(b, l, _NONE_, "<string heredoc line>");
+    Marker m = enter_section_(b, l, _NONE_, STRING_HEREDOC_LINE, "<string heredoc line>");
     r = heredocLinePrefix(b, l + 1);
     r = r && quoteStringBody(b, l + 1);
     r = r && consumeToken(b, EOL);
-    exit_section_(b, l, m, STRING_HEREDOC_LINE, r, false, null);
+    exit_section_(b, l, m, r, false, null);
     return r;
   }
 
@@ -5315,11 +5315,11 @@ public class ElixirParser implements PsiParser, LightPsiParser {
     if (!recursion_guard_(b, l, "twoInfixOperator")) return false;
     if (!nextTokenIs(b, "<++, --, .., <>>", EOL, TWO_OPERATOR)) return false;
     boolean r;
-    Marker m = enter_section_(b, l, _NONE_, "<++, --, .., <>>");
+    Marker m = enter_section_(b, l, _NONE_, TWO_INFIX_OPERATOR, "<++, --, .., <>>");
     r = twoInfixOperator_0(b, l + 1);
     r = r && consumeToken(b, TWO_OPERATOR);
     r = r && twoInfixOperator_2(b, l + 1);
-    exit_section_(b, l, m, TWO_INFIX_OPERATOR, r, false, null);
+    exit_section_(b, l, m, r, false, null);
     return r;
   }
 
@@ -5353,11 +5353,11 @@ public class ElixirParser implements PsiParser, LightPsiParser {
     if (!recursion_guard_(b, l, "typeInfixOperator")) return false;
     if (!nextTokenIs(b, "<::>", EOL, TYPE_OPERATOR)) return false;
     boolean r;
-    Marker m = enter_section_(b, l, _NONE_, "<::>");
+    Marker m = enter_section_(b, l, _NONE_, TYPE_INFIX_OPERATOR, "<::>");
     r = typeInfixOperator_0(b, l + 1);
     r = r && consumeToken(b, TYPE_OPERATOR);
     r = r && typeInfixOperator_2(b, l + 1);
-    exit_section_(b, l, m, TYPE_INFIX_OPERATOR, r, false, null);
+    exit_section_(b, l, m, r, false, null);
     return r;
   }
 
@@ -5390,10 +5390,10 @@ public class ElixirParser implements PsiParser, LightPsiParser {
   public static boolean unaryNumericOperation(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "unaryNumericOperation")) return false;
     boolean r;
-    Marker m = enter_section_(b, l, _NONE_, "<unary numeric operation>");
+    Marker m = enter_section_(b, l, _NONE_, UNARY_NUMERIC_OPERATION, "<unary numeric operation>");
     r = unaryPrefixOperator(b, l + 1);
     r = r && numeric(b, l + 1);
-    exit_section_(b, l, m, UNARY_NUMERIC_OPERATION, r, false, null);
+    exit_section_(b, l, m, r, false, null);
     return r;
   }
 
@@ -5402,10 +5402,10 @@ public class ElixirParser implements PsiParser, LightPsiParser {
   public static boolean unaryPrefixOperator(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "unaryPrefixOperator")) return false;
     boolean r;
-    Marker m = enter_section_(b, l, _NONE_, "<+, -, !, ^, not, ~~~>");
+    Marker m = enter_section_(b, l, _NONE_, UNARY_PREFIX_OPERATOR, "<+, -, !, ^, not, ~~~>");
     r = unaryPrefixOperator_0(b, l + 1);
     r = r && unaryPrefixOperator_1(b, l + 1);
-    exit_section_(b, l, m, UNARY_PREFIX_OPERATOR, r, false, null);
+    exit_section_(b, l, m, r, false, null);
     return r;
   }
 
@@ -5468,11 +5468,11 @@ public class ElixirParser implements PsiParser, LightPsiParser {
     if (!recursion_guard_(b, l, "unknownBaseWholeNumber")) return false;
     if (!nextTokenIs(b, BASE_WHOLE_NUMBER_PREFIX)) return false;
     boolean r, p;
-    Marker m = enter_section_(b, l, _NONE_, null);
+    Marker m = enter_section_(b, l, _NONE_, UNKNOWN_BASE_WHOLE_NUMBER, null);
     r = consumeTokens(b, 2, BASE_WHOLE_NUMBER_PREFIX, UNKNOWN_WHOLE_NUMBER_BASE);
     p = r; // pin = 2
     r = r && unknownBaseWholeNumber_2(b, l + 1);
-    exit_section_(b, l, m, UNKNOWN_BASE_WHOLE_NUMBER, r, p, null);
+    exit_section_(b, l, m, r, p, null);
     return r || p;
   }
 
@@ -5511,9 +5511,9 @@ public class ElixirParser implements PsiParser, LightPsiParser {
   private static boolean unqualifiedNoParenthesesManyArgumentsCall_1(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "unqualifiedNoParenthesesManyArgumentsCall_1")) return false;
     boolean r;
-    Marker m = enter_section_(b, l, _NOT_, null);
+    Marker m = enter_section_(b, l, _NOT_);
     r = !consumeToken(b, KEYWORD_PAIR_COLON);
-    exit_section_(b, l, m, null, r, false, null);
+    exit_section_(b, l, m, r, false, null);
     return r;
   }
 
@@ -5534,9 +5534,9 @@ public class ElixirParser implements PsiParser, LightPsiParser {
   private static boolean variable_1(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "variable_1")) return false;
     boolean r;
-    Marker m = enter_section_(b, l, _NOT_, null);
+    Marker m = enter_section_(b, l, _NOT_);
     r = !consumeToken(b, KEYWORD_PAIR_COLON);
-    exit_section_(b, l, m, null, r, false, null);
+    exit_section_(b, l, m, r, false, null);
     return r;
   }
 
@@ -5546,11 +5546,11 @@ public class ElixirParser implements PsiParser, LightPsiParser {
     if (!recursion_guard_(b, l, "whenInfixOperator")) return false;
     if (!nextTokenIs(b, "<when>", EOL, WHEN_OPERATOR)) return false;
     boolean r;
-    Marker m = enter_section_(b, l, _NONE_, "<when>");
+    Marker m = enter_section_(b, l, _NONE_, WHEN_INFIX_OPERATOR, "<when>");
     r = whenInfixOperator_0(b, l + 1);
     r = r && consumeToken(b, WHEN_OPERATOR);
     r = r && whenInfixOperator_2(b, l + 1);
-    exit_section_(b, l, m, WHEN_INFIX_OPERATOR, r, false, null);
+    exit_section_(b, l, m, r, false, null);
     return r;
   }
 
@@ -5737,7 +5737,7 @@ public class ElixirParser implements PsiParser, LightPsiParser {
 
   public static boolean matchedCaptureNonNumericOperation(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "matchedCaptureNonNumericOperation")) return false;
-    if (!nextTokenIsFast(b, CAPTURE_OPERATOR)) return false;
+    if (!nextTokenIsSmart(b, CAPTURE_OPERATOR)) return false;
     boolean r, p;
     Marker m = enter_section_(b, l, _NONE_, null);
     r = matchedCaptureNonNumericOperation_0(b, l + 1);
@@ -5762,9 +5762,9 @@ public class ElixirParser implements PsiParser, LightPsiParser {
   private static boolean matchedCaptureNonNumericOperation_0_1(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "matchedCaptureNonNumericOperation_0_1")) return false;
     boolean r;
-    Marker m = enter_section_(b, l, _NOT_, null);
+    Marker m = enter_section_(b, l, _NOT_);
     r = !numeric(b, l + 1);
-    exit_section_(b, l, m, null, r, false, null);
+    exit_section_(b, l, m, r, false, null);
     return r;
   }
 
@@ -5805,9 +5805,9 @@ public class ElixirParser implements PsiParser, LightPsiParser {
   private static boolean matchedUnaryNonNumericOperation_0_1(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "matchedUnaryNonNumericOperation_0_1")) return false;
     boolean r;
-    Marker m = enter_section_(b, l, _NOT_, null);
+    Marker m = enter_section_(b, l, _NOT_);
     r = !numeric(b, l + 1);
-    exit_section_(b, l, m, null, r, false, null);
+    exit_section_(b, l, m, r, false, null);
     return r;
   }
 
@@ -5845,7 +5845,7 @@ public class ElixirParser implements PsiParser, LightPsiParser {
   // atIdentifier noParenthesesOneArgument
   public static boolean matchedAtUnqualifiedNoParenthesesCall(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "matchedAtUnqualifiedNoParenthesesCall")) return false;
-    if (!nextTokenIsFast(b, AT_OPERATOR)) return false;
+    if (!nextTokenIsSmart(b, AT_OPERATOR)) return false;
     boolean r;
     Marker m = enter_section_(b);
     r = atIdentifier(b, l + 1);
@@ -5857,7 +5857,7 @@ public class ElixirParser implements PsiParser, LightPsiParser {
   // identifier noParenthesesOneArgument
   public static boolean matchedUnqualifiedNoParenthesesCall(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "matchedUnqualifiedNoParenthesesCall")) return false;
-    if (!nextTokenIsFast(b, IDENTIFIER_TOKEN)) return false;
+    if (!nextTokenIsSmart(b, IDENTIFIER_TOKEN)) return false;
     boolean r;
     Marker m = enter_section_(b);
     r = identifier(b, l + 1);
@@ -5918,16 +5918,16 @@ public class ElixirParser implements PsiParser, LightPsiParser {
   private static boolean matchedQualifiedNoArgumentsCall_0_2(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "matchedQualifiedNoArgumentsCall_0_2")) return false;
     boolean r;
-    Marker m = enter_section_(b, l, _NOT_, null);
+    Marker m = enter_section_(b, l, _NOT_);
     r = !consumeTokenSmart(b, CALL);
-    exit_section_(b, l, m, null, r, false, null);
+    exit_section_(b, l, m, r, false, null);
     return r;
   }
 
   // atPrefixOperator IDENTIFIER_TOKEN CALL bracketArguments
   public static boolean matchedAtUnqualifiedBracketOperation(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "matchedAtUnqualifiedBracketOperation")) return false;
-    if (!nextTokenIsFast(b, AT_OPERATOR)) return false;
+    if (!nextTokenIsSmart(b, AT_OPERATOR)) return false;
     boolean r;
     Marker m = enter_section_(b);
     r = atPrefixOperator(b, l + 1);
@@ -5939,7 +5939,7 @@ public class ElixirParser implements PsiParser, LightPsiParser {
 
   public static boolean matchedAtNonNumericOperation(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "matchedAtNonNumericOperation")) return false;
-    if (!nextTokenIsFast(b, AT_OPERATOR)) return false;
+    if (!nextTokenIsSmart(b, AT_OPERATOR)) return false;
     boolean r, p;
     Marker m = enter_section_(b, l, _NONE_, null);
     r = matchedAtNonNumericOperation_0(b, l + 1);
@@ -5964,16 +5964,16 @@ public class ElixirParser implements PsiParser, LightPsiParser {
   private static boolean matchedAtNonNumericOperation_0_1(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "matchedAtNonNumericOperation_0_1")) return false;
     boolean r;
-    Marker m = enter_section_(b, l, _NOT_, null);
+    Marker m = enter_section_(b, l, _NOT_);
     r = !numeric(b, l + 1);
-    exit_section_(b, l, m, null, r, false, null);
+    exit_section_(b, l, m, r, false, null);
     return r;
   }
 
   // identifier matchedParenthesesArguments
   public static boolean matchedUnqualifiedParenthesesCall(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "matchedUnqualifiedParenthesesCall")) return false;
-    if (!nextTokenIsFast(b, IDENTIFIER_TOKEN)) return false;
+    if (!nextTokenIsSmart(b, IDENTIFIER_TOKEN)) return false;
     boolean r;
     Marker m = enter_section_(b);
     r = identifier(b, l + 1);
@@ -5985,7 +5985,7 @@ public class ElixirParser implements PsiParser, LightPsiParser {
   // identifier CALL bracketArguments
   public static boolean matchedUnqualifiedBracketOperation(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "matchedUnqualifiedBracketOperation")) return false;
-    if (!nextTokenIsFast(b, IDENTIFIER_TOKEN)) return false;
+    if (!nextTokenIsSmart(b, IDENTIFIER_TOKEN)) return false;
     boolean r;
     Marker m = enter_section_(b);
     r = identifier(b, l + 1);
@@ -5998,7 +5998,7 @@ public class ElixirParser implements PsiParser, LightPsiParser {
   // identifier !KEYWORD_PAIR_COLON
   public static boolean matchedUnqualifiedNoArgumentsCall(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "matchedUnqualifiedNoArgumentsCall")) return false;
-    if (!nextTokenIsFast(b, IDENTIFIER_TOKEN)) return false;
+    if (!nextTokenIsSmart(b, IDENTIFIER_TOKEN)) return false;
     boolean r;
     Marker m = enter_section_(b);
     r = identifier(b, l + 1);
@@ -6011,9 +6011,9 @@ public class ElixirParser implements PsiParser, LightPsiParser {
   private static boolean matchedUnqualifiedNoArgumentsCall_1(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "matchedUnqualifiedNoArgumentsCall_1")) return false;
     boolean r;
-    Marker m = enter_section_(b, l, _NOT_, null);
+    Marker m = enter_section_(b, l, _NOT_);
     r = !consumeTokenSmart(b, KEYWORD_PAIR_COLON);
-    exit_section_(b, l, m, null, r, false, null);
+    exit_section_(b, l, m, r, false, null);
     return r;
   }
 
@@ -6021,9 +6021,9 @@ public class ElixirParser implements PsiParser, LightPsiParser {
   public static boolean matchedAccessExpression(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "matchedAccessExpression")) return false;
     boolean r;
-    Marker m = enter_section_(b, l, _COLLAPSE_, "<matched access expression>");
+    Marker m = enter_section_(b, l, _COLLAPSE_, ACCESS_EXPRESSION, "<matched access expression>");
     r = accessExpression(b, l + 1);
-    exit_section_(b, l, m, ACCESS_EXPRESSION, r, false, null);
+    exit_section_(b, l, m, r, false, null);
     return r;
   }
 
@@ -6186,7 +6186,7 @@ public class ElixirParser implements PsiParser, LightPsiParser {
 
   public static boolean unmatchedCaptureNonNumericOperation(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "unmatchedCaptureNonNumericOperation")) return false;
-    if (!nextTokenIsFast(b, CAPTURE_OPERATOR)) return false;
+    if (!nextTokenIsSmart(b, CAPTURE_OPERATOR)) return false;
     boolean r, p;
     Marker m = enter_section_(b, l, _NONE_, null);
     r = unmatchedCaptureNonNumericOperation_0(b, l + 1);
@@ -6211,9 +6211,9 @@ public class ElixirParser implements PsiParser, LightPsiParser {
   private static boolean unmatchedCaptureNonNumericOperation_0_1(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "unmatchedCaptureNonNumericOperation_0_1")) return false;
     boolean r;
-    Marker m = enter_section_(b, l, _NOT_, null);
+    Marker m = enter_section_(b, l, _NOT_);
     r = !numeric(b, l + 1);
-    exit_section_(b, l, m, null, r, false, null);
+    exit_section_(b, l, m, r, false, null);
     return r;
   }
 
@@ -6254,9 +6254,9 @@ public class ElixirParser implements PsiParser, LightPsiParser {
   private static boolean unmatchedUnaryNonNumericOperation_0_1(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "unmatchedUnaryNonNumericOperation_0_1")) return false;
     boolean r;
-    Marker m = enter_section_(b, l, _NOT_, null);
+    Marker m = enter_section_(b, l, _NOT_);
     r = !numeric(b, l + 1);
-    exit_section_(b, l, m, null, r, false, null);
+    exit_section_(b, l, m, r, false, null);
     return r;
   }
 
@@ -6310,7 +6310,7 @@ public class ElixirParser implements PsiParser, LightPsiParser {
   // atIdentifier noParenthesesOneArgument doBlock?
   public static boolean unmatchedAtUnqualifiedNoParenthesesCall(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "unmatchedAtUnqualifiedNoParenthesesCall")) return false;
-    if (!nextTokenIsFast(b, AT_OPERATOR)) return false;
+    if (!nextTokenIsSmart(b, AT_OPERATOR)) return false;
     boolean r;
     Marker m = enter_section_(b);
     r = atIdentifier(b, l + 1);
@@ -6330,7 +6330,7 @@ public class ElixirParser implements PsiParser, LightPsiParser {
   // identifier noParenthesesOneArgument doBlock?
   public static boolean unmatchedUnqualifiedNoParenthesesCall(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "unmatchedUnqualifiedNoParenthesesCall")) return false;
-    if (!nextTokenIsFast(b, IDENTIFIER_TOKEN)) return false;
+    if (!nextTokenIsSmart(b, IDENTIFIER_TOKEN)) return false;
     boolean r;
     Marker m = enter_section_(b);
     r = identifier(b, l + 1);
@@ -6408,9 +6408,9 @@ public class ElixirParser implements PsiParser, LightPsiParser {
   private static boolean unmatchedQualifiedNoArgumentsCall_0_2(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "unmatchedQualifiedNoArgumentsCall_0_2")) return false;
     boolean r;
-    Marker m = enter_section_(b, l, _NOT_, null);
+    Marker m = enter_section_(b, l, _NOT_);
     r = !consumeTokenSmart(b, CALL);
-    exit_section_(b, l, m, null, r, false, null);
+    exit_section_(b, l, m, r, false, null);
     return r;
   }
 
@@ -6424,7 +6424,7 @@ public class ElixirParser implements PsiParser, LightPsiParser {
   // atPrefixOperator IDENTIFIER_TOKEN CALL bracketArguments
   public static boolean unmatchedAtUnqualifiedBracketOperation(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "unmatchedAtUnqualifiedBracketOperation")) return false;
-    if (!nextTokenIsFast(b, AT_OPERATOR)) return false;
+    if (!nextTokenIsSmart(b, AT_OPERATOR)) return false;
     boolean r;
     Marker m = enter_section_(b);
     r = atPrefixOperator(b, l + 1);
@@ -6436,7 +6436,7 @@ public class ElixirParser implements PsiParser, LightPsiParser {
 
   public static boolean unmatchedAtNonNumericOperation(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "unmatchedAtNonNumericOperation")) return false;
-    if (!nextTokenIsFast(b, AT_OPERATOR)) return false;
+    if (!nextTokenIsSmart(b, AT_OPERATOR)) return false;
     boolean r, p;
     Marker m = enter_section_(b, l, _NONE_, null);
     r = unmatchedAtNonNumericOperation_0(b, l + 1);
@@ -6461,16 +6461,16 @@ public class ElixirParser implements PsiParser, LightPsiParser {
   private static boolean unmatchedAtNonNumericOperation_0_1(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "unmatchedAtNonNumericOperation_0_1")) return false;
     boolean r;
-    Marker m = enter_section_(b, l, _NOT_, null);
+    Marker m = enter_section_(b, l, _NOT_);
     r = !numeric(b, l + 1);
-    exit_section_(b, l, m, null, r, false, null);
+    exit_section_(b, l, m, r, false, null);
     return r;
   }
 
   // identifier matchedParenthesesArguments doBlock?
   public static boolean unmatchedUnqualifiedParenthesesCall(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "unmatchedUnqualifiedParenthesesCall")) return false;
-    if (!nextTokenIsFast(b, IDENTIFIER_TOKEN)) return false;
+    if (!nextTokenIsSmart(b, IDENTIFIER_TOKEN)) return false;
     boolean r;
     Marker m = enter_section_(b);
     r = identifier(b, l + 1);
@@ -6490,7 +6490,7 @@ public class ElixirParser implements PsiParser, LightPsiParser {
   // identifier CALL bracketArguments
   public static boolean unmatchedUnqualifiedBracketOperation(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "unmatchedUnqualifiedBracketOperation")) return false;
-    if (!nextTokenIsFast(b, IDENTIFIER_TOKEN)) return false;
+    if (!nextTokenIsSmart(b, IDENTIFIER_TOKEN)) return false;
     boolean r;
     Marker m = enter_section_(b);
     r = identifier(b, l + 1);
@@ -6503,7 +6503,7 @@ public class ElixirParser implements PsiParser, LightPsiParser {
   // identifier !KEYWORD_PAIR_COLON doBlock?
   public static boolean unmatchedUnqualifiedNoArgumentsCall(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "unmatchedUnqualifiedNoArgumentsCall")) return false;
-    if (!nextTokenIsFast(b, IDENTIFIER_TOKEN)) return false;
+    if (!nextTokenIsSmart(b, IDENTIFIER_TOKEN)) return false;
     boolean r;
     Marker m = enter_section_(b);
     r = identifier(b, l + 1);
@@ -6517,9 +6517,9 @@ public class ElixirParser implements PsiParser, LightPsiParser {
   private static boolean unmatchedUnqualifiedNoArgumentsCall_1(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "unmatchedUnqualifiedNoArgumentsCall_1")) return false;
     boolean r;
-    Marker m = enter_section_(b, l, _NOT_, null);
+    Marker m = enter_section_(b, l, _NOT_);
     r = !consumeTokenSmart(b, KEYWORD_PAIR_COLON);
-    exit_section_(b, l, m, null, r, false, null);
+    exit_section_(b, l, m, r, false, null);
     return r;
   }
 
@@ -6534,9 +6534,9 @@ public class ElixirParser implements PsiParser, LightPsiParser {
   public static boolean unmatchedAccessExpression(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "unmatchedAccessExpression")) return false;
     boolean r;
-    Marker m = enter_section_(b, l, _COLLAPSE_, "<unmatched access expression>");
+    Marker m = enter_section_(b, l, _COLLAPSE_, ACCESS_EXPRESSION, "<unmatched access expression>");
     r = accessExpression(b, l + 1);
-    exit_section_(b, l, m, ACCESS_EXPRESSION, r, false, null);
+    exit_section_(b, l, m, r, false, null);
     return r;
   }
 

--- a/gen/org/elixir_lang/psi/ElixirMatchedAdditionOperation.java
+++ b/gen/org/elixir_lang/psi/ElixirMatchedAdditionOperation.java
@@ -77,7 +77,7 @@ public interface ElixirMatchedAdditionOperation extends ElixirMatchedExpression,
   @Nullable
   Integer resolvedSecondaryArity();
 
-  @NotNull
+  @Nullable
   Quotable rightOperand();
 
   @Nullable

--- a/gen/org/elixir_lang/psi/ElixirMatchedAndOperation.java
+++ b/gen/org/elixir_lang/psi/ElixirMatchedAndOperation.java
@@ -77,7 +77,7 @@ public interface ElixirMatchedAndOperation extends ElixirMatchedExpression, Name
   @Nullable
   Integer resolvedSecondaryArity();
 
-  @NotNull
+  @Nullable
   Quotable rightOperand();
 
   @Nullable

--- a/gen/org/elixir_lang/psi/ElixirMatchedArrowOperation.java
+++ b/gen/org/elixir_lang/psi/ElixirMatchedArrowOperation.java
@@ -77,7 +77,7 @@ public interface ElixirMatchedArrowOperation extends ElixirMatchedExpression, Na
   @Nullable
   Integer resolvedSecondaryArity();
 
-  @NotNull
+  @Nullable
   Quotable rightOperand();
 
   @Nullable

--- a/gen/org/elixir_lang/psi/ElixirMatchedComparisonOperation.java
+++ b/gen/org/elixir_lang/psi/ElixirMatchedComparisonOperation.java
@@ -77,7 +77,7 @@ public interface ElixirMatchedComparisonOperation extends ElixirMatchedExpressio
   @Nullable
   Integer resolvedSecondaryArity();
 
-  @NotNull
+  @Nullable
   Quotable rightOperand();
 
   @Nullable

--- a/gen/org/elixir_lang/psi/ElixirMatchedInMatchOperation.java
+++ b/gen/org/elixir_lang/psi/ElixirMatchedInMatchOperation.java
@@ -77,7 +77,7 @@ public interface ElixirMatchedInMatchOperation extends ElixirMatchedExpression, 
   @Nullable
   Integer resolvedSecondaryArity();
 
-  @NotNull
+  @Nullable
   Quotable rightOperand();
 
   @Nullable

--- a/gen/org/elixir_lang/psi/ElixirMatchedInOperation.java
+++ b/gen/org/elixir_lang/psi/ElixirMatchedInOperation.java
@@ -72,7 +72,7 @@ public interface ElixirMatchedInOperation extends ElixirMatchedExpression, Call,
   @Nullable
   Integer resolvedSecondaryArity();
 
-  @NotNull
+  @Nullable
   Quotable rightOperand();
 
   @Nullable

--- a/gen/org/elixir_lang/psi/ElixirMatchedMatchOperation.java
+++ b/gen/org/elixir_lang/psi/ElixirMatchedMatchOperation.java
@@ -77,7 +77,7 @@ public interface ElixirMatchedMatchOperation extends ElixirMatchedExpression, Na
   @Nullable
   Integer resolvedSecondaryArity();
 
-  @NotNull
+  @Nullable
   Quotable rightOperand();
 
   @Nullable

--- a/gen/org/elixir_lang/psi/ElixirMatchedMultiplicationOperation.java
+++ b/gen/org/elixir_lang/psi/ElixirMatchedMultiplicationOperation.java
@@ -77,7 +77,7 @@ public interface ElixirMatchedMultiplicationOperation extends ElixirMatchedExpre
   @Nullable
   Integer resolvedSecondaryArity();
 
-  @NotNull
+  @Nullable
   Quotable rightOperand();
 
   @Nullable

--- a/gen/org/elixir_lang/psi/ElixirMatchedOrOperation.java
+++ b/gen/org/elixir_lang/psi/ElixirMatchedOrOperation.java
@@ -77,7 +77,7 @@ public interface ElixirMatchedOrOperation extends ElixirMatchedExpression, Named
   @Nullable
   Integer resolvedSecondaryArity();
 
-  @NotNull
+  @Nullable
   Quotable rightOperand();
 
   @Nullable

--- a/gen/org/elixir_lang/psi/ElixirMatchedPipeOperation.java
+++ b/gen/org/elixir_lang/psi/ElixirMatchedPipeOperation.java
@@ -77,7 +77,7 @@ public interface ElixirMatchedPipeOperation extends ElixirMatchedExpression, Nam
   @Nullable
   Integer resolvedSecondaryArity();
 
-  @NotNull
+  @Nullable
   Quotable rightOperand();
 
   @Nullable

--- a/gen/org/elixir_lang/psi/ElixirMatchedRelationalOperation.java
+++ b/gen/org/elixir_lang/psi/ElixirMatchedRelationalOperation.java
@@ -77,7 +77,7 @@ public interface ElixirMatchedRelationalOperation extends ElixirMatchedExpressio
   @Nullable
   Integer resolvedSecondaryArity();
 
-  @NotNull
+  @Nullable
   Quotable rightOperand();
 
   @Nullable

--- a/gen/org/elixir_lang/psi/ElixirMatchedTwoOperation.java
+++ b/gen/org/elixir_lang/psi/ElixirMatchedTwoOperation.java
@@ -77,7 +77,7 @@ public interface ElixirMatchedTwoOperation extends ElixirMatchedExpression, Name
   @Nullable
   Integer resolvedSecondaryArity();
 
-  @NotNull
+  @Nullable
   Quotable rightOperand();
 
   @Nullable

--- a/gen/org/elixir_lang/psi/ElixirMatchedTypeOperation.java
+++ b/gen/org/elixir_lang/psi/ElixirMatchedTypeOperation.java
@@ -77,7 +77,7 @@ public interface ElixirMatchedTypeOperation extends ElixirMatchedExpression, Nam
   @Nullable
   Integer resolvedSecondaryArity();
 
-  @NotNull
+  @Nullable
   Quotable rightOperand();
 
   @Nullable

--- a/gen/org/elixir_lang/psi/ElixirMatchedWhenOperation.java
+++ b/gen/org/elixir_lang/psi/ElixirMatchedWhenOperation.java
@@ -77,7 +77,7 @@ public interface ElixirMatchedWhenOperation extends ElixirMatchedExpression, Nam
   @Nullable
   Integer resolvedSecondaryArity();
 
-  @NotNull
+  @Nullable
   Quotable rightOperand();
 
   @Nullable

--- a/gen/org/elixir_lang/psi/ElixirStabParenthesesSignature.java
+++ b/gen/org/elixir_lang/psi/ElixirStabParenthesesSignature.java
@@ -32,7 +32,7 @@ public interface ElixirStabParenthesesSignature extends Quotable, When {
   @NotNull
   OtpErlangObject quote();
 
-  @NotNull
+  @Nullable
   Quotable rightOperand();
 
 }

--- a/gen/org/elixir_lang/psi/ElixirUnmatchedAdditionOperation.java
+++ b/gen/org/elixir_lang/psi/ElixirUnmatchedAdditionOperation.java
@@ -77,7 +77,7 @@ public interface ElixirUnmatchedAdditionOperation extends ElixirUnmatchedExpress
   @Nullable
   Integer resolvedSecondaryArity();
 
-  @NotNull
+  @Nullable
   Quotable rightOperand();
 
   @Nullable

--- a/gen/org/elixir_lang/psi/ElixirUnmatchedAndOperation.java
+++ b/gen/org/elixir_lang/psi/ElixirUnmatchedAndOperation.java
@@ -77,7 +77,7 @@ public interface ElixirUnmatchedAndOperation extends ElixirUnmatchedExpression, 
   @Nullable
   Integer resolvedSecondaryArity();
 
-  @NotNull
+  @Nullable
   Quotable rightOperand();
 
   @Nullable

--- a/gen/org/elixir_lang/psi/ElixirUnmatchedArrowOperation.java
+++ b/gen/org/elixir_lang/psi/ElixirUnmatchedArrowOperation.java
@@ -77,7 +77,7 @@ public interface ElixirUnmatchedArrowOperation extends ElixirUnmatchedExpression
   @Nullable
   Integer resolvedSecondaryArity();
 
-  @NotNull
+  @Nullable
   Quotable rightOperand();
 
   @Nullable

--- a/gen/org/elixir_lang/psi/ElixirUnmatchedComparisonOperation.java
+++ b/gen/org/elixir_lang/psi/ElixirUnmatchedComparisonOperation.java
@@ -77,7 +77,7 @@ public interface ElixirUnmatchedComparisonOperation extends ElixirUnmatchedExpre
   @Nullable
   Integer resolvedSecondaryArity();
 
-  @NotNull
+  @Nullable
   Quotable rightOperand();
 
   @Nullable

--- a/gen/org/elixir_lang/psi/ElixirUnmatchedInMatchOperation.java
+++ b/gen/org/elixir_lang/psi/ElixirUnmatchedInMatchOperation.java
@@ -77,7 +77,7 @@ public interface ElixirUnmatchedInMatchOperation extends ElixirUnmatchedExpressi
   @Nullable
   Integer resolvedSecondaryArity();
 
-  @NotNull
+  @Nullable
   Quotable rightOperand();
 
   @Nullable

--- a/gen/org/elixir_lang/psi/ElixirUnmatchedInOperation.java
+++ b/gen/org/elixir_lang/psi/ElixirUnmatchedInOperation.java
@@ -72,7 +72,7 @@ public interface ElixirUnmatchedInOperation extends ElixirUnmatchedExpression, C
   @Nullable
   Integer resolvedSecondaryArity();
 
-  @NotNull
+  @Nullable
   Quotable rightOperand();
 
   @Nullable

--- a/gen/org/elixir_lang/psi/ElixirUnmatchedMatchOperation.java
+++ b/gen/org/elixir_lang/psi/ElixirUnmatchedMatchOperation.java
@@ -77,7 +77,7 @@ public interface ElixirUnmatchedMatchOperation extends ElixirUnmatchedExpression
   @Nullable
   Integer resolvedSecondaryArity();
 
-  @NotNull
+  @Nullable
   Quotable rightOperand();
 
   @Nullable

--- a/gen/org/elixir_lang/psi/ElixirUnmatchedMultiplicationOperation.java
+++ b/gen/org/elixir_lang/psi/ElixirUnmatchedMultiplicationOperation.java
@@ -77,7 +77,7 @@ public interface ElixirUnmatchedMultiplicationOperation extends ElixirUnmatchedE
   @Nullable
   Integer resolvedSecondaryArity();
 
-  @NotNull
+  @Nullable
   Quotable rightOperand();
 
   @Nullable

--- a/gen/org/elixir_lang/psi/ElixirUnmatchedOrOperation.java
+++ b/gen/org/elixir_lang/psi/ElixirUnmatchedOrOperation.java
@@ -77,7 +77,7 @@ public interface ElixirUnmatchedOrOperation extends ElixirUnmatchedExpression, N
   @Nullable
   Integer resolvedSecondaryArity();
 
-  @NotNull
+  @Nullable
   Quotable rightOperand();
 
   @Nullable

--- a/gen/org/elixir_lang/psi/ElixirUnmatchedPipeOperation.java
+++ b/gen/org/elixir_lang/psi/ElixirUnmatchedPipeOperation.java
@@ -77,7 +77,7 @@ public interface ElixirUnmatchedPipeOperation extends ElixirUnmatchedExpression,
   @Nullable
   Integer resolvedSecondaryArity();
 
-  @NotNull
+  @Nullable
   Quotable rightOperand();
 
   @Nullable

--- a/gen/org/elixir_lang/psi/ElixirUnmatchedRelationalOperation.java
+++ b/gen/org/elixir_lang/psi/ElixirUnmatchedRelationalOperation.java
@@ -77,7 +77,7 @@ public interface ElixirUnmatchedRelationalOperation extends ElixirUnmatchedExpre
   @Nullable
   Integer resolvedSecondaryArity();
 
-  @NotNull
+  @Nullable
   Quotable rightOperand();
 
   @Nullable

--- a/gen/org/elixir_lang/psi/ElixirUnmatchedTwoOperation.java
+++ b/gen/org/elixir_lang/psi/ElixirUnmatchedTwoOperation.java
@@ -77,7 +77,7 @@ public interface ElixirUnmatchedTwoOperation extends ElixirUnmatchedExpression, 
   @Nullable
   Integer resolvedSecondaryArity();
 
-  @NotNull
+  @Nullable
   Quotable rightOperand();
 
   @Nullable

--- a/gen/org/elixir_lang/psi/ElixirUnmatchedTypeOperation.java
+++ b/gen/org/elixir_lang/psi/ElixirUnmatchedTypeOperation.java
@@ -77,7 +77,7 @@ public interface ElixirUnmatchedTypeOperation extends ElixirUnmatchedExpression,
   @Nullable
   Integer resolvedSecondaryArity();
 
-  @NotNull
+  @Nullable
   Quotable rightOperand();
 
   @Nullable

--- a/gen/org/elixir_lang/psi/ElixirUnmatchedWhenOperation.java
+++ b/gen/org/elixir_lang/psi/ElixirUnmatchedWhenOperation.java
@@ -77,7 +77,7 @@ public interface ElixirUnmatchedWhenOperation extends ElixirUnmatchedExpression,
   @Nullable
   Integer resolvedSecondaryArity();
 
-  @NotNull
+  @Nullable
   Quotable rightOperand();
 
   @Nullable

--- a/gen/org/elixir_lang/psi/impl/ElixirAccessExpressionImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirAccessExpressionImpl.java
@@ -18,8 +18,12 @@ public class ElixirAccessExpressionImpl extends ASTWrapperPsiElement implements 
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitAccessExpression(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitAccessExpression(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirAdditionInfixOperatorImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirAdditionInfixOperatorImpl.java
@@ -16,8 +16,12 @@ public class ElixirAdditionInfixOperatorImpl extends ASTWrapperPsiElement implem
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitAdditionInfixOperator(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitAdditionInfixOperator(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirAliasImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirAliasImpl.java
@@ -20,8 +20,12 @@ public class ElixirAliasImpl extends ASTWrapperPsiElement implements ElixirAlias
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitAlias(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitAlias(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirAndInfixOperatorImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirAndInfixOperatorImpl.java
@@ -16,8 +16,12 @@ public class ElixirAndInfixOperatorImpl extends ASTWrapperPsiElement implements 
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitAndInfixOperator(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitAndInfixOperator(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirAnonymousFunctionImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirAnonymousFunctionImpl.java
@@ -20,8 +20,12 @@ public class ElixirAnonymousFunctionImpl extends ASTWrapperPsiElement implements
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitAnonymousFunction(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitAnonymousFunction(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirArrowInfixOperatorImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirArrowInfixOperatorImpl.java
@@ -16,8 +16,12 @@ public class ElixirArrowInfixOperatorImpl extends ASTWrapperPsiElement implement
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitArrowInfixOperator(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitArrowInfixOperator(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirAssociationsBaseImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirAssociationsBaseImpl.java
@@ -17,8 +17,12 @@ public class ElixirAssociationsBaseImpl extends ASTWrapperPsiElement implements 
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitAssociationsBase(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitAssociationsBase(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirAssociationsImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirAssociationsImpl.java
@@ -16,8 +16,12 @@ public class ElixirAssociationsImpl extends ASTWrapperPsiElement implements Elix
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitAssociations(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitAssociations(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirAtIdentifierImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirAtIdentifierImpl.java
@@ -16,8 +16,12 @@ public class ElixirAtIdentifierImpl extends ASTWrapperPsiElement implements Elix
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitAtIdentifier(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitAtIdentifier(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirAtNumericOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirAtNumericOperationImpl.java
@@ -17,8 +17,12 @@ public class ElixirAtNumericOperationImpl extends ASTWrapperPsiElement implement
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitAtNumericOperation(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitAtNumericOperation(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirAtPrefixOperatorImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirAtPrefixOperatorImpl.java
@@ -16,8 +16,12 @@ public class ElixirAtPrefixOperatorImpl extends ASTWrapperPsiElement implements 
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitAtPrefixOperator(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitAtPrefixOperator(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirAtomImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirAtomImpl.java
@@ -18,8 +18,12 @@ public class ElixirAtomImpl extends ASTWrapperPsiElement implements ElixirAtom {
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitAtom(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitAtom(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirAtomKeywordImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirAtomKeywordImpl.java
@@ -15,8 +15,12 @@ public class ElixirAtomKeywordImpl extends ASTWrapperPsiElement implements Elixi
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitAtomKeyword(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitAtomKeyword(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirBinaryDigitsImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirBinaryDigitsImpl.java
@@ -16,8 +16,12 @@ public class ElixirBinaryDigitsImpl extends ASTWrapperPsiElement implements Elix
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitBinaryDigits(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitBinaryDigits(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirBinaryWholeNumberImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirBinaryWholeNumberImpl.java
@@ -20,8 +20,12 @@ public class ElixirBinaryWholeNumberImpl extends ASTWrapperPsiElement implements
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitBinaryWholeNumber(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitBinaryWholeNumber(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirBitStringImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirBitStringImpl.java
@@ -18,8 +18,12 @@ public class ElixirBitStringImpl extends ASTWrapperPsiElement implements ElixirB
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitBitString(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitBitString(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirBlockIdentifierImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirBlockIdentifierImpl.java
@@ -15,8 +15,12 @@ public class ElixirBlockIdentifierImpl extends ASTWrapperPsiElement implements E
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitBlockIdentifier(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitBlockIdentifier(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirBlockItemImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirBlockItemImpl.java
@@ -18,8 +18,12 @@ public class ElixirBlockItemImpl extends ASTWrapperPsiElement implements ElixirB
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitBlockItem(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitBlockItem(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirBlockListImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirBlockListImpl.java
@@ -19,8 +19,12 @@ public class ElixirBlockListImpl extends ASTWrapperPsiElement implements ElixirB
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitBlockList(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitBlockList(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirBracketArgumentsImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirBracketArgumentsImpl.java
@@ -15,8 +15,12 @@ public class ElixirBracketArgumentsImpl extends ASTWrapperPsiElement implements 
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitBracketArguments(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitBracketArguments(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirCaptureNumericOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirCaptureNumericOperationImpl.java
@@ -17,8 +17,12 @@ public class ElixirCaptureNumericOperationImpl extends ASTWrapperPsiElement impl
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitCaptureNumericOperation(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitCaptureNumericOperation(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirCapturePrefixOperatorImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirCapturePrefixOperatorImpl.java
@@ -16,8 +16,12 @@ public class ElixirCapturePrefixOperatorImpl extends ASTWrapperPsiElement implem
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitCapturePrefixOperator(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitCapturePrefixOperator(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirCharListHeredocImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirCharListHeredocImpl.java
@@ -20,8 +20,12 @@ public class ElixirCharListHeredocImpl extends ASTWrapperPsiElement implements E
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitCharListHeredoc(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitCharListHeredoc(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirCharListHeredocLineImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirCharListHeredocLineImpl.java
@@ -14,8 +14,12 @@ public class ElixirCharListHeredocLineImpl extends ASTWrapperPsiElement implemen
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitCharListHeredocLine(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitCharListHeredocLine(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirCharListLineImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirCharListLineImpl.java
@@ -21,8 +21,12 @@ public class ElixirCharListLineImpl extends ASTWrapperPsiElement implements Elix
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitCharListLine(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitCharListLine(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirCharTokenImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirCharTokenImpl.java
@@ -15,8 +15,12 @@ public class ElixirCharTokenImpl extends ASTWrapperPsiElement implements ElixirC
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitCharToken(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitCharToken(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirComparisonInfixOperatorImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirComparisonInfixOperatorImpl.java
@@ -16,8 +16,12 @@ public class ElixirComparisonInfixOperatorImpl extends ASTWrapperPsiElement impl
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitComparisonInfixOperator(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitComparisonInfixOperator(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirContainerAssociationOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirContainerAssociationOperationImpl.java
@@ -20,8 +20,12 @@ public class ElixirContainerAssociationOperationImpl extends ASTWrapperPsiElemen
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitContainerAssociationOperation(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitContainerAssociationOperation(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirDecimalDigitsImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirDecimalDigitsImpl.java
@@ -16,8 +16,12 @@ public class ElixirDecimalDigitsImpl extends ASTWrapperPsiElement implements Eli
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitDecimalDigits(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitDecimalDigits(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirDecimalFloatExponentImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirDecimalFloatExponentImpl.java
@@ -16,8 +16,12 @@ public class ElixirDecimalFloatExponentImpl extends ASTWrapperPsiElement impleme
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitDecimalFloatExponent(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitDecimalFloatExponent(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirDecimalFloatExponentSignImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirDecimalFloatExponentSignImpl.java
@@ -14,8 +14,12 @@ public class ElixirDecimalFloatExponentSignImpl extends ASTWrapperPsiElement imp
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitDecimalFloatExponentSign(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitDecimalFloatExponentSign(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirDecimalFloatFractionalImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirDecimalFloatFractionalImpl.java
@@ -15,8 +15,12 @@ public class ElixirDecimalFloatFractionalImpl extends ASTWrapperPsiElement imple
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitDecimalFloatFractional(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitDecimalFloatFractional(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirDecimalFloatImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirDecimalFloatImpl.java
@@ -15,8 +15,12 @@ public class ElixirDecimalFloatImpl extends ASTWrapperPsiElement implements Elix
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitDecimalFloat(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitDecimalFloat(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirDecimalFloatIntegralImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirDecimalFloatIntegralImpl.java
@@ -15,8 +15,12 @@ public class ElixirDecimalFloatIntegralImpl extends ASTWrapperPsiElement impleme
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitDecimalFloatIntegral(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitDecimalFloatIntegral(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirDecimalWholeNumberImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirDecimalWholeNumberImpl.java
@@ -20,8 +20,12 @@ public class ElixirDecimalWholeNumberImpl extends ASTWrapperPsiElement implement
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitDecimalWholeNumber(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitDecimalWholeNumber(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirDoBlockImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirDoBlockImpl.java
@@ -18,8 +18,12 @@ public class ElixirDoBlockImpl extends ASTWrapperPsiElement implements ElixirDoB
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitDoBlock(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitDoBlock(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirDotInfixOperatorImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirDotInfixOperatorImpl.java
@@ -16,8 +16,12 @@ public class ElixirDotInfixOperatorImpl extends ASTWrapperPsiElement implements 
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitDotInfixOperator(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitDotInfixOperator(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirEmptyParenthesesImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirEmptyParenthesesImpl.java
@@ -15,8 +15,12 @@ public class ElixirEmptyParenthesesImpl extends ASTWrapperPsiElement implements 
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitEmptyParentheses(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitEmptyParentheses(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirEnclosedHexadecimalEscapeSequenceImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirEnclosedHexadecimalEscapeSequenceImpl.java
@@ -14,8 +14,12 @@ public class ElixirEnclosedHexadecimalEscapeSequenceImpl extends ASTWrapperPsiEl
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitEnclosedHexadecimalEscapeSequence(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitEnclosedHexadecimalEscapeSequence(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirEndOfExpressionImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirEndOfExpressionImpl.java
@@ -14,8 +14,12 @@ public class ElixirEndOfExpressionImpl extends ASTWrapperPsiElement implements E
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitEndOfExpression(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitEndOfExpression(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirEscapedCharacterImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirEscapedCharacterImpl.java
@@ -14,8 +14,12 @@ public class ElixirEscapedCharacterImpl extends ASTWrapperPsiElement implements 
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitEscapedCharacter(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitEscapedCharacter(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirEscapedEOLImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirEscapedEOLImpl.java
@@ -14,8 +14,12 @@ public class ElixirEscapedEOLImpl extends ASTWrapperPsiElement implements Elixir
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitEscapedEOL(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitEscapedEOL(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirHeredocLinePrefixImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirHeredocLinePrefixImpl.java
@@ -16,8 +16,12 @@ public class ElixirHeredocLinePrefixImpl extends ASTWrapperPsiElement implements
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitHeredocLinePrefix(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitHeredocLinePrefix(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirHeredocPrefixImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirHeredocPrefixImpl.java
@@ -14,8 +14,12 @@ public class ElixirHeredocPrefixImpl extends ASTWrapperPsiElement implements Eli
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitHeredocPrefix(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitHeredocPrefix(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirHexadecimalDigitsImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirHexadecimalDigitsImpl.java
@@ -16,8 +16,12 @@ public class ElixirHexadecimalDigitsImpl extends ASTWrapperPsiElement implements
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitHexadecimalDigits(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitHexadecimalDigits(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirHexadecimalEscapePrefixImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirHexadecimalEscapePrefixImpl.java
@@ -14,8 +14,12 @@ public class ElixirHexadecimalEscapePrefixImpl extends ASTWrapperPsiElement impl
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitHexadecimalEscapePrefix(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitHexadecimalEscapePrefix(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirHexadecimalWholeNumberImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirHexadecimalWholeNumberImpl.java
@@ -20,8 +20,12 @@ public class ElixirHexadecimalWholeNumberImpl extends ASTWrapperPsiElement imple
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitHexadecimalWholeNumber(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitHexadecimalWholeNumber(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirIdentifierImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirIdentifierImpl.java
@@ -15,8 +15,12 @@ public class ElixirIdentifierImpl extends ASTWrapperPsiElement implements Elixir
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitIdentifier(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitIdentifier(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirInInfixOperatorImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirInInfixOperatorImpl.java
@@ -16,8 +16,12 @@ public class ElixirInInfixOperatorImpl extends ASTWrapperPsiElement implements E
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitInInfixOperator(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitInInfixOperator(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirInMatchInfixOperatorImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirInMatchInfixOperatorImpl.java
@@ -16,8 +16,12 @@ public class ElixirInMatchInfixOperatorImpl extends ASTWrapperPsiElement impleme
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitInMatchInfixOperator(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitInMatchInfixOperator(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirInterpolatedCharListBodyImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirInterpolatedCharListBodyImpl.java
@@ -16,8 +16,12 @@ public class ElixirInterpolatedCharListBodyImpl extends ASTWrapperPsiElement imp
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitInterpolatedCharListBody(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitInterpolatedCharListBody(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirInterpolatedCharListHeredocLineImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirInterpolatedCharListHeredocLineImpl.java
@@ -14,8 +14,12 @@ public class ElixirInterpolatedCharListHeredocLineImpl extends ASTWrapperPsiElem
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitInterpolatedCharListHeredocLine(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitInterpolatedCharListHeredocLine(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirInterpolatedCharListSigilHeredocImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirInterpolatedCharListSigilHeredocImpl.java
@@ -20,8 +20,12 @@ public class ElixirInterpolatedCharListSigilHeredocImpl extends ASTWrapperPsiEle
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitInterpolatedCharListSigilHeredoc(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitInterpolatedCharListSigilHeredoc(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirInterpolatedCharListSigilLineImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirInterpolatedCharListSigilLineImpl.java
@@ -18,8 +18,12 @@ public class ElixirInterpolatedCharListSigilLineImpl extends ASTWrapperPsiElemen
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitInterpolatedCharListSigilLine(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitInterpolatedCharListSigilLine(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirInterpolatedRegexBodyImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirInterpolatedRegexBodyImpl.java
@@ -16,8 +16,12 @@ public class ElixirInterpolatedRegexBodyImpl extends ASTWrapperPsiElement implem
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitInterpolatedRegexBody(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitInterpolatedRegexBody(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirInterpolatedRegexHeredocImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirInterpolatedRegexHeredocImpl.java
@@ -20,8 +20,12 @@ public class ElixirInterpolatedRegexHeredocImpl extends ASTWrapperPsiElement imp
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitInterpolatedRegexHeredoc(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitInterpolatedRegexHeredoc(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirInterpolatedRegexHeredocLineImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirInterpolatedRegexHeredocLineImpl.java
@@ -14,8 +14,12 @@ public class ElixirInterpolatedRegexHeredocLineImpl extends ASTWrapperPsiElement
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitInterpolatedRegexHeredocLine(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitInterpolatedRegexHeredocLine(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirInterpolatedRegexLineImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirInterpolatedRegexLineImpl.java
@@ -18,8 +18,12 @@ public class ElixirInterpolatedRegexLineImpl extends ASTWrapperPsiElement implem
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitInterpolatedRegexLine(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitInterpolatedRegexLine(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirInterpolatedSigilBodyImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirInterpolatedSigilBodyImpl.java
@@ -16,8 +16,12 @@ public class ElixirInterpolatedSigilBodyImpl extends ASTWrapperPsiElement implem
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitInterpolatedSigilBody(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitInterpolatedSigilBody(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirInterpolatedSigilHeredocImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirInterpolatedSigilHeredocImpl.java
@@ -20,8 +20,12 @@ public class ElixirInterpolatedSigilHeredocImpl extends ASTWrapperPsiElement imp
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitInterpolatedSigilHeredoc(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitInterpolatedSigilHeredoc(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirInterpolatedSigilHeredocLineImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirInterpolatedSigilHeredocLineImpl.java
@@ -14,8 +14,12 @@ public class ElixirInterpolatedSigilHeredocLineImpl extends ASTWrapperPsiElement
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitInterpolatedSigilHeredocLine(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitInterpolatedSigilHeredocLine(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirInterpolatedSigilLineImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirInterpolatedSigilLineImpl.java
@@ -18,8 +18,12 @@ public class ElixirInterpolatedSigilLineImpl extends ASTWrapperPsiElement implem
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitInterpolatedSigilLine(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitInterpolatedSigilLine(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirInterpolatedStringBodyImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirInterpolatedStringBodyImpl.java
@@ -16,8 +16,12 @@ public class ElixirInterpolatedStringBodyImpl extends ASTWrapperPsiElement imple
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitInterpolatedStringBody(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitInterpolatedStringBody(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirInterpolatedStringHeredocLineImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirInterpolatedStringHeredocLineImpl.java
@@ -14,8 +14,12 @@ public class ElixirInterpolatedStringHeredocLineImpl extends ASTWrapperPsiElemen
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitInterpolatedStringHeredocLine(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitInterpolatedStringHeredocLine(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirInterpolatedStringSigilHeredocImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirInterpolatedStringSigilHeredocImpl.java
@@ -20,8 +20,12 @@ public class ElixirInterpolatedStringSigilHeredocImpl extends ASTWrapperPsiEleme
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitInterpolatedStringSigilHeredoc(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitInterpolatedStringSigilHeredoc(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirInterpolatedStringSigilLineImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirInterpolatedStringSigilLineImpl.java
@@ -18,8 +18,12 @@ public class ElixirInterpolatedStringSigilLineImpl extends ASTWrapperPsiElement 
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitInterpolatedStringSigilLine(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitInterpolatedStringSigilLine(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirInterpolatedWordsBodyImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirInterpolatedWordsBodyImpl.java
@@ -16,8 +16,12 @@ public class ElixirInterpolatedWordsBodyImpl extends ASTWrapperPsiElement implem
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitInterpolatedWordsBody(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitInterpolatedWordsBody(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirInterpolatedWordsHeredocImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirInterpolatedWordsHeredocImpl.java
@@ -20,8 +20,12 @@ public class ElixirInterpolatedWordsHeredocImpl extends ASTWrapperPsiElement imp
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitInterpolatedWordsHeredoc(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitInterpolatedWordsHeredoc(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirInterpolatedWordsHeredocLineImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirInterpolatedWordsHeredocLineImpl.java
@@ -14,8 +14,12 @@ public class ElixirInterpolatedWordsHeredocLineImpl extends ASTWrapperPsiElement
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitInterpolatedWordsHeredocLine(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitInterpolatedWordsHeredocLine(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirInterpolatedWordsLineImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirInterpolatedWordsLineImpl.java
@@ -18,8 +18,12 @@ public class ElixirInterpolatedWordsLineImpl extends ASTWrapperPsiElement implem
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitInterpolatedWordsLine(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitInterpolatedWordsLine(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirInterpolationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirInterpolationImpl.java
@@ -17,8 +17,12 @@ public class ElixirInterpolationImpl extends ASTWrapperPsiElement implements Eli
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitInterpolation(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitInterpolation(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirKeywordKeyImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirKeywordKeyImpl.java
@@ -18,8 +18,12 @@ public class ElixirKeywordKeyImpl extends ASTWrapperPsiElement implements Elixir
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitKeywordKey(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitKeywordKey(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirKeywordPairImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirKeywordPairImpl.java
@@ -15,8 +15,12 @@ public class ElixirKeywordPairImpl extends ASTWrapperPsiElement implements Elixi
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitKeywordPair(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitKeywordPair(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirKeywordsImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirKeywordsImpl.java
@@ -20,8 +20,12 @@ public class ElixirKeywordsImpl extends ASTWrapperPsiElement implements ElixirKe
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitKeywords(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitKeywords(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirListImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirListImpl.java
@@ -18,8 +18,12 @@ public class ElixirListImpl extends ASTWrapperPsiElement implements ElixirList {
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitList(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitList(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirLiteralCharListBodyImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirLiteralCharListBodyImpl.java
@@ -16,8 +16,12 @@ public class ElixirLiteralCharListBodyImpl extends ASTWrapperPsiElement implemen
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitLiteralCharListBody(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitLiteralCharListBody(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirLiteralCharListHeredocLineImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirLiteralCharListHeredocLineImpl.java
@@ -14,8 +14,12 @@ public class ElixirLiteralCharListHeredocLineImpl extends ASTWrapperPsiElement i
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitLiteralCharListHeredocLine(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitLiteralCharListHeredocLine(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirLiteralCharListSigilHeredocImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirLiteralCharListSigilHeredocImpl.java
@@ -20,8 +20,12 @@ public class ElixirLiteralCharListSigilHeredocImpl extends ASTWrapperPsiElement 
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitLiteralCharListSigilHeredoc(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitLiteralCharListSigilHeredoc(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirLiteralCharListSigilLineImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirLiteralCharListSigilLineImpl.java
@@ -18,8 +18,12 @@ public class ElixirLiteralCharListSigilLineImpl extends ASTWrapperPsiElement imp
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitLiteralCharListSigilLine(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitLiteralCharListSigilLine(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirLiteralRegexBodyImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirLiteralRegexBodyImpl.java
@@ -16,8 +16,12 @@ public class ElixirLiteralRegexBodyImpl extends ASTWrapperPsiElement implements 
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitLiteralRegexBody(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitLiteralRegexBody(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirLiteralRegexHeredocImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirLiteralRegexHeredocImpl.java
@@ -20,8 +20,12 @@ public class ElixirLiteralRegexHeredocImpl extends ASTWrapperPsiElement implemen
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitLiteralRegexHeredoc(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitLiteralRegexHeredoc(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirLiteralRegexHeredocLineImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirLiteralRegexHeredocLineImpl.java
@@ -14,8 +14,12 @@ public class ElixirLiteralRegexHeredocLineImpl extends ASTWrapperPsiElement impl
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitLiteralRegexHeredocLine(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitLiteralRegexHeredocLine(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirLiteralRegexLineImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirLiteralRegexLineImpl.java
@@ -18,8 +18,12 @@ public class ElixirLiteralRegexLineImpl extends ASTWrapperPsiElement implements 
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitLiteralRegexLine(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitLiteralRegexLine(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirLiteralSigilBodyImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirLiteralSigilBodyImpl.java
@@ -16,8 +16,12 @@ public class ElixirLiteralSigilBodyImpl extends ASTWrapperPsiElement implements 
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitLiteralSigilBody(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitLiteralSigilBody(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirLiteralSigilHeredocImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirLiteralSigilHeredocImpl.java
@@ -20,8 +20,12 @@ public class ElixirLiteralSigilHeredocImpl extends ASTWrapperPsiElement implemen
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitLiteralSigilHeredoc(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitLiteralSigilHeredoc(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirLiteralSigilHeredocLineImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirLiteralSigilHeredocLineImpl.java
@@ -14,8 +14,12 @@ public class ElixirLiteralSigilHeredocLineImpl extends ASTWrapperPsiElement impl
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitLiteralSigilHeredocLine(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitLiteralSigilHeredocLine(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirLiteralSigilLineImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirLiteralSigilLineImpl.java
@@ -18,8 +18,12 @@ public class ElixirLiteralSigilLineImpl extends ASTWrapperPsiElement implements 
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitLiteralSigilLine(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitLiteralSigilLine(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirLiteralStringBodyImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirLiteralStringBodyImpl.java
@@ -16,8 +16,12 @@ public class ElixirLiteralStringBodyImpl extends ASTWrapperPsiElement implements
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitLiteralStringBody(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitLiteralStringBody(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirLiteralStringHeredocLineImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirLiteralStringHeredocLineImpl.java
@@ -14,8 +14,12 @@ public class ElixirLiteralStringHeredocLineImpl extends ASTWrapperPsiElement imp
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitLiteralStringHeredocLine(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitLiteralStringHeredocLine(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirLiteralStringSigilHeredocImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirLiteralStringSigilHeredocImpl.java
@@ -20,8 +20,12 @@ public class ElixirLiteralStringSigilHeredocImpl extends ASTWrapperPsiElement im
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitLiteralStringSigilHeredoc(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitLiteralStringSigilHeredoc(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirLiteralStringSigilLineImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirLiteralStringSigilLineImpl.java
@@ -18,8 +18,12 @@ public class ElixirLiteralStringSigilLineImpl extends ASTWrapperPsiElement imple
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitLiteralStringSigilLine(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitLiteralStringSigilLine(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirLiteralWordsBodyImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirLiteralWordsBodyImpl.java
@@ -16,8 +16,12 @@ public class ElixirLiteralWordsBodyImpl extends ASTWrapperPsiElement implements 
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitLiteralWordsBody(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitLiteralWordsBody(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirLiteralWordsHeredocImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirLiteralWordsHeredocImpl.java
@@ -20,8 +20,12 @@ public class ElixirLiteralWordsHeredocImpl extends ASTWrapperPsiElement implemen
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitLiteralWordsHeredoc(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitLiteralWordsHeredoc(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirLiteralWordsHeredocLineImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirLiteralWordsHeredocLineImpl.java
@@ -14,8 +14,12 @@ public class ElixirLiteralWordsHeredocLineImpl extends ASTWrapperPsiElement impl
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitLiteralWordsHeredocLine(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitLiteralWordsHeredocLine(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirLiteralWordsLineImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirLiteralWordsLineImpl.java
@@ -18,8 +18,12 @@ public class ElixirLiteralWordsLineImpl extends ASTWrapperPsiElement implements 
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitLiteralWordsLine(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitLiteralWordsLine(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirMapArgumentsImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMapArgumentsImpl.java
@@ -18,8 +18,12 @@ public class ElixirMapArgumentsImpl extends ASTWrapperPsiElement implements Elix
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitMapArguments(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitMapArguments(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirMapConstructionArgumentsImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMapConstructionArgumentsImpl.java
@@ -16,8 +16,12 @@ public class ElixirMapConstructionArgumentsImpl extends ASTWrapperPsiElement imp
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitMapConstructionArguments(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitMapConstructionArguments(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirMapOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMapOperationImpl.java
@@ -17,8 +17,12 @@ public class ElixirMapOperationImpl extends ASTWrapperPsiElement implements Elix
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitMapOperation(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitMapOperation(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirMapPrefixOperatorImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMapPrefixOperatorImpl.java
@@ -16,8 +16,12 @@ public class ElixirMapPrefixOperatorImpl extends ASTWrapperPsiElement implements
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitMapPrefixOperator(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitMapPrefixOperator(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirMapUpdateArgumentsImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMapUpdateArgumentsImpl.java
@@ -15,8 +15,12 @@ public class ElixirMapUpdateArgumentsImpl extends ASTWrapperPsiElement implement
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitMapUpdateArguments(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitMapUpdateArguments(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirMatchInfixOperatorImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMatchInfixOperatorImpl.java
@@ -16,8 +16,12 @@ public class ElixirMatchInfixOperatorImpl extends ASTWrapperPsiElement implement
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitMatchInfixOperator(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitMatchInfixOperator(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirMatchedAdditionOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMatchedAdditionOperationImpl.java
@@ -19,8 +19,12 @@ public class ElixirMatchedAdditionOperationImpl extends ElixirMatchedExpressionI
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitMatchedAdditionOperation(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitMatchedAdditionOperation(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 
@@ -136,7 +140,7 @@ public class ElixirMatchedAdditionOperationImpl extends ElixirMatchedExpressionI
     return ElixirPsiImplUtil.resolvedSecondaryArity(this);
   }
 
-  @NotNull
+  @Nullable
   public Quotable rightOperand() {
     return ElixirPsiImplUtil.rightOperand(this);
   }

--- a/gen/org/elixir_lang/psi/impl/ElixirMatchedAndOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMatchedAndOperationImpl.java
@@ -19,8 +19,12 @@ public class ElixirMatchedAndOperationImpl extends ElixirMatchedExpressionImpl i
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitMatchedAndOperation(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitMatchedAndOperation(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 
@@ -136,7 +140,7 @@ public class ElixirMatchedAndOperationImpl extends ElixirMatchedExpressionImpl i
     return ElixirPsiImplUtil.resolvedSecondaryArity(this);
   }
 
-  @NotNull
+  @Nullable
   public Quotable rightOperand() {
     return ElixirPsiImplUtil.rightOperand(this);
   }

--- a/gen/org/elixir_lang/psi/impl/ElixirMatchedArrowOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMatchedArrowOperationImpl.java
@@ -19,8 +19,12 @@ public class ElixirMatchedArrowOperationImpl extends ElixirMatchedExpressionImpl
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitMatchedArrowOperation(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitMatchedArrowOperation(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 
@@ -136,7 +140,7 @@ public class ElixirMatchedArrowOperationImpl extends ElixirMatchedExpressionImpl
     return ElixirPsiImplUtil.resolvedSecondaryArity(this);
   }
 
-  @NotNull
+  @Nullable
   public Quotable rightOperand() {
     return ElixirPsiImplUtil.rightOperand(this);
   }

--- a/gen/org/elixir_lang/psi/impl/ElixirMatchedAtNonNumericOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMatchedAtNonNumericOperationImpl.java
@@ -15,8 +15,12 @@ public class ElixirMatchedAtNonNumericOperationImpl extends ElixirMatchedExpress
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitMatchedAtNonNumericOperation(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitMatchedAtNonNumericOperation(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirMatchedAtUnqualifiedBracketOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMatchedAtUnqualifiedBracketOperationImpl.java
@@ -16,8 +16,12 @@ public class ElixirMatchedAtUnqualifiedBracketOperationImpl extends ElixirMatche
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitMatchedAtUnqualifiedBracketOperation(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitMatchedAtUnqualifiedBracketOperation(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirMatchedAtUnqualifiedNoParenthesesCallImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMatchedAtUnqualifiedNoParenthesesCallImpl.java
@@ -22,8 +22,12 @@ public class ElixirMatchedAtUnqualifiedNoParenthesesCallImpl extends NamedStubbe
     super(stub, nodeType);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitMatchedAtUnqualifiedNoParenthesesCall(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitMatchedAtUnqualifiedNoParenthesesCall(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirMatchedBracketOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMatchedBracketOperationImpl.java
@@ -16,8 +16,12 @@ public class ElixirMatchedBracketOperationImpl extends ElixirMatchedExpressionIm
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitMatchedBracketOperation(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitMatchedBracketOperation(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirMatchedCaptureNonNumericOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMatchedCaptureNonNumericOperationImpl.java
@@ -16,8 +16,12 @@ public class ElixirMatchedCaptureNonNumericOperationImpl extends ElixirMatchedEx
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitMatchedCaptureNonNumericOperation(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitMatchedCaptureNonNumericOperation(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirMatchedComparisonOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMatchedComparisonOperationImpl.java
@@ -19,8 +19,12 @@ public class ElixirMatchedComparisonOperationImpl extends ElixirMatchedExpressio
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitMatchedComparisonOperation(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitMatchedComparisonOperation(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 
@@ -136,7 +140,7 @@ public class ElixirMatchedComparisonOperationImpl extends ElixirMatchedExpressio
     return ElixirPsiImplUtil.resolvedSecondaryArity(this);
   }
 
-  @NotNull
+  @Nullable
   public Quotable rightOperand() {
     return ElixirPsiImplUtil.rightOperand(this);
   }

--- a/gen/org/elixir_lang/psi/impl/ElixirMatchedDotCallImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMatchedDotCallImpl.java
@@ -25,8 +25,12 @@ public class ElixirMatchedDotCallImpl extends NamedStubbedPsiElementBase<Matched
     super(stub, nodeType);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitMatchedDotCall(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitMatchedDotCall(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirMatchedExpressionImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMatchedExpressionImpl.java
@@ -14,8 +14,12 @@ public class ElixirMatchedExpressionImpl extends ASTWrapperPsiElement implements
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitMatchedExpression(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitMatchedExpression(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirMatchedInMatchOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMatchedInMatchOperationImpl.java
@@ -19,8 +19,12 @@ public class ElixirMatchedInMatchOperationImpl extends ElixirMatchedExpressionIm
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitMatchedInMatchOperation(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitMatchedInMatchOperation(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 
@@ -136,7 +140,7 @@ public class ElixirMatchedInMatchOperationImpl extends ElixirMatchedExpressionIm
     return ElixirPsiImplUtil.resolvedSecondaryArity(this);
   }
 
-  @NotNull
+  @Nullable
   public Quotable rightOperand() {
     return ElixirPsiImplUtil.rightOperand(this);
   }

--- a/gen/org/elixir_lang/psi/impl/ElixirMatchedInOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMatchedInOperationImpl.java
@@ -19,8 +19,12 @@ public class ElixirMatchedInOperationImpl extends ElixirMatchedExpressionImpl im
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitMatchedInOperation(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitMatchedInOperation(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 
@@ -127,7 +131,7 @@ public class ElixirMatchedInOperationImpl extends ElixirMatchedExpressionImpl im
     return ElixirPsiImplUtil.resolvedSecondaryArity(this);
   }
 
-  @NotNull
+  @Nullable
   public Quotable rightOperand() {
     return ElixirPsiImplUtil.rightOperand(this);
   }

--- a/gen/org/elixir_lang/psi/impl/ElixirMatchedMatchOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMatchedMatchOperationImpl.java
@@ -19,8 +19,12 @@ public class ElixirMatchedMatchOperationImpl extends ElixirMatchedExpressionImpl
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitMatchedMatchOperation(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitMatchedMatchOperation(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 
@@ -136,7 +140,7 @@ public class ElixirMatchedMatchOperationImpl extends ElixirMatchedExpressionImpl
     return ElixirPsiImplUtil.resolvedSecondaryArity(this);
   }
 
-  @NotNull
+  @Nullable
   public Quotable rightOperand() {
     return ElixirPsiImplUtil.rightOperand(this);
   }

--- a/gen/org/elixir_lang/psi/impl/ElixirMatchedMultiplicationOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMatchedMultiplicationOperationImpl.java
@@ -19,8 +19,12 @@ public class ElixirMatchedMultiplicationOperationImpl extends ElixirMatchedExpre
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitMatchedMultiplicationOperation(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitMatchedMultiplicationOperation(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 
@@ -136,7 +140,7 @@ public class ElixirMatchedMultiplicationOperationImpl extends ElixirMatchedExpre
     return ElixirPsiImplUtil.resolvedSecondaryArity(this);
   }
 
-  @NotNull
+  @Nullable
   public Quotable rightOperand() {
     return ElixirPsiImplUtil.rightOperand(this);
   }

--- a/gen/org/elixir_lang/psi/impl/ElixirMatchedOrOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMatchedOrOperationImpl.java
@@ -19,8 +19,12 @@ public class ElixirMatchedOrOperationImpl extends ElixirMatchedExpressionImpl im
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitMatchedOrOperation(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitMatchedOrOperation(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 
@@ -136,7 +140,7 @@ public class ElixirMatchedOrOperationImpl extends ElixirMatchedExpressionImpl im
     return ElixirPsiImplUtil.resolvedSecondaryArity(this);
   }
 
-  @NotNull
+  @Nullable
   public Quotable rightOperand() {
     return ElixirPsiImplUtil.rightOperand(this);
   }

--- a/gen/org/elixir_lang/psi/impl/ElixirMatchedParenthesesArgumentsImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMatchedParenthesesArgumentsImpl.java
@@ -18,8 +18,12 @@ public class ElixirMatchedParenthesesArgumentsImpl extends ASTWrapperPsiElement 
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitMatchedParenthesesArguments(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitMatchedParenthesesArguments(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirMatchedPipeOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMatchedPipeOperationImpl.java
@@ -19,8 +19,12 @@ public class ElixirMatchedPipeOperationImpl extends ElixirMatchedExpressionImpl 
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitMatchedPipeOperation(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitMatchedPipeOperation(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 
@@ -136,7 +140,7 @@ public class ElixirMatchedPipeOperationImpl extends ElixirMatchedExpressionImpl 
     return ElixirPsiImplUtil.resolvedSecondaryArity(this);
   }
 
-  @NotNull
+  @Nullable
   public Quotable rightOperand() {
     return ElixirPsiImplUtil.rightOperand(this);
   }

--- a/gen/org/elixir_lang/psi/impl/ElixirMatchedQualifiedAliasImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMatchedQualifiedAliasImpl.java
@@ -18,8 +18,12 @@ public class ElixirMatchedQualifiedAliasImpl extends ElixirMatchedExpressionImpl
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitMatchedQualifiedAlias(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitMatchedQualifiedAlias(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirMatchedQualifiedBracketOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMatchedQualifiedBracketOperationImpl.java
@@ -13,8 +13,12 @@ public class ElixirMatchedQualifiedBracketOperationImpl extends ElixirMatchedExp
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitMatchedQualifiedBracketOperation(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitMatchedQualifiedBracketOperation(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirMatchedQualifiedNoArgumentsCallImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMatchedQualifiedNoArgumentsCallImpl.java
@@ -22,8 +22,12 @@ public class ElixirMatchedQualifiedNoArgumentsCallImpl extends NamedStubbedPsiEl
     super(stub, nodeType);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitMatchedQualifiedNoArgumentsCall(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitMatchedQualifiedNoArgumentsCall(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirMatchedQualifiedNoParenthesesCallImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMatchedQualifiedNoParenthesesCallImpl.java
@@ -22,8 +22,12 @@ public class ElixirMatchedQualifiedNoParenthesesCallImpl extends NamedStubbedPsi
     super(stub, nodeType);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitMatchedQualifiedNoParenthesesCall(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitMatchedQualifiedNoParenthesesCall(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirMatchedQualifiedParenthesesCallImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMatchedQualifiedParenthesesCallImpl.java
@@ -22,8 +22,12 @@ public class ElixirMatchedQualifiedParenthesesCallImpl extends NamedStubbedPsiEl
     super(stub, nodeType);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitMatchedQualifiedParenthesesCall(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitMatchedQualifiedParenthesesCall(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirMatchedRelationalOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMatchedRelationalOperationImpl.java
@@ -19,8 +19,12 @@ public class ElixirMatchedRelationalOperationImpl extends ElixirMatchedExpressio
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitMatchedRelationalOperation(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitMatchedRelationalOperation(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 
@@ -136,7 +140,7 @@ public class ElixirMatchedRelationalOperationImpl extends ElixirMatchedExpressio
     return ElixirPsiImplUtil.resolvedSecondaryArity(this);
   }
 
-  @NotNull
+  @Nullable
   public Quotable rightOperand() {
     return ElixirPsiImplUtil.rightOperand(this);
   }

--- a/gen/org/elixir_lang/psi/impl/ElixirMatchedTwoOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMatchedTwoOperationImpl.java
@@ -19,8 +19,12 @@ public class ElixirMatchedTwoOperationImpl extends ElixirMatchedExpressionImpl i
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitMatchedTwoOperation(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitMatchedTwoOperation(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 
@@ -136,7 +140,7 @@ public class ElixirMatchedTwoOperationImpl extends ElixirMatchedExpressionImpl i
     return ElixirPsiImplUtil.resolvedSecondaryArity(this);
   }
 
-  @NotNull
+  @Nullable
   public Quotable rightOperand() {
     return ElixirPsiImplUtil.rightOperand(this);
   }

--- a/gen/org/elixir_lang/psi/impl/ElixirMatchedTypeOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMatchedTypeOperationImpl.java
@@ -19,8 +19,12 @@ public class ElixirMatchedTypeOperationImpl extends ElixirMatchedExpressionImpl 
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitMatchedTypeOperation(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitMatchedTypeOperation(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 
@@ -136,7 +140,7 @@ public class ElixirMatchedTypeOperationImpl extends ElixirMatchedExpressionImpl 
     return ElixirPsiImplUtil.resolvedSecondaryArity(this);
   }
 
-  @NotNull
+  @Nullable
   public Quotable rightOperand() {
     return ElixirPsiImplUtil.rightOperand(this);
   }

--- a/gen/org/elixir_lang/psi/impl/ElixirMatchedUnaryNonNumericOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMatchedUnaryNonNumericOperationImpl.java
@@ -16,8 +16,12 @@ public class ElixirMatchedUnaryNonNumericOperationImpl extends ElixirMatchedExpr
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitMatchedUnaryNonNumericOperation(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitMatchedUnaryNonNumericOperation(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirMatchedUnqualifiedBracketOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMatchedUnqualifiedBracketOperationImpl.java
@@ -16,8 +16,12 @@ public class ElixirMatchedUnqualifiedBracketOperationImpl extends ElixirMatchedE
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitMatchedUnqualifiedBracketOperation(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitMatchedUnqualifiedBracketOperation(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirMatchedUnqualifiedNoArgumentsCallImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMatchedUnqualifiedNoArgumentsCallImpl.java
@@ -25,8 +25,12 @@ public class ElixirMatchedUnqualifiedNoArgumentsCallImpl extends NamedStubbedPsi
     super(stub, nodeType);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitMatchedUnqualifiedNoArgumentsCall(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitMatchedUnqualifiedNoArgumentsCall(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirMatchedUnqualifiedNoParenthesesCallImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMatchedUnqualifiedNoParenthesesCallImpl.java
@@ -22,8 +22,12 @@ public class ElixirMatchedUnqualifiedNoParenthesesCallImpl extends NamedStubbedP
     super(stub, nodeType);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitMatchedUnqualifiedNoParenthesesCall(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitMatchedUnqualifiedNoParenthesesCall(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirMatchedUnqualifiedParenthesesCallImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMatchedUnqualifiedParenthesesCallImpl.java
@@ -22,8 +22,12 @@ public class ElixirMatchedUnqualifiedParenthesesCallImpl extends NamedStubbedPsi
     super(stub, nodeType);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitMatchedUnqualifiedParenthesesCall(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitMatchedUnqualifiedParenthesesCall(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirMatchedWhenOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMatchedWhenOperationImpl.java
@@ -19,8 +19,12 @@ public class ElixirMatchedWhenOperationImpl extends ElixirMatchedExpressionImpl 
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitMatchedWhenOperation(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitMatchedWhenOperation(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 
@@ -136,7 +140,7 @@ public class ElixirMatchedWhenOperationImpl extends ElixirMatchedExpressionImpl 
     return ElixirPsiImplUtil.resolvedSecondaryArity(this);
   }
 
-  @NotNull
+  @Nullable
   public Quotable rightOperand() {
     return ElixirPsiImplUtil.rightOperand(this);
   }

--- a/gen/org/elixir_lang/psi/impl/ElixirMultiplicationInfixOperatorImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMultiplicationInfixOperatorImpl.java
@@ -16,8 +16,12 @@ public class ElixirMultiplicationInfixOperatorImpl extends ASTWrapperPsiElement 
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitMultiplicationInfixOperator(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitMultiplicationInfixOperator(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirNoParenthesesArgumentsImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirNoParenthesesArgumentsImpl.java
@@ -18,8 +18,12 @@ public class ElixirNoParenthesesArgumentsImpl extends ASTWrapperPsiElement imple
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitNoParenthesesArguments(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitNoParenthesesArguments(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirNoParenthesesKeywordPairImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirNoParenthesesKeywordPairImpl.java
@@ -15,8 +15,12 @@ public class ElixirNoParenthesesKeywordPairImpl extends ASTWrapperPsiElement imp
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitNoParenthesesKeywordPair(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitNoParenthesesKeywordPair(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirNoParenthesesKeywordsImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirNoParenthesesKeywordsImpl.java
@@ -20,8 +20,12 @@ public class ElixirNoParenthesesKeywordsImpl extends ASTWrapperPsiElement implem
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitNoParenthesesKeywords(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitNoParenthesesKeywords(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirNoParenthesesManyStrictNoParenthesesExpressionImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirNoParenthesesManyStrictNoParenthesesExpressionImpl.java
@@ -16,8 +16,12 @@ public class ElixirNoParenthesesManyStrictNoParenthesesExpressionImpl extends AS
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitNoParenthesesManyStrictNoParenthesesExpression(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitNoParenthesesManyStrictNoParenthesesExpression(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirNoParenthesesOneArgumentImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirNoParenthesesOneArgumentImpl.java
@@ -21,8 +21,12 @@ public class ElixirNoParenthesesOneArgumentImpl extends ASTWrapperPsiElement imp
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitNoParenthesesOneArgument(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitNoParenthesesOneArgument(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirNoParenthesesStrictImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirNoParenthesesStrictImpl.java
@@ -19,8 +19,12 @@ public class ElixirNoParenthesesStrictImpl extends ASTWrapperPsiElement implemen
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitNoParenthesesStrict(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitNoParenthesesStrict(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirOctalDigitsImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirOctalDigitsImpl.java
@@ -16,8 +16,12 @@ public class ElixirOctalDigitsImpl extends ASTWrapperPsiElement implements Elixi
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitOctalDigits(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitOctalDigits(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirOctalWholeNumberImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirOctalWholeNumberImpl.java
@@ -20,8 +20,12 @@ public class ElixirOctalWholeNumberImpl extends ASTWrapperPsiElement implements 
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitOctalWholeNumber(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitOctalWholeNumber(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirOpenHexadecimalEscapeSequenceImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirOpenHexadecimalEscapeSequenceImpl.java
@@ -14,8 +14,12 @@ public class ElixirOpenHexadecimalEscapeSequenceImpl extends ASTWrapperPsiElemen
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitOpenHexadecimalEscapeSequence(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitOpenHexadecimalEscapeSequence(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirOrInfixOperatorImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirOrInfixOperatorImpl.java
@@ -16,8 +16,12 @@ public class ElixirOrInfixOperatorImpl extends ASTWrapperPsiElement implements E
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitOrInfixOperator(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitOrInfixOperator(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirParenthesesArgumentsImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirParenthesesArgumentsImpl.java
@@ -19,8 +19,12 @@ public class ElixirParenthesesArgumentsImpl extends ASTWrapperPsiElement impleme
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitParenthesesArguments(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitParenthesesArguments(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirParentheticalStabImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirParentheticalStabImpl.java
@@ -17,8 +17,12 @@ public class ElixirParentheticalStabImpl extends ASTWrapperPsiElement implements
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitParentheticalStab(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitParentheticalStab(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirPipeInfixOperatorImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirPipeInfixOperatorImpl.java
@@ -16,8 +16,12 @@ public class ElixirPipeInfixOperatorImpl extends ASTWrapperPsiElement implements
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitPipeInfixOperator(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitPipeInfixOperator(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirQuoteCharListBodyImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirQuoteCharListBodyImpl.java
@@ -16,8 +16,12 @@ public class ElixirQuoteCharListBodyImpl extends ASTWrapperPsiElement implements
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitQuoteCharListBody(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitQuoteCharListBody(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirQuoteHexadecimalEscapeSequenceImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirQuoteHexadecimalEscapeSequenceImpl.java
@@ -14,8 +14,12 @@ public class ElixirQuoteHexadecimalEscapeSequenceImpl extends ASTWrapperPsiEleme
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitQuoteHexadecimalEscapeSequence(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitQuoteHexadecimalEscapeSequence(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirQuoteStringBodyImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirQuoteStringBodyImpl.java
@@ -16,8 +16,12 @@ public class ElixirQuoteStringBodyImpl extends ASTWrapperPsiElement implements E
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitQuoteStringBody(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitQuoteStringBody(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirRelationalInfixOperatorImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirRelationalInfixOperatorImpl.java
@@ -16,8 +16,12 @@ public class ElixirRelationalInfixOperatorImpl extends ASTWrapperPsiElement impl
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitRelationalInfixOperator(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitRelationalInfixOperator(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirRelativeIdentifierImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirRelativeIdentifierImpl.java
@@ -15,8 +15,12 @@ public class ElixirRelativeIdentifierImpl extends ASTWrapperPsiElement implement
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitRelativeIdentifier(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitRelativeIdentifier(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirSigilHexadecimalEscapeSequenceImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirSigilHexadecimalEscapeSequenceImpl.java
@@ -14,8 +14,12 @@ public class ElixirSigilHexadecimalEscapeSequenceImpl extends ASTWrapperPsiEleme
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitSigilHexadecimalEscapeSequence(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitSigilHexadecimalEscapeSequence(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirSigilModifiersImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirSigilModifiersImpl.java
@@ -15,8 +15,12 @@ public class ElixirSigilModifiersImpl extends ASTWrapperPsiElement implements El
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitSigilModifiers(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitSigilModifiers(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirStabBodyImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirStabBodyImpl.java
@@ -17,8 +17,12 @@ public class ElixirStabBodyImpl extends ASTWrapperPsiElement implements ElixirSt
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitStabBody(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitStabBody(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirStabImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirStabImpl.java
@@ -18,8 +18,12 @@ public class ElixirStabImpl extends ASTWrapperPsiElement implements ElixirStab {
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitStab(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitStab(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirStabInfixOperatorImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirStabInfixOperatorImpl.java
@@ -16,8 +16,12 @@ public class ElixirStabInfixOperatorImpl extends ASTWrapperPsiElement implements
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitStabInfixOperator(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitStabInfixOperator(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirStabNoParenthesesSignatureImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirStabNoParenthesesSignatureImpl.java
@@ -16,8 +16,12 @@ public class ElixirStabNoParenthesesSignatureImpl extends ASTWrapperPsiElement i
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitStabNoParenthesesSignature(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitStabNoParenthesesSignature(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirStabOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirStabOperationImpl.java
@@ -15,8 +15,12 @@ public class ElixirStabOperationImpl extends ASTWrapperPsiElement implements Eli
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitStabOperation(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitStabOperation(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirStabParenthesesSignatureImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirStabParenthesesSignatureImpl.java
@@ -15,8 +15,12 @@ public class ElixirStabParenthesesSignatureImpl extends ASTWrapperPsiElement imp
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitStabParenthesesSignature(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitStabParenthesesSignature(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 
@@ -65,7 +69,7 @@ public class ElixirStabParenthesesSignatureImpl extends ASTWrapperPsiElement imp
     return ElixirPsiImplUtil.quote(this);
   }
 
-  @NotNull
+  @Nullable
   public Quotable rightOperand() {
     return ElixirPsiImplUtil.rightOperand(this);
   }

--- a/gen/org/elixir_lang/psi/impl/ElixirStringHeredocImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirStringHeredocImpl.java
@@ -20,8 +20,12 @@ public class ElixirStringHeredocImpl extends ASTWrapperPsiElement implements Eli
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitStringHeredoc(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitStringHeredoc(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirStringHeredocLineImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirStringHeredocLineImpl.java
@@ -14,8 +14,12 @@ public class ElixirStringHeredocLineImpl extends ASTWrapperPsiElement implements
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitStringHeredocLine(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitStringHeredocLine(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirStringLineImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirStringLineImpl.java
@@ -21,8 +21,12 @@ public class ElixirStringLineImpl extends ASTWrapperPsiElement implements Elixir
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitStringLine(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitStringLine(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirStructOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirStructOperationImpl.java
@@ -15,8 +15,12 @@ public class ElixirStructOperationImpl extends ASTWrapperPsiElement implements E
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitStructOperation(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitStructOperation(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirTupleImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirTupleImpl.java
@@ -18,8 +18,12 @@ public class ElixirTupleImpl extends ASTWrapperPsiElement implements ElixirTuple
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitTuple(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitTuple(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirTwoInfixOperatorImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirTwoInfixOperatorImpl.java
@@ -16,8 +16,12 @@ public class ElixirTwoInfixOperatorImpl extends ASTWrapperPsiElement implements 
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitTwoInfixOperator(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitTwoInfixOperator(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirTypeInfixOperatorImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirTypeInfixOperatorImpl.java
@@ -16,8 +16,12 @@ public class ElixirTypeInfixOperatorImpl extends ASTWrapperPsiElement implements
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitTypeInfixOperator(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitTypeInfixOperator(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirUnaryNumericOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnaryNumericOperationImpl.java
@@ -17,8 +17,12 @@ public class ElixirUnaryNumericOperationImpl extends ASTWrapperPsiElement implem
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitUnaryNumericOperation(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitUnaryNumericOperation(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirUnaryPrefixOperatorImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnaryPrefixOperatorImpl.java
@@ -16,8 +16,12 @@ public class ElixirUnaryPrefixOperatorImpl extends ASTWrapperPsiElement implemen
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitUnaryPrefixOperator(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitUnaryPrefixOperator(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirUnknownBaseDigitsImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnknownBaseDigitsImpl.java
@@ -17,8 +17,12 @@ public class ElixirUnknownBaseDigitsImpl extends ASTWrapperPsiElement implements
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitUnknownBaseDigits(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitUnknownBaseDigits(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirUnknownBaseWholeNumberImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnknownBaseWholeNumberImpl.java
@@ -20,8 +20,12 @@ public class ElixirUnknownBaseWholeNumberImpl extends ASTWrapperPsiElement imple
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitUnknownBaseWholeNumber(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitUnknownBaseWholeNumber(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirUnmatchedAdditionOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnmatchedAdditionOperationImpl.java
@@ -19,8 +19,12 @@ public class ElixirUnmatchedAdditionOperationImpl extends ElixirUnmatchedExpress
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitUnmatchedAdditionOperation(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitUnmatchedAdditionOperation(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 
@@ -136,7 +140,7 @@ public class ElixirUnmatchedAdditionOperationImpl extends ElixirUnmatchedExpress
     return ElixirPsiImplUtil.resolvedSecondaryArity(this);
   }
 
-  @NotNull
+  @Nullable
   public Quotable rightOperand() {
     return ElixirPsiImplUtil.rightOperand(this);
   }

--- a/gen/org/elixir_lang/psi/impl/ElixirUnmatchedAndOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnmatchedAndOperationImpl.java
@@ -19,8 +19,12 @@ public class ElixirUnmatchedAndOperationImpl extends ElixirUnmatchedExpressionIm
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitUnmatchedAndOperation(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitUnmatchedAndOperation(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 
@@ -136,7 +140,7 @@ public class ElixirUnmatchedAndOperationImpl extends ElixirUnmatchedExpressionIm
     return ElixirPsiImplUtil.resolvedSecondaryArity(this);
   }
 
-  @NotNull
+  @Nullable
   public Quotable rightOperand() {
     return ElixirPsiImplUtil.rightOperand(this);
   }

--- a/gen/org/elixir_lang/psi/impl/ElixirUnmatchedArrowOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnmatchedArrowOperationImpl.java
@@ -19,8 +19,12 @@ public class ElixirUnmatchedArrowOperationImpl extends ElixirUnmatchedExpression
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitUnmatchedArrowOperation(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitUnmatchedArrowOperation(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 
@@ -136,7 +140,7 @@ public class ElixirUnmatchedArrowOperationImpl extends ElixirUnmatchedExpression
     return ElixirPsiImplUtil.resolvedSecondaryArity(this);
   }
 
-  @NotNull
+  @Nullable
   public Quotable rightOperand() {
     return ElixirPsiImplUtil.rightOperand(this);
   }

--- a/gen/org/elixir_lang/psi/impl/ElixirUnmatchedAtNonNumericOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnmatchedAtNonNumericOperationImpl.java
@@ -15,8 +15,12 @@ public class ElixirUnmatchedAtNonNumericOperationImpl extends ElixirUnmatchedExp
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitUnmatchedAtNonNumericOperation(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitUnmatchedAtNonNumericOperation(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirUnmatchedAtUnqualifiedBracketOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnmatchedAtUnqualifiedBracketOperationImpl.java
@@ -16,8 +16,12 @@ public class ElixirUnmatchedAtUnqualifiedBracketOperationImpl extends ElixirUnma
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitUnmatchedAtUnqualifiedBracketOperation(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitUnmatchedAtUnqualifiedBracketOperation(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirUnmatchedAtUnqualifiedNoParenthesesCallImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnmatchedAtUnqualifiedNoParenthesesCallImpl.java
@@ -22,8 +22,12 @@ public class ElixirUnmatchedAtUnqualifiedNoParenthesesCallImpl extends NamedStub
     super(stub, nodeType);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitUnmatchedAtUnqualifiedNoParenthesesCall(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitUnmatchedAtUnqualifiedNoParenthesesCall(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirUnmatchedBracketOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnmatchedBracketOperationImpl.java
@@ -16,8 +16,12 @@ public class ElixirUnmatchedBracketOperationImpl extends ElixirUnmatchedExpressi
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitUnmatchedBracketOperation(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitUnmatchedBracketOperation(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirUnmatchedCaptureNonNumericOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnmatchedCaptureNonNumericOperationImpl.java
@@ -16,8 +16,12 @@ public class ElixirUnmatchedCaptureNonNumericOperationImpl extends ElixirUnmatch
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitUnmatchedCaptureNonNumericOperation(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitUnmatchedCaptureNonNumericOperation(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirUnmatchedComparisonOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnmatchedComparisonOperationImpl.java
@@ -19,8 +19,12 @@ public class ElixirUnmatchedComparisonOperationImpl extends ElixirUnmatchedExpre
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitUnmatchedComparisonOperation(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitUnmatchedComparisonOperation(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 
@@ -136,7 +140,7 @@ public class ElixirUnmatchedComparisonOperationImpl extends ElixirUnmatchedExpre
     return ElixirPsiImplUtil.resolvedSecondaryArity(this);
   }
 
-  @NotNull
+  @Nullable
   public Quotable rightOperand() {
     return ElixirPsiImplUtil.rightOperand(this);
   }

--- a/gen/org/elixir_lang/psi/impl/ElixirUnmatchedDotCallImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnmatchedDotCallImpl.java
@@ -25,8 +25,12 @@ public class ElixirUnmatchedDotCallImpl extends NamedStubbedPsiElementBase<Unmat
     super(stub, nodeType);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitUnmatchedDotCall(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitUnmatchedDotCall(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirUnmatchedExpressionImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnmatchedExpressionImpl.java
@@ -14,8 +14,12 @@ public class ElixirUnmatchedExpressionImpl extends ASTWrapperPsiElement implemen
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitUnmatchedExpression(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitUnmatchedExpression(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirUnmatchedInMatchOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnmatchedInMatchOperationImpl.java
@@ -19,8 +19,12 @@ public class ElixirUnmatchedInMatchOperationImpl extends ElixirUnmatchedExpressi
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitUnmatchedInMatchOperation(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitUnmatchedInMatchOperation(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 
@@ -136,7 +140,7 @@ public class ElixirUnmatchedInMatchOperationImpl extends ElixirUnmatchedExpressi
     return ElixirPsiImplUtil.resolvedSecondaryArity(this);
   }
 
-  @NotNull
+  @Nullable
   public Quotable rightOperand() {
     return ElixirPsiImplUtil.rightOperand(this);
   }

--- a/gen/org/elixir_lang/psi/impl/ElixirUnmatchedInOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnmatchedInOperationImpl.java
@@ -19,8 +19,12 @@ public class ElixirUnmatchedInOperationImpl extends ElixirUnmatchedExpressionImp
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitUnmatchedInOperation(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitUnmatchedInOperation(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 
@@ -127,7 +131,7 @@ public class ElixirUnmatchedInOperationImpl extends ElixirUnmatchedExpressionImp
     return ElixirPsiImplUtil.resolvedSecondaryArity(this);
   }
 
-  @NotNull
+  @Nullable
   public Quotable rightOperand() {
     return ElixirPsiImplUtil.rightOperand(this);
   }

--- a/gen/org/elixir_lang/psi/impl/ElixirUnmatchedMatchOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnmatchedMatchOperationImpl.java
@@ -19,8 +19,12 @@ public class ElixirUnmatchedMatchOperationImpl extends ElixirUnmatchedExpression
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitUnmatchedMatchOperation(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitUnmatchedMatchOperation(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 
@@ -136,7 +140,7 @@ public class ElixirUnmatchedMatchOperationImpl extends ElixirUnmatchedExpression
     return ElixirPsiImplUtil.resolvedSecondaryArity(this);
   }
 
-  @NotNull
+  @Nullable
   public Quotable rightOperand() {
     return ElixirPsiImplUtil.rightOperand(this);
   }

--- a/gen/org/elixir_lang/psi/impl/ElixirUnmatchedMultiplicationOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnmatchedMultiplicationOperationImpl.java
@@ -19,8 +19,12 @@ public class ElixirUnmatchedMultiplicationOperationImpl extends ElixirUnmatchedE
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitUnmatchedMultiplicationOperation(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitUnmatchedMultiplicationOperation(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 
@@ -136,7 +140,7 @@ public class ElixirUnmatchedMultiplicationOperationImpl extends ElixirUnmatchedE
     return ElixirPsiImplUtil.resolvedSecondaryArity(this);
   }
 
-  @NotNull
+  @Nullable
   public Quotable rightOperand() {
     return ElixirPsiImplUtil.rightOperand(this);
   }

--- a/gen/org/elixir_lang/psi/impl/ElixirUnmatchedOrOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnmatchedOrOperationImpl.java
@@ -19,8 +19,12 @@ public class ElixirUnmatchedOrOperationImpl extends ElixirUnmatchedExpressionImp
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitUnmatchedOrOperation(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitUnmatchedOrOperation(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 
@@ -136,7 +140,7 @@ public class ElixirUnmatchedOrOperationImpl extends ElixirUnmatchedExpressionImp
     return ElixirPsiImplUtil.resolvedSecondaryArity(this);
   }
 
-  @NotNull
+  @Nullable
   public Quotable rightOperand() {
     return ElixirPsiImplUtil.rightOperand(this);
   }

--- a/gen/org/elixir_lang/psi/impl/ElixirUnmatchedPipeOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnmatchedPipeOperationImpl.java
@@ -19,8 +19,12 @@ public class ElixirUnmatchedPipeOperationImpl extends ElixirUnmatchedExpressionI
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitUnmatchedPipeOperation(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitUnmatchedPipeOperation(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 
@@ -136,7 +140,7 @@ public class ElixirUnmatchedPipeOperationImpl extends ElixirUnmatchedExpressionI
     return ElixirPsiImplUtil.resolvedSecondaryArity(this);
   }
 
-  @NotNull
+  @Nullable
   public Quotable rightOperand() {
     return ElixirPsiImplUtil.rightOperand(this);
   }

--- a/gen/org/elixir_lang/psi/impl/ElixirUnmatchedQualifiedAliasImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnmatchedQualifiedAliasImpl.java
@@ -18,8 +18,12 @@ public class ElixirUnmatchedQualifiedAliasImpl extends ElixirUnmatchedExpression
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitUnmatchedQualifiedAlias(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitUnmatchedQualifiedAlias(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirUnmatchedQualifiedBracketOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnmatchedQualifiedBracketOperationImpl.java
@@ -13,8 +13,12 @@ public class ElixirUnmatchedQualifiedBracketOperationImpl extends ElixirUnmatche
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitUnmatchedQualifiedBracketOperation(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitUnmatchedQualifiedBracketOperation(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirUnmatchedQualifiedNoArgumentsCallImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnmatchedQualifiedNoArgumentsCallImpl.java
@@ -22,8 +22,12 @@ public class ElixirUnmatchedQualifiedNoArgumentsCallImpl extends NamedStubbedPsi
     super(stub, nodeType);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitUnmatchedQualifiedNoArgumentsCall(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitUnmatchedQualifiedNoArgumentsCall(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirUnmatchedQualifiedNoParenthesesCallImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnmatchedQualifiedNoParenthesesCallImpl.java
@@ -22,8 +22,12 @@ public class ElixirUnmatchedQualifiedNoParenthesesCallImpl extends NamedStubbedP
     super(stub, nodeType);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitUnmatchedQualifiedNoParenthesesCall(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitUnmatchedQualifiedNoParenthesesCall(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirUnmatchedQualifiedParenthesesCallImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnmatchedQualifiedParenthesesCallImpl.java
@@ -22,8 +22,12 @@ public class ElixirUnmatchedQualifiedParenthesesCallImpl extends NamedStubbedPsi
     super(stub, nodeType);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitUnmatchedQualifiedParenthesesCall(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitUnmatchedQualifiedParenthesesCall(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirUnmatchedRelationalOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnmatchedRelationalOperationImpl.java
@@ -19,8 +19,12 @@ public class ElixirUnmatchedRelationalOperationImpl extends ElixirUnmatchedExpre
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitUnmatchedRelationalOperation(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitUnmatchedRelationalOperation(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 
@@ -136,7 +140,7 @@ public class ElixirUnmatchedRelationalOperationImpl extends ElixirUnmatchedExpre
     return ElixirPsiImplUtil.resolvedSecondaryArity(this);
   }
 
-  @NotNull
+  @Nullable
   public Quotable rightOperand() {
     return ElixirPsiImplUtil.rightOperand(this);
   }

--- a/gen/org/elixir_lang/psi/impl/ElixirUnmatchedTwoOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnmatchedTwoOperationImpl.java
@@ -19,8 +19,12 @@ public class ElixirUnmatchedTwoOperationImpl extends ElixirUnmatchedExpressionIm
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitUnmatchedTwoOperation(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitUnmatchedTwoOperation(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 
@@ -136,7 +140,7 @@ public class ElixirUnmatchedTwoOperationImpl extends ElixirUnmatchedExpressionIm
     return ElixirPsiImplUtil.resolvedSecondaryArity(this);
   }
 
-  @NotNull
+  @Nullable
   public Quotable rightOperand() {
     return ElixirPsiImplUtil.rightOperand(this);
   }

--- a/gen/org/elixir_lang/psi/impl/ElixirUnmatchedTypeOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnmatchedTypeOperationImpl.java
@@ -19,8 +19,12 @@ public class ElixirUnmatchedTypeOperationImpl extends ElixirUnmatchedExpressionI
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitUnmatchedTypeOperation(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitUnmatchedTypeOperation(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 
@@ -136,7 +140,7 @@ public class ElixirUnmatchedTypeOperationImpl extends ElixirUnmatchedExpressionI
     return ElixirPsiImplUtil.resolvedSecondaryArity(this);
   }
 
-  @NotNull
+  @Nullable
   public Quotable rightOperand() {
     return ElixirPsiImplUtil.rightOperand(this);
   }

--- a/gen/org/elixir_lang/psi/impl/ElixirUnmatchedUnaryNonNumericOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnmatchedUnaryNonNumericOperationImpl.java
@@ -16,8 +16,12 @@ public class ElixirUnmatchedUnaryNonNumericOperationImpl extends ElixirUnmatched
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitUnmatchedUnaryNonNumericOperation(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitUnmatchedUnaryNonNumericOperation(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirUnmatchedUnqualifiedBracketOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnmatchedUnqualifiedBracketOperationImpl.java
@@ -16,8 +16,12 @@ public class ElixirUnmatchedUnqualifiedBracketOperationImpl extends ElixirUnmatc
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitUnmatchedUnqualifiedBracketOperation(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitUnmatchedUnqualifiedBracketOperation(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirUnmatchedUnqualifiedNoArgumentsCallImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnmatchedUnqualifiedNoArgumentsCallImpl.java
@@ -25,8 +25,12 @@ public class ElixirUnmatchedUnqualifiedNoArgumentsCallImpl extends NamedStubbedP
     super(stub, nodeType);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitUnmatchedUnqualifiedNoArgumentsCall(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitUnmatchedUnqualifiedNoArgumentsCall(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirUnmatchedUnqualifiedNoParenthesesCallImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnmatchedUnqualifiedNoParenthesesCallImpl.java
@@ -22,8 +22,12 @@ public class ElixirUnmatchedUnqualifiedNoParenthesesCallImpl extends NamedStubbe
     super(stub, nodeType);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitUnmatchedUnqualifiedNoParenthesesCall(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitUnmatchedUnqualifiedNoParenthesesCall(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirUnmatchedUnqualifiedParenthesesCallImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnmatchedUnqualifiedParenthesesCallImpl.java
@@ -22,8 +22,12 @@ public class ElixirUnmatchedUnqualifiedParenthesesCallImpl extends NamedStubbedP
     super(stub, nodeType);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitUnmatchedUnqualifiedParenthesesCall(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitUnmatchedUnqualifiedParenthesesCall(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirUnmatchedWhenOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnmatchedWhenOperationImpl.java
@@ -19,8 +19,12 @@ public class ElixirUnmatchedWhenOperationImpl extends ElixirUnmatchedExpressionI
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitUnmatchedWhenOperation(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitUnmatchedWhenOperation(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 
@@ -136,7 +140,7 @@ public class ElixirUnmatchedWhenOperationImpl extends ElixirUnmatchedExpressionI
     return ElixirPsiImplUtil.resolvedSecondaryArity(this);
   }
 
-  @NotNull
+  @Nullable
   public Quotable rightOperand() {
     return ElixirPsiImplUtil.rightOperand(this);
   }

--- a/gen/org/elixir_lang/psi/impl/ElixirUnqualifiedNoParenthesesManyArgumentsCallImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnqualifiedNoParenthesesManyArgumentsCallImpl.java
@@ -25,8 +25,12 @@ public class ElixirUnqualifiedNoParenthesesManyArgumentsCallImpl extends NamedSt
     super(stub, nodeType);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitUnqualifiedNoParenthesesManyArgumentsCall(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitUnqualifiedNoParenthesesManyArgumentsCall(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirVariableImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirVariableImpl.java
@@ -15,8 +15,12 @@ public class ElixirVariableImpl extends ASTWrapperPsiElement implements ElixirVa
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitVariable(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitVariable(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirWhenInfixOperatorImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirWhenInfixOperatorImpl.java
@@ -16,8 +16,12 @@ public class ElixirWhenInfixOperatorImpl extends ASTWrapperPsiElement implements
     super(node);
   }
 
+  public void accept(@NotNull ElixirVisitor visitor) {
+    visitor.visitWhenInfixOperator(this);
+  }
+
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof ElixirVisitor) ((ElixirVisitor)visitor).visitWhenInfixOperator(this);
+    if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/src/META-INF/plugin.xml
+++ b/src/META-INF/plugin.xml
@@ -772,7 +772,8 @@
   </change-notes>
 
   <!-- please see http://confluence.jetbrains.com/display/IDEADEV/Build+Number+Ranges for description -->
-  <idea-version since-build="131"/>
+  <!-- 141 == IntelliJ IDEA 14.1, which is the oldest version compatible with GrammarKit 1.3.0 -->
+  <idea-version since-build="141"/>
 
   <!-- please see http://confluence.jetbrains.com/display/IDEADEV/Plugin+Compatibility+with+IntelliJ+Platform+Products
        on how to target different products -->

--- a/src/org/elixir_lang/action/CreateElixirModuleAction.java
+++ b/src/org/elixir_lang/action/CreateElixirModuleAction.java
@@ -118,39 +118,7 @@ public class CreateElixirModuleAction extends CreateFromTemplateAction<ElixirFil
                                                        @NotNull String basename,
                                                        @NotNull String moduleName,
                                                        @NotNull String templateName) {
-        Class klass = FileTemplateManager.class;
-        FileTemplateManager fileTemplateManager = null;
-
-        try {
-            // After 14.0
-            Method getDefaultInstance = klass.getDeclaredMethod("getDefaultInstance");
-
-            try {
-                fileTemplateManager = (FileTemplateManager) getDefaultInstance.invoke(null);
-            } catch (IllegalAccessException e) {
-                e.printStackTrace();
-            } catch (InvocationTargetException e) {
-                e.printStackTrace();
-            }
-        } catch (NoSuchMethodException getDefaultInstanceNoSuchMethodException) {
-            // In 14.0
-            try {
-                Method getInstance = klass.getDeclaredMethod("getInstance");
-
-                try {
-                    fileTemplateManager = (FileTemplateManager) getInstance.invoke(null);
-                } catch (IllegalAccessException e) {
-                    e.printStackTrace();
-                } catch (InvocationTargetException e) {
-                    e.printStackTrace();
-                }
-            } catch (NoSuchMethodException getInstanceNoSuchMethodException) {
-                getDefaultInstanceNoSuchMethodException.printStackTrace();
-            }
-        }
-
-        assert fileTemplateManager != null;
-
+        FileTemplateManager fileTemplateManager = FileTemplateManager.getDefaultInstance();
         FileTemplate template = fileTemplateManager.getInternalTemplate(templateName);
 
         Properties defaultProperties = fileTemplateManager.getDefaultProperties();

--- a/src/org/elixir_lang/annonator/ModuleAttribute.java
+++ b/src/org/elixir_lang/annonator/ModuleAttribute.java
@@ -760,6 +760,9 @@ public class ModuleAttribute implements Annotator, DumbAware {
                     annotationHolder,
                     typeTextAttributesKey
             );
+        } else if (psiElement instanceof AtUnqualifiedNoParenthesesCall) {
+            /* Occurs in the case of typing a {@code @type name ::} above a {@code @doc <HEREDOC>} and the
+               {@code @doc <HEREDOC>} is interpreted as the right-operand of {@code ::} */
         } else if (psiElement instanceof ElixirAccessExpression ||
                 psiElement instanceof ElixirAssociationsBase ||
                 psiElement instanceof ElixirAssociations ||

--- a/src/org/elixir_lang/annonator/ModuleAttribute.java
+++ b/src/org/elixir_lang/annonator/ModuleAttribute.java
@@ -312,12 +312,14 @@ public class ModuleAttribute implements Annotator, DumbAware {
 
                 PsiElement rightOperand = infix.rightOperand();
 
-                highlightTypesAndTypeParameterUsages(
-                        rightOperand,
-                        typeParameterNameSet,
-                        annotationHolder,
-                        ElixirSyntaxHighlighter.TYPE
-                );
+                if (rightOperand != null) {
+                    highlightTypesAndTypeParameterUsages(
+                            rightOperand,
+                            typeParameterNameSet,
+                            annotationHolder,
+                            ElixirSyntaxHighlighter.TYPE
+                    );
+                }
             } else if (grandChild instanceof ElixirMatchedUnqualifiedParenthesesCall) {
                 // seen as `unquote(ast)`, but could also be just the beginning of typing
                 ElixirMatchedUnqualifiedParenthesesCall matchedUnqualifiedParenthesesCall = (ElixirMatchedUnqualifiedParenthesesCall) grandChild;
@@ -507,22 +509,28 @@ public class ModuleAttribute implements Annotator, DumbAware {
 
                     PsiElement matchedTypeOperationRightOperand = matchedTypeOperation.rightOperand();
 
-                    highlightTypesAndTypeParameterUsages(
-                            matchedTypeOperationRightOperand,
-                            typeParameterNameSet,
-                            annotationHolder,
-                            ElixirSyntaxHighlighter.TYPE
-                    );
+                    if (matchedTypeOperationRightOperand != null) {
+                        highlightTypesAndTypeParameterUsages(
+                                matchedTypeOperationRightOperand,
+                                typeParameterNameSet,
+                                annotationHolder,
+                                ElixirSyntaxHighlighter.TYPE
+                        );
+                    }
                 } else {
                     cannotHighlightTypes(leftOperand);
                 }
 
-                highlightTypesAndSpecificationTypeParameterDeclarations(
-                        matchedWhenOperation.rightOperand(),
-                        typeParameterNameSet,
-                        annotationHolder,
-                        ElixirSyntaxHighlighter.TYPE
-                );
+                Quotable rightOperand = matchedWhenOperation.rightOperand();
+
+                if (rightOperand != null) {
+                    highlightTypesAndSpecificationTypeParameterDeclarations(
+                            rightOperand,
+                            typeParameterNameSet,
+                            annotationHolder,
+                            ElixirSyntaxHighlighter.TYPE
+                    );
+                }
             }
         }
     }
@@ -552,7 +560,7 @@ public class ModuleAttribute implements Annotator, DumbAware {
         );
     }
 
-    private void highlightTypesAndSpecificationTypeParameterDeclarations(PsiElement psiElement,
+    private void highlightTypesAndSpecificationTypeParameterDeclarations(@NotNull PsiElement psiElement,
                                                                          Set<String> typeParameterNameSet,
                                                                          AnnotationHolder annotationHolder,
                                                                          TextAttributesKey typeTextAttributesKey) {
@@ -718,7 +726,7 @@ public class ModuleAttribute implements Annotator, DumbAware {
     }
 
     private void highlightTypesAndTypeParameterUsages(
-            Infix infix,
+            @NotNull Infix infix,
             Set<String> typeParameterNameSet,
             AnnotationHolder annotationHolder,
             TextAttributesKey typeTextAttributesKey) {
@@ -728,15 +736,20 @@ public class ModuleAttribute implements Annotator, DumbAware {
                 annotationHolder,
                 typeTextAttributesKey
         );
-        highlightTypesAndTypeParameterUsages(
-                infix.rightOperand(),
-                typeParameterNameSet,
-                annotationHolder,
-                typeTextAttributesKey
-        );
+
+        PsiElement rightOperand = infix.rightOperand();
+
+        if (rightOperand != null) {
+            highlightTypesAndTypeParameterUsages(
+                    rightOperand,
+                    typeParameterNameSet,
+                    annotationHolder,
+                    typeTextAttributesKey
+            );
+        }
     }
 
-    private void highlightTypesAndTypeParameterUsages(PsiElement psiElement,
+    private void highlightTypesAndTypeParameterUsages(@NotNull PsiElement psiElement,
                                                       Set<String> typeParameterNameSet,
                                                       AnnotationHolder annotationHolder,
                                                       TextAttributesKey typeTextAttributesKey) {
@@ -1058,7 +1071,7 @@ public class ModuleAttribute implements Annotator, DumbAware {
         return Collections.singleton(noParenthesesKeywordPair.getKeywordKey().getText());
     }
 
-    private Set<String> specificationTypeParameterNameSet(PsiElement psiElement) {
+    private Set<String> specificationTypeParameterNameSet(@NotNull PsiElement psiElement) {
         Set<String> parameterNameSet;
 
         if (psiElement instanceof ElixirAccessExpression ||

--- a/src/org/elixir_lang/errorreport/Submitter.java
+++ b/src/org/elixir_lang/errorreport/Submitter.java
@@ -24,10 +24,10 @@ import com.intellij.util.Consumer;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.awt.*;
+import java.awt.Component;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.util.*;
+import java.util.Collections;
 import java.util.List;
 
 /**

--- a/src/org/elixir_lang/psi/impl/ElixirPsiImplUtil.java
+++ b/src/org/elixir_lang/psi/impl/ElixirPsiImplUtil.java
@@ -756,8 +756,8 @@ public class ElixirPsiImplUtil {
     public static Quotable leftOperand(Infix infix) {
         PsiElement[] children = infix.getChildren();
 
-        if (children.length != 3) {
-            error(Infix.class, "Infix operation expected 3 children, but has " + children.length, infix);
+        if (children.length < 2 || 3 < children.length) {
+            error(Infix.class, "Infix operation expected 2-3 children, but has " + children.length, infix);
         }
 
         return (Quotable) children[0];

--- a/src/org/elixir_lang/psi/impl/ElixirPsiImplUtil.java
+++ b/src/org/elixir_lang/psi/impl/ElixirPsiImplUtil.java
@@ -1286,7 +1286,14 @@ public class ElixirPsiImplUtil {
         OtpErlangObject quotedOperator = operator.quote();
 
         Quotable rightOperand = infix.rightOperand();
-        OtpErlangObject quotedRightOperand = rightOperand.quote();
+        OtpErlangObject quotedRightOperand;
+
+        if (rightOperand != null) {
+            quotedRightOperand = rightOperand.quote();
+        } else {
+            // this is not valid Elixir quoting, but something needs to be there for quoting to work
+            quotedRightOperand = NIL;
+        }
 
         return quotedFunctionCall(
                 quotedOperator,
@@ -4242,15 +4249,18 @@ if (quoted == null) {
     }
 
     @Contract(pure = true)
-    @NotNull
+    @Nullable
     public static Quotable rightOperand(Infix infix) {
         PsiElement[] children = infix.getChildren();
+        Quotable rightOperand = null;
 
-        if (children.length != 3) {
-            error(Infix.class, "Excepted infix operations to have 3 children, but have " + children.length, infix);
+        /* rightOperand won't be there when Pratt Parser recovered from error in right-operand by matching up through
+           the operator only. */
+        if (children.length == 3) {
+            rightOperand = (Quotable) children[2];
         }
 
-        return (Quotable) children[2];
+        return rightOperand;
     }
 
     @Contract(pure = true)

--- a/src/org/elixir_lang/psi/operation/Infix.java
+++ b/src/org/elixir_lang/psi/operation/Infix.java
@@ -1,6 +1,8 @@
 package org.elixir_lang.psi.operation;
 
 import org.elixir_lang.psi.Quotable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * A binary operator with a left operand, operator, and right operand
@@ -8,6 +10,15 @@ import org.elixir_lang.psi.Quotable;
  * Created by luke.imhoff on 3/18/15.
  */
 public interface Infix extends Operation {
+  @NotNull
   Quotable leftOperand();
+
+  /**
+   *
+   * @return {@code null} if there was an error in element (such as when the user is still typing it) and so the
+   *   Pratt Parser error handling matched up through the operator, but was ok not having the right-operand; otherwise,
+   *   the operand to the right of the operator.
+   */
+  @Nullable
   Quotable rightOperand();
 }


### PR DESCRIPTION
# Changelog
* Enhancements
  * Update to Grammar Kit 1.3.0.
* Bug Fixes
  * Properly handle the `Infix#rightOperand` being `null` due to the Pratt Parser matching up through the operator and then ignoring the mismatched right operand, which leads to the `Infix` having only 2 elements: the left operand and the operator.
  * `@doc` and other module attributes appearing as the right operand of `@type name ::` will be ignored as it is common when adding a new type above pre-existing, documented functions.
  * Only error in `Infix#leftOperand` if there are not 2-3 children for `Infix` instead of a strict 3.
* Incompatible Changes
  * Drop support for IntelliJ 14.0 because the parser generated by Grammar Kit 1.3.0 is not compatible with the OpenAPI libraries shipped in IntelliJ 14.0.  Still compatible with 14.1 through 2016.1.