### PR TITLE
Bug fixes

### DIFF
--- a/src/org/elixir_lang/annonator/ModuleAttribute.java
+++ b/src/org/elixir_lang/annonator/ModuleAttribute.java
@@ -365,6 +365,19 @@ public class ModuleAttribute implements Annotator, DumbAware {
                 } else {
                     cannotHighlightTypes(matchedUnqualifiedParenthesesCall);
                 }
+            } else if (grandChild instanceof UnqualifiedNoArgumentsCall) {
+                // assume it's a type name that is being typed
+                Call grandChildCall = (Call) grandChild;
+                PsiElement functionNameElement = grandChildCall.functionNameElement();
+
+                if (functionNameElement != null) {
+                    highlight(
+                            functionNameElement.getTextRange(),
+                            annotationHolder,
+                            ElixirSyntaxHighlighter.TYPE
+                    );
+                }
+
             } else {
                 cannotHighlightTypes(grandChild);
             }

--- a/src/org/elixir_lang/psi/AtNonNumericOperation.java
+++ b/src/org/elixir_lang/psi/AtNonNumericOperation.java
@@ -3,14 +3,14 @@ package org.elixir_lang.psi;
 import com.intellij.psi.PsiReference;
 import org.elixir_lang.psi.operation.Prefix;
 import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * {@code atPrefixOperator !numeric ...}
  */
 public interface AtNonNumericOperation extends ModuleAttributeNameable, Prefix {
     @Contract(pure=true)
-    @NotNull
+    @Nullable
     @Override
     PsiReference getReference();
 }

--- a/src/org/elixir_lang/psi/FoldingBuilder.java
+++ b/src/org/elixir_lang/psi/FoldingBuilder.java
@@ -6,6 +6,7 @@ import com.intellij.lang.folding.FoldingDescriptor;
 import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.editor.FoldingGroup;
 import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiReference;
 import com.intellij.psi.util.PsiTreeUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -36,35 +37,39 @@ public class FoldingBuilder extends FoldingBuilderEx {
         );
 
         for (final AtNonNumericOperation atNonNumericOperation : atNonNumericOperationCollection) {
-            PsiElement target = atNonNumericOperation.getReference().resolve();
+            PsiReference reference = atNonNumericOperation.getReference();
 
-            if (target != null) {
-                assert target instanceof AtUnqualifiedNoParenthesesCall;
+            if (reference != null) {
+                PsiElement target = reference.resolve();
 
-                final AtUnqualifiedNoParenthesesCall atUnqualifiedNoParenthesesCall = (AtUnqualifiedNoParenthesesCall) target;
+                if (target != null) {
+                    assert target instanceof AtUnqualifiedNoParenthesesCall;
 
-                String moduleAttributeName = atNonNumericOperation.moduleAttributeName();
-                FoldingGroup foldingGroup = foldingGroupByModuleAttributeName.get(moduleAttributeName);
+                    final AtUnqualifiedNoParenthesesCall atUnqualifiedNoParenthesesCall = (AtUnqualifiedNoParenthesesCall) target;
 
-                if (foldingGroup == null) {
-                    foldingGroup = FoldingGroup.newGroup(moduleAttributeName);
-                    foldingGroupByModuleAttributeName.put(moduleAttributeName, foldingGroup);
-                }
+                    String moduleAttributeName = atNonNumericOperation.moduleAttributeName();
+                    FoldingGroup foldingGroup = foldingGroupByModuleAttributeName.get(moduleAttributeName);
 
-                foldingDescriptorList.add(
-                        new FoldingDescriptor(
-                                atNonNumericOperation.getNode(),
-                                atNonNumericOperation.getTextRange(),
-                                foldingGroup,
-                                Collections.<Object>singleton(atUnqualifiedNoParenthesesCall)
-                        ) {
-                            @Nullable
-                            @Override
-                            public String getPlaceholderText() {
-                                return atUnqualifiedNoParenthesesCall.getNoParenthesesOneArgument().getText();
+                    if (foldingGroup == null) {
+                        foldingGroup = FoldingGroup.newGroup(moduleAttributeName);
+                        foldingGroupByModuleAttributeName.put(moduleAttributeName, foldingGroup);
+                    }
+
+                    foldingDescriptorList.add(
+                            new FoldingDescriptor(
+                                    atNonNumericOperation.getNode(),
+                                    atNonNumericOperation.getTextRange(),
+                                    foldingGroup,
+                                    Collections.<Object>singleton(atUnqualifiedNoParenthesesCall)
+                            ) {
+                                @Nullable
+                                @Override
+                                public String getPlaceholderText() {
+                                    return atUnqualifiedNoParenthesesCall.getNoParenthesesOneArgument().getText();
+                                }
                             }
-                        }
-                );
+                    );
+                }
             }
         }
 

--- a/src/org/elixir_lang/psi/impl/ElixirPsiImplUtil.java
+++ b/src/org/elixir_lang/psi/impl/ElixirPsiImplUtil.java
@@ -1441,7 +1441,7 @@ public class ElixirPsiImplUtil {
             keepProcessing = processor.execute(rightOperand, state);
         }
 
-        if (checkLeft && keepProcessing) {
+        if (checkLeft && leftOperand != null && keepProcessing) {
             keepProcessing = processor.execute(leftOperand, state);
         }
 


### PR DESCRIPTION
# Changelog

## Bug Fixes
* Highlight `foo` in `@spec foo` as a type, which occurs while typing a new `@spec` before `::` can be typed.
* Check if `leftOperand` is `null` even when `checkLeft` is `true` because `checkLeft` can be `true` and `leftOperand` is `null` when the `lastParent` is the operand or operation as a whole, but there is an error in the unnormalized `leftOperand` leading to the normalized `leftOperand` being `null`.
* Check if reference is `null` before checking if it resolves to `null` when replacing module attribute usages with their value because `AtNonNumericOperation`s can have a `null` reference when they are non-referencing, like `@spec`.