### PR TITLE
Use error logger instead of naked assert of processDeclarations(Match

### DIFF
--- a/src/org/elixir_lang/psi/impl/ElixirPsiImplUtil.java
+++ b/src/org/elixir_lang/psi/impl/ElixirPsiImplUtil.java
@@ -1440,17 +1440,24 @@ public class ElixirPsiImplUtil {
             checkLeft = true;
         }
 
-        assert checkRight || checkLeft;
-
         boolean keepProcessing = true;
 
-        // check right-operand first if both sides need to be checked because only left-side can do rebinding
-        if (checkRight && rightOperand != null) {
-            keepProcessing = processor.execute(rightOperand, state);
-        }
+        if (checkRight || checkLeft) {
+            // check right-operand first if both sides need to be checked because only left-side can do rebinding
+            if (checkRight && rightOperand != null) {
+                keepProcessing = processor.execute(rightOperand, state);
+            }
 
-        if (checkLeft && leftOperand != null && keepProcessing) {
-            keepProcessing = processor.execute(leftOperand, state);
+            if (checkLeft && leftOperand != null && keepProcessing) {
+                keepProcessing = processor.execute(leftOperand, state);
+            }
+        } else {
+            error(
+                    Match.class,
+                    "Could not determine whether to check left operand, right operand, or both of match, " +
+                            "so checking none when processing declarations",
+                    match
+            );
         }
 
         return keepProcessing;


### PR DESCRIPTION
Fixes #339

# Changelog
## Bug Fixes
* Instead of `assert checkRight || checkLeft` in `Match.processDeclaraions`, do the normal code if `checkRight || checkLeft` and log an error report otherwise, so that the exact code that trigger this error can be reported and the method fixed to handle that form of `Match` later.