### PR TITLE
Check if parameter is null before Variable.execute call

### DIFF
--- a/src/org/elixir_lang/psi/scope/Variable.java
+++ b/src/org/elixir_lang/psi/scope/Variable.java
@@ -457,10 +457,12 @@ public abstract class Variable implements PsiScopeProcessor {
         boolean keepProcessing = true;
 
         for (PsiElement parameter : parameters) {
-            keepProcessing = execute(parameter, state);
+            if (parameter != null) {
+                keepProcessing = execute(parameter, state);
 
-            if (!keepProcessing) {
-                break;
+                if (!keepProcessing) {
+                    break;
+                }
             }
         }
 


### PR DESCRIPTION
Fixes #326

# Changelog
## Bug Fixes
* Check if `parameter` is `null` before `Variable#execute` call in `Variable#execute(PsiElement[], ResolveState)`.