### PR TITLE
Be able to parse mix version from 1.3.0+

### DIFF
--- a/src/org/elixir_lang/mix/settings/MixConfigurationForm.java
+++ b/src/org/elixir_lang/mix/settings/MixConfigurationForm.java
@@ -109,38 +109,35 @@ public class MixConfigurationForm {
     ProcessOutput output = null;
 
     for (String[] arguments : MIX_ARGUMENTS_ARRAY) {
-      try {
-        output = ElixirSystemUtil.getProcessOutput(3000, workDir, exePath, arguments);
-
-        String myMixVersionTextText = transformStdoutLine(
-                output,
-                new Function<String, String>(){
-                  @Override
-                  public String fun(String line) {
-                    // Elixir X.Y.Z for mix.bat before 1.2
-                    // Mix X.Y.Z for all others
-                    if (line.startsWith("Mix")) {
-                      return line;
-                    }
-
-                    return null;
+      String myMixVersionTextText = transformStdoutLine(
+              new Function<String, String>(){
+                @Override
+                public String fun(String line) {
+                  // Elixir X.Y.Z for mix.bat before 1.2
+                  // Mix X.Y.Z for all others
+                  if (line.startsWith("Mix")) {
+                    return line;
                   }
-                }
-        );
 
-        if (myMixVersionTextText != null) {
-          myMixVersionText.setText(myMixVersionTextText);
-          return true;
-        }
-      } catch (ExecutionException executionException) {
-        LOGGER.warn(executionException);
+                  return null;
+                }
+              },
+              3000,
+              workDir,
+              exePath,
+              arguments
+      );
+
+      if (myMixVersionTextText != null) {
+        myMixVersionText.setText(myMixVersionTextText);
+        return true;
       }
     }
 
-    if (output != null) {
-      String stdErr = output.getStderr();
-      myMixVersionText.setText("N/A" + (StringUtil.isNotEmpty(stdErr) ? ": Error: " + stdErr : ""));
-    }
+//    if (output != null) {
+//      String stdErr = output.getStderr();
+//      myMixVersionText.setText("N/A" + (StringUtil.isNotEmpty(stdErr) ? ": Error: " + stdErr : ""));
+//    }
 
     return false;
   }

--- a/src/org/elixir_lang/sdk/ElixirSdkType.java
+++ b/src/org/elixir_lang/sdk/ElixirSdkType.java
@@ -34,6 +34,7 @@ import javax.swing.*;
 import java.io.File;
 import java.util.*;
 
+import static org.elixir_lang.sdk.ElixirSystemUtil.STANDARD_TIMEOUT;
 import static org.elixir_lang.sdk.ElixirSystemUtil.transformStdoutLine;
 
 /**
@@ -186,28 +187,25 @@ public class ElixirSdkType extends SdkType {
       return null;
     }
 
-    try{
-      ProcessOutput output = ElixirSystemUtil.getProcessOutput(sdkHome, elixir.getAbsolutePath(), "-e", "IO.puts System.build_info[:version]");
-
-      ElixirSdkRelease release = transformStdoutLine(
-              output,
-              new Function<String, ElixirSdkRelease>() {
-                @Override
-                public ElixirSdkRelease fun(String line) {
-                  return ElixirSdkRelease.fromString(line);
-                }
+    ElixirSdkRelease release = transformStdoutLine(
+            new Function<String, ElixirSdkRelease>() {
+              @Override
+              public ElixirSdkRelease fun(String line) {
+                return ElixirSdkRelease.fromString(line);
               }
-      );
+            },
+            STANDARD_TIMEOUT,
+            sdkHome,
+            elixir.getAbsolutePath(),
+            "-e",
+            "IO.puts System.build_info[:version]"
+    );
 
-      if (release != null) {
-        mySdkHomeToReleaseCache.put(getVersionCacheKey(sdkHome), release);
-        return release;
-      }
-    } catch (ExecutionException ignore) {
-      LOG.warn(ignore);
+    if (release != null) {
+      mySdkHomeToReleaseCache.put(getVersionCacheKey(sdkHome), release);
     }
 
-    return null;
+    return release;
   }
 
   @Nullable

--- a/src/org/elixir_lang/sdk/ElixirSystemUtil.java
+++ b/src/org/elixir_lang/sdk/ElixirSystemUtil.java
@@ -4,17 +4,44 @@ import com.intellij.execution.ExecutionException;
 import com.intellij.execution.configurations.GeneralCommandLine;
 import com.intellij.execution.process.CapturingProcessHandler;
 import com.intellij.execution.process.ProcessOutput;
+import com.intellij.util.Function;
 import com.intellij.util.PlatformUtils;
+import com.intellij.util.containers.ContainerUtil;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.io.File;
+import java.util.List;
 
 /**
  * Created by zyuyou on 2015/5/27.
- * 
+ *
  */
 public class ElixirSystemUtil {
   public static final int STANDARD_TIMEOUT = 10 * 1000;
+
+  @Nullable
+  public static <T> T transformStdoutLine(ProcessOutput output, Function<String, T> lineTransformer) {
+    List<String> lines;
+
+    if (output.getExitCode() != 0 || output.isTimeout() || output.isCancelled()) {
+      lines = ContainerUtil.emptyList();
+    } else {
+      lines = output.getStdoutLines();
+    }
+
+    T transformed = null;
+
+    for (String line : lines) {
+      transformed = lineTransformer.fun(line);
+
+      if (transformed != null) {
+        break;
+      }
+    }
+
+    return transformed;
+  }
 
   @NotNull
   public static ProcessOutput getProcessOutput(@NotNull String workDir,

--- a/src/org/elixir_lang/sdk/ElixirSystemUtil.java
+++ b/src/org/elixir_lang/sdk/ElixirSystemUtil.java
@@ -69,13 +69,6 @@ public class ElixirSystemUtil {
   }
 
   @NotNull
-  public static ProcessOutput getProcessOutput(@NotNull String workDir,
-                                               @NotNull String exePath,
-                                               @NotNull String... arguments) throws ExecutionException{
-    return getProcessOutput(STANDARD_TIMEOUT, workDir, exePath, arguments);
-  }
-
-  @NotNull
   public static ProcessOutput getProcessOutput(int timeout,
                                                @NotNull String workDir,
                                                @NotNull String exePath,


### PR DESCRIPTION
Fixes #329

# Changelog
## Enhancements
* Share code between `mix --version` parsing and `elixir` version parsing.

## Bug Fixes
* Check all lines of output for mix version as Elixir 1.3.0 changed the format of `mix --version`, so that it includes the Erlang header (`Erlang/OTP ... [erts-...] [source] [64-bit] [smp:..:..] [async-threads:..] [hipe] [kernel-poll:false] [dtrace]`) on the first line and `Mix <version>` on the 3rd line.  Previously the parsing expected `Mix <version>` to be the first line. 