### PR TITLE
Resolve and fold both @for and @protocol in defimpl

### DIFF
--- a/.idea/runConfigurations/org_elixir_lang.xml
+++ b/.idea/runConfigurations/org_elixir_lang.xml
@@ -28,9 +28,6 @@
     <RunnerSettings RunnerId="Run" />
     <ConfigurationWrapper RunnerId="Debug" />
     <ConfigurationWrapper RunnerId="Run" />
-    <method>
-      <option name="Make" enabled="true" />
-      <option name="ToolBeforeRunTask" enabled="true" actionId="Tool_External Tools_intellij_elixir" />
-    </method>
+    <method />
   </configuration>
 </component>

--- a/src/org/elixir_lang/psi/scope/module_attribute/Implementation.java
+++ b/src/org/elixir_lang/psi/scope/module_attribute/Implementation.java
@@ -1,0 +1,121 @@
+package org.elixir_lang.psi.scope.module_attribute;
+
+import com.intellij.openapi.util.Key;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiElementResolveResult;
+import com.intellij.psi.ResolveResult;
+import com.intellij.psi.ResolveState;
+import com.intellij.psi.scope.PsiScopeProcessor;
+import com.intellij.psi.util.PsiTreeUtil;
+import org.elixir_lang.psi.QualifiableAlias;
+import org.elixir_lang.psi.call.Call;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.elixir_lang.psi.impl.ElixirPsiImplUtil.ENTRANCE;
+
+public class Implementation implements PsiScopeProcessor {
+    /*
+     *
+     * Static Methods
+     *
+     */
+
+    public static List<ResolveResult> resolveResultList(boolean incompleteCode, @NotNull PsiElement entrance) {
+        List<ResolveResult> resolveResultList;
+
+        Implementation implementation = new Implementation(incompleteCode);
+        PsiTreeUtil.treeWalkUp(
+                implementation,
+                entrance,
+                entrance.getContainingFile(),
+                ResolveState.initial().put(ENTRANCE, entrance)
+        );
+
+        return implementation.getResolveResultList();
+    }
+
+    /*
+     * Fields
+     */
+
+    private final boolean incompleteCode;
+    @Nullable
+    private List<ResolveResult> resolveResultList = null;
+
+    /*
+     * Constructors
+     */
+
+    public Implementation(boolean incompleteCode) {
+        this.incompleteCode = incompleteCode;
+    }
+
+    /*
+     *
+     * Instance Methods
+     *
+     */
+
+    /*
+     * Public Instance Methods
+     */
+
+    @Override
+    public boolean execute(@NotNull PsiElement element, @NotNull ResolveState state) {
+        boolean keepProcessing = true;
+
+        if (element instanceof Call) {
+            keepProcessing = execute((Call) element, state);
+        }
+
+        return keepProcessing;
+    }
+
+    @Nullable
+    @Override
+    public <T> T getHint(@NotNull Key<T> hintKey) {
+        return null;
+    }
+
+    @Nullable
+    public List<ResolveResult> getResolveResultList() {
+        return resolveResultList;
+    }
+
+    @Override
+    public void handleEvent(@NotNull Event event, @Nullable Object associated) {
+
+    }
+
+    /*
+     * Private Instance Methods
+     */
+
+    private boolean execute(@NotNull Call call, @NotNull @SuppressWarnings("unused") ResolveState state) {
+        boolean keepProcessing = true;
+
+        if (org.elixir_lang.structure_view.element.modular.Implementation.is(call)) {
+            QualifiableAlias protocolNameElement = org.elixir_lang.structure_view.element.modular.Implementation.protocolNameElement(call);
+            PsiElement element;
+            boolean validResult;
+
+            if (protocolNameElement != null) {
+                element = protocolNameElement;
+                validResult = incompleteCode;
+            } else {
+                element = call;
+                validResult = false;
+            }
+
+            resolveResultList = Collections.<ResolveResult>singletonList(new PsiElementResolveResult(element, validResult));
+
+            keepProcessing = false;
+        }
+
+        return keepProcessing;
+    }
+}

--- a/src/org/elixir_lang/psi/scope/module_attribute/implemetation/For.java
+++ b/src/org/elixir_lang/psi/scope/module_attribute/implemetation/For.java
@@ -7,7 +7,6 @@ import com.intellij.psi.ResolveResult;
 import com.intellij.psi.ResolveState;
 import com.intellij.psi.scope.PsiScopeProcessor;
 import com.intellij.psi.util.PsiTreeUtil;
-import org.elixir_lang.psi.QualifiableAlias;
 import org.elixir_lang.psi.call.Call;
 import org.elixir_lang.structure_view.element.modular.Module;
 import org.jetbrains.annotations.NotNull;
@@ -19,7 +18,6 @@ import java.util.List;
 import static org.elixir_lang.psi.call.name.Function.DEFMODULE;
 import static org.elixir_lang.psi.call.name.Module.KERNEL;
 import static org.elixir_lang.psi.impl.ElixirPsiImplUtil.ENTRANCE;
-import static org.elixir_lang.structure_view.element.CallDefinitionClause.elementDescription;
 import static org.elixir_lang.structure_view.element.CallDefinitionClause.enclosingModularMacroCall;
 
 public class For implements PsiScopeProcessor {
@@ -29,10 +27,8 @@ public class For implements PsiScopeProcessor {
      *
      */
 
-    public static List<ResolveResult> resolveResultList(boolean incompleteCode, @NotNull PsiElement entrance) {
-        List<ResolveResult> resolveResultList;
-
-        For scopeProcessor = new For(incompleteCode);
+    public static List<ResolveResult> resolveResultList(boolean validResult, @NotNull PsiElement entrance) {
+        For scopeProcessor = new For(validResult);
         PsiTreeUtil.treeWalkUp(
                 scopeProcessor,
                 entrance,
@@ -47,7 +43,7 @@ public class For implements PsiScopeProcessor {
      * Fields
      */
 
-    private final boolean incompleteCode;
+    private final boolean validResult;
     @Nullable
     private List<ResolveResult> resolveResultList = null;
 
@@ -55,8 +51,8 @@ public class For implements PsiScopeProcessor {
      * Constructors
      */
 
-    public For(boolean incompleteCode) {
-        this.incompleteCode = incompleteCode;
+    public For(boolean validResult) {
+        this.validResult = validResult;
     }
 
     /*
@@ -108,14 +104,14 @@ public class For implements PsiScopeProcessor {
             boolean validResult;
 
             if (element != null) {
-                validResult = !incompleteCode;
+                validResult = this.validResult;
             } else {
                 Call enclosingModularMacroCall = enclosingModularMacroCall(call);
 
                 if (enclosingModularMacroCall != null) {
                     if (enclosingModularMacroCall.isCalling(KERNEL, DEFMODULE)) {
                         element = Module.nameIdentifier(enclosingModularMacroCall);
-                        validResult = !incompleteCode;
+                        validResult = this.validResult;
                     } else {
                         element = enclosingModularMacroCall;
                         validResult = false;

--- a/src/org/elixir_lang/psi/scope/module_attribute/implemetation/For.java
+++ b/src/org/elixir_lang/psi/scope/module_attribute/implemetation/For.java
@@ -1,0 +1,136 @@
+package org.elixir_lang.psi.scope.module_attribute.implemetation;
+
+import com.intellij.openapi.util.Key;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiElementResolveResult;
+import com.intellij.psi.ResolveResult;
+import com.intellij.psi.ResolveState;
+import com.intellij.psi.scope.PsiScopeProcessor;
+import com.intellij.psi.util.PsiTreeUtil;
+import org.elixir_lang.psi.QualifiableAlias;
+import org.elixir_lang.psi.call.Call;
+import org.elixir_lang.structure_view.element.modular.Module;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.elixir_lang.psi.call.name.Function.DEFMODULE;
+import static org.elixir_lang.psi.call.name.Module.KERNEL;
+import static org.elixir_lang.psi.impl.ElixirPsiImplUtil.ENTRANCE;
+import static org.elixir_lang.structure_view.element.CallDefinitionClause.elementDescription;
+import static org.elixir_lang.structure_view.element.CallDefinitionClause.enclosingModularMacroCall;
+
+public class For implements PsiScopeProcessor {
+    /*
+     *
+     * Static Methods
+     *
+     */
+
+    public static List<ResolveResult> resolveResultList(boolean incompleteCode, @NotNull PsiElement entrance) {
+        List<ResolveResult> resolveResultList;
+
+        For scopeProcessor = new For(incompleteCode);
+        PsiTreeUtil.treeWalkUp(
+                scopeProcessor,
+                entrance,
+                entrance.getContainingFile(),
+                ResolveState.initial().put(ENTRANCE, entrance)
+        );
+
+        return scopeProcessor.getResolveResultList();
+    }
+
+    /*
+     * Fields
+     */
+
+    private final boolean incompleteCode;
+    @Nullable
+    private List<ResolveResult> resolveResultList = null;
+
+    /*
+     * Constructors
+     */
+
+    public For(boolean incompleteCode) {
+        this.incompleteCode = incompleteCode;
+    }
+
+    /*
+     *
+     * Instance Methods
+     *
+     */
+
+    /*
+     * Public Instance Methods
+     */
+
+    @Override
+    public boolean execute(@NotNull PsiElement element, @NotNull ResolveState state) {
+        boolean keepProcessing = true;
+
+        if (element instanceof Call) {
+            keepProcessing = execute((Call) element, state);
+        }
+
+        return keepProcessing;
+    }
+
+    @Nullable
+    @Override
+    public <T> T getHint(@NotNull Key<T> hintKey) {
+        return null;
+    }
+
+    @Nullable
+    public List<ResolveResult> getResolveResultList() {
+        return resolveResultList;
+    }
+
+    @Override
+    public void handleEvent(@NotNull Event event, @Nullable Object associated) {
+
+    }
+
+    /*
+     * Private Instance Methods
+     */
+
+    private boolean execute(@NotNull Call call, @NotNull @SuppressWarnings("unused") ResolveState state) {
+        boolean keepProcessing = true;
+
+        if (org.elixir_lang.structure_view.element.modular.Implementation.is(call)) {
+            PsiElement element = org.elixir_lang.structure_view.element.modular.Implementation.forNameElement(call);
+            boolean validResult;
+
+            if (element != null) {
+                validResult = !incompleteCode;
+            } else {
+                Call enclosingModularMacroCall = enclosingModularMacroCall(call);
+
+                if (enclosingModularMacroCall != null) {
+                    if (enclosingModularMacroCall.isCalling(KERNEL, DEFMODULE)) {
+                        element = Module.nameIdentifier(enclosingModularMacroCall);
+                        validResult = !incompleteCode;
+                    } else {
+                        element = enclosingModularMacroCall;
+                        validResult = false;
+                    }
+                } else {
+                    element = call;
+                    validResult = false;
+                }
+            }
+
+            resolveResultList = Collections.<ResolveResult>singletonList(new PsiElementResolveResult(element, validResult));
+
+            keepProcessing = false;
+        }
+
+        return keepProcessing;
+    }
+}

--- a/src/org/elixir_lang/psi/scope/module_attribute/implemetation/Protocol.java
+++ b/src/org/elixir_lang/psi/scope/module_attribute/implemetation/Protocol.java
@@ -24,10 +24,8 @@ public class Protocol implements PsiScopeProcessor {
      *
      */
 
-    public static List<ResolveResult> resolveResultList(boolean incompleteCode, @NotNull PsiElement entrance) {
-        List<ResolveResult> resolveResultList;
-
-        Protocol protocol = new Protocol(incompleteCode);
+    public static List<ResolveResult> resolveResultList(boolean validResult, @NotNull PsiElement entrance) {
+        Protocol protocol = new Protocol(validResult);
         PsiTreeUtil.treeWalkUp(
                 protocol,
                 entrance,
@@ -42,7 +40,7 @@ public class Protocol implements PsiScopeProcessor {
      * Fields
      */
 
-    private final boolean incompleteCode;
+    private final boolean validResult;
     @Nullable
     private List<ResolveResult> resolveResultList = null;
 
@@ -50,8 +48,8 @@ public class Protocol implements PsiScopeProcessor {
      * Constructors
      */
 
-    public Protocol(boolean incompleteCode) {
-        this.incompleteCode = incompleteCode;
+    public Protocol(boolean validResult) {
+        this.validResult = !validResult;
     }
 
     /*
@@ -105,7 +103,7 @@ public class Protocol implements PsiScopeProcessor {
 
             if (protocolNameElement != null) {
                 element = protocolNameElement;
-                validResult = !incompleteCode;
+                validResult = this.validResult;
             } else {
                 element = call;
                 validResult = false;

--- a/src/org/elixir_lang/psi/scope/module_attribute/implemetation/Protocol.java
+++ b/src/org/elixir_lang/psi/scope/module_attribute/implemetation/Protocol.java
@@ -1,4 +1,4 @@
-package org.elixir_lang.psi.scope.module_attribute;
+package org.elixir_lang.psi.scope.module_attribute.implemetation;
 
 import com.intellij.openapi.util.Key;
 import com.intellij.psi.PsiElement;
@@ -17,7 +17,7 @@ import java.util.List;
 
 import static org.elixir_lang.psi.impl.ElixirPsiImplUtil.ENTRANCE;
 
-public class Implementation implements PsiScopeProcessor {
+public class Protocol implements PsiScopeProcessor {
     /*
      *
      * Static Methods
@@ -27,15 +27,15 @@ public class Implementation implements PsiScopeProcessor {
     public static List<ResolveResult> resolveResultList(boolean incompleteCode, @NotNull PsiElement entrance) {
         List<ResolveResult> resolveResultList;
 
-        Implementation implementation = new Implementation(incompleteCode);
+        Protocol protocol = new Protocol(incompleteCode);
         PsiTreeUtil.treeWalkUp(
-                implementation,
+                protocol,
                 entrance,
                 entrance.getContainingFile(),
                 ResolveState.initial().put(ENTRANCE, entrance)
         );
 
-        return implementation.getResolveResultList();
+        return protocol.getResolveResultList();
     }
 
     /*
@@ -50,7 +50,7 @@ public class Implementation implements PsiScopeProcessor {
      * Constructors
      */
 
-    public Implementation(boolean incompleteCode) {
+    public Protocol(boolean incompleteCode) {
         this.incompleteCode = incompleteCode;
     }
 
@@ -105,7 +105,7 @@ public class Implementation implements PsiScopeProcessor {
 
             if (protocolNameElement != null) {
                 element = protocolNameElement;
-                validResult = incompleteCode;
+                validResult = !incompleteCode;
             } else {
                 element = call;
                 validResult = false;

--- a/src/org/elixir_lang/psi/scope/variable/MultiResolve.java
+++ b/src/org/elixir_lang/psi/scope/variable/MultiResolve.java
@@ -31,7 +31,7 @@ public class MultiResolve extends Variable {
      */
 
     private static final Key<PsiElement> LAST_BINDING_KEY = new Key<PsiElement>("LAST_BINDING_KEY");
-    private static final Condition<ResolveResult> HAS_VALID_RESULT_CONDITION = new Condition<ResolveResult>() {
+    public static final Condition<ResolveResult> HAS_VALID_RESULT_CONDITION = new Condition<ResolveResult>() {
         @Override
         public boolean value(ResolveResult resolveResult) {
             return resolveResult.isValidResult();

--- a/src/org/elixir_lang/reference/ModuleAttribute.java
+++ b/src/org/elixir_lang/reference/ModuleAttribute.java
@@ -3,20 +3,27 @@ package org.elixir_lang.reference;
 import com.google.common.collect.Sets;
 import com.intellij.codeInsight.lookup.LookupElement;
 import com.intellij.codeInsight.lookup.LookupElementBuilder;
+import com.intellij.openapi.util.Key;
 import com.intellij.openapi.util.TextRange;
-import com.intellij.psi.PsiElement;
-import com.intellij.psi.PsiElementResolveResult;
-import com.intellij.psi.PsiPolyVariantReferenceBase;
-import com.intellij.psi.ResolveResult;
+import com.intellij.psi.*;
+import com.intellij.psi.scope.PsiScopeProcessor;
+import com.intellij.psi.util.PsiTreeUtil;
 import com.intellij.util.IncorrectOperationException;
 import org.apache.commons.lang.NotImplementedException;
 import org.elixir_lang.psi.*;
+import org.elixir_lang.psi.call.Call;
 import org.elixir_lang.psi.impl.ElixirPsiImplUtil;
+import org.elixir_lang.structure_view.element.modular.Implementation;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+
+import static org.elixir_lang.psi.call.name.Function.DEFIMPL;
+import static org.elixir_lang.psi.call.name.Module.KERNEL;
+import static org.elixir_lang.structure_view.element.modular.Implementation.protocolNameElement;
 
 /**
  * Created by limhoff on 12/30/15.
@@ -200,7 +207,15 @@ public class ModuleAttribute extends PsiPolyVariantReferenceBase<PsiElement> {
         }
 
         if (!isNonReferencing) {
-            resultList.addAll(multiResolveUpFromElement(myElement, incompleteCode));
+            String value = getValue();
+
+            if (value.equals("@protocol")) {
+                resultList.addAll(
+                        org.elixir_lang.psi.scope.module_attribute.Implementation.resolveResultList(incompleteCode, myElement)
+                );
+            } else {
+                resultList.addAll(multiResolveUpFromElement(myElement, incompleteCode));
+            }
         }
 
         return resultList.toArray(new ResolveResult[resultList.size()]);

--- a/src/org/elixir_lang/reference/ModuleAttribute.java
+++ b/src/org/elixir_lang/reference/ModuleAttribute.java
@@ -3,28 +3,23 @@ package org.elixir_lang.reference;
 import com.google.common.collect.Sets;
 import com.intellij.codeInsight.lookup.LookupElement;
 import com.intellij.codeInsight.lookup.LookupElementBuilder;
-import com.intellij.openapi.util.BusyObject;
-import com.intellij.openapi.util.Key;
 import com.intellij.openapi.util.TextRange;
 import com.intellij.psi.*;
-import com.intellij.psi.scope.PsiScopeProcessor;
-import com.intellij.psi.util.PsiTreeUtil;
 import com.intellij.util.IncorrectOperationException;
+import com.intellij.util.containers.ContainerUtil;
 import org.apache.commons.lang.NotImplementedException;
 import org.elixir_lang.psi.*;
 import org.elixir_lang.psi.call.Call;
 import org.elixir_lang.psi.impl.ElixirPsiImplUtil;
 import org.elixir_lang.structure_view.element.modular.Implementation;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
-import static org.elixir_lang.psi.call.name.Function.DEFIMPL;
-import static org.elixir_lang.psi.call.name.Module.KERNEL;
-import static org.elixir_lang.structure_view.element.modular.Implementation.protocolNameElement;
+import static org.elixir_lang.psi.scope.variable.MultiResolve.HAS_VALID_RESULT_CONDITION;
 
 /**
  * Created by limhoff on 12/30/15.
@@ -212,10 +207,36 @@ public class ModuleAttribute extends PsiPolyVariantReferenceBase<PsiElement> {
 
             if (value.equals("@protocol")) {
                 resultList.addAll(
-                        org.elixir_lang.psi.scope.module_attribute.Implementation.resolveResultList(incompleteCode, myElement)
+                        org.elixir_lang.psi.scope.module_attribute.implemetation.Protocol.resolveResultList(incompleteCode, myElement)
                 );
-            } else {
-                resultList.addAll(multiResolveUpFromElement(myElement, incompleteCode));
+            }
+
+            if (incompleteCode || !ContainerUtil.exists(resultList, HAS_VALID_RESULT_CONDITION)) {
+                if (incompleteCode && "@protocol".startsWith(value)) {
+                    resultList.addAll(
+                            org.elixir_lang.psi.scope.module_attribute.implemetation.Protocol.resolveResultList(true, myElement)
+                    );
+                }
+
+                if (incompleteCode || !ContainerUtil.exists(resultList, HAS_VALID_RESULT_CONDITION)) {
+                    if (value.equals("@for")) {
+                        resultList.addAll(
+                                org.elixir_lang.psi.scope.module_attribute.implemetation.For.resolveResultList(incompleteCode, myElement)
+                        );
+                    }
+
+                    if (incompleteCode || !ContainerUtil.exists(resultList, HAS_VALID_RESULT_CONDITION)) {
+                        if (incompleteCode && "@for".startsWith(value)) {
+                            resultList.addAll(
+                                    org.elixir_lang.psi.scope.module_attribute.implemetation.For.resolveResultList(true, myElement)
+                            );
+                        }
+
+                        if (incompleteCode || !ContainerUtil.exists(resultList, HAS_VALID_RESULT_CONDITION)) {
+                            resultList.addAll(multiResolveUpFromElement(myElement, incompleteCode));
+                        }
+                    }
+                }
             }
         }
 

--- a/src/org/elixir_lang/reference/ModuleAttribute.java
+++ b/src/org/elixir_lang/reference/ModuleAttribute.java
@@ -13,6 +13,7 @@ import org.elixir_lang.psi.call.Call;
 import org.elixir_lang.psi.impl.ElixirPsiImplUtil;
 import org.elixir_lang.structure_view.element.modular.Implementation;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -203,27 +204,16 @@ public class ModuleAttribute extends PsiPolyVariantReferenceBase<PsiElement> {
         }
 
         if (!isNonReferencing) {
-            String value = getValue();
-            Boolean validResult = null;
+            Boolean validResult;
 
-            if (value.equals("@protocol")) {
-                validResult = true;
-            } else if (incompleteCode && "@protocol".startsWith(value)) {
-                validResult = false;
-            }
+            validResult = validResult("@protocol", incompleteCode);
 
             if (validResult != null) {
                 resultList.addAll(org.elixir_lang.psi.scope.module_attribute.implemetation.Protocol.resolveResultList(validResult, myElement));
             }
 
             if (incompleteCode || !ContainerUtil.exists(resultList, HAS_VALID_RESULT_CONDITION)) {
-                validResult = null;
-
-                if (value.equals("@for")) {
-                    validResult = true;
-                } else if (incompleteCode && "@for".startsWith(value)) {
-                    validResult = false;
-                }
+                validResult = validResult("@for", incompleteCode);
 
                 if (validResult != null) {
                     resultList.addAll(org.elixir_lang.psi.scope.module_attribute.implemetation.For.resolveResultList(validResult, myElement));
@@ -322,5 +312,19 @@ public class ModuleAttribute extends PsiPolyVariantReferenceBase<PsiElement> {
         }
 
         return lookupElementList;
+    }
+
+    @Nullable
+    private Boolean validResult(@NotNull String moduleAttributeName, boolean incompleteCode) {
+        Boolean validResult = null;
+        String value = getValue();
+
+        if (value.equals(moduleAttributeName)) {
+            validResult = true;
+        } else if (incompleteCode && moduleAttributeName.startsWith(value)) {
+            validResult = false;
+        }
+
+        return validResult;
     }
 }

--- a/src/org/elixir_lang/reference/ModuleAttribute.java
+++ b/src/org/elixir_lang/reference/ModuleAttribute.java
@@ -204,38 +204,33 @@ public class ModuleAttribute extends PsiPolyVariantReferenceBase<PsiElement> {
 
         if (!isNonReferencing) {
             String value = getValue();
+            Boolean validResult = null;
 
             if (value.equals("@protocol")) {
-                resultList.addAll(
-                        org.elixir_lang.psi.scope.module_attribute.implemetation.Protocol.resolveResultList(incompleteCode, myElement)
-                );
+                validResult = true;
+            } else if (incompleteCode && "@protocol".startsWith(value)) {
+                validResult = false;
+            }
+
+            if (validResult != null) {
+                resultList.addAll(org.elixir_lang.psi.scope.module_attribute.implemetation.Protocol.resolveResultList(validResult, myElement));
             }
 
             if (incompleteCode || !ContainerUtil.exists(resultList, HAS_VALID_RESULT_CONDITION)) {
-                if (incompleteCode && "@protocol".startsWith(value)) {
-                    resultList.addAll(
-                            org.elixir_lang.psi.scope.module_attribute.implemetation.Protocol.resolveResultList(true, myElement)
-                    );
+                validResult = null;
+
+                if (value.equals("@for")) {
+                    validResult = true;
+                } else if (incompleteCode && "@for".startsWith(value)) {
+                    validResult = false;
+                }
+
+                if (validResult != null) {
+                    resultList.addAll(org.elixir_lang.psi.scope.module_attribute.implemetation.For.resolveResultList(validResult, myElement));
                 }
 
                 if (incompleteCode || !ContainerUtil.exists(resultList, HAS_VALID_RESULT_CONDITION)) {
-                    if (value.equals("@for")) {
-                        resultList.addAll(
-                                org.elixir_lang.psi.scope.module_attribute.implemetation.For.resolveResultList(incompleteCode, myElement)
-                        );
-                    }
-
-                    if (incompleteCode || !ContainerUtil.exists(resultList, HAS_VALID_RESULT_CONDITION)) {
-                        if (incompleteCode && "@for".startsWith(value)) {
-                            resultList.addAll(
-                                    org.elixir_lang.psi.scope.module_attribute.implemetation.For.resolveResultList(true, myElement)
-                            );
-                        }
-
-                        if (incompleteCode || !ContainerUtil.exists(resultList, HAS_VALID_RESULT_CONDITION)) {
-                            resultList.addAll(multiResolveUpFromElement(myElement, incompleteCode));
-                        }
-                    }
+                    resultList.addAll(multiResolveUpFromElement(myElement, incompleteCode));
                 }
             }
         }

--- a/src/org/elixir_lang/reference/ModuleAttribute.java
+++ b/src/org/elixir_lang/reference/ModuleAttribute.java
@@ -3,6 +3,7 @@ package org.elixir_lang.reference;
 import com.google.common.collect.Sets;
 import com.intellij.codeInsight.lookup.LookupElement;
 import com.intellij.codeInsight.lookup.LookupElementBuilder;
+import com.intellij.openapi.util.BusyObject;
 import com.intellij.openapi.util.Key;
 import com.intellij.openapi.util.TextRange;
 import com.intellij.psi.*;
@@ -271,6 +272,23 @@ public class ModuleAttribute extends PsiPolyVariantReferenceBase<PsiElement> {
                                 atUnqualifiedNoParenthesesCall
                         )
                 );
+            } else if (sibling instanceof Call) {
+                Call siblingCall = (Call) sibling;
+
+                if (Implementation.is(siblingCall)) {
+                    PsiElement element = Implementation.protocolNameElement(siblingCall);
+
+                    if (element == null) {
+                        element = siblingCall;
+                    }
+
+                    lookupElementList.add(
+                            LookupElementBuilder.createWithSmartPointer(
+                                    "@protocol",
+                                    element
+                            )
+                    );
+                }
             }
         }
 

--- a/src/org/elixir_lang/structure_view/element/CallDefinitionClause.java
+++ b/src/org/elixir_lang/structure_view/element/CallDefinitionClause.java
@@ -87,6 +87,7 @@ public class CallDefinitionClause extends Element<Call> implements Presentable, 
      *
      * @param call a def(macro)?p?
      */
+    @Nullable
     public static Call enclosingModularMacroCall(@NotNull Call call) {
         Call enclosedCall = call;
         Call enclosingMacroCall;
@@ -100,6 +101,7 @@ public class CallDefinitionClause extends Element<Call> implements Presentable, 
                 break;
             }
         }
+
         return enclosingMacroCall;
     }
 

--- a/src/org/elixir_lang/structure_view/element/modular/Implementation.java
+++ b/src/org/elixir_lang/structure_view/element/modular/Implementation.java
@@ -40,26 +40,34 @@ public class Implementation extends Module {
 
     @Nullable
     public static String forName(@Nullable Modular enclosingModular, @NotNull Call call) {
-        PsiElement[] finalArguments = ElixirPsiImplUtil.finalArguments(call);
+        PsiElement forNameElement = forNameElement(call);
         String forName = null;
 
-        if (finalArguments != null) {
-            if (finalArguments.length > 1) {
-                PsiElement finalArgument = finalArguments[finalArguments.length - 1];
-
-                if (finalArgument instanceof QuotableKeywordList) {
-                    QuotableKeywordList quotableKeywordList = (QuotableKeywordList) finalArgument;
-                    PsiElement keywordValue = ElixirPsiImplUtil.keywordValue(quotableKeywordList, FOR);
-
-                    forName = keywordValue.getText();
-                }
-            } else if (enclosingModular != null) {
-                org.elixir_lang.navigation.item_presentation.Parent parentPresentation = (org.elixir_lang.navigation.item_presentation.Parent) enclosingModular.getPresentation();
-                forName = parentPresentation.getLocatedPresentableText();
-            }
+        if (forNameElement != null) {
+            forName = forNameElement.getText();
+        } else if (enclosingModular != null) {
+            org.elixir_lang.navigation.item_presentation.Parent parentPresentation = (org.elixir_lang.navigation.item_presentation.Parent) enclosingModular.getPresentation();
+            forName = parentPresentation.getLocatedPresentableText();
         }
 
         return forName;
+    }
+
+    @Nullable
+    public static PsiElement forNameElement(@NotNull Call call) {
+        PsiElement[] finalArguments = ElixirPsiImplUtil.finalArguments(call);
+        PsiElement forNameElement = null;
+
+        if (finalArguments != null && finalArguments.length > 0) {
+            PsiElement finalArgument = finalArguments[finalArguments.length - 1];
+
+            if (finalArgument instanceof QuotableKeywordList) {
+                QuotableKeywordList quotableKeywordList = (QuotableKeywordList) finalArgument;
+                forNameElement = ElixirPsiImplUtil.keywordValue(quotableKeywordList, FOR);
+            }
+        }
+
+        return forNameElement;
     }
 
     public static boolean is(Call call) {

--- a/src/org/elixir_lang/structure_view/element/modular/Implementation.java
+++ b/src/org/elixir_lang/structure_view/element/modular/Implementation.java
@@ -87,9 +87,21 @@ public class Implementation extends Module {
     }
 
     @Nullable
-    public static String protocolName(Call call) {
-        PsiElement[] finalArguments = ElixirPsiImplUtil.finalArguments(call);
+    public static String protocolName(@NotNull Call call) {
+        QualifiableAlias protocolNameElement = protocolNameElement(call);
         String protocolName = null;
+
+        if (protocolNameElement != null) {
+            protocolName = protocolName(protocolNameElement);
+        }
+
+        return protocolName;
+    }
+
+    @Nullable
+    public static QualifiableAlias protocolNameElement(@NotNull Call call) {
+        PsiElement[] finalArguments = ElixirPsiImplUtil.finalArguments(call);
+        QualifiableAlias protocolNameElement = null;
 
         if (finalArguments != null && finalArguments.length > 0) {
             PsiElement firstFinalArgument = finalArguments[0];
@@ -102,17 +114,16 @@ public class Implementation extends Module {
                     PsiElement accessExpressionChild = accessExpressionChildren[0];
 
                     if (accessExpressionChild instanceof QualifiableAlias) {
-                        protocolName = protocolName((QualifiableAlias) accessExpressionChild);
+                        protocolNameElement = (QualifiableAlias) accessExpressionChild;
                     }
                 }
             } else if (firstFinalArgument instanceof QualifiableAlias) {
-                protocolName = protocolName((QualifiableAlias) firstFinalArgument);
+                protocolNameElement = (QualifiableAlias) firstFinalArgument;
             }
         }
 
-        return protocolName;
+        return protocolNameElement;
     }
-
 
     /*
      * Private Static Methods


### PR DESCRIPTION
Resolves #304

# Changelog
## Enhancements
- `@for` folds to the resolved module name in `defimpl`
- `@protocol` folds to the protocol name in `defimpl`

## Bug Fixes
- `@for` is no longer marked as unresolved in `defimpl` and instead resolve to the either the `<name>` in `for: <name>` or the module name for the enclosing module when `for: ` is not given.
- `@protocol` is no longer marked as unresolved in `defimpl` and instead resolve to the `<name`> in `defimpl <name>`.

