### PR TITLE
Leave normal highlighting for char tokens when highlighting types

### DIFF
--- a/src/org/elixir_lang/annonator/ModuleAttribute.java
+++ b/src/org/elixir_lang/annonator/ModuleAttribute.java
@@ -826,6 +826,7 @@ public class ModuleAttribute implements Annotator, DumbAware {
                 psiElement instanceof ElixirAtom ||
                 psiElement instanceof ElixirAtomKeyword ||
                 psiElement instanceof ElixirBitString ||
+                psiElement instanceof ElixirCharToken ||
                 psiElement instanceof ElixirDecimalWholeNumber ||
                 psiElement instanceof ElixirKeywordKey ||
                 psiElement instanceof ElixirStringLine ||


### PR DESCRIPTION
Fixes #311

# Changelog
## Bug Fixes
* Leave normal highlighting for char tokens when highlighting types