### PR TITLE
Use error reporter instead of assert in Prefix#operator

### DIFF
--- a/src/org/elixir_lang/psi/impl/ElixirPsiImplUtil.java
+++ b/src/org/elixir_lang/psi/impl/ElixirPsiImplUtil.java
@@ -943,7 +943,9 @@ public class ElixirPsiImplUtil {
     public static Operator operator(Prefix prefix) {
         PsiElement[] children = prefix.getChildren();
 
-        assert children.length == 2;
+        if (children.length != 2) {
+            error(Prefix.class, "Prefix operation does not have 2 children, but " + children.length, prefix);
+        }
 
         return (Operator) children[0];
     }


### PR DESCRIPTION
# Changelog
* Bug Fixes
  * Use the error reporter logger instead of plain `assert` in `Prefix#operator`.  **NOTE: This does not address error recovery recovery since I don't have a regression test case.**