### PR TITLE
Add Unknown modular for custom macros that behave like Modules

### DIFF
--- a/src/org/elixir_lang/navigation/item_presentation/modular/Module.java
+++ b/src/org/elixir_lang/navigation/item_presentation/modular/Module.java
@@ -1,5 +1,6 @@
 package org.elixir_lang.navigation.item_presentation.modular;
 
+import com.intellij.icons.AllIcons;
 import com.intellij.navigation.ItemPresentation;
 import com.intellij.psi.PsiElement;
 import org.elixir_lang.icons.ElixirIcons;
@@ -16,7 +17,7 @@ public class Module implements ItemPresentation, Parent {
      */
 
     @NotNull
-    private final Call call;
+    protected final Call call;
     @Nullable
     private final String location;
 
@@ -48,7 +49,7 @@ public class Module implements ItemPresentation, Parent {
     public String getPresentableText() {
         PsiElement[] primaryArguments = call.primaryArguments();
 
-        assert primaryArguments.length > 0;
+        assert primaryArguments != null && primaryArguments.length > 0;
 
         return primaryArguments[0].getText();
     }
@@ -88,13 +89,13 @@ public class Module implements ItemPresentation, Parent {
     }
 
     /**
-     * The module icon.
+     * Question mark icon
      *
      * @param unused Used to mean if open/close icons for tree renderer. No longer in use. The parameter is only there for API compatibility reason.
      */
     @Override
     @NotNull
     public Icon getIcon(boolean unused) {
-        return ElixirIcons.MODULE;
+        return AllIcons.General.QuestionDialog;
     }
 }

--- a/src/org/elixir_lang/navigation/item_presentation/modular/Unknown.java
+++ b/src/org/elixir_lang/navigation/item_presentation/modular/Unknown.java
@@ -1,0 +1,63 @@
+package org.elixir_lang.navigation.item_presentation.modular;
+
+import com.intellij.icons.AllIcons;
+import com.intellij.psi.PsiElement;
+import org.elixir_lang.icons.ElixirIcons;
+import org.elixir_lang.psi.call.Call;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.*;
+
+public class Unknown extends Module {
+    /*
+     * Constructors
+     */
+
+    /**
+     * @param location the parent name of the Module that scopes {@code call}; {@code null} when scope is {@code quote}.
+     * @param call     a {@code <module>.def<suffix>/2} call nested in {@code parent}.
+     */
+    public Unknown(@Nullable String location, @NotNull Call call) {
+        super(location, call);
+    }
+
+    /*
+     * Instance Methods
+     */
+
+    /**
+     * Returns the name of the object to be presented in most renderers across the program.
+     *
+     * @return the function name.
+     */
+    @NotNull
+    @Override
+    public String getPresentableText() {
+        PsiElement[] primaryArguments = call.primaryArguments();
+        String presentableText;
+
+        if (primaryArguments != null && primaryArguments.length > 0) {
+            presentableText = primaryArguments[0].getText();
+        } else {
+            presentableText = call.functionName();
+
+            if (presentableText == null) {
+                presentableText = "?";
+            }
+        }
+
+        return presentableText;
+    }
+
+    /**
+     * The module icon.
+     *
+     * @param unused Used to mean if open/close icons for tree renderer. No longer in use. The parameter is only there for API compatibility reason.
+     */
+    @NotNull
+    @Override
+    public Icon getIcon(boolean unused) {
+        return AllIcons.General.QuestionDialog;
+    }
+}

--- a/src/org/elixir_lang/structure_view/Model.java
+++ b/src/org/elixir_lang/structure_view/Model.java
@@ -16,6 +16,7 @@ import org.elixir_lang.structure_view.element.Exception;
 import org.elixir_lang.structure_view.element.modular.Implementation;
 import org.elixir_lang.structure_view.element.modular.Module;
 import org.elixir_lang.structure_view.element.modular.Protocol;
+import org.elixir_lang.structure_view.element.modular.Unknown;
 import org.elixir_lang.structure_view.element.structure.Field;
 import org.elixir_lang.structure_view.element.structure.FieldWithDefaultValue;
 import org.elixir_lang.structure_view.element.structure.Structure;
@@ -55,7 +56,8 @@ public class Model extends TextEditorBasedStructureViewModel implements Structur
                 Quote.is(call) ||
                 Structure.is(call) ||
                 Type.is(call) ||
-                Use.is(call);
+                Use.is(call) ||
+                Unknown.is(call);
     }
 
     /*

--- a/src/org/elixir_lang/structure_view/element/CallDefinitionClause.java
+++ b/src/org/elixir_lang/structure_view/element/CallDefinitionClause.java
@@ -10,10 +10,7 @@ import org.apache.commons.lang.math.IntRange;
 import org.elixir_lang.navigation.item_presentation.NameArity;
 import org.elixir_lang.psi.call.Call;
 import org.elixir_lang.psi.impl.ElixirPsiImplUtil;
-import org.elixir_lang.structure_view.element.modular.Implementation;
-import org.elixir_lang.structure_view.element.modular.Modular;
-import org.elixir_lang.structure_view.element.modular.Module;
-import org.elixir_lang.structure_view.element.modular.Protocol;
+import org.elixir_lang.structure_view.element.modular.*;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -136,6 +133,9 @@ public class CallDefinitionClause extends Element<Call> implements Presentable, 
             }
 
             modular = quote.modular();
+        } else if (Unknown.is(enclosingMacroCall)) {
+            Modular grandScope = enclosingModular(enclosingMacroCall);
+            modular = new Unknown(grandScope, enclosingMacroCall);
         }
 
         return modular;

--- a/src/org/elixir_lang/structure_view/element/File.java
+++ b/src/org/elixir_lang/structure_view/element/File.java
@@ -8,6 +8,7 @@ import org.elixir_lang.psi.call.Call;
 import org.elixir_lang.structure_view.element.modular.Implementation;
 import org.elixir_lang.structure_view.element.modular.Module;
 import org.elixir_lang.structure_view.element.modular.Protocol;
+import org.elixir_lang.structure_view.element.modular.Unknown;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
@@ -47,6 +48,8 @@ public class File extends Element<ElixirFile> {
                     treeElementList.add(new Protocol(call));
                 } else if (Quote.is(call)) {
                     treeElementList.add(new Quote(call));
+                } else if (Unknown.is(call)) { // should always be last because it will match all macro calls
+                    treeElementList.add(new Unknown(call));
                 }
             }
 

--- a/src/org/elixir_lang/structure_view/element/modular/Module.java
+++ b/src/org/elixir_lang/structure_view/element/modular/Module.java
@@ -211,6 +211,8 @@ public class Module extends Element<Call> implements Modular {
                     org.elixir_lang.structure_view.element.Use use = new org.elixir_lang.structure_view.element.Use(modular, childCall);
                     useSet.add(use);
                     treeElementList.add(use);
+                } else if (Unknown.is(childCall)) { // Should always be last since it will match all macro calls
+                    treeElementList.add(new Unknown(modular, childCall));
                 }
             }
 

--- a/src/org/elixir_lang/structure_view/element/modular/Unknown.java
+++ b/src/org/elixir_lang/structure_view/element/modular/Unknown.java
@@ -1,0 +1,44 @@
+package org.elixir_lang.structure_view.element.modular;
+
+import com.intellij.navigation.ItemPresentation;
+import org.elixir_lang.psi.call.Call;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class Unknown extends Module {
+    /*
+     * Static Methods
+     */
+
+    public static boolean is(Call call) {
+        return call.hasDoBlockOrKeyword();
+    }
+
+    /*
+     * Constructors
+     */
+
+    /**
+     * @param parent the parent {@link Module} or {@link org.elixir_lang.structure_view.element.Quote} that scopes
+     *               {@code call}.
+     * @param call   the {@code <module>.def<suffix>/2} call nested in {@code parent}.
+     */
+    public Unknown(@Nullable Modular parent, @NotNull Call call) {
+        super(parent, call);
+    }
+
+    /*
+     * Instance Methods
+     */
+
+    /**
+     * Returns the presentation of the tree element.
+     *
+     * @return the element presentation.
+     */
+    @NotNull
+    @Override
+    public ItemPresentation getPresentation() {
+        return new org.elixir_lang.navigation.item_presentation.modular.Unknown(location(), navigationItem);
+    }
+}

--- a/src/org/elixir_lang/structure_view/element/modular/Unknown.java
+++ b/src/org/elixir_lang/structure_view/element/modular/Unknown.java
@@ -18,6 +18,10 @@ public class Unknown extends Module {
      * Constructors
      */
 
+    public Unknown(@NotNull Call call) {
+        super(call);
+    }
+
     /**
      * @param parent the parent {@link Module} or {@link org.elixir_lang.structure_view.element.Quote} that scopes
      *               {@code call}.


### PR DESCRIPTION
Fixes #332

# Changelog
## Enhancements
* Allow Unknown modulars in the Structure pane, in addition to Go To Symbol.  Their icon is a big ? to indicate their correct usage is unknown.

## Bug Fixes
* If no known modular (Module, Implementation, Protocol, Quote, or Use) matches the call, then use Unknown, which accepts any macro with a `do` block or keyword.  This allows Go To Symbol to no error in projects using Dogma as `defrule` is now treated as Unknown instead of causing an error that the enclosing modular could not be found.