### PR TITLE
Build jps-builder using only Java 1.6 compatible .classes

### DIFF
--- a/.idea/libraries/idea.xml
+++ b/.idea/libraries/idea.xml
@@ -1,0 +1,9 @@
+<component name="libraryTable">
+  <library name="idea">
+    <CLASSES>
+      <root url="jar:///Applications/IntelliJ IDEA 14.1 CE.app/Contents/lib/idea.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES />
+  </library>
+</component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -31,7 +31,7 @@
     <ConfirmationsSetting value="0" id="Add" />
     <ConfirmationsSetting value="0" id="Remove" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_6" default="false" assert-keyword="true" jdk-15="true" project-jdk-name="IntelliJ IDEA Community Edition IC-145.258.11" project-jdk-type="IDEA JDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_6" default="false" assert-keyword="true" jdk-15="true" project-jdk-name="IntelliJ IDEA Community Edition IC-141.3056.4" project-jdk-type="IDEA JDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,6 +84,7 @@ doctoc .
 
 #### IntelliJ IDEA
 
+##### For Plugin
 An IntelliJ Platform Plugin SDK must be setup to develop plugins, but the paths are tied to the version of IntellIJ IDEA
 you have installed, so you will likely need to fix the paths to match your environment.
 
@@ -101,7 +102,7 @@ you have installed, so you will likely need to fix the paths to match your envir
             1. You can download [JDK 1.6 from Apple](https://support.apple.com/kb/DL1572?locale=en_US)
         3. Click OK
     5. In the “Select Home Directory for IntelliJ Platform Plugin SDK” select the IntelliJ IDEA Community Edition
-       Contents: `/Applications/IntelliJ IDEA 15 CE.app/Contents`.
+       Contents: `/Applications/IntelliJ IDEA 14.1 CE.app/Contents`.
         **NOTE: Use Community Edition even if you have IntelliJ IDEA Ultimate Edition installed, so that the built
                 plugin works with Community Edition.**
     6. In the “Select Internal Java  Platform” window
@@ -112,6 +113,50 @@ you have installed, so you will likely need to fix the paths to match your envir
         2. Click the + Icon
         3. Select “~/git/JetBrains/intellij-community”
         4. In the “Detected Roots” window, click “OK” to add all roots.
+    8. Click OK to close “Project Structure”
+
+##### For JPS Builder Compile Server
+
+Compile servers must be compatible all the way back to Java 1.6, but they also link to `openapi.jar`, which in new IntelliJ versions, like 2016.1, contains Java 1.8 only (`MAJOR.MINOR` `52.0`) `.class` files.  To ensure the jps-builder module is built so it will only use Java 1.6 compatible `.class` files in IntelliJ 14.1 through IntelliJ 2016.1, a separate, minimal IntelliJ Platform Plugin SDK is used for the `jps-builder` and `jps-shared` modules.
+ 
+ 1. Files > Project Structure
+ 2. In the "Project Structure" window
+     1. Select Platform Settings > SDKs
+    2. Click “+”
+    3. Chose “IntelliJ Platform Plugin SDK”
+    4. A modal **may** pop-up saying “Cannot Create SDK”, “You need to configure a Java SDK first”.
+        1. Click OK
+        2. In the “Select Home Directory for JDK” select the JDK 1.6 directory:
+           “/Library/Java/JavaVirtualMachines/1.6.0.jdk/Contents/Home”.
+           **NOTE: JDK 1.6 is used, even though it is unsupported by Oracle, to give the greatest compatibility with
+                   older JetBrains IDE versions**
+            1. You can download [JDK 1.6 from Apple](https://support.apple.com/kb/DL1572?locale=en_US)
+        3. Click OK
+    5. In the “Select Home Directory for IntelliJ Platform Plugin SDK” select the IntelliJ IDEA Community Edition
+       Contents: `/Applications/IntelliJ IDEA 14.1 CE.app/Contents`.
+        **NOTE: Use Community Edition even if you have IntelliJ IDEA Ultimate Edition installed, so that the built
+                plugin works with Community Edition.**
+    6. In the “Select Internal Java  Platform” window
+        1. Select “1.6”
+        2. Click OK
+    7. Select the “IntelliJ IDEA Community Edition” SDK.
+        1. Change the Name to "IntelliJ IDEA Community Edition (JPS-Builder)"
+        2. Minimize the number of jars included from "IntelliJ IDEA Community Edition"
+            1. Select all `/Applications/IntelliJ IDEA 14.1 CE.app/Contents` jars
+            2. Unselect (with Cmd+Click) the minimal jars needed
+                * `/Applications/IntelliJ IDEA 14.1 CE.app/Contents/lib/annotations.jar` 
+                * `/Applications/IntelliJ IDEA 14.1 CE.app/Contents/lib/jdom.jar` 
+                * `/Applications/IntelliJ IDEA 14.1 CE.app/Contents/lib/jps-model.jar` 
+                * `/Applications/IntelliJ IDEA 14.1 CE.app/Contents/lib/jps-server.jar` 
+                * `/Applications/IntelliJ IDEA 14.1 CE.app/Contents/lib/openapi.jar` 
+                * `/Applications/IntelliJ IDEA 14.1 CE.app/Contents/lib/trove4j.jar` 
+                * `/Applications/IntelliJ IDEA 14.1 CE.app/Contents/lib/util.jar` 
+            3. Click the - Icon to remove the unneeded jars
+        3. Add the Sourcepath
+            1. Select the Sourcepath tab
+            2. Click the + Icon
+            3. Select “~/git/JetBrains/intellij-community”
+            4. In the “Detected Roots” window, click “OK” to add all roots.
     8. Click OK to close “Project Structure”
 
 #### IntelliJ Erlang

--- a/intellij-elixir.iml
+++ b/intellij-elixir.iml
@@ -14,7 +14,7 @@
       <excludeFolder url="file://$MODULE_DIR$/dependencies" />
       <excludeFolder url="file://$MODULE_DIR$/tmp" />
     </content>
-    <orderEntry type="inheritedJdk" />
+    <orderEntry type="jdk" jdkName="IntelliJ IDEA Community Edition IC-141.3056.4" jdkType="IDEA JDK" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="module-library">
       <library name="JUnit4">

--- a/jps-builder/jps-builder.iml
+++ b/jps-builder/jps-builder.iml
@@ -6,8 +6,10 @@
       <sourceFolder url="file://$MODULE_DIR$/src" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/tests" isTestSource="true" />
     </content>
-    <orderEntry type="inheritedJdk" />
+    <orderEntry type="jdk" jdkName="IntelliJ IDEA Community Edition IC-141.3056.4 (JPS-Builder)" jdkType="IDEA JDK" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="module" module-name="jps-shared" />
+    <orderEntry type="library" scope="TEST" name="idea" level="project" />
+    <orderEntry type="library" scope="TEST" name="junit-4.12" level="project" />
   </component>
 </module>

--- a/jps-builder/src/org/elixir_lang/jps/builder/ElixirBuilder.java
+++ b/jps-builder/src/org/elixir_lang/jps/builder/ElixirBuilder.java
@@ -1,16 +1,28 @@
 package org.elixir_lang.jps.builder;
 
-import com.intellij.execution.ExecutionException;
-import com.intellij.execution.configurations.GeneralCommandLine;
+// 52.0 in openapi.jar
+// import com.intellij.execution.ExecutionException;
+// 52.0 in openapi.jar
+//import com.intellij.execution.configurations.GeneralCommandLine;
+// 50.0 in util.jar
 import com.intellij.execution.process.BaseOSProcessHandler;
+// 50.0 in util.jar
 import com.intellij.execution.process.ProcessAdapter;
+// 50.0 in util.jar
 import com.intellij.openapi.diagnostic.Logger;
+// 50.0 in util.jar
 import com.intellij.openapi.util.io.FileUtil;
+// 49.0 in util.jar
 import com.intellij.openapi.util.io.FileUtilRt;
+// 50.0 in util.jar
 import com.intellij.openapi.util.text.StringUtil;
+// 50.0 in util.jar
 import com.intellij.util.CommonProcessors;
+// 49.0 in util.jar
 import com.intellij.util.Function;
+// 50.0 in util.jar
 import com.intellij.util.containers.ContainerUtil;
+// 49.0 in trove4j.jar
 import gnu.trove.THashSet;
 import org.elixir_lang.jps.mix.JpsMixConfigurationExtension;
 import org.elixir_lang.jps.model.ElixirCompilerOptions;
@@ -19,21 +31,37 @@ import org.elixir_lang.jps.model.JpsElixirModuleType;
 import org.elixir_lang.jps.model.JpsElixirSdkType;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+// 50.0 in jsp-builders.jar
 import org.jetbrains.jps.builders.BuildOutputConsumer;
+// 50.0 in jsp-builders.jar
 import org.jetbrains.jps.builders.DirtyFilesHolder;
+// 50.0 in jsp-builders.jar
 import org.jetbrains.jps.builders.FileProcessor;
+// 50.0 in jsp-builders.jar
 import org.jetbrains.jps.incremental.CompileContext;
+// 50.0 in jsp-builders.jar
 import org.jetbrains.jps.incremental.ProjectBuildException;
+// 50.0 in jsp-builders.jar
 import org.jetbrains.jps.incremental.TargetBuilder;
+// 50.0 in jsp-builders.jar
 import org.jetbrains.jps.incremental.messages.BuildMessage;
+// 50.0 in jsp-builders.jar
 import org.jetbrains.jps.incremental.messages.CompilerMessage;
+// 50.0 in jsp-builders.jar
 import org.jetbrains.jps.incremental.resources.ResourcesBuilder;
+// 50.0 in jsp-builders.jar
 import org.jetbrains.jps.incremental.resources.StandardResourceBuilderEnabler;
+// 50.0 in openapi.jar
 import org.jetbrains.jps.model.JpsDummyElement;
+// 50.0 in openapi.jar
 import org.jetbrains.jps.model.JpsProject;
+// 50.0 in openapi.jar
 import org.jetbrains.jps.model.java.JavaSourceRootType;
+// 50.0 in openapi.jar
 import org.jetbrains.jps.model.java.JpsJavaExtensionService;
+// 50.0 in openapi.jar
 import org.jetbrains.jps.model.library.sdk.JpsSdk;
+// 50.0 in openapi.jar
 import org.jetbrains.jps.model.module.*;
 
 import java.io.File;

--- a/jps-builder/src/org/elixir_lang/jps/builder/ExecutionException.java
+++ b/jps-builder/src/org/elixir_lang/jps/builder/ExecutionException.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2016 Luke Imhoff
+ * Copyright 2000-2009 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.elixir_lang.jps.builder;
+
+public class ExecutionException extends Exception {
+    public ExecutionException(final String s) {
+        super(s);
+    }
+
+    public ExecutionException(final Throwable cause) {
+        super(cause == null ? null : cause.getMessage(), cause);
+    }
+
+    public ExecutionException(final String s, Throwable cause) {
+        super(s, cause);
+    }
+}

--- a/jps-builder/src/org/elixir_lang/jps/builder/GeneralCommandLine.java
+++ b/jps-builder/src/org/elixir_lang/jps/builder/GeneralCommandLine.java
@@ -1,0 +1,291 @@
+/*
+ * Copyright 2016 Luke Imhoff
+ * Copyright 2000-2014 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.elixir_lang.jps.builder;
+
+import com.intellij.execution.CommandLineUtil;
+import com.intellij.ide.IdeBundle;
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.util.Key;
+import com.intellij.openapi.util.SystemInfo;
+import com.intellij.openapi.util.UserDataHolder;
+import com.intellij.openapi.util.text.StringUtil;
+import com.intellij.util.EnvironmentUtil;
+import com.intellij.util.PlatformUtils;
+import com.intellij.util.containers.ContainerUtil;
+import com.intellij.util.text.CaseInsensitiveStringHashingStrategy;
+import gnu.trove.THashMap;
+import org.jetbrains.annotations.NonNls;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.*;
+
+/**
+ * OS-independent way of executing external processes with complex parameters.
+ * <p/>
+ * Main idea of the class is to accept parameters "as-is", just as they should look to an external process, and quote/escape them
+ * as required by the underlying platform.
+ *
+ * @see com.intellij.execution.process.OSProcessHandler
+ */
+public class GeneralCommandLine implements UserDataHolder {
+    private static final Logger LOG = Logger.getInstance("#org.elixir_lang.jps.builders.GeneralCommandLine");
+
+    private String myExePath = null;
+    private File myWorkDirectory = null;
+    private final Map<String, String> myEnvParams = new MyTHashMap();
+    private final ParametersList myProgramParams = new ParametersList();
+    private Map<Object, Object> myUserData = null;
+
+    public GeneralCommandLine() { }
+
+    @SuppressWarnings("unused")
+    public String getExePath() {
+        return myExePath;
+    }
+
+    public void setExePath(@NotNull @NonNls final String exePath) {
+        myExePath = exePath.trim();
+    }
+
+    public File getWorkDirectory() {
+        return myWorkDirectory;
+    }
+
+    @NotNull
+    public GeneralCommandLine withWorkDirectory(@Nullable final String path) {
+        return withWorkDirectory(path != null ? new File(path) : null);
+    }
+
+    @NotNull
+    public GeneralCommandLine withWorkDirectory(@Nullable final File workDirectory) {
+        myWorkDirectory = workDirectory;
+        return this;
+    }
+
+    /**
+     * Note: the map returned is forgiving to passing null values into putAll().
+     */
+    @NotNull
+    public Map<String, String> getEnvironment() {
+        return myEnvParams;
+    }
+
+    /**
+     * @deprecated use {@link #getEnvironment()} (to remove in IDEA 14)
+     */
+    @SuppressWarnings("unused")
+    public Map<String, String> getEnvParams() {
+        return getEnvironment();
+    }
+
+    /**
+     * @deprecated use {@link #getEnvironment()} (to remove in IDEA 14)
+     */
+    @SuppressWarnings("unused")
+    public void setEnvParams(@Nullable Map<String, String> envParams) {
+        myEnvParams.clear();
+        if (envParams != null) {
+            myEnvParams.putAll(envParams);
+        }
+    }
+
+    /**
+     * @return unmodifiable map of the parent environment, that will be passed to the process if isPassParentEnvironment() == true
+     */
+    @NotNull
+    public Map<String, String> getParentEnvironment() {
+        return PlatformUtils.isAppCode() ? System.getenv() // Temporarily fix for OC-8606
+                : EnvironmentUtil.getEnvironmentMap();
+    }
+
+    public void addParameters(final String... parameters) {
+        for (String parameter : parameters) {
+            addParameter(parameter);
+        }
+    }
+
+    public void addParameters(@NotNull final List<String> parameters) {
+        for (final String parameter : parameters) {
+            addParameter(parameter);
+        }
+    }
+
+    public void addParameter(@NotNull @NonNls final String parameter) {
+        myProgramParams.add(parameter);
+    }
+
+    @SuppressWarnings("unused")
+    public ParametersList getParametersList() {
+        return myProgramParams;
+    }
+
+    /**
+     * Returns string representation of this command line.<br/>
+     * Warning: resulting string is not OS-dependent - <b>do not</b> use it for executing this command line.
+     *
+     * @return single-string representation of this command line.
+     */
+    public String getCommandLineString() {
+        return getCommandLineString(null);
+    }
+
+    /**
+     * Returns string representation of this command line.<br/>
+     * Warning: resulting string is not OS-dependent - <b>do not</b> use it for executing this command line.
+     *
+     * @param exeName use this executable name instead of given by {@link #setExePath(String)}
+     * @return single-string representation of this command line.
+     */
+    public String getCommandLineString(@Nullable final String exeName) {
+        return ParametersList.join(getCommandLineList(exeName));
+    }
+
+    public List<String> getCommandLineList(@Nullable final String exeName) {
+        final List<String> commands = new ArrayList<String>();
+        if (exeName != null) {
+            commands.add(exeName);
+        }
+        else if (myExePath != null) {
+            commands.add(myExePath);
+        }
+        else {
+            commands.add("<null>");
+        }
+        commands.addAll(myProgramParams.getList());
+        return commands;
+    }
+
+    @SuppressWarnings("UnresolvedPropertyKey")
+    @NotNull
+    public Process createProcess() throws ExecutionException {
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Executing [" + getCommandLineString() + "]");
+        }
+
+        List<String> commands;
+        try {
+            checkWorkingDirectory();
+
+            if (StringUtil.isEmptyOrSpaces(myExePath)) {
+                throw new ExecutionException(IdeBundle.message("run.configuration.error.executable.not.specified"));
+            }
+
+            commands = CommandLineUtil.toCommandLine(myExePath, myProgramParams.getList());
+        }
+        catch (ExecutionException e) {
+            LOG.info(e);
+            throw e;
+        }
+
+        try {
+            return startProcess(commands);
+        }
+        catch (IOException e) {
+            LOG.info(e);
+            throw new ProcessNotCreatedException(e.getMessage(), e, this);
+        }
+    }
+
+    @NotNull
+    protected Process startProcess(@NotNull List<String> commands) throws IOException {
+        ProcessBuilder builder = new ProcessBuilder(commands);
+        setupEnvironment(builder.environment());
+        builder.directory(myWorkDirectory);
+        builder.redirectErrorStream(false);
+        return builder.start();
+    }
+
+    @SuppressWarnings("UnresolvedPropertyKey")
+    private void checkWorkingDirectory() throws ExecutionException {
+        if (myWorkDirectory == null) {
+            return;
+        }
+        if (!myWorkDirectory.exists()) {
+            throw new ExecutionException(
+                    IdeBundle.message("run.configuration.error.working.directory.does.not.exist", myWorkDirectory.getAbsolutePath()));
+        }
+        if (!myWorkDirectory.isDirectory()) {
+            throw new ExecutionException(IdeBundle.message("run.configuration.error.working.directory.not.directory"));
+        }
+    }
+
+    protected void setupEnvironment(@NotNull Map<String, String> environment) {
+        environment.clear();
+        environment.putAll(getParentEnvironment());
+
+        if (!myEnvParams.isEmpty()) {
+            if (SystemInfo.isWindows) {
+                THashMap<String, String> envVars = new THashMap<String, String>(CaseInsensitiveStringHashingStrategy.INSTANCE);
+                envVars.putAll(environment);
+                envVars.putAll(myEnvParams);
+                environment.clear();
+                environment.putAll(envVars);
+            }
+            else {
+                environment.putAll(myEnvParams);
+            }
+        }
+    }
+
+    @Override
+    public String toString() {
+        return myExePath + " " + myProgramParams;
+    }
+
+    @Override
+    public <T> T getUserData(@NotNull final Key<T> key) {
+        if (myUserData != null) {
+            @SuppressWarnings({"UnnecessaryLocalVariable", "unchecked"}) final T t = (T)myUserData.get(key);
+            return t;
+        }
+        return null;
+    }
+
+    @Override
+    public <T> void putUserData(@NotNull final Key<T> key, @Nullable final T value) {
+        if (myUserData == null) {
+            myUserData = ContainerUtil.newHashMap();
+        }
+        myUserData.put(key, value);
+    }
+
+    private static class MyTHashMap extends THashMap<String, String> {
+        @Override
+        public String put(String key, String value) {
+            if (key == null || value == null) {
+                LOG.error(new Exception("Nulls are not allowed"));
+                return null;
+            }
+            if (key.isEmpty()) {
+                // Windows: passing an environment variable with empty name causes "CreateProcess error=87, The parameter is incorrect"
+                LOG.warn("Skipping environment variable with empty name, value: " + value);
+                return null;
+            }
+            return super.put(key, value);
+        }
+
+        @Override
+        public void putAll(Map<? extends String, ? extends String> map) {
+            if (map != null) {
+                super.putAll(map);
+            }
+        }
+    }
+}

--- a/jps-builder/src/org/elixir_lang/jps/builder/ParametersList.java
+++ b/jps-builder/src/org/elixir_lang/jps/builder/ParametersList.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2016 Luke Imhoff
+ * Copyright 2000-2013 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.elixir_lang.jps.builder;
+
+import com.intellij.openapi.application.Application;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.application.PathMacros;
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.util.text.StringUtil;
+import com.intellij.util.ArrayUtil;
+import com.intellij.util.EnvironmentUtil;
+import com.intellij.util.execution.ParametersListUtil;
+import org.jetbrains.annotations.NonNls;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.*;
+
+public class ParametersList implements Cloneable {
+    private static final Logger LOG = Logger.getInstance("#org.elixir_lang.jps.builder.ParametersList");
+
+    private List<String> myParameters = new ArrayList<String>();
+    private Map<String, String> myMacroMap = null;
+    private List<ParamsGroup> myGroups = new ArrayList<ParamsGroup>();
+
+    @NotNull
+    public String[] getArray() {
+        return ArrayUtil.toStringArray(getList());
+    }
+
+    @NotNull
+    public List<String> getList() {
+        if (myGroups.isEmpty()) {
+            return Collections.unmodifiableList(myParameters);
+        }
+
+        final List<String> params = new ArrayList<String>();
+        params.addAll(myParameters);
+        for (ParamsGroup group : myGroups) {
+            params.addAll(group.getParameters());
+        }
+        return Collections.unmodifiableList(params);
+    }
+
+    public void add(@NonNls final String parameter) {
+        myParameters.add(expandMacros(parameter));
+    }
+
+    public List<String> getParameters() {
+        return Collections.unmodifiableList(myParameters);
+    }
+
+    public void set(int ind, final @NonNls String value) {
+        myParameters.set(ind, value);
+    }
+
+    public String get(int ind) {
+        return myParameters.get(ind);
+    }
+
+    public void add(@NonNls final String name, @NonNls final String value) {
+        add(name);
+        add(value);
+    }
+
+    public void addAll(final String... parameters) {
+        addAll(Arrays.asList(parameters));
+    }
+
+    public void addAll(final List<String> parameters) {
+        // Don't use myParameters.addAll(parameters) , it does not call expandMacros(parameter)
+        for (String parameter : parameters) {
+            add(parameter);
+        }
+    }
+
+    @Override
+    public ParametersList clone() {
+        try {
+            final ParametersList clone = (ParametersList)super.clone();
+            clone.myParameters = new ArrayList<String>(myParameters);
+            clone.myGroups = new ArrayList<ParamsGroup>(myGroups.size() + 1);
+            for (ParamsGroup group : myGroups) {
+                clone.myGroups.add(group.clone());
+            }
+            return clone;
+        }
+        catch (CloneNotSupportedException e) {
+            LOG.error(e);
+            return null;
+        }
+    }
+
+    /**
+     * @see ParametersListUtil#join(java.util.List)
+     */
+    @NotNull
+    public static String join(@NotNull final List<String> parameters) {
+        return ParametersListUtil.join(parameters);
+    }
+
+    /**
+     * @see ParametersListUtil#parseToArray(String)
+     */
+    @NotNull
+    public static String[] parse(@NotNull final String string) {
+        return ParametersListUtil.parseToArray(string);
+    }
+
+    public String expandMacros(String text) {
+        final Map<String, String> macroMap = getMacroMap();
+        final Set<String> set = macroMap.keySet();
+        for (final String from : set) {
+            final String to = macroMap.get(from);
+            text = StringUtil.replace(text, from, to, true);
+        }
+        return text;
+    }
+
+    private Map<String, String> getMacroMap() {
+        if (myMacroMap == null) {
+            // the insertion order is important for later iterations, so LinkedHashMap is used
+            myMacroMap = new LinkedHashMap<String, String>();
+
+            // ApplicationManager.getApplication() will return null if executed in ParameterListTest
+            final Application application = ApplicationManager.getApplication();
+            if (application != null) {
+                final PathMacros pathMacros = PathMacros.getInstance();
+                if (pathMacros != null) {
+                    for (String name : pathMacros.getUserMacroNames()) {
+                        final String value = pathMacros.getValue(name);
+                        if (value != null) {
+                            myMacroMap.put("${" + name + "}", value);
+                        }
+                    }
+                }
+                final Map<String, String> env = EnvironmentUtil.getEnvironmentMap();
+                for (String name : env.keySet()) {
+                    final String key = "${" + name + "}";
+                    if (!myMacroMap.containsKey(key)) {
+                        myMacroMap.put(key, env.get(name));
+                    }
+                }
+            }
+        }
+        return myMacroMap;
+    }
+
+    @Override
+    public String toString() {
+        return myParameters.toString();
+    }
+
+}

--- a/jps-builder/src/org/elixir_lang/jps/builder/ParamsGroup.java
+++ b/jps-builder/src/org/elixir_lang/jps/builder/ParamsGroup.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2016 Luke Imhoff
+ * Copyright 2000-2011 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.elixir_lang.jps.builder;
+
+import com.intellij.openapi.diagnostic.Logger;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+
+/**
+ * @author Roman.Chernyatchik
+ *
+ * Group of linked params. Sometime it's much more convenient to split cmdline in logical groups.
+ * In this case it will be easier to patch such grouped argements using custom extentions
+ *
+ * E.g.: we want to add Coverage support to all existing Ruby run configurations(ruby applications,
+ * different kinds of ruby tests, rails configuration, etc). Coverage support require to reorder args
+ * in cmdline, add rcov runner script, etc. Without groups it would be harder to parse abstract list of arguments
+ */
+public class ParamsGroup implements Cloneable {
+    private static final Logger LOG = Logger.getInstance(ParamsGroup.class.getName());
+
+    private String myGroupId;
+    private ParametersList myGroupParams = new ParametersList();
+
+    public ParamsGroup(@NotNull final String groupId) {
+        myGroupId = groupId;
+    }
+
+    public String getId() {
+        return myGroupId;
+    }
+
+    public List<String> getParameters() {
+        return myGroupParams.getList();
+    }
+
+    @Override
+    public ParamsGroup clone() {
+        try {
+            final ParamsGroup clone = (ParamsGroup)super.clone();
+            clone.myGroupId = myGroupId;
+            clone.myGroupParams = myGroupParams.clone();
+            return clone;
+        }
+        catch (CloneNotSupportedException e) {
+            LOG.error(e);
+            return null;
+        }
+    }
+
+    @Override
+    public String toString() {
+        return myGroupId;
+    }
+}

--- a/jps-builder/src/org/elixir_lang/jps/builder/ProcessNotCreatedException.java
+++ b/jps-builder/src/org/elixir_lang/jps/builder/ProcessNotCreatedException.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2016 Luke Imhoff
+ * Copyright 2000-2009 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.elixir_lang.jps.builder;
+
+public class ProcessNotCreatedException extends ExecutionException {
+    private final GeneralCommandLine myCommandLine;
+
+    public ProcessNotCreatedException(final String s, final Throwable cause, final GeneralCommandLine commandLine) {
+        super(s, cause);
+        myCommandLine = commandLine;
+    }
+
+    @SuppressWarnings("unused")
+    public GeneralCommandLine getCommandLine() {
+        return myCommandLine;
+    }
+}

--- a/jps-shared/jps-shared.iml
+++ b/jps-shared/jps-shared.iml
@@ -5,7 +5,7 @@
     <content url="file://$MODULE_DIR$">
       <sourceFolder url="file://$MODULE_DIR$/src" isTestSource="false" />
     </content>
-    <orderEntry type="inheritedJdk" />
+    <orderEntry type="jdk" jdkName="IntelliJ IDEA Community Edition IC-141.3056.4 (JPS-Builder)" jdkType="IDEA JDK" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
 </module>


### PR DESCRIPTION
Fixes #290
Fixes #293
Fixes #295
Fixes #302
Fixes #313

# Changelog
## Bug Fixes
* In IntelliJ 14.1, all of `openapi.jar` targets Java 1.6 (with `MAJOR.MINOR` `50.0`), but in IntelliJ 2016.1, some of `openapi.jar` targets only Java 1.8 (with `MAJOR.MINOR` `52.0`), since `jps-builders` require parts of `openapi.jar` and must target Java 1.6 even for IntelliJ 2016.1, the `52.0` `.class`es needed to be ported into `org.elixir_lang.jps.builder`, so that the `52.0` version in `openapi.jar` wouldn't be attempted to be loaded.
  
   This ended up being 5 classes:

    * `ExecutionException`
    * `GeneralCommandLine`
    * `ParametersList`
    * `ParamsGroup`
    * `ProcessNotCreatedException`

    Only `GeneralCommandLine` was used directly, all others are dependencies
of it.

# Thanks    
Thanks to @cedriessen for pointing that all the weird loading bugs were related to https://github.com/ignatov/intellij-erlang/issues/727 and then @ignatov, @deadok22, and @chashnikov for helping from that issue.