### PR TITLE
Fix isVariable and variableUseScope for var!(config)[:url]

### DIFF
--- a/src/org/elixir_lang/annonator/Kernel.java
+++ b/src/org/elixir_lang/annonator/Kernel.java
@@ -133,7 +133,7 @@ public class Kernel implements Annotator, DumbAware {
                             UNLESS,
                             "update_in",
                             USE,
-                            "var!"
+                            VAR_BANG
                     }
             )
     );

--- a/src/org/elixir_lang/psi/call/name/Function.java
+++ b/src/org/elixir_lang/psi/call/name/Function.java
@@ -25,4 +25,5 @@ public class Function {
     public static final String UNLESS = "unless";
     public static final String USE = "use";
     public static final String UNQUOTE = "unquote";
+    public static final String VAR_BANG = "var!";
 }

--- a/src/org/elixir_lang/psi/impl/ElixirPsiImplUtil.java
+++ b/src/org/elixir_lang/psi/impl/ElixirPsiImplUtil.java
@@ -443,7 +443,8 @@ public class ElixirPsiImplUtil {
                     call.isCalling(org.elixir_lang.psi.call.name.Module.KERNEL, COND) ||
                     call.isCalling(org.elixir_lang.psi.call.name.Module.KERNEL, IF) ||
                     call.isCalling(org.elixir_lang.psi.call.name.Module.KERNEL, RECEIVE) ||
-                    call.isCalling(org.elixir_lang.psi.call.name.Module.KERNEL, UNLESS)
+                    call.isCalling(org.elixir_lang.psi.call.name.Module.KERNEL, UNLESS) ||
+                    call.isCalling(org.elixir_lang.psi.call.name.Module.KERNEL, VAR_BANG)
                     ) {
                useScopeSelector = UseScopeSelector.SELF_AND_FOLLOWING_SIBLINGS;
             } else if (CallDefinitionClause.is(call) || isModular(call) || hasDoBlockOrKeyword(call)) {

--- a/src/org/elixir_lang/reference/Callable.java
+++ b/src/org/elixir_lang/reference/Callable.java
@@ -17,6 +17,7 @@ import org.elixir_lang.errorreport.Logger;
 import org.elixir_lang.psi.*;
 import org.elixir_lang.psi.call.Call;
 import org.elixir_lang.psi.call.name.*;
+import org.elixir_lang.psi.call.name.Module;
 import org.elixir_lang.psi.operation.*;
 import org.elixir_lang.psi.scope.variable.MultiResolve;
 import org.elixir_lang.psi.scope.variable.Variants;
@@ -551,6 +552,8 @@ public class Callable extends PsiReferenceBase<Call> implements PsiPolyVariantRe
         } else if (call.isCalling(org.elixir_lang.psi.call.name.Module.KERNEL, Function.DESTRUCTURE)) {
             isVariable = true;
         } else if (call.isCallingMacro(org.elixir_lang.psi.call.name.Module.KERNEL, Function.FOR)) {
+            isVariable = true;
+        } else if (call.isCalling(Module.KERNEL, Function.VAR_BANG)) {
             isVariable = true;
         } else {
             PsiElement parent = call.getParent();


### PR DESCRIPTION
Fixes #327

# Changelog
## Bug Fixes
* Fix `isVariable` and `variableUseScope` for `var!(name)[...]`