### PR TITLE
Function separator

### DIFF
--- a/gen/org/elixir_lang/psi/ElixirMatchedWhenOperation.java
+++ b/gen/org/elixir_lang/psi/ElixirMatchedWhenOperation.java
@@ -7,13 +7,13 @@ import com.intellij.psi.ResolveState;
 import com.intellij.psi.scope.PsiScopeProcessor;
 import org.apache.commons.lang.math.IntRange;
 import org.elixir_lang.psi.call.Named;
-import org.elixir_lang.psi.operation.Infix;
+import org.elixir_lang.psi.operation.When;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 
-public interface ElixirMatchedWhenOperation extends ElixirMatchedExpression, Named, Infix {
+public interface ElixirMatchedWhenOperation extends ElixirMatchedExpression, Named, When {
 
   @NotNull
   List<ElixirMatchedExpression> getMatchedExpressionList();

--- a/gen/org/elixir_lang/psi/ElixirUnmatchedWhenOperation.java
+++ b/gen/org/elixir_lang/psi/ElixirUnmatchedWhenOperation.java
@@ -7,13 +7,13 @@ import com.intellij.psi.ResolveState;
 import com.intellij.psi.scope.PsiScopeProcessor;
 import org.apache.commons.lang.math.IntRange;
 import org.elixir_lang.psi.call.Named;
-import org.elixir_lang.psi.operation.Infix;
+import org.elixir_lang.psi.operation.When;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 
-public interface ElixirUnmatchedWhenOperation extends ElixirUnmatchedExpression, Named, Infix {
+public interface ElixirUnmatchedWhenOperation extends ElixirUnmatchedExpression, Named, When {
 
   @NotNull
   List<ElixirUnmatchedExpression> getUnmatchedExpressionList();

--- a/gen/org/elixir_lang/psi/ElixirVisitor.java
+++ b/gen/org/elixir_lang/psi/ElixirVisitor.java
@@ -626,7 +626,7 @@ public class ElixirVisitor extends PsiElementVisitor {
   public void visitMatchedWhenOperation(@NotNull ElixirMatchedWhenOperation o) {
     visitMatchedExpression(o);
     // visitNamed(o);
-    // visitInfix(o);
+    // visitWhen(o);
   }
 
   public void visitMultiplicationInfixOperator(@NotNull ElixirMultiplicationInfixOperator o) {
@@ -957,7 +957,7 @@ public class ElixirVisitor extends PsiElementVisitor {
   public void visitUnmatchedWhenOperation(@NotNull ElixirUnmatchedWhenOperation o) {
     visitUnmatchedExpression(o);
     // visitNamed(o);
-    // visitInfix(o);
+    // visitWhen(o);
   }
 
   public void visitUnqualifiedNoParenthesesManyArgumentsCall(@NotNull ElixirUnqualifiedNoParenthesesManyArgumentsCall o) {

--- a/src/META-INF/plugin.xml
+++ b/src/META-INF/plugin.xml
@@ -1298,6 +1298,8 @@
     <annotator implementationClass="org.elixir_lang.annonator.Kernel" language="Elixir"/>
     <annotator implementationClass="org.elixir_lang.annonator.Map" language="Elixir"/>
     <annotator implementationClass="org.elixir_lang.annonator.ModuleAttribute" language="Elixir"/>
+
+    <codeInsight.lineMarkerProvider implementationClass="org.elixir_lang.code_insight.line_marker_provider.CallDefinition" language="Elixir"/>
     <elementDescriptionProvider implementation="org.elixir_lang.psi.ElementDescriptionProvider"/>
     <gotoSymbolContributor implementation="org.elixir_lang.navigation.GotoSymbolContributor"/>
     <lang.commenter language="Elixir" implementationClass="org.elixir_lang.ElixirCommenter"/>

--- a/src/org/elixir_lang/Elixir.bnf
+++ b/src/org/elixir_lang/Elixir.bnf
@@ -47,7 +47,7 @@
   /* infix operations that work as name identifier owner calls - specifically support getNameIdentifier so they can
      return their operator, so it is easy to use a different operator when making customer operators like in Bitwise or
      the free arrow operators */
-  implements(        "(un)?matched(Arrow|Comparison|Multiplication|Or|Relational|When)Operation")=[
+  implements(        "(un)?matched(Arrow|Comparison|Multiplication|Or|Relational)Operation")=[
     "org.elixir_lang.psi.call.Named"
     "org.elixir_lang.psi.operation.Infix"
   ]
@@ -118,6 +118,12 @@
   implements("(un)?matchedTypeOperation")=[
     "org.elixir_lang.psi.call.Named"
     "org.elixir_lang.psi.operation.Type"
+  ]
+  // methods set by infix operations above
+
+  implements("(un)?matchedWhenOperation")=[
+    "org.elixir_lang.psi.call.Named"
+    "org.elixir_lang.psi.operation.When"
   ]
   // methods set by infix operations above
 

--- a/src/org/elixir_lang/annonator/ModuleAttribute.java
+++ b/src/org/elixir_lang/annonator/ModuleAttribute.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Set;
 
 import static org.elixir_lang.psi.call.name.Function.UNQUOTE;
+import static org.elixir_lang.psi.call.name.Module.KERNEL;
 import static org.elixir_lang.reference.ModuleAttribute.*;
 
 /**
@@ -1047,31 +1048,34 @@ public class ModuleAttribute implements Annotator, DumbAware {
             Set<String> typeParameterNameSet,
             AnnotationHolder annotationHolder,
             TextAttributesKey typeTextAttributesKey) {
-        PsiElement functionNameElement = unqualifiedParenthesesCall.functionNameElement();
+        if (!unqualifiedParenthesesCall.isCalling(KERNEL, UNQUOTE, 1)) {
+            PsiElement functionNameElement = unqualifiedParenthesesCall.functionNameElement();
 
-        if (functionNameElement != null) {
+            if (functionNameElement != null) {
 
-            highlight(functionNameElement.getTextRange(), annotationHolder, typeTextAttributesKey);
 
-            highlightTypesAndTypeParameterUsages(
-                    unqualifiedParenthesesCall.primaryArguments(),
-                    typeParameterNameSet,
-                    annotationHolder,
-                    typeTextAttributesKey
-            );
+                highlight(functionNameElement.getTextRange(), annotationHolder, typeTextAttributesKey);
 
-            PsiElement[] secondaryArguments = unqualifiedParenthesesCall.secondaryArguments();
-
-            if (secondaryArguments != null) {
                 highlightTypesAndTypeParameterUsages(
-                        secondaryArguments,
+                        unqualifiedParenthesesCall.primaryArguments(),
                         typeParameterNameSet,
                         annotationHolder,
                         typeTextAttributesKey
                 );
+
+                PsiElement[] secondaryArguments = unqualifiedParenthesesCall.secondaryArguments();
+
+                if (secondaryArguments != null) {
+                    highlightTypesAndTypeParameterUsages(
+                            secondaryArguments,
+                            typeParameterNameSet,
+                            annotationHolder,
+                            typeTextAttributesKey
+                    );
+                }
+            } else {
+                error("Cannot highlight types and type parameter usages", unqualifiedParenthesesCall);
             }
-        } else {
-            error("Cannot highlight types and type parameter usages", unqualifiedParenthesesCall);
         }
     }
 

--- a/src/org/elixir_lang/code_insight/line_marker_provider/CallDefinition.java
+++ b/src/org/elixir_lang/code_insight/line_marker_provider/CallDefinition.java
@@ -10,23 +10,22 @@ import com.intellij.openapi.editor.colors.EditorColorsScheme;
 import com.intellij.openapi.editor.markup.GutterIconRenderer;
 import com.intellij.openapi.editor.markup.SeparatorPlacement;
 import com.intellij.openapi.util.Pair;
-import com.intellij.psi.PsiElement;
+import com.intellij.psi.*;
 import org.apache.commons.lang.math.IntRange;
 import org.elixir_lang.psi.AtUnqualifiedNoParenthesesCall;
 import org.elixir_lang.psi.call.Call;
-import org.elixir_lang.psi.impl.ElixirPsiImplUtil;
-import org.elixir_lang.reference.ModuleAttribute;
 import org.elixir_lang.structure_view.element.CallDefinitionClause;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
-import static org.elixir_lang.psi.impl.ElixirPsiImplUtil.ATOM_KEYWORDS;
-import static org.elixir_lang.psi.impl.ElixirPsiImplUtil.moduleAttributeName;
-import static org.elixir_lang.psi.impl.ElixirPsiImplUtil.previousSiblingExpression;
+import static org.elixir_lang.psi.impl.ElixirPsiImplUtil.*;
 import static org.elixir_lang.structure_view.element.CallDefinitionClause.nameArityRange;
+import static org.elixir_lang.structure_view.element.CallDefinitionSpecification.*;
 
 public class CallDefinition implements LineMarkerProvider {
     /*
@@ -105,7 +104,169 @@ public class CallDefinition implements LineMarkerProvider {
         String moduleAttributeName = moduleAttributeName(atUnqualifiedNoParenthesesCall);
 
         if (moduleAttributeName.equals("@doc")) {
-            lineMarkerInfo = callDefinitionSeparator(atUnqualifiedNoParenthesesCall);
+            PsiElement previousExpression = siblingExpression(atUnqualifiedNoParenthesesCall, PREVIOUS_SIBLING);
+            boolean firstInGroup = true;
+
+            if (previousExpression instanceof AtUnqualifiedNoParenthesesCall) {
+                AtUnqualifiedNoParenthesesCall previousModuleAttribute =
+                        (AtUnqualifiedNoParenthesesCall) previousExpression;
+                String previousModuleAttributeName = moduleAttributeName(previousModuleAttribute);
+
+                if (previousModuleAttributeName.equals("@spec")) {
+                    Pair<String, Integer> moduleAttributeNameArity = moduleAttributeNameArity(previousModuleAttribute);
+
+                    if (moduleAttributeNameArity != null) {
+                        Call nextSiblingCallDefinitionClause = siblingCallDefinitionClause(atUnqualifiedNoParenthesesCall, NEXT_SIBLING);
+
+                        if (nextSiblingCallDefinitionClause != null) {
+                            Pair<String, IntRange> nameArityRange = nameArityRange(nextSiblingCallDefinitionClause);
+
+                            if (nameArityRange != null) {
+                                IntRange arityRange = nameArityRange.second;
+
+                                if (arityRange.containsInteger(moduleAttributeNameArity.second)) {
+                                    // the previous spec is part of the group
+                                    firstInGroup = false;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            if (firstInGroup) {
+                lineMarkerInfo = callDefinitionSeparator(atUnqualifiedNoParenthesesCall);
+            }
+        } else if (moduleAttributeName.equals("@spec")) {
+            PsiElement previousExpression = siblingExpression(atUnqualifiedNoParenthesesCall, PREVIOUS_SIBLING);
+            boolean firstInGroup = true;
+
+            if (previousExpression instanceof AtUnqualifiedNoParenthesesCall) {
+                AtUnqualifiedNoParenthesesCall previousModuleAttribute =
+                        (AtUnqualifiedNoParenthesesCall) previousExpression;
+                String previousModuleAttributeName = moduleAttributeName(previousModuleAttribute);
+
+                if (previousModuleAttributeName.equals("@doc")) {
+                    firstInGroup = false;
+                } else if (previousModuleAttributeName.equals("@spec")) {
+                    Pair<String, Integer> moduleAttributeNameArity =
+                            moduleAttributeNameArity(atUnqualifiedNoParenthesesCall);
+
+                    if (moduleAttributeNameArity != null) {
+                        Pair<String, Integer> previousModuleAttributeNameArity =
+                                moduleAttributeNameArity(previousModuleAttribute);
+
+                        if (previousModuleAttributeNameArity != null) {
+                            // name match, now check if the arities match.
+                            if (moduleAttributeNameArity.first.equals(previousModuleAttributeNameArity.first)) {
+                                Integer moduleAttributeArity = moduleAttributeNameArity.second;
+                                Integer previousModuleAttributeArity = previousModuleAttributeNameArity.second;
+
+                                if (moduleAttributeArity.equals(previousModuleAttributeArity)) {
+                                    /* same arity with different pattern is same function, so the previous @spec should
+                                       check if it is first because this one isn't */
+                                    firstInGroup = false;
+                                } else {
+                                    /* same name, but different arity needs to determine if the call definition has an
+                                       arity range. */
+                                    Call specification = specification(atUnqualifiedNoParenthesesCall);
+
+                                    if (specification != null) {
+                                        Call type = specificationType(specification);
+
+                                        if (type != null) {
+                                            PsiReference reference = type.getReference();
+
+                                            if (reference != null) {
+                                                List<PsiElement> resolvedList = null;
+
+                                                if (reference instanceof PsiPolyVariantReference) {
+                                                    PsiPolyVariantReference polyVariantReference =
+                                                            (PsiPolyVariantReference) reference;
+
+                                                    ResolveResult[] resolveResults =
+                                                            polyVariantReference.multiResolve(false);
+
+
+                                                    if (resolveResults.length > 0) {
+                                                        resolvedList = new ArrayList<PsiElement>();
+
+                                                        for (ResolveResult resolveResult : resolveResults) {
+                                                            resolvedList.add(resolveResult.getElement());
+                                                        }
+                                                    }
+                                                } else {
+                                                    PsiElement resolved = reference.resolve();
+
+                                                    if (resolved != null) {
+                                                        resolvedList = Collections.singletonList(resolved);
+                                                    }
+                                                }
+
+                                                if (resolvedList != null && resolvedList.size() > 0) {
+                                                    for (PsiElement resolved : resolvedList) {
+                                                        if (resolved instanceof Call) {
+                                                            Pair<String, IntRange> resolvedNameArityRange =
+                                                                    nameArityRange((Call) resolved);
+
+                                                            if (resolvedNameArityRange != null) {
+                                                                IntRange resolvedArityRange = resolvedNameArityRange.second;
+
+                                                                if (resolvedArityRange.containsInteger(moduleAttributeArity) &&
+                                                                        resolvedArityRange.containsInteger(previousModuleAttributeArity)) {
+                                                                    // the current @spec and the previous @spec apply to the same call definition clause
+                                                                    firstInGroup = false;
+
+                                                                    break;
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            } else {
+                Call specification = specification(atUnqualifiedNoParenthesesCall);
+
+                if (specification != null) {
+                    Call type = specificationType(specification);
+
+                    if (type != null) {
+                        PsiReference reference = type.getReference();
+
+                        if (reference != null) {
+                            if (reference instanceof PsiPolyVariantReference) {
+                                PsiPolyVariantReference polyVariantReference = (PsiPolyVariantReference) reference;
+
+                                ResolveResult[] resolveResults = polyVariantReference.multiResolve(false);
+                                PsiFile containingFile = type.getContainingFile();
+
+                                for (ResolveResult resolveResult : resolveResults) {
+                                    PsiElement element = resolveResult.getElement();
+
+                                    if (element != null) {
+                                        if (element.getContainingFile().equals(containingFile) &&
+                                                element.getTextOffset() < type.getTextOffset()) {
+                                            firstInGroup = false;
+                                            break;
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            if (firstInGroup) {
+                lineMarkerInfo = callDefinitionSeparator(atUnqualifiedNoParenthesesCall);
+            }
         }
 
         return lineMarkerInfo;
@@ -116,7 +277,7 @@ public class CallDefinition implements LineMarkerProvider {
         LineMarkerInfo lineMarkerInfo = null;
 
         if (daemonCodeAnalyzerSettings.SHOW_METHOD_SEPARATORS && CallDefinitionClause.is(call)) {
-            Call previousCallDefinitionClause = previousCallDefinitionClause(call);
+            Call previousCallDefinitionClause = siblingCallDefinitionClause(call, PREVIOUS_SIBLING);
             boolean firstClause;
 
             if (previousCallDefinitionClause == null) {
@@ -143,6 +304,23 @@ public class CallDefinition implements LineMarkerProvider {
 
                     if (moduleAttributeName.equals("@doc")) {
                         firstClause = false;
+                    } else if (moduleAttributeName.equals("@spec")) {
+                        Pair<String, IntRange> callNameArityRange = nameArityRange(call);
+
+                        if (callNameArityRange != null) {
+                            Pair<String, Integer> specNameArity =
+                                    moduleAttributeNameArity(previousModuleAttributeDefinition);
+
+                            if (specNameArity != null) {
+                                Integer specArity = specNameArity.second;
+
+                                IntRange callArityRange = callNameArityRange.second;
+
+                                if (callArityRange.containsInteger(specArity)) {
+                                    firstClause = false;
+                                }
+                            }
+                        }
                     }
                 }
             }
@@ -156,23 +334,24 @@ public class CallDefinition implements LineMarkerProvider {
     }
 
     @Nullable
-    private Call previousCallDefinitionClause(@NotNull PsiElement element) {
+    private Call siblingCallDefinitionClause(@NotNull PsiElement element,
+                                             @NotNull com.intellij.util.Function<PsiElement, PsiElement> function) {
         PsiElement expression = element;
-        Call previous = null;
+        Call siblingCallDefinitionClause = null;
 
         while (expression != null) {
-            expression = previousSiblingExpression(expression);
+            expression = siblingExpression(expression, function);
 
             if (expression instanceof Call) {
                 Call call = (Call) expression;
 
                 if (CallDefinitionClause.is(call)) {
-                    previous = call;
+                    siblingCallDefinitionClause = call;
                     break;
                 }
             }
         }
 
-        return previous;
+        return siblingCallDefinitionClause;
     }
 }

--- a/src/org/elixir_lang/code_insight/line_marker_provider/CallDefinition.java
+++ b/src/org/elixir_lang/code_insight/line_marker_provider/CallDefinition.java
@@ -1,0 +1,92 @@
+package org.elixir_lang.code_insight.line_marker_provider;
+
+import com.intellij.codeHighlighting.Pass;
+import com.intellij.codeInsight.daemon.DaemonCodeAnalyzerSettings;
+import com.intellij.codeInsight.daemon.LineMarkerInfo;
+import com.intellij.codeInsight.daemon.LineMarkerProvider;
+import com.intellij.openapi.editor.colors.CodeInsightColors;
+import com.intellij.openapi.editor.colors.EditorColorsManager;
+import com.intellij.openapi.editor.colors.EditorColorsScheme;
+import com.intellij.openapi.editor.markup.GutterIconRenderer;
+import com.intellij.openapi.editor.markup.SeparatorPlacement;
+import com.intellij.psi.PsiElement;
+import org.elixir_lang.psi.call.Call;
+import org.elixir_lang.structure_view.element.CallDefinitionClause;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Collection;
+import java.util.List;
+
+public class CallDefinition implements LineMarkerProvider {
+    /*
+     * Fields
+     */
+
+    private final DaemonCodeAnalyzerSettings daemonCodeAnalyzerSettings;
+    private final EditorColorsManager editorColorsManager;
+
+    /*
+     * Constructors
+     */
+
+    public CallDefinition(DaemonCodeAnalyzerSettings daemonCodeAnalyzerSettings,
+                          EditorColorsManager editorColorsManager) {
+        this.daemonCodeAnalyzerSettings = daemonCodeAnalyzerSettings;
+        this.editorColorsManager = editorColorsManager;
+    }
+
+    /*
+     *
+     * Instance Methods
+     *
+     */
+
+    /*
+     * Public Instance Methods
+     */
+
+    @Override
+    public void collectSlowLineMarkers(@NotNull List<PsiElement> elements, @NotNull Collection<LineMarkerInfo> result) {
+        assert elements != null;
+        // do nothing
+    }
+
+    @Nullable
+    @Override
+    public LineMarkerInfo getLineMarkerInfo(@NotNull PsiElement element) {
+        LineMarkerInfo lineMarkerInfo = null;
+
+        if (element instanceof Call) {
+            lineMarkerInfo = getLineMarkerInfo((Call) element);
+        }
+
+        return lineMarkerInfo;
+    }
+
+    /*
+     * Private Instance Methods
+     */
+
+    @Nullable
+    private LineMarkerInfo getLineMarkerInfo(@NotNull Call call) {
+        LineMarkerInfo lineMarkerInfo = null;
+
+        if (daemonCodeAnalyzerSettings.SHOW_METHOD_SEPARATORS && CallDefinitionClause.is(call)) {
+            lineMarkerInfo = new LineMarkerInfo<Call>(
+                    call,
+                    call.getTextRange(),
+                    null,
+                    Pass.UPDATE_ALL,
+                    null,
+                    null,
+                    GutterIconRenderer.Alignment.RIGHT
+            );
+            EditorColorsScheme editorColorsScheme = editorColorsManager.getGlobalScheme();
+            lineMarkerInfo.separatorColor = editorColorsScheme.getColor(CodeInsightColors.METHOD_SEPARATORS_COLOR);
+            lineMarkerInfo.separatorPlacement = SeparatorPlacement.TOP;
+        }
+
+        return lineMarkerInfo;
+    }
+}

--- a/src/org/elixir_lang/reference/CallDefinitionClause.java
+++ b/src/org/elixir_lang/reference/CallDefinitionClause.java
@@ -1,0 +1,164 @@
+package org.elixir_lang.reference;
+
+import com.intellij.codeInsight.lookup.LookupElement;
+import com.intellij.openapi.util.Pair;
+import com.intellij.openapi.util.TextRange;
+import com.intellij.psi.*;
+import org.apache.commons.lang.math.IntRange;
+import org.elixir_lang.annonator.Kernel;
+import org.elixir_lang.psi.AtUnqualifiedNoParenthesesCall;
+import org.elixir_lang.psi.call.Call;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.elixir_lang.psi.impl.ElixirPsiImplUtil.macroChildCalls;
+import static org.elixir_lang.structure_view.element.CallDefinitionClause.enclosingModularMacroCall;
+import static org.elixir_lang.structure_view.element.CallDefinitionSpecification.typeNameArity;
+
+public class CallDefinitionClause extends PsiReferenceBase<Call> implements PsiPolyVariantReference {
+    /*
+     *
+     * Fields
+     *
+     */
+
+    @NotNull
+    private final AtUnqualifiedNoParenthesesCall moduleAttribute;
+
+    /*
+     *
+     * Constructors
+     *
+     */
+
+    /**
+     * @param call {@code foo(arg1, ...) :: return1} in {@code @spec foo(arg1, ...) :: return1}
+     * @param moduleAttribute {@code @spec foo(arg1, ...) ... return1}, so that the tree doesn't have to be walked up
+     *   again if there is a {@code when}.
+     */
+    public CallDefinitionClause(@NotNull Call call, @NotNull AtUnqualifiedNoParenthesesCall moduleAttribute) {
+        super(call, TextRange.create(0, call.getTextLength()));
+        this.moduleAttribute = moduleAttribute;
+    }
+
+    /*
+     *
+     * Instance Methods
+     *
+     */
+
+    /*
+     * Public Instance Methods
+     */
+
+    /**
+     * Returns the array of String, {@link PsiElement} and/or {@link LookupElement}
+     * instances representing all identifiers that are visible at the location of the reference. The contents
+     * of the returned array is used to build the lookup list for basic code completion. (The list
+     * of visible identifiers may not be filtered by the completion prefix string - the
+     * filtering is performed later by IDEA core.)
+     *
+     * @return the array of available identifiers.
+     */
+    @NotNull
+    @Override
+    public Object[] getVariants() {
+        return new Object[0];
+    }
+
+    /**
+     * Returns the results of resolving the reference.
+     *
+     * @param incompleteCode if true, the code in the context of which the reference is
+     *                       being resolved is considered incomplete, and the method may return additional
+     *                       invalid results.
+     * @return the array of results for resolving the reference.
+     */
+    @NotNull
+    @Override
+    public ResolveResult[] multiResolve(boolean incompleteCode) {
+        Call enclosingModularMacroCall = enclosingModularMacroCall(moduleAttribute);
+        List<ResolveResult> resolveResultList = null;
+
+        if (enclosingModularMacroCall != null) {
+            Call[] siblings = macroChildCalls(enclosingModularMacroCall);
+
+            if (siblings != null && siblings.length > 0) {
+                Pair<String, Integer> nameArity = typeNameArity(myElement);
+                String name = nameArity.first;
+                int arity = nameArity.second;
+
+                for (Call call : siblings) {
+                    if (org.elixir_lang.structure_view.element.CallDefinitionClause.is(call)) {
+                        Pair<String, IntRange> callNameArityRange =
+                                org.elixir_lang.structure_view.element.CallDefinitionClause.nameArityRange(call);
+
+                        if (callNameArityRange != null) {
+                            String callName = callNameArityRange.first;
+
+                            if (callName.equals(name)) {
+                                IntRange callArityRange = callNameArityRange.second;
+
+                                if (callArityRange.containsInteger(arity)) {
+                                    resolveResultList = add(resolveResultList, call, true);
+                                } else if (arity < callArityRange.getMaximumInteger()) {
+                                    resolveResultList = add(resolveResultList, call, false);
+                                }
+                            } else if (incompleteCode && callName.startsWith(name)) {
+                                IntRange callArityRange = callNameArityRange.second;
+
+                                if (callArityRange.containsInteger(arity)) {
+                                    resolveResultList = add(resolveResultList, call, false);
+                                } else if (arity < callArityRange.getMaximumInteger()) {
+                                    resolveResultList = add(resolveResultList, call, false);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        ResolveResult[] resolveResults;
+
+        if (resolveResultList != null) {
+            resolveResults = resolveResultList.toArray(new ResolveResult[resolveResultList.size()]);
+        } else {
+            resolveResults = new ResolveResult[0];
+        }
+
+        return resolveResults;
+    }
+
+    /**
+     * Returns the element which is the target of the reference.
+     *
+     * @return the target element, or null if it was not possible to resolve the reference to a valid target.
+     */
+    @Nullable
+    @Override
+    public PsiElement resolve() {
+        ResolveResult[] resolveResults = multiResolve(false);
+        return resolveResults.length == 1 ? resolveResults[0].getElement() : null;
+    }
+
+    /*
+     * Private Instance Methods
+     */
+
+    @NotNull
+    private List<ResolveResult> add(@Nullable List<ResolveResult> resolveResultList,
+                                    @NotNull Call call,
+                                    boolean validResult) {
+        if (resolveResultList == null) {
+            resolveResultList = new ArrayList<ResolveResult>();
+        }
+
+        resolveResultList.add(new PsiElementResolveResult(call, validResult));
+
+        return resolveResultList;
+    }
+}

--- a/src/org/elixir_lang/structure_view/element/CallDefinitionClause.java
+++ b/src/org/elixir_lang/structure_view/element/CallDefinitionClause.java
@@ -72,6 +72,22 @@ public class CallDefinitionClause extends Element<Call> implements Presentable, 
     @Nullable
     public static Modular enclosingModular(@NotNull Call call) {
         Modular modular = null;
+        Call enclosingMacroCall = enclosingModularMacroCall(call);
+
+        if (enclosingMacroCall != null) {
+            modular = modular(enclosingMacroCall);
+        }
+
+        return modular;
+    }
+
+    /**
+     * The enclosing macro call that acts as the modular scope of {@code call}.  Ignores enclosing {@code for} calls that
+     * {@link ElixirPsiImplUtil#enclosingMacroCall} doesn't.
+     *
+     * @param call a def(macro)?p?
+     */
+    public static Call enclosingModularMacroCall(@NotNull Call call) {
         Call enclosedCall = call;
         Call enclosingMacroCall;
 
@@ -84,12 +100,7 @@ public class CallDefinitionClause extends Element<Call> implements Presentable, 
                 break;
             }
         }
-
-        if (enclosingMacroCall != null) {
-            modular = modular(enclosingMacroCall);
-        }
-
-        return modular;
+        return enclosingMacroCall;
     }
 
     @Contract(pure = true)

--- a/src/org/elixir_lang/structure_view/element/CallDefinitionSpecification.java
+++ b/src/org/elixir_lang/structure_view/element/CallDefinitionSpecification.java
@@ -170,7 +170,7 @@ public class CallDefinitionSpecification extends Element<AtUnqualifiedNoParenthe
         return type;
     }
 
-    @Nullable
+    @NotNull
     public static Pair<String, Integer> typeNameArity(@NotNull Call type) {
         String name = type.functionName();
         int arity = type.resolvedFinalArity();


### PR DESCRIPTION
# Changelog
## Enhancements
* Show a function separator (Preferences > Editor > General > Appearance > Show method separators) above the group of `@doc`, `@spec` and `def`, `defp`, `defmacro`, and `defmacrop` (call definition clauses) of the same name and arity range.  Arity range will be used if one of the call definition clauses uses default arguments.