### PR TITLE
Regnereate parser using Grammar Kit 1.4.1

### DIFF
--- a/gen/org/elixir_lang/parser/ElixirParser.java
+++ b/gen/org/elixir_lang/parser/ElixirParser.java
@@ -327,101 +327,11 @@ public class ElixirParser implements PsiParser, LightPsiParser {
     else if (t == MATCH_INFIX_OPERATOR) {
       r = matchInfixOperator(b, 0);
     }
-    else if (t == MATCHED_ADDITION_OPERATION) {
-      r = matchedExpression(b, 0, 13);
-    }
-    else if (t == MATCHED_AND_OPERATION) {
-      r = matchedExpression(b, 0, 7);
-    }
-    else if (t == MATCHED_ARROW_OPERATION) {
-      r = matchedExpression(b, 0, 10);
-    }
-    else if (t == MATCHED_AT_NON_NUMERIC_OPERATION) {
-      r = matchedAtNonNumericOperation(b, 0);
-    }
-    else if (t == MATCHED_AT_UNQUALIFIED_BRACKET_OPERATION) {
-      r = matchedAtUnqualifiedBracketOperation(b, 0);
-    }
-    else if (t == MATCHED_AT_UNQUALIFIED_NO_PARENTHESES_CALL) {
-      r = matchedAtUnqualifiedNoParenthesesCall(b, 0);
-    }
-    else if (t == MATCHED_BRACKET_OPERATION) {
-      r = matchedExpression(b, 0, 20);
-    }
-    else if (t == MATCHED_CAPTURE_NON_NUMERIC_OPERATION) {
-      r = matchedCaptureNonNumericOperation(b, 0);
-    }
-    else if (t == MATCHED_COMPARISON_OPERATION) {
-      r = matchedExpression(b, 0, 8);
-    }
-    else if (t == MATCHED_DOT_CALL) {
-      r = matchedExpression(b, 0, 16);
-    }
     else if (t == MATCHED_EXPRESSION) {
       r = matchedExpression(b, 0, -1);
     }
-    else if (t == MATCHED_IN_MATCH_OPERATION) {
-      r = matchedExpression(b, 0, 0);
-    }
-    else if (t == MATCHED_IN_OPERATION) {
-      r = matchedExpression(b, 0, 11);
-    }
-    else if (t == MATCHED_MATCH_OPERATION) {
-      r = matchedExpression(b, 0, 5);
-    }
-    else if (t == MATCHED_MULTIPLICATION_OPERATION) {
-      r = matchedExpression(b, 0, 14);
-    }
-    else if (t == MATCHED_OR_OPERATION) {
-      r = matchedExpression(b, 0, 6);
-    }
     else if (t == MATCHED_PARENTHESES_ARGUMENTS) {
       r = matchedParenthesesArguments(b, 0);
-    }
-    else if (t == MATCHED_PIPE_OPERATION) {
-      r = matchedExpression(b, 0, 4);
-    }
-    else if (t == MATCHED_QUALIFIED_ALIAS) {
-      r = matchedExpression(b, 0, 21);
-    }
-    else if (t == MATCHED_QUALIFIED_BRACKET_OPERATION) {
-      r = matchedExpression(b, 0, 22);
-    }
-    else if (t == MATCHED_QUALIFIED_NO_ARGUMENTS_CALL) {
-      r = matchedExpression(b, 0, 24);
-    }
-    else if (t == MATCHED_QUALIFIED_NO_PARENTHESES_CALL) {
-      r = matchedExpression(b, 0, 17);
-    }
-    else if (t == MATCHED_QUALIFIED_PARENTHESES_CALL) {
-      r = matchedExpression(b, 0, 23);
-    }
-    else if (t == MATCHED_RELATIONAL_OPERATION) {
-      r = matchedExpression(b, 0, 9);
-    }
-    else if (t == MATCHED_TWO_OPERATION) {
-      r = matchedExpression(b, 0, 12);
-    }
-    else if (t == MATCHED_TYPE_OPERATION) {
-      r = matchedExpression(b, 0, 3);
-    }
-    else if (t == MATCHED_UNARY_NON_NUMERIC_OPERATION) {
-      r = matchedUnaryNonNumericOperation(b, 0);
-    }
-    else if (t == MATCHED_UNQUALIFIED_BRACKET_OPERATION) {
-      r = matchedUnqualifiedBracketOperation(b, 0);
-    }
-    else if (t == MATCHED_UNQUALIFIED_NO_ARGUMENTS_CALL) {
-      r = matchedUnqualifiedNoArgumentsCall(b, 0);
-    }
-    else if (t == MATCHED_UNQUALIFIED_NO_PARENTHESES_CALL) {
-      r = matchedUnqualifiedNoParenthesesCall(b, 0);
-    }
-    else if (t == MATCHED_UNQUALIFIED_PARENTHESES_CALL) {
-      r = matchedUnqualifiedParenthesesCall(b, 0);
-    }
-    else if (t == MATCHED_WHEN_OPERATION) {
-      r = matchedExpression(b, 0, 2);
     }
     else if (t == MULTIPLICATION_INFIX_OPERATOR) {
       r = multiplicationInfixOperator(b, 0);
@@ -537,98 +447,8 @@ public class ElixirParser implements PsiParser, LightPsiParser {
     else if (t == UNKNOWN_BASE_WHOLE_NUMBER) {
       r = unknownBaseWholeNumber(b, 0);
     }
-    else if (t == UNMATCHED_ADDITION_OPERATION) {
-      r = unmatchedExpression(b, 0, 13);
-    }
-    else if (t == UNMATCHED_AND_OPERATION) {
-      r = unmatchedExpression(b, 0, 7);
-    }
-    else if (t == UNMATCHED_ARROW_OPERATION) {
-      r = unmatchedExpression(b, 0, 10);
-    }
-    else if (t == UNMATCHED_AT_NON_NUMERIC_OPERATION) {
-      r = unmatchedAtNonNumericOperation(b, 0);
-    }
-    else if (t == UNMATCHED_AT_UNQUALIFIED_BRACKET_OPERATION) {
-      r = unmatchedAtUnqualifiedBracketOperation(b, 0);
-    }
-    else if (t == UNMATCHED_AT_UNQUALIFIED_NO_PARENTHESES_CALL) {
-      r = unmatchedAtUnqualifiedNoParenthesesCall(b, 0);
-    }
-    else if (t == UNMATCHED_BRACKET_OPERATION) {
-      r = unmatchedExpression(b, 0, 20);
-    }
-    else if (t == UNMATCHED_CAPTURE_NON_NUMERIC_OPERATION) {
-      r = unmatchedCaptureNonNumericOperation(b, 0);
-    }
-    else if (t == UNMATCHED_COMPARISON_OPERATION) {
-      r = unmatchedExpression(b, 0, 8);
-    }
-    else if (t == UNMATCHED_DOT_CALL) {
-      r = unmatchedExpression(b, 0, 16);
-    }
     else if (t == UNMATCHED_EXPRESSION) {
       r = unmatchedExpression(b, 0, -1);
-    }
-    else if (t == UNMATCHED_IN_MATCH_OPERATION) {
-      r = unmatchedExpression(b, 0, 0);
-    }
-    else if (t == UNMATCHED_IN_OPERATION) {
-      r = unmatchedExpression(b, 0, 11);
-    }
-    else if (t == UNMATCHED_MATCH_OPERATION) {
-      r = unmatchedExpression(b, 0, 5);
-    }
-    else if (t == UNMATCHED_MULTIPLICATION_OPERATION) {
-      r = unmatchedExpression(b, 0, 14);
-    }
-    else if (t == UNMATCHED_OR_OPERATION) {
-      r = unmatchedExpression(b, 0, 6);
-    }
-    else if (t == UNMATCHED_PIPE_OPERATION) {
-      r = unmatchedExpression(b, 0, 4);
-    }
-    else if (t == UNMATCHED_QUALIFIED_ALIAS) {
-      r = unmatchedExpression(b, 0, 21);
-    }
-    else if (t == UNMATCHED_QUALIFIED_BRACKET_OPERATION) {
-      r = unmatchedExpression(b, 0, 22);
-    }
-    else if (t == UNMATCHED_QUALIFIED_NO_ARGUMENTS_CALL) {
-      r = unmatchedExpression(b, 0, 24);
-    }
-    else if (t == UNMATCHED_QUALIFIED_NO_PARENTHESES_CALL) {
-      r = unmatchedExpression(b, 0, 17);
-    }
-    else if (t == UNMATCHED_QUALIFIED_PARENTHESES_CALL) {
-      r = unmatchedExpression(b, 0, 23);
-    }
-    else if (t == UNMATCHED_RELATIONAL_OPERATION) {
-      r = unmatchedExpression(b, 0, 9);
-    }
-    else if (t == UNMATCHED_TWO_OPERATION) {
-      r = unmatchedExpression(b, 0, 12);
-    }
-    else if (t == UNMATCHED_TYPE_OPERATION) {
-      r = unmatchedExpression(b, 0, 3);
-    }
-    else if (t == UNMATCHED_UNARY_NON_NUMERIC_OPERATION) {
-      r = unmatchedUnaryNonNumericOperation(b, 0);
-    }
-    else if (t == UNMATCHED_UNQUALIFIED_BRACKET_OPERATION) {
-      r = unmatchedUnqualifiedBracketOperation(b, 0);
-    }
-    else if (t == UNMATCHED_UNQUALIFIED_NO_ARGUMENTS_CALL) {
-      r = unmatchedUnqualifiedNoArgumentsCall(b, 0);
-    }
-    else if (t == UNMATCHED_UNQUALIFIED_NO_PARENTHESES_CALL) {
-      r = unmatchedUnqualifiedNoParenthesesCall(b, 0);
-    }
-    else if (t == UNMATCHED_UNQUALIFIED_PARENTHESES_CALL) {
-      r = unmatchedUnqualifiedParenthesesCall(b, 0);
-    }
-    else if (t == UNMATCHED_WHEN_OPERATION) {
-      r = unmatchedExpression(b, 0, 2);
     }
     else if (t == UNQUALIFIED_NO_PARENTHESES_MANY_ARGUMENTS_CALL) {
       r = unqualifiedNoParenthesesManyArgumentsCall(b, 0);
@@ -650,22 +470,22 @@ public class ElixirParser implements PsiParser, LightPsiParser {
   }
 
   public static final TokenSet[] EXTENDS_SETS_ = new TokenSet[] {
-    create_token_set_(MATCHED_ADDITION_OPERATION, MATCHED_AND_OPERATION, MATCHED_ARROW_OPERATION, MATCHED_AT_NON_NUMERIC_OPERATION,
-      MATCHED_AT_UNQUALIFIED_BRACKET_OPERATION, MATCHED_AT_UNQUALIFIED_NO_PARENTHESES_CALL, MATCHED_BRACKET_OPERATION, MATCHED_CAPTURE_NON_NUMERIC_OPERATION,
-      MATCHED_COMPARISON_OPERATION, MATCHED_DOT_CALL, MATCHED_EXPRESSION, MATCHED_IN_MATCH_OPERATION,
-      MATCHED_IN_OPERATION, MATCHED_MATCH_OPERATION, MATCHED_MULTIPLICATION_OPERATION, MATCHED_OR_OPERATION,
-      MATCHED_PIPE_OPERATION, MATCHED_QUALIFIED_ALIAS, MATCHED_QUALIFIED_BRACKET_OPERATION, MATCHED_QUALIFIED_NO_ARGUMENTS_CALL,
-      MATCHED_QUALIFIED_NO_PARENTHESES_CALL, MATCHED_QUALIFIED_PARENTHESES_CALL, MATCHED_RELATIONAL_OPERATION, MATCHED_TWO_OPERATION,
-      MATCHED_TYPE_OPERATION, MATCHED_UNARY_NON_NUMERIC_OPERATION, MATCHED_UNQUALIFIED_BRACKET_OPERATION, MATCHED_UNQUALIFIED_NO_ARGUMENTS_CALL,
-      MATCHED_UNQUALIFIED_NO_PARENTHESES_CALL, MATCHED_UNQUALIFIED_PARENTHESES_CALL, MATCHED_WHEN_OPERATION),
-    create_token_set_(UNMATCHED_ADDITION_OPERATION, UNMATCHED_AND_OPERATION, UNMATCHED_ARROW_OPERATION, UNMATCHED_AT_NON_NUMERIC_OPERATION,
-      UNMATCHED_AT_UNQUALIFIED_BRACKET_OPERATION, UNMATCHED_AT_UNQUALIFIED_NO_PARENTHESES_CALL, UNMATCHED_BRACKET_OPERATION, UNMATCHED_CAPTURE_NON_NUMERIC_OPERATION,
-      UNMATCHED_COMPARISON_OPERATION, UNMATCHED_DOT_CALL, UNMATCHED_EXPRESSION, UNMATCHED_IN_MATCH_OPERATION,
-      UNMATCHED_IN_OPERATION, UNMATCHED_MATCH_OPERATION, UNMATCHED_MULTIPLICATION_OPERATION, UNMATCHED_OR_OPERATION,
-      UNMATCHED_PIPE_OPERATION, UNMATCHED_QUALIFIED_ALIAS, UNMATCHED_QUALIFIED_BRACKET_OPERATION, UNMATCHED_QUALIFIED_NO_ARGUMENTS_CALL,
-      UNMATCHED_QUALIFIED_NO_PARENTHESES_CALL, UNMATCHED_QUALIFIED_PARENTHESES_CALL, UNMATCHED_RELATIONAL_OPERATION, UNMATCHED_TWO_OPERATION,
-      UNMATCHED_TYPE_OPERATION, UNMATCHED_UNARY_NON_NUMERIC_OPERATION, UNMATCHED_UNQUALIFIED_BRACKET_OPERATION, UNMATCHED_UNQUALIFIED_NO_ARGUMENTS_CALL,
-      UNMATCHED_UNQUALIFIED_NO_PARENTHESES_CALL, UNMATCHED_UNQUALIFIED_PARENTHESES_CALL, UNMATCHED_WHEN_OPERATION),
+    create_token_set_(ACCESS_EXPRESSION, MATCHED_ADDITION_OPERATION, MATCHED_AND_OPERATION, MATCHED_ARROW_OPERATION,
+      MATCHED_AT_NON_NUMERIC_OPERATION, MATCHED_AT_UNQUALIFIED_BRACKET_OPERATION, MATCHED_AT_UNQUALIFIED_NO_PARENTHESES_CALL, MATCHED_BRACKET_OPERATION,
+      MATCHED_CAPTURE_NON_NUMERIC_OPERATION, MATCHED_COMPARISON_OPERATION, MATCHED_DOT_CALL, MATCHED_EXPRESSION,
+      MATCHED_IN_MATCH_OPERATION, MATCHED_IN_OPERATION, MATCHED_MATCH_OPERATION, MATCHED_MULTIPLICATION_OPERATION,
+      MATCHED_OR_OPERATION, MATCHED_PIPE_OPERATION, MATCHED_QUALIFIED_ALIAS, MATCHED_QUALIFIED_BRACKET_OPERATION,
+      MATCHED_QUALIFIED_NO_ARGUMENTS_CALL, MATCHED_QUALIFIED_NO_PARENTHESES_CALL, MATCHED_QUALIFIED_PARENTHESES_CALL, MATCHED_RELATIONAL_OPERATION,
+      MATCHED_TWO_OPERATION, MATCHED_TYPE_OPERATION, MATCHED_UNARY_NON_NUMERIC_OPERATION, MATCHED_UNQUALIFIED_BRACKET_OPERATION,
+      MATCHED_UNQUALIFIED_NO_ARGUMENTS_CALL, MATCHED_UNQUALIFIED_NO_PARENTHESES_CALL, MATCHED_UNQUALIFIED_PARENTHESES_CALL, MATCHED_WHEN_OPERATION),
+    create_token_set_(ACCESS_EXPRESSION, UNMATCHED_ADDITION_OPERATION, UNMATCHED_AND_OPERATION, UNMATCHED_ARROW_OPERATION,
+      UNMATCHED_AT_NON_NUMERIC_OPERATION, UNMATCHED_AT_UNQUALIFIED_BRACKET_OPERATION, UNMATCHED_AT_UNQUALIFIED_NO_PARENTHESES_CALL, UNMATCHED_BRACKET_OPERATION,
+      UNMATCHED_CAPTURE_NON_NUMERIC_OPERATION, UNMATCHED_COMPARISON_OPERATION, UNMATCHED_DOT_CALL, UNMATCHED_EXPRESSION,
+      UNMATCHED_IN_MATCH_OPERATION, UNMATCHED_IN_OPERATION, UNMATCHED_MATCH_OPERATION, UNMATCHED_MULTIPLICATION_OPERATION,
+      UNMATCHED_OR_OPERATION, UNMATCHED_PIPE_OPERATION, UNMATCHED_QUALIFIED_ALIAS, UNMATCHED_QUALIFIED_BRACKET_OPERATION,
+      UNMATCHED_QUALIFIED_NO_ARGUMENTS_CALL, UNMATCHED_QUALIFIED_NO_PARENTHESES_CALL, UNMATCHED_QUALIFIED_PARENTHESES_CALL, UNMATCHED_RELATIONAL_OPERATION,
+      UNMATCHED_TWO_OPERATION, UNMATCHED_TYPE_OPERATION, UNMATCHED_UNARY_NON_NUMERIC_OPERATION, UNMATCHED_UNQUALIFIED_BRACKET_OPERATION,
+      UNMATCHED_UNQUALIFIED_NO_ARGUMENTS_CALL, UNMATCHED_UNQUALIFIED_NO_PARENTHESES_CALL, UNMATCHED_UNQUALIFIED_PARENTHESES_CALL, UNMATCHED_WHEN_OPERATION),
   };
 
   /* ********************************************************** */

--- a/gen/org/elixir_lang/psi/ElixirEscapedEOL.java
+++ b/gen/org/elixir_lang/psi/ElixirEscapedEOL.java
@@ -3,6 +3,4 @@ package org.elixir_lang.psi;
 
 public interface ElixirEscapedEOL extends EscapeSequence {
 
-  int codePoint();
-
 }

--- a/gen/org/elixir_lang/psi/ElixirVisitor.java
+++ b/gen/org/elixir_lang/psi/ElixirVisitor.java
@@ -184,7 +184,7 @@ public class ElixirVisitor extends PsiElementVisitor {
     visitEscapeSequence(o);
   }
 
-  public void visitEscapedEOL(@NotNull ElixirEscapedEOL o) {
+  public void visitEscapedEol(@NotNull ElixirEscapedEOL o) {
     visitEscapeSequence(o);
   }
 

--- a/gen/org/elixir_lang/psi/impl/ElixirAccessExpressionImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirAccessExpressionImpl.java
@@ -5,6 +5,7 @@ import com.ericsson.otp.erlang.OtpErlangObject;
 import com.intellij.extapi.psi.ASTWrapperPsiElement;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElementVisitor;
+import com.intellij.psi.util.PsiTreeUtil;
 import org.elixir_lang.psi.*;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -27,265 +28,265 @@ public class ElixirAccessExpressionImpl extends ASTWrapperPsiElement implements 
   @Override
   @Nullable
   public ElixirAlias getAlias() {
-    return findChildByClass(ElixirAlias.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirAlias.class);
   }
 
   @Override
   @Nullable
   public ElixirAnonymousFunction getAnonymousFunction() {
-    return findChildByClass(ElixirAnonymousFunction.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirAnonymousFunction.class);
   }
 
   @Override
   @Nullable
   public ElixirAtNumericOperation getAtNumericOperation() {
-    return findChildByClass(ElixirAtNumericOperation.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirAtNumericOperation.class);
   }
 
   @Override
   @Nullable
   public ElixirAtom getAtom() {
-    return findChildByClass(ElixirAtom.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirAtom.class);
   }
 
   @Override
   @Nullable
   public ElixirAtomKeyword getAtomKeyword() {
-    return findChildByClass(ElixirAtomKeyword.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirAtomKeyword.class);
   }
 
   @Override
   @Nullable
   public ElixirBinaryWholeNumber getBinaryWholeNumber() {
-    return findChildByClass(ElixirBinaryWholeNumber.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirBinaryWholeNumber.class);
   }
 
   @Override
   @Nullable
   public ElixirBitString getBitString() {
-    return findChildByClass(ElixirBitString.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirBitString.class);
   }
 
   @Override
   @Nullable
   public ElixirCaptureNumericOperation getCaptureNumericOperation() {
-    return findChildByClass(ElixirCaptureNumericOperation.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirCaptureNumericOperation.class);
   }
 
   @Override
   @Nullable
   public ElixirCharListHeredoc getCharListHeredoc() {
-    return findChildByClass(ElixirCharListHeredoc.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirCharListHeredoc.class);
   }
 
   @Override
   @Nullable
   public ElixirCharListLine getCharListLine() {
-    return findChildByClass(ElixirCharListLine.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirCharListLine.class);
   }
 
   @Override
   @Nullable
   public ElixirCharToken getCharToken() {
-    return findChildByClass(ElixirCharToken.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirCharToken.class);
   }
 
   @Override
   @Nullable
   public ElixirDecimalFloat getDecimalFloat() {
-    return findChildByClass(ElixirDecimalFloat.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirDecimalFloat.class);
   }
 
   @Override
   @Nullable
   public ElixirDecimalWholeNumber getDecimalWholeNumber() {
-    return findChildByClass(ElixirDecimalWholeNumber.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirDecimalWholeNumber.class);
   }
 
   @Override
   @Nullable
   public ElixirHexadecimalWholeNumber getHexadecimalWholeNumber() {
-    return findChildByClass(ElixirHexadecimalWholeNumber.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirHexadecimalWholeNumber.class);
   }
 
   @Override
   @Nullable
   public ElixirInterpolatedCharListSigilHeredoc getInterpolatedCharListSigilHeredoc() {
-    return findChildByClass(ElixirInterpolatedCharListSigilHeredoc.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirInterpolatedCharListSigilHeredoc.class);
   }
 
   @Override
   @Nullable
   public ElixirInterpolatedCharListSigilLine getInterpolatedCharListSigilLine() {
-    return findChildByClass(ElixirInterpolatedCharListSigilLine.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirInterpolatedCharListSigilLine.class);
   }
 
   @Override
   @Nullable
   public ElixirInterpolatedRegexHeredoc getInterpolatedRegexHeredoc() {
-    return findChildByClass(ElixirInterpolatedRegexHeredoc.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirInterpolatedRegexHeredoc.class);
   }
 
   @Override
   @Nullable
   public ElixirInterpolatedRegexLine getInterpolatedRegexLine() {
-    return findChildByClass(ElixirInterpolatedRegexLine.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirInterpolatedRegexLine.class);
   }
 
   @Override
   @Nullable
   public ElixirInterpolatedSigilHeredoc getInterpolatedSigilHeredoc() {
-    return findChildByClass(ElixirInterpolatedSigilHeredoc.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirInterpolatedSigilHeredoc.class);
   }
 
   @Override
   @Nullable
   public ElixirInterpolatedSigilLine getInterpolatedSigilLine() {
-    return findChildByClass(ElixirInterpolatedSigilLine.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirInterpolatedSigilLine.class);
   }
 
   @Override
   @Nullable
   public ElixirInterpolatedStringSigilHeredoc getInterpolatedStringSigilHeredoc() {
-    return findChildByClass(ElixirInterpolatedStringSigilHeredoc.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirInterpolatedStringSigilHeredoc.class);
   }
 
   @Override
   @Nullable
   public ElixirInterpolatedStringSigilLine getInterpolatedStringSigilLine() {
-    return findChildByClass(ElixirInterpolatedStringSigilLine.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirInterpolatedStringSigilLine.class);
   }
 
   @Override
   @Nullable
   public ElixirInterpolatedWordsHeredoc getInterpolatedWordsHeredoc() {
-    return findChildByClass(ElixirInterpolatedWordsHeredoc.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirInterpolatedWordsHeredoc.class);
   }
 
   @Override
   @Nullable
   public ElixirInterpolatedWordsLine getInterpolatedWordsLine() {
-    return findChildByClass(ElixirInterpolatedWordsLine.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirInterpolatedWordsLine.class);
   }
 
   @Override
   @Nullable
   public ElixirList getList() {
-    return findChildByClass(ElixirList.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirList.class);
   }
 
   @Override
   @Nullable
   public ElixirLiteralCharListSigilHeredoc getLiteralCharListSigilHeredoc() {
-    return findChildByClass(ElixirLiteralCharListSigilHeredoc.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirLiteralCharListSigilHeredoc.class);
   }
 
   @Override
   @Nullable
   public ElixirLiteralCharListSigilLine getLiteralCharListSigilLine() {
-    return findChildByClass(ElixirLiteralCharListSigilLine.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirLiteralCharListSigilLine.class);
   }
 
   @Override
   @Nullable
   public ElixirLiteralRegexHeredoc getLiteralRegexHeredoc() {
-    return findChildByClass(ElixirLiteralRegexHeredoc.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirLiteralRegexHeredoc.class);
   }
 
   @Override
   @Nullable
   public ElixirLiteralRegexLine getLiteralRegexLine() {
-    return findChildByClass(ElixirLiteralRegexLine.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirLiteralRegexLine.class);
   }
 
   @Override
   @Nullable
   public ElixirLiteralSigilHeredoc getLiteralSigilHeredoc() {
-    return findChildByClass(ElixirLiteralSigilHeredoc.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirLiteralSigilHeredoc.class);
   }
 
   @Override
   @Nullable
   public ElixirLiteralSigilLine getLiteralSigilLine() {
-    return findChildByClass(ElixirLiteralSigilLine.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirLiteralSigilLine.class);
   }
 
   @Override
   @Nullable
   public ElixirLiteralStringSigilHeredoc getLiteralStringSigilHeredoc() {
-    return findChildByClass(ElixirLiteralStringSigilHeredoc.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirLiteralStringSigilHeredoc.class);
   }
 
   @Override
   @Nullable
   public ElixirLiteralStringSigilLine getLiteralStringSigilLine() {
-    return findChildByClass(ElixirLiteralStringSigilLine.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirLiteralStringSigilLine.class);
   }
 
   @Override
   @Nullable
   public ElixirLiteralWordsHeredoc getLiteralWordsHeredoc() {
-    return findChildByClass(ElixirLiteralWordsHeredoc.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirLiteralWordsHeredoc.class);
   }
 
   @Override
   @Nullable
   public ElixirLiteralWordsLine getLiteralWordsLine() {
-    return findChildByClass(ElixirLiteralWordsLine.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirLiteralWordsLine.class);
   }
 
   @Override
   @Nullable
   public ElixirMapOperation getMapOperation() {
-    return findChildByClass(ElixirMapOperation.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirMapOperation.class);
   }
 
   @Override
   @Nullable
   public ElixirOctalWholeNumber getOctalWholeNumber() {
-    return findChildByClass(ElixirOctalWholeNumber.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirOctalWholeNumber.class);
   }
 
   @Override
   @Nullable
   public ElixirParentheticalStab getParentheticalStab() {
-    return findChildByClass(ElixirParentheticalStab.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirParentheticalStab.class);
   }
 
   @Override
   @Nullable
   public ElixirStringHeredoc getStringHeredoc() {
-    return findChildByClass(ElixirStringHeredoc.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirStringHeredoc.class);
   }
 
   @Override
   @Nullable
   public ElixirStringLine getStringLine() {
-    return findChildByClass(ElixirStringLine.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirStringLine.class);
   }
 
   @Override
   @Nullable
   public ElixirStructOperation getStructOperation() {
-    return findChildByClass(ElixirStructOperation.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirStructOperation.class);
   }
 
   @Override
   @Nullable
   public ElixirTuple getTuple() {
-    return findChildByClass(ElixirTuple.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirTuple.class);
   }
 
   @Override
   @Nullable
   public ElixirUnaryNumericOperation getUnaryNumericOperation() {
-    return findChildByClass(ElixirUnaryNumericOperation.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirUnaryNumericOperation.class);
   }
 
   @Override
   @Nullable
   public ElixirUnknownBaseWholeNumber getUnknownBaseWholeNumber() {
-    return findChildByClass(ElixirUnknownBaseWholeNumber.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirUnknownBaseWholeNumber.class);
   }
 
   public boolean isModuleName() {

--- a/gen/org/elixir_lang/psi/impl/ElixirAnonymousFunctionImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirAnonymousFunctionImpl.java
@@ -38,7 +38,7 @@ public class ElixirAnonymousFunctionImpl extends ASTWrapperPsiElement implements
   @Override
   @NotNull
   public ElixirStab getStab() {
-    return findNotNullChildByClass(ElixirStab.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirStab.class));
   }
 
   @NotNull

--- a/gen/org/elixir_lang/psi/impl/ElixirAssociationsImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirAssociationsImpl.java
@@ -5,6 +5,7 @@ import com.ericsson.otp.erlang.OtpErlangObject;
 import com.intellij.extapi.psi.ASTWrapperPsiElement;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElementVisitor;
+import com.intellij.psi.util.PsiTreeUtil;
 import org.elixir_lang.psi.ElixirAssociations;
 import org.elixir_lang.psi.ElixirAssociationsBase;
 import org.elixir_lang.psi.ElixirVisitor;
@@ -28,7 +29,7 @@ public class ElixirAssociationsImpl extends ASTWrapperPsiElement implements Elix
   @Override
   @NotNull
   public ElixirAssociationsBase getAssociationsBase() {
-    return findNotNullChildByClass(ElixirAssociationsBase.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirAssociationsBase.class));
   }
 
   @NotNull

--- a/gen/org/elixir_lang/psi/impl/ElixirAtIdentifierImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirAtIdentifierImpl.java
@@ -5,6 +5,7 @@ import com.intellij.extapi.psi.ASTWrapperPsiElement;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.PsiReference;
+import com.intellij.psi.util.PsiTreeUtil;
 import org.elixir_lang.psi.ElixirAtIdentifier;
 import org.elixir_lang.psi.ElixirAtPrefixOperator;
 import org.elixir_lang.psi.ElixirVisitor;
@@ -28,7 +29,7 @@ public class ElixirAtIdentifierImpl extends ASTWrapperPsiElement implements Elix
   @Override
   @NotNull
   public ElixirAtPrefixOperator getAtPrefixOperator() {
-    return findNotNullChildByClass(ElixirAtPrefixOperator.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirAtPrefixOperator.class));
   }
 
   @NotNull

--- a/gen/org/elixir_lang/psi/impl/ElixirAtNumericOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirAtNumericOperationImpl.java
@@ -6,6 +6,7 @@ import com.intellij.extapi.psi.ASTWrapperPsiElement;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
+import com.intellij.psi.util.PsiTreeUtil;
 import org.apache.commons.lang.math.IntRange;
 import org.elixir_lang.psi.*;
 import org.jetbrains.annotations.NotNull;
@@ -29,49 +30,49 @@ public class ElixirAtNumericOperationImpl extends ASTWrapperPsiElement implement
   @Override
   @NotNull
   public ElixirAtPrefixOperator getAtPrefixOperator() {
-    return findNotNullChildByClass(ElixirAtPrefixOperator.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirAtPrefixOperator.class));
   }
 
   @Override
   @Nullable
   public ElixirBinaryWholeNumber getBinaryWholeNumber() {
-    return findChildByClass(ElixirBinaryWholeNumber.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirBinaryWholeNumber.class);
   }
 
   @Override
   @Nullable
   public ElixirCharToken getCharToken() {
-    return findChildByClass(ElixirCharToken.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirCharToken.class);
   }
 
   @Override
   @Nullable
   public ElixirDecimalFloat getDecimalFloat() {
-    return findChildByClass(ElixirDecimalFloat.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirDecimalFloat.class);
   }
 
   @Override
   @Nullable
   public ElixirDecimalWholeNumber getDecimalWholeNumber() {
-    return findChildByClass(ElixirDecimalWholeNumber.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirDecimalWholeNumber.class);
   }
 
   @Override
   @Nullable
   public ElixirHexadecimalWholeNumber getHexadecimalWholeNumber() {
-    return findChildByClass(ElixirHexadecimalWholeNumber.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirHexadecimalWholeNumber.class);
   }
 
   @Override
   @Nullable
   public ElixirOctalWholeNumber getOctalWholeNumber() {
-    return findChildByClass(ElixirOctalWholeNumber.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirOctalWholeNumber.class);
   }
 
   @Override
   @Nullable
   public ElixirUnknownBaseWholeNumber getUnknownBaseWholeNumber() {
-    return findChildByClass(ElixirUnknownBaseWholeNumber.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirUnknownBaseWholeNumber.class);
   }
 
   @Nullable

--- a/gen/org/elixir_lang/psi/impl/ElixirAtomImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirAtomImpl.java
@@ -5,6 +5,7 @@ import com.ericsson.otp.erlang.OtpErlangObject;
 import com.intellij.extapi.psi.ASTWrapperPsiElement;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElementVisitor;
+import com.intellij.psi.util.PsiTreeUtil;
 import org.elixir_lang.psi.ElixirAtom;
 import org.elixir_lang.psi.ElixirCharListLine;
 import org.elixir_lang.psi.ElixirStringLine;
@@ -30,13 +31,13 @@ public class ElixirAtomImpl extends ASTWrapperPsiElement implements ElixirAtom {
   @Override
   @Nullable
   public ElixirCharListLine getCharListLine() {
-    return findChildByClass(ElixirCharListLine.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirCharListLine.class);
   }
 
   @Override
   @Nullable
   public ElixirStringLine getStringLine() {
-    return findChildByClass(ElixirStringLine.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirStringLine.class);
   }
 
   @NotNull

--- a/gen/org/elixir_lang/psi/impl/ElixirBitStringImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirBitStringImpl.java
@@ -36,7 +36,7 @@ public class ElixirBitStringImpl extends ASTWrapperPsiElement implements ElixirB
   @Override
   @Nullable
   public ElixirKeywords getKeywords() {
-    return findChildByClass(ElixirKeywords.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirKeywords.class);
   }
 
   @Override

--- a/gen/org/elixir_lang/psi/impl/ElixirBlockItemImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirBlockItemImpl.java
@@ -30,7 +30,7 @@ public class ElixirBlockItemImpl extends ASTWrapperPsiElement implements ElixirB
   @Override
   @NotNull
   public ElixirBlockIdentifier getBlockIdentifier() {
-    return findNotNullChildByClass(ElixirBlockIdentifier.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirBlockIdentifier.class));
   }
 
   @Override
@@ -42,7 +42,7 @@ public class ElixirBlockItemImpl extends ASTWrapperPsiElement implements ElixirB
   @Override
   @Nullable
   public ElixirStab getStab() {
-    return findChildByClass(ElixirStab.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirStab.class);
   }
 
   @NotNull

--- a/gen/org/elixir_lang/psi/impl/ElixirBracketArgumentsImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirBracketArgumentsImpl.java
@@ -5,6 +5,7 @@ import com.ericsson.otp.erlang.OtpErlangObject;
 import com.intellij.extapi.psi.ASTWrapperPsiElement;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElementVisitor;
+import com.intellij.psi.util.PsiTreeUtil;
 import org.elixir_lang.psi.*;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -27,19 +28,19 @@ public class ElixirBracketArgumentsImpl extends ASTWrapperPsiElement implements 
   @Override
   @Nullable
   public ElixirEmptyParentheses getEmptyParentheses() {
-    return findChildByClass(ElixirEmptyParentheses.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirEmptyParentheses.class);
   }
 
   @Override
   @Nullable
   public ElixirKeywords getKeywords() {
-    return findChildByClass(ElixirKeywords.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirKeywords.class);
   }
 
   @Override
   @Nullable
   public ElixirUnmatchedExpression getUnmatchedExpression() {
-    return findChildByClass(ElixirUnmatchedExpression.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirUnmatchedExpression.class);
   }
 
   @NotNull

--- a/gen/org/elixir_lang/psi/impl/ElixirCaptureNumericOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirCaptureNumericOperationImpl.java
@@ -6,6 +6,7 @@ import com.intellij.extapi.psi.ASTWrapperPsiElement;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
+import com.intellij.psi.util.PsiTreeUtil;
 import org.apache.commons.lang.math.IntRange;
 import org.elixir_lang.psi.*;
 import org.jetbrains.annotations.NotNull;
@@ -29,49 +30,49 @@ public class ElixirCaptureNumericOperationImpl extends ASTWrapperPsiElement impl
   @Override
   @Nullable
   public ElixirBinaryWholeNumber getBinaryWholeNumber() {
-    return findChildByClass(ElixirBinaryWholeNumber.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirBinaryWholeNumber.class);
   }
 
   @Override
   @NotNull
   public ElixirCapturePrefixOperator getCapturePrefixOperator() {
-    return findNotNullChildByClass(ElixirCapturePrefixOperator.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirCapturePrefixOperator.class));
   }
 
   @Override
   @Nullable
   public ElixirCharToken getCharToken() {
-    return findChildByClass(ElixirCharToken.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirCharToken.class);
   }
 
   @Override
   @Nullable
   public ElixirDecimalFloat getDecimalFloat() {
-    return findChildByClass(ElixirDecimalFloat.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirDecimalFloat.class);
   }
 
   @Override
   @Nullable
   public ElixirDecimalWholeNumber getDecimalWholeNumber() {
-    return findChildByClass(ElixirDecimalWholeNumber.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirDecimalWholeNumber.class);
   }
 
   @Override
   @Nullable
   public ElixirHexadecimalWholeNumber getHexadecimalWholeNumber() {
-    return findChildByClass(ElixirHexadecimalWholeNumber.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirHexadecimalWholeNumber.class);
   }
 
   @Override
   @Nullable
   public ElixirOctalWholeNumber getOctalWholeNumber() {
-    return findChildByClass(ElixirOctalWholeNumber.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirOctalWholeNumber.class);
   }
 
   @Override
   @Nullable
   public ElixirUnknownBaseWholeNumber getUnknownBaseWholeNumber() {
-    return findChildByClass(ElixirUnknownBaseWholeNumber.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirUnknownBaseWholeNumber.class);
   }
 
   @Nullable

--- a/gen/org/elixir_lang/psi/impl/ElixirCharListHeredocImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirCharListHeredocImpl.java
@@ -38,7 +38,7 @@ public class ElixirCharListHeredocImpl extends ASTWrapperPsiElement implements E
   @Override
   @Nullable
   public ElixirHeredocPrefix getHeredocPrefix() {
-    return findChildByClass(ElixirHeredocPrefix.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirHeredocPrefix.class);
   }
 
   @NotNull

--- a/gen/org/elixir_lang/psi/impl/ElixirCharListHeredocLineImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirCharListHeredocLineImpl.java
@@ -5,6 +5,7 @@ import com.ericsson.otp.erlang.OtpErlangObject;
 import com.intellij.extapi.psi.ASTWrapperPsiElement;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElementVisitor;
+import com.intellij.psi.util.PsiTreeUtil;
 import org.elixir_lang.psi.*;
 import org.jetbrains.annotations.NotNull;
 
@@ -26,13 +27,13 @@ public class ElixirCharListHeredocLineImpl extends ASTWrapperPsiElement implemen
   @Override
   @NotNull
   public ElixirHeredocLinePrefix getHeredocLinePrefix() {
-    return findNotNullChildByClass(ElixirHeredocLinePrefix.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirHeredocLinePrefix.class));
   }
 
   @Override
   @NotNull
   public ElixirQuoteCharListBody getQuoteCharListBody() {
-    return findNotNullChildByClass(ElixirQuoteCharListBody.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirQuoteCharListBody.class));
   }
 
   public Body getBody() {

--- a/gen/org/elixir_lang/psi/impl/ElixirCharListLineImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirCharListLineImpl.java
@@ -7,6 +7,7 @@ import com.intellij.extapi.psi.ASTWrapperPsiElement;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.tree.IElementType;
+import com.intellij.psi.util.PsiTreeUtil;
 import org.elixir_lang.psi.Body;
 import org.elixir_lang.psi.ElixirCharListLine;
 import org.elixir_lang.psi.ElixirQuoteCharListBody;
@@ -33,7 +34,7 @@ public class ElixirCharListLineImpl extends ASTWrapperPsiElement implements Elix
   @Override
   @NotNull
   public ElixirQuoteCharListBody getQuoteCharListBody() {
-    return findNotNullChildByClass(ElixirQuoteCharListBody.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirQuoteCharListBody.class));
   }
 
   @NotNull

--- a/gen/org/elixir_lang/psi/impl/ElixirCharTokenImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirCharTokenImpl.java
@@ -5,6 +5,7 @@ import com.ericsson.otp.erlang.OtpErlangObject;
 import com.intellij.extapi.psi.ASTWrapperPsiElement;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElementVisitor;
+import com.intellij.psi.util.PsiTreeUtil;
 import org.elixir_lang.psi.*;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -27,19 +28,19 @@ public class ElixirCharTokenImpl extends ASTWrapperPsiElement implements ElixirC
   @Override
   @Nullable
   public ElixirEscapedCharacter getEscapedCharacter() {
-    return findChildByClass(ElixirEscapedCharacter.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirEscapedCharacter.class);
   }
 
   @Override
   @Nullable
   public ElixirEscapedEOL getEscapedEOL() {
-    return findChildByClass(ElixirEscapedEOL.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirEscapedEOL.class);
   }
 
   @Override
   @Nullable
   public ElixirQuoteHexadecimalEscapeSequence getQuoteHexadecimalEscapeSequence() {
-    return findChildByClass(ElixirQuoteHexadecimalEscapeSequence.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirQuoteHexadecimalEscapeSequence.class);
   }
 
   @NotNull

--- a/gen/org/elixir_lang/psi/impl/ElixirDecimalFloatExponentImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirDecimalFloatExponentImpl.java
@@ -4,6 +4,7 @@ package org.elixir_lang.psi.impl;
 import com.intellij.extapi.psi.ASTWrapperPsiElement;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElementVisitor;
+import com.intellij.psi.util.PsiTreeUtil;
 import org.elixir_lang.psi.ElixirDecimalFloatExponent;
 import org.elixir_lang.psi.ElixirDecimalFloatExponentSign;
 import org.elixir_lang.psi.ElixirDecimalWholeNumber;
@@ -28,13 +29,13 @@ public class ElixirDecimalFloatExponentImpl extends ASTWrapperPsiElement impleme
   @Override
   @NotNull
   public ElixirDecimalFloatExponentSign getDecimalFloatExponentSign() {
-    return findNotNullChildByClass(ElixirDecimalFloatExponentSign.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirDecimalFloatExponentSign.class));
   }
 
   @Override
   @NotNull
   public ElixirDecimalWholeNumber getDecimalWholeNumber() {
-    return findNotNullChildByClass(ElixirDecimalWholeNumber.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirDecimalWholeNumber.class));
   }
 
 }

--- a/gen/org/elixir_lang/psi/impl/ElixirDecimalFloatFractionalImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirDecimalFloatFractionalImpl.java
@@ -4,6 +4,7 @@ package org.elixir_lang.psi.impl;
 import com.intellij.extapi.psi.ASTWrapperPsiElement;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElementVisitor;
+import com.intellij.psi.util.PsiTreeUtil;
 import org.elixir_lang.psi.ElixirDecimalFloatFractional;
 import org.elixir_lang.psi.ElixirDecimalWholeNumber;
 import org.elixir_lang.psi.ElixirVisitor;
@@ -27,7 +28,7 @@ public class ElixirDecimalFloatFractionalImpl extends ASTWrapperPsiElement imple
   @Override
   @NotNull
   public ElixirDecimalWholeNumber getDecimalWholeNumber() {
-    return findNotNullChildByClass(ElixirDecimalWholeNumber.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirDecimalWholeNumber.class));
   }
 
 }

--- a/gen/org/elixir_lang/psi/impl/ElixirDecimalFloatImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirDecimalFloatImpl.java
@@ -5,6 +5,7 @@ import com.ericsson.otp.erlang.OtpErlangObject;
 import com.intellij.extapi.psi.ASTWrapperPsiElement;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElementVisitor;
+import com.intellij.psi.util.PsiTreeUtil;
 import org.elixir_lang.psi.*;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -27,19 +28,19 @@ public class ElixirDecimalFloatImpl extends ASTWrapperPsiElement implements Elix
   @Override
   @Nullable
   public ElixirDecimalFloatExponent getDecimalFloatExponent() {
-    return findChildByClass(ElixirDecimalFloatExponent.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirDecimalFloatExponent.class);
   }
 
   @Override
   @NotNull
   public ElixirDecimalFloatFractional getDecimalFloatFractional() {
-    return findNotNullChildByClass(ElixirDecimalFloatFractional.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirDecimalFloatFractional.class));
   }
 
   @Override
   @NotNull
   public ElixirDecimalFloatIntegral getDecimalFloatIntegral() {
-    return findNotNullChildByClass(ElixirDecimalFloatIntegral.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirDecimalFloatIntegral.class));
   }
 
   @NotNull

--- a/gen/org/elixir_lang/psi/impl/ElixirDecimalFloatIntegralImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirDecimalFloatIntegralImpl.java
@@ -4,6 +4,7 @@ package org.elixir_lang.psi.impl;
 import com.intellij.extapi.psi.ASTWrapperPsiElement;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElementVisitor;
+import com.intellij.psi.util.PsiTreeUtil;
 import org.elixir_lang.psi.ElixirDecimalFloatIntegral;
 import org.elixir_lang.psi.ElixirDecimalWholeNumber;
 import org.elixir_lang.psi.ElixirVisitor;
@@ -27,7 +28,7 @@ public class ElixirDecimalFloatIntegralImpl extends ASTWrapperPsiElement impleme
   @Override
   @NotNull
   public ElixirDecimalWholeNumber getDecimalWholeNumber() {
-    return findNotNullChildByClass(ElixirDecimalWholeNumber.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirDecimalWholeNumber.class));
   }
 
 }

--- a/gen/org/elixir_lang/psi/impl/ElixirDoBlockImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirDoBlockImpl.java
@@ -30,7 +30,7 @@ public class ElixirDoBlockImpl extends ASTWrapperPsiElement implements ElixirDoB
   @Override
   @Nullable
   public ElixirBlockList getBlockList() {
-    return findChildByClass(ElixirBlockList.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirBlockList.class);
   }
 
   @Override
@@ -42,7 +42,7 @@ public class ElixirDoBlockImpl extends ASTWrapperPsiElement implements ElixirDoB
   @Override
   @Nullable
   public ElixirStab getStab() {
-    return findChildByClass(ElixirStab.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirStab.class);
   }
 
   @NotNull

--- a/gen/org/elixir_lang/psi/impl/ElixirEscapedEOLImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirEscapedEOLImpl.java
@@ -15,7 +15,7 @@ public class ElixirEscapedEOLImpl extends ASTWrapperPsiElement implements Elixir
   }
 
   public void accept(@NotNull ElixirVisitor visitor) {
-    visitor.visitEscapedEOL(this);
+    visitor.visitEscapedEol(this);
   }
 
   public void accept(@NotNull PsiElementVisitor visitor) {

--- a/gen/org/elixir_lang/psi/impl/ElixirInterpolatedCharListHeredocLineImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirInterpolatedCharListHeredocLineImpl.java
@@ -5,6 +5,7 @@ import com.ericsson.otp.erlang.OtpErlangObject;
 import com.intellij.extapi.psi.ASTWrapperPsiElement;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElementVisitor;
+import com.intellij.psi.util.PsiTreeUtil;
 import org.elixir_lang.psi.*;
 import org.jetbrains.annotations.NotNull;
 
@@ -26,13 +27,13 @@ public class ElixirInterpolatedCharListHeredocLineImpl extends ASTWrapperPsiElem
   @Override
   @NotNull
   public ElixirHeredocLinePrefix getHeredocLinePrefix() {
-    return findNotNullChildByClass(ElixirHeredocLinePrefix.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirHeredocLinePrefix.class));
   }
 
   @Override
   @NotNull
   public ElixirInterpolatedCharListBody getInterpolatedCharListBody() {
-    return findNotNullChildByClass(ElixirInterpolatedCharListBody.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirInterpolatedCharListBody.class));
   }
 
   public Body getBody() {

--- a/gen/org/elixir_lang/psi/impl/ElixirInterpolatedCharListSigilHeredocImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirInterpolatedCharListSigilHeredocImpl.java
@@ -32,7 +32,7 @@ public class ElixirInterpolatedCharListSigilHeredocImpl extends ASTWrapperPsiEle
   @Override
   @Nullable
   public ElixirHeredocPrefix getHeredocPrefix() {
-    return findChildByClass(ElixirHeredocPrefix.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirHeredocPrefix.class);
   }
 
   @Override
@@ -44,7 +44,7 @@ public class ElixirInterpolatedCharListSigilHeredocImpl extends ASTWrapperPsiEle
   @Override
   @Nullable
   public ElixirSigilModifiers getSigilModifiers() {
-    return findChildByClass(ElixirSigilModifiers.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirSigilModifiers.class);
   }
 
   @NotNull

--- a/gen/org/elixir_lang/psi/impl/ElixirInterpolatedCharListSigilLineImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirInterpolatedCharListSigilLineImpl.java
@@ -7,6 +7,7 @@ import com.intellij.extapi.psi.ASTWrapperPsiElement;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.tree.IElementType;
+import com.intellij.psi.util.PsiTreeUtil;
 import org.elixir_lang.psi.*;
 import org.jetbrains.annotations.NotNull;
 
@@ -30,13 +31,13 @@ public class ElixirInterpolatedCharListSigilLineImpl extends ASTWrapperPsiElemen
   @Override
   @NotNull
   public ElixirInterpolatedCharListBody getInterpolatedCharListBody() {
-    return findNotNullChildByClass(ElixirInterpolatedCharListBody.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirInterpolatedCharListBody.class));
   }
 
   @Override
   @NotNull
   public ElixirSigilModifiers getSigilModifiers() {
-    return findNotNullChildByClass(ElixirSigilModifiers.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirSigilModifiers.class));
   }
 
   @NotNull

--- a/gen/org/elixir_lang/psi/impl/ElixirInterpolatedRegexHeredocImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirInterpolatedRegexHeredocImpl.java
@@ -32,7 +32,7 @@ public class ElixirInterpolatedRegexHeredocImpl extends ASTWrapperPsiElement imp
   @Override
   @Nullable
   public ElixirHeredocPrefix getHeredocPrefix() {
-    return findChildByClass(ElixirHeredocPrefix.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirHeredocPrefix.class);
   }
 
   @Override
@@ -44,7 +44,7 @@ public class ElixirInterpolatedRegexHeredocImpl extends ASTWrapperPsiElement imp
   @Override
   @Nullable
   public ElixirSigilModifiers getSigilModifiers() {
-    return findChildByClass(ElixirSigilModifiers.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirSigilModifiers.class);
   }
 
   @NotNull

--- a/gen/org/elixir_lang/psi/impl/ElixirInterpolatedRegexHeredocLineImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirInterpolatedRegexHeredocLineImpl.java
@@ -5,6 +5,7 @@ import com.ericsson.otp.erlang.OtpErlangObject;
 import com.intellij.extapi.psi.ASTWrapperPsiElement;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElementVisitor;
+import com.intellij.psi.util.PsiTreeUtil;
 import org.elixir_lang.psi.*;
 import org.jetbrains.annotations.NotNull;
 
@@ -26,13 +27,13 @@ public class ElixirInterpolatedRegexHeredocLineImpl extends ASTWrapperPsiElement
   @Override
   @NotNull
   public ElixirHeredocLinePrefix getHeredocLinePrefix() {
-    return findNotNullChildByClass(ElixirHeredocLinePrefix.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirHeredocLinePrefix.class));
   }
 
   @Override
   @NotNull
   public ElixirInterpolatedRegexBody getInterpolatedRegexBody() {
-    return findNotNullChildByClass(ElixirInterpolatedRegexBody.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirInterpolatedRegexBody.class));
   }
 
   public Body getBody() {

--- a/gen/org/elixir_lang/psi/impl/ElixirInterpolatedRegexLineImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirInterpolatedRegexLineImpl.java
@@ -7,6 +7,7 @@ import com.intellij.extapi.psi.ASTWrapperPsiElement;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.tree.IElementType;
+import com.intellij.psi.util.PsiTreeUtil;
 import org.elixir_lang.psi.*;
 import org.jetbrains.annotations.NotNull;
 
@@ -30,13 +31,13 @@ public class ElixirInterpolatedRegexLineImpl extends ASTWrapperPsiElement implem
   @Override
   @NotNull
   public ElixirInterpolatedRegexBody getInterpolatedRegexBody() {
-    return findNotNullChildByClass(ElixirInterpolatedRegexBody.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirInterpolatedRegexBody.class));
   }
 
   @Override
   @NotNull
   public ElixirSigilModifiers getSigilModifiers() {
-    return findNotNullChildByClass(ElixirSigilModifiers.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirSigilModifiers.class));
   }
 
   @NotNull

--- a/gen/org/elixir_lang/psi/impl/ElixirInterpolatedSigilHeredocImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirInterpolatedSigilHeredocImpl.java
@@ -32,7 +32,7 @@ public class ElixirInterpolatedSigilHeredocImpl extends ASTWrapperPsiElement imp
   @Override
   @Nullable
   public ElixirHeredocPrefix getHeredocPrefix() {
-    return findChildByClass(ElixirHeredocPrefix.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirHeredocPrefix.class);
   }
 
   @Override
@@ -44,7 +44,7 @@ public class ElixirInterpolatedSigilHeredocImpl extends ASTWrapperPsiElement imp
   @Override
   @Nullable
   public ElixirSigilModifiers getSigilModifiers() {
-    return findChildByClass(ElixirSigilModifiers.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirSigilModifiers.class);
   }
 
   @NotNull

--- a/gen/org/elixir_lang/psi/impl/ElixirInterpolatedSigilHeredocLineImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirInterpolatedSigilHeredocLineImpl.java
@@ -5,6 +5,7 @@ import com.ericsson.otp.erlang.OtpErlangObject;
 import com.intellij.extapi.psi.ASTWrapperPsiElement;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElementVisitor;
+import com.intellij.psi.util.PsiTreeUtil;
 import org.elixir_lang.psi.*;
 import org.jetbrains.annotations.NotNull;
 
@@ -26,13 +27,13 @@ public class ElixirInterpolatedSigilHeredocLineImpl extends ASTWrapperPsiElement
   @Override
   @NotNull
   public ElixirHeredocLinePrefix getHeredocLinePrefix() {
-    return findNotNullChildByClass(ElixirHeredocLinePrefix.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirHeredocLinePrefix.class));
   }
 
   @Override
   @NotNull
   public ElixirInterpolatedSigilBody getInterpolatedSigilBody() {
-    return findNotNullChildByClass(ElixirInterpolatedSigilBody.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirInterpolatedSigilBody.class));
   }
 
   public Body getBody() {

--- a/gen/org/elixir_lang/psi/impl/ElixirInterpolatedSigilLineImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirInterpolatedSigilLineImpl.java
@@ -7,6 +7,7 @@ import com.intellij.extapi.psi.ASTWrapperPsiElement;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.tree.IElementType;
+import com.intellij.psi.util.PsiTreeUtil;
 import org.elixir_lang.psi.*;
 import org.jetbrains.annotations.NotNull;
 
@@ -30,13 +31,13 @@ public class ElixirInterpolatedSigilLineImpl extends ASTWrapperPsiElement implem
   @Override
   @NotNull
   public ElixirInterpolatedSigilBody getInterpolatedSigilBody() {
-    return findNotNullChildByClass(ElixirInterpolatedSigilBody.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirInterpolatedSigilBody.class));
   }
 
   @Override
   @NotNull
   public ElixirSigilModifiers getSigilModifiers() {
-    return findNotNullChildByClass(ElixirSigilModifiers.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirSigilModifiers.class));
   }
 
   @NotNull

--- a/gen/org/elixir_lang/psi/impl/ElixirInterpolatedStringHeredocLineImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirInterpolatedStringHeredocLineImpl.java
@@ -5,6 +5,7 @@ import com.ericsson.otp.erlang.OtpErlangObject;
 import com.intellij.extapi.psi.ASTWrapperPsiElement;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElementVisitor;
+import com.intellij.psi.util.PsiTreeUtil;
 import org.elixir_lang.psi.*;
 import org.jetbrains.annotations.NotNull;
 
@@ -26,13 +27,13 @@ public class ElixirInterpolatedStringHeredocLineImpl extends ASTWrapperPsiElemen
   @Override
   @NotNull
   public ElixirHeredocLinePrefix getHeredocLinePrefix() {
-    return findNotNullChildByClass(ElixirHeredocLinePrefix.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirHeredocLinePrefix.class));
   }
 
   @Override
   @NotNull
   public ElixirInterpolatedStringBody getInterpolatedStringBody() {
-    return findNotNullChildByClass(ElixirInterpolatedStringBody.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirInterpolatedStringBody.class));
   }
 
   public Body getBody() {

--- a/gen/org/elixir_lang/psi/impl/ElixirInterpolatedStringSigilHeredocImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirInterpolatedStringSigilHeredocImpl.java
@@ -32,7 +32,7 @@ public class ElixirInterpolatedStringSigilHeredocImpl extends ASTWrapperPsiEleme
   @Override
   @Nullable
   public ElixirHeredocPrefix getHeredocPrefix() {
-    return findChildByClass(ElixirHeredocPrefix.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirHeredocPrefix.class);
   }
 
   @Override
@@ -44,7 +44,7 @@ public class ElixirInterpolatedStringSigilHeredocImpl extends ASTWrapperPsiEleme
   @Override
   @Nullable
   public ElixirSigilModifiers getSigilModifiers() {
-    return findChildByClass(ElixirSigilModifiers.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirSigilModifiers.class);
   }
 
   @NotNull

--- a/gen/org/elixir_lang/psi/impl/ElixirInterpolatedStringSigilLineImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirInterpolatedStringSigilLineImpl.java
@@ -7,6 +7,7 @@ import com.intellij.extapi.psi.ASTWrapperPsiElement;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.tree.IElementType;
+import com.intellij.psi.util.PsiTreeUtil;
 import org.elixir_lang.psi.*;
 import org.jetbrains.annotations.NotNull;
 
@@ -30,13 +31,13 @@ public class ElixirInterpolatedStringSigilLineImpl extends ASTWrapperPsiElement 
   @Override
   @NotNull
   public ElixirInterpolatedStringBody getInterpolatedStringBody() {
-    return findNotNullChildByClass(ElixirInterpolatedStringBody.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirInterpolatedStringBody.class));
   }
 
   @Override
   @NotNull
   public ElixirSigilModifiers getSigilModifiers() {
-    return findNotNullChildByClass(ElixirSigilModifiers.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirSigilModifiers.class));
   }
 
   @NotNull

--- a/gen/org/elixir_lang/psi/impl/ElixirInterpolatedWordsHeredocImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirInterpolatedWordsHeredocImpl.java
@@ -32,7 +32,7 @@ public class ElixirInterpolatedWordsHeredocImpl extends ASTWrapperPsiElement imp
   @Override
   @Nullable
   public ElixirHeredocPrefix getHeredocPrefix() {
-    return findChildByClass(ElixirHeredocPrefix.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirHeredocPrefix.class);
   }
 
   @Override
@@ -44,7 +44,7 @@ public class ElixirInterpolatedWordsHeredocImpl extends ASTWrapperPsiElement imp
   @Override
   @Nullable
   public ElixirSigilModifiers getSigilModifiers() {
-    return findChildByClass(ElixirSigilModifiers.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirSigilModifiers.class);
   }
 
   @NotNull

--- a/gen/org/elixir_lang/psi/impl/ElixirInterpolatedWordsHeredocLineImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirInterpolatedWordsHeredocLineImpl.java
@@ -5,6 +5,7 @@ import com.ericsson.otp.erlang.OtpErlangObject;
 import com.intellij.extapi.psi.ASTWrapperPsiElement;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElementVisitor;
+import com.intellij.psi.util.PsiTreeUtil;
 import org.elixir_lang.psi.*;
 import org.jetbrains.annotations.NotNull;
 
@@ -26,13 +27,13 @@ public class ElixirInterpolatedWordsHeredocLineImpl extends ASTWrapperPsiElement
   @Override
   @NotNull
   public ElixirHeredocLinePrefix getHeredocLinePrefix() {
-    return findNotNullChildByClass(ElixirHeredocLinePrefix.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirHeredocLinePrefix.class));
   }
 
   @Override
   @NotNull
   public ElixirInterpolatedWordsBody getInterpolatedWordsBody() {
-    return findNotNullChildByClass(ElixirInterpolatedWordsBody.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirInterpolatedWordsBody.class));
   }
 
   public Body getBody() {

--- a/gen/org/elixir_lang/psi/impl/ElixirInterpolatedWordsLineImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirInterpolatedWordsLineImpl.java
@@ -7,6 +7,7 @@ import com.intellij.extapi.psi.ASTWrapperPsiElement;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.tree.IElementType;
+import com.intellij.psi.util.PsiTreeUtil;
 import org.elixir_lang.psi.*;
 import org.jetbrains.annotations.NotNull;
 
@@ -30,13 +31,13 @@ public class ElixirInterpolatedWordsLineImpl extends ASTWrapperPsiElement implem
   @Override
   @NotNull
   public ElixirInterpolatedWordsBody getInterpolatedWordsBody() {
-    return findNotNullChildByClass(ElixirInterpolatedWordsBody.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirInterpolatedWordsBody.class));
   }
 
   @Override
   @NotNull
   public ElixirSigilModifiers getSigilModifiers() {
-    return findNotNullChildByClass(ElixirSigilModifiers.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirSigilModifiers.class));
   }
 
   @NotNull

--- a/gen/org/elixir_lang/psi/impl/ElixirKeywordKeyImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirKeywordKeyImpl.java
@@ -6,6 +6,7 @@ import com.intellij.extapi.psi.ASTWrapperPsiElement;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
+import com.intellij.psi.util.PsiTreeUtil;
 import org.elixir_lang.psi.ElixirCharListLine;
 import org.elixir_lang.psi.ElixirKeywordKey;
 import org.elixir_lang.psi.ElixirStringLine;
@@ -31,13 +32,13 @@ public class ElixirKeywordKeyImpl extends ASTWrapperPsiElement implements Elixir
   @Override
   @Nullable
   public ElixirCharListLine getCharListLine() {
-    return findChildByClass(ElixirCharListLine.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirCharListLine.class);
   }
 
   @Override
   @Nullable
   public ElixirStringLine getStringLine() {
-    return findChildByClass(ElixirStringLine.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirStringLine.class);
   }
 
   @Nullable

--- a/gen/org/elixir_lang/psi/impl/ElixirKeywordPairImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirKeywordPairImpl.java
@@ -5,6 +5,7 @@ import com.ericsson.otp.erlang.OtpErlangObject;
 import com.intellij.extapi.psi.ASTWrapperPsiElement;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElementVisitor;
+import com.intellij.psi.util.PsiTreeUtil;
 import org.elixir_lang.psi.*;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -27,19 +28,19 @@ public class ElixirKeywordPairImpl extends ASTWrapperPsiElement implements Elixi
   @Override
   @Nullable
   public ElixirEmptyParentheses getEmptyParentheses() {
-    return findChildByClass(ElixirEmptyParentheses.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirEmptyParentheses.class);
   }
 
   @Override
   @NotNull
   public ElixirKeywordKey getKeywordKey() {
-    return findNotNullChildByClass(ElixirKeywordKey.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirKeywordKey.class));
   }
 
   @Override
   @Nullable
   public ElixirUnmatchedExpression getUnmatchedExpression() {
-    return findChildByClass(ElixirUnmatchedExpression.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirUnmatchedExpression.class);
   }
 
   public Quotable getKeywordValue() {

--- a/gen/org/elixir_lang/psi/impl/ElixirListImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirListImpl.java
@@ -36,7 +36,7 @@ public class ElixirListImpl extends ASTWrapperPsiElement implements ElixirList {
   @Override
   @Nullable
   public ElixirKeywords getKeywords() {
-    return findChildByClass(ElixirKeywords.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirKeywords.class);
   }
 
   @Override

--- a/gen/org/elixir_lang/psi/impl/ElixirLiteralCharListHeredocLineImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirLiteralCharListHeredocLineImpl.java
@@ -5,6 +5,7 @@ import com.ericsson.otp.erlang.OtpErlangObject;
 import com.intellij.extapi.psi.ASTWrapperPsiElement;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElementVisitor;
+import com.intellij.psi.util.PsiTreeUtil;
 import org.elixir_lang.psi.*;
 import org.jetbrains.annotations.NotNull;
 
@@ -26,13 +27,13 @@ public class ElixirLiteralCharListHeredocLineImpl extends ASTWrapperPsiElement i
   @Override
   @NotNull
   public ElixirHeredocLinePrefix getHeredocLinePrefix() {
-    return findNotNullChildByClass(ElixirHeredocLinePrefix.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirHeredocLinePrefix.class));
   }
 
   @Override
   @NotNull
   public ElixirLiteralCharListBody getLiteralCharListBody() {
-    return findNotNullChildByClass(ElixirLiteralCharListBody.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirLiteralCharListBody.class));
   }
 
   public Body getBody() {

--- a/gen/org/elixir_lang/psi/impl/ElixirLiteralCharListSigilHeredocImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirLiteralCharListSigilHeredocImpl.java
@@ -32,7 +32,7 @@ public class ElixirLiteralCharListSigilHeredocImpl extends ASTWrapperPsiElement 
   @Override
   @Nullable
   public ElixirHeredocPrefix getHeredocPrefix() {
-    return findChildByClass(ElixirHeredocPrefix.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirHeredocPrefix.class);
   }
 
   @Override
@@ -44,7 +44,7 @@ public class ElixirLiteralCharListSigilHeredocImpl extends ASTWrapperPsiElement 
   @Override
   @Nullable
   public ElixirSigilModifiers getSigilModifiers() {
-    return findChildByClass(ElixirSigilModifiers.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirSigilModifiers.class);
   }
 
   @NotNull

--- a/gen/org/elixir_lang/psi/impl/ElixirLiteralCharListSigilLineImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirLiteralCharListSigilLineImpl.java
@@ -7,6 +7,7 @@ import com.intellij.extapi.psi.ASTWrapperPsiElement;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.tree.IElementType;
+import com.intellij.psi.util.PsiTreeUtil;
 import org.elixir_lang.psi.*;
 import org.jetbrains.annotations.NotNull;
 
@@ -30,13 +31,13 @@ public class ElixirLiteralCharListSigilLineImpl extends ASTWrapperPsiElement imp
   @Override
   @NotNull
   public ElixirLiteralCharListBody getLiteralCharListBody() {
-    return findNotNullChildByClass(ElixirLiteralCharListBody.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirLiteralCharListBody.class));
   }
 
   @Override
   @NotNull
   public ElixirSigilModifiers getSigilModifiers() {
-    return findNotNullChildByClass(ElixirSigilModifiers.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirSigilModifiers.class));
   }
 
   @NotNull

--- a/gen/org/elixir_lang/psi/impl/ElixirLiteralRegexHeredocImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirLiteralRegexHeredocImpl.java
@@ -32,7 +32,7 @@ public class ElixirLiteralRegexHeredocImpl extends ASTWrapperPsiElement implemen
   @Override
   @Nullable
   public ElixirHeredocPrefix getHeredocPrefix() {
-    return findChildByClass(ElixirHeredocPrefix.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirHeredocPrefix.class);
   }
 
   @Override
@@ -44,7 +44,7 @@ public class ElixirLiteralRegexHeredocImpl extends ASTWrapperPsiElement implemen
   @Override
   @Nullable
   public ElixirSigilModifiers getSigilModifiers() {
-    return findChildByClass(ElixirSigilModifiers.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirSigilModifiers.class);
   }
 
   @NotNull

--- a/gen/org/elixir_lang/psi/impl/ElixirLiteralRegexHeredocLineImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirLiteralRegexHeredocLineImpl.java
@@ -5,6 +5,7 @@ import com.ericsson.otp.erlang.OtpErlangObject;
 import com.intellij.extapi.psi.ASTWrapperPsiElement;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElementVisitor;
+import com.intellij.psi.util.PsiTreeUtil;
 import org.elixir_lang.psi.*;
 import org.jetbrains.annotations.NotNull;
 
@@ -26,13 +27,13 @@ public class ElixirLiteralRegexHeredocLineImpl extends ASTWrapperPsiElement impl
   @Override
   @NotNull
   public ElixirHeredocLinePrefix getHeredocLinePrefix() {
-    return findNotNullChildByClass(ElixirHeredocLinePrefix.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirHeredocLinePrefix.class));
   }
 
   @Override
   @NotNull
   public ElixirLiteralRegexBody getLiteralRegexBody() {
-    return findNotNullChildByClass(ElixirLiteralRegexBody.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirLiteralRegexBody.class));
   }
 
   public Body getBody() {

--- a/gen/org/elixir_lang/psi/impl/ElixirLiteralRegexLineImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirLiteralRegexLineImpl.java
@@ -7,6 +7,7 @@ import com.intellij.extapi.psi.ASTWrapperPsiElement;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.tree.IElementType;
+import com.intellij.psi.util.PsiTreeUtil;
 import org.elixir_lang.psi.*;
 import org.jetbrains.annotations.NotNull;
 
@@ -30,13 +31,13 @@ public class ElixirLiteralRegexLineImpl extends ASTWrapperPsiElement implements 
   @Override
   @NotNull
   public ElixirLiteralRegexBody getLiteralRegexBody() {
-    return findNotNullChildByClass(ElixirLiteralRegexBody.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirLiteralRegexBody.class));
   }
 
   @Override
   @NotNull
   public ElixirSigilModifiers getSigilModifiers() {
-    return findNotNullChildByClass(ElixirSigilModifiers.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirSigilModifiers.class));
   }
 
   @NotNull

--- a/gen/org/elixir_lang/psi/impl/ElixirLiteralSigilHeredocImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirLiteralSigilHeredocImpl.java
@@ -32,7 +32,7 @@ public class ElixirLiteralSigilHeredocImpl extends ASTWrapperPsiElement implemen
   @Override
   @Nullable
   public ElixirHeredocPrefix getHeredocPrefix() {
-    return findChildByClass(ElixirHeredocPrefix.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirHeredocPrefix.class);
   }
 
   @Override
@@ -44,7 +44,7 @@ public class ElixirLiteralSigilHeredocImpl extends ASTWrapperPsiElement implemen
   @Override
   @Nullable
   public ElixirSigilModifiers getSigilModifiers() {
-    return findChildByClass(ElixirSigilModifiers.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirSigilModifiers.class);
   }
 
   @NotNull

--- a/gen/org/elixir_lang/psi/impl/ElixirLiteralSigilHeredocLineImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirLiteralSigilHeredocLineImpl.java
@@ -5,6 +5,7 @@ import com.ericsson.otp.erlang.OtpErlangObject;
 import com.intellij.extapi.psi.ASTWrapperPsiElement;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElementVisitor;
+import com.intellij.psi.util.PsiTreeUtil;
 import org.elixir_lang.psi.*;
 import org.jetbrains.annotations.NotNull;
 
@@ -26,13 +27,13 @@ public class ElixirLiteralSigilHeredocLineImpl extends ASTWrapperPsiElement impl
   @Override
   @NotNull
   public ElixirHeredocLinePrefix getHeredocLinePrefix() {
-    return findNotNullChildByClass(ElixirHeredocLinePrefix.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirHeredocLinePrefix.class));
   }
 
   @Override
   @NotNull
   public ElixirLiteralSigilBody getLiteralSigilBody() {
-    return findNotNullChildByClass(ElixirLiteralSigilBody.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirLiteralSigilBody.class));
   }
 
   public Body getBody() {

--- a/gen/org/elixir_lang/psi/impl/ElixirLiteralSigilLineImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirLiteralSigilLineImpl.java
@@ -7,6 +7,7 @@ import com.intellij.extapi.psi.ASTWrapperPsiElement;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.tree.IElementType;
+import com.intellij.psi.util.PsiTreeUtil;
 import org.elixir_lang.psi.*;
 import org.jetbrains.annotations.NotNull;
 
@@ -30,13 +31,13 @@ public class ElixirLiteralSigilLineImpl extends ASTWrapperPsiElement implements 
   @Override
   @NotNull
   public ElixirLiteralSigilBody getLiteralSigilBody() {
-    return findNotNullChildByClass(ElixirLiteralSigilBody.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirLiteralSigilBody.class));
   }
 
   @Override
   @NotNull
   public ElixirSigilModifiers getSigilModifiers() {
-    return findNotNullChildByClass(ElixirSigilModifiers.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirSigilModifiers.class));
   }
 
   @NotNull

--- a/gen/org/elixir_lang/psi/impl/ElixirLiteralStringHeredocLineImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirLiteralStringHeredocLineImpl.java
@@ -5,6 +5,7 @@ import com.ericsson.otp.erlang.OtpErlangObject;
 import com.intellij.extapi.psi.ASTWrapperPsiElement;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElementVisitor;
+import com.intellij.psi.util.PsiTreeUtil;
 import org.elixir_lang.psi.*;
 import org.jetbrains.annotations.NotNull;
 
@@ -26,13 +27,13 @@ public class ElixirLiteralStringHeredocLineImpl extends ASTWrapperPsiElement imp
   @Override
   @NotNull
   public ElixirHeredocLinePrefix getHeredocLinePrefix() {
-    return findNotNullChildByClass(ElixirHeredocLinePrefix.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirHeredocLinePrefix.class));
   }
 
   @Override
   @NotNull
   public ElixirLiteralStringBody getLiteralStringBody() {
-    return findNotNullChildByClass(ElixirLiteralStringBody.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirLiteralStringBody.class));
   }
 
   public Body getBody() {

--- a/gen/org/elixir_lang/psi/impl/ElixirLiteralStringSigilHeredocImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirLiteralStringSigilHeredocImpl.java
@@ -32,7 +32,7 @@ public class ElixirLiteralStringSigilHeredocImpl extends ASTWrapperPsiElement im
   @Override
   @Nullable
   public ElixirHeredocPrefix getHeredocPrefix() {
-    return findChildByClass(ElixirHeredocPrefix.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirHeredocPrefix.class);
   }
 
   @Override
@@ -44,7 +44,7 @@ public class ElixirLiteralStringSigilHeredocImpl extends ASTWrapperPsiElement im
   @Override
   @Nullable
   public ElixirSigilModifiers getSigilModifiers() {
-    return findChildByClass(ElixirSigilModifiers.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirSigilModifiers.class);
   }
 
   @NotNull

--- a/gen/org/elixir_lang/psi/impl/ElixirLiteralStringSigilLineImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirLiteralStringSigilLineImpl.java
@@ -7,6 +7,7 @@ import com.intellij.extapi.psi.ASTWrapperPsiElement;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.tree.IElementType;
+import com.intellij.psi.util.PsiTreeUtil;
 import org.elixir_lang.psi.*;
 import org.jetbrains.annotations.NotNull;
 
@@ -30,13 +31,13 @@ public class ElixirLiteralStringSigilLineImpl extends ASTWrapperPsiElement imple
   @Override
   @NotNull
   public ElixirLiteralStringBody getLiteralStringBody() {
-    return findNotNullChildByClass(ElixirLiteralStringBody.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirLiteralStringBody.class));
   }
 
   @Override
   @NotNull
   public ElixirSigilModifiers getSigilModifiers() {
-    return findNotNullChildByClass(ElixirSigilModifiers.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirSigilModifiers.class));
   }
 
   @NotNull

--- a/gen/org/elixir_lang/psi/impl/ElixirLiteralWordsHeredocImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirLiteralWordsHeredocImpl.java
@@ -32,7 +32,7 @@ public class ElixirLiteralWordsHeredocImpl extends ASTWrapperPsiElement implemen
   @Override
   @Nullable
   public ElixirHeredocPrefix getHeredocPrefix() {
-    return findChildByClass(ElixirHeredocPrefix.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirHeredocPrefix.class);
   }
 
   @Override
@@ -44,7 +44,7 @@ public class ElixirLiteralWordsHeredocImpl extends ASTWrapperPsiElement implemen
   @Override
   @Nullable
   public ElixirSigilModifiers getSigilModifiers() {
-    return findChildByClass(ElixirSigilModifiers.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirSigilModifiers.class);
   }
 
   @NotNull

--- a/gen/org/elixir_lang/psi/impl/ElixirLiteralWordsHeredocLineImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirLiteralWordsHeredocLineImpl.java
@@ -5,6 +5,7 @@ import com.ericsson.otp.erlang.OtpErlangObject;
 import com.intellij.extapi.psi.ASTWrapperPsiElement;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElementVisitor;
+import com.intellij.psi.util.PsiTreeUtil;
 import org.elixir_lang.psi.*;
 import org.jetbrains.annotations.NotNull;
 
@@ -26,13 +27,13 @@ public class ElixirLiteralWordsHeredocLineImpl extends ASTWrapperPsiElement impl
   @Override
   @NotNull
   public ElixirHeredocLinePrefix getHeredocLinePrefix() {
-    return findNotNullChildByClass(ElixirHeredocLinePrefix.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirHeredocLinePrefix.class));
   }
 
   @Override
   @NotNull
   public ElixirLiteralWordsBody getLiteralWordsBody() {
-    return findNotNullChildByClass(ElixirLiteralWordsBody.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirLiteralWordsBody.class));
   }
 
   public Body getBody() {

--- a/gen/org/elixir_lang/psi/impl/ElixirLiteralWordsLineImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirLiteralWordsLineImpl.java
@@ -7,6 +7,7 @@ import com.intellij.extapi.psi.ASTWrapperPsiElement;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.tree.IElementType;
+import com.intellij.psi.util.PsiTreeUtil;
 import org.elixir_lang.psi.*;
 import org.jetbrains.annotations.NotNull;
 
@@ -30,13 +31,13 @@ public class ElixirLiteralWordsLineImpl extends ASTWrapperPsiElement implements 
   @Override
   @NotNull
   public ElixirLiteralWordsBody getLiteralWordsBody() {
-    return findNotNullChildByClass(ElixirLiteralWordsBody.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirLiteralWordsBody.class));
   }
 
   @Override
   @NotNull
   public ElixirSigilModifiers getSigilModifiers() {
-    return findNotNullChildByClass(ElixirSigilModifiers.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirSigilModifiers.class));
   }
 
   @NotNull

--- a/gen/org/elixir_lang/psi/impl/ElixirMapArgumentsImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMapArgumentsImpl.java
@@ -5,6 +5,7 @@ import com.ericsson.otp.erlang.OtpErlangObject;
 import com.intellij.extapi.psi.ASTWrapperPsiElement;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElementVisitor;
+import com.intellij.psi.util.PsiTreeUtil;
 import org.elixir_lang.psi.ElixirMapArguments;
 import org.elixir_lang.psi.ElixirMapConstructionArguments;
 import org.elixir_lang.psi.ElixirMapUpdateArguments;
@@ -30,13 +31,13 @@ public class ElixirMapArgumentsImpl extends ASTWrapperPsiElement implements Elix
   @Override
   @Nullable
   public ElixirMapConstructionArguments getMapConstructionArguments() {
-    return findChildByClass(ElixirMapConstructionArguments.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirMapConstructionArguments.class);
   }
 
   @Override
   @Nullable
   public ElixirMapUpdateArguments getMapUpdateArguments() {
-    return findChildByClass(ElixirMapUpdateArguments.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirMapUpdateArguments.class);
   }
 
   @NotNull

--- a/gen/org/elixir_lang/psi/impl/ElixirMapConstructionArgumentsImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMapConstructionArgumentsImpl.java
@@ -6,6 +6,7 @@ import com.intellij.extapi.psi.ASTWrapperPsiElement;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
+import com.intellij.psi.util.PsiTreeUtil;
 import org.elixir_lang.psi.*;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -28,19 +29,19 @@ public class ElixirMapConstructionArgumentsImpl extends ASTWrapperPsiElement imp
   @Override
   @Nullable
   public ElixirAssociations getAssociations() {
-    return findChildByClass(ElixirAssociations.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirAssociations.class);
   }
 
   @Override
   @Nullable
   public ElixirAssociationsBase getAssociationsBase() {
-    return findChildByClass(ElixirAssociationsBase.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirAssociationsBase.class);
   }
 
   @Override
   @Nullable
   public ElixirKeywords getKeywords() {
-    return findChildByClass(ElixirKeywords.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirKeywords.class);
   }
 
   @NotNull

--- a/gen/org/elixir_lang/psi/impl/ElixirMapOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMapOperationImpl.java
@@ -5,6 +5,7 @@ import com.ericsson.otp.erlang.OtpErlangObject;
 import com.intellij.extapi.psi.ASTWrapperPsiElement;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElementVisitor;
+import com.intellij.psi.util.PsiTreeUtil;
 import org.elixir_lang.psi.ElixirMapArguments;
 import org.elixir_lang.psi.ElixirMapOperation;
 import org.elixir_lang.psi.ElixirMapPrefixOperator;
@@ -29,13 +30,13 @@ public class ElixirMapOperationImpl extends ASTWrapperPsiElement implements Elix
   @Override
   @NotNull
   public ElixirMapArguments getMapArguments() {
-    return findNotNullChildByClass(ElixirMapArguments.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirMapArguments.class));
   }
 
   @Override
   @NotNull
   public ElixirMapPrefixOperator getMapPrefixOperator() {
-    return findNotNullChildByClass(ElixirMapPrefixOperator.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirMapPrefixOperator.class));
   }
 
   @NotNull

--- a/gen/org/elixir_lang/psi/impl/ElixirMapUpdateArgumentsImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMapUpdateArgumentsImpl.java
@@ -5,6 +5,7 @@ import com.ericsson.otp.erlang.OtpErlangObject;
 import com.intellij.extapi.psi.ASTWrapperPsiElement;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElementVisitor;
+import com.intellij.psi.util.PsiTreeUtil;
 import org.elixir_lang.psi.*;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -27,31 +28,31 @@ public class ElixirMapUpdateArgumentsImpl extends ASTWrapperPsiElement implement
   @Override
   @Nullable
   public ElixirAssociations getAssociations() {
-    return findChildByClass(ElixirAssociations.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirAssociations.class);
   }
 
   @Override
   @Nullable
   public ElixirAssociationsBase getAssociationsBase() {
-    return findChildByClass(ElixirAssociationsBase.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirAssociationsBase.class);
   }
 
   @Override
   @Nullable
   public ElixirKeywords getKeywords() {
-    return findChildByClass(ElixirKeywords.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirKeywords.class);
   }
 
   @Override
   @NotNull
   public ElixirMatchedMatchOperation getMatchedMatchOperation() {
-    return findNotNullChildByClass(ElixirMatchedMatchOperation.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirMatchedMatchOperation.class));
   }
 
   @Override
   @NotNull
   public ElixirPipeInfixOperator getPipeInfixOperator() {
-    return findNotNullChildByClass(ElixirPipeInfixOperator.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirPipeInfixOperator.class));
   }
 
   @NotNull

--- a/gen/org/elixir_lang/psi/impl/ElixirMatchedAdditionOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMatchedAdditionOperationImpl.java
@@ -33,7 +33,7 @@ public class ElixirMatchedAdditionOperationImpl extends ElixirMatchedExpressionI
   @Override
   @NotNull
   public ElixirAdditionInfixOperator getAdditionInfixOperator() {
-    return findNotNullChildByClass(ElixirAdditionInfixOperator.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirAdditionInfixOperator.class));
   }
 
   @Override

--- a/gen/org/elixir_lang/psi/impl/ElixirMatchedAndOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMatchedAndOperationImpl.java
@@ -34,7 +34,7 @@ public class ElixirMatchedAndOperationImpl extends ElixirMatchedExpressionImpl i
   @Override
   @NotNull
   public ElixirAndInfixOperator getAndInfixOperator() {
-    return findNotNullChildByClass(ElixirAndInfixOperator.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirAndInfixOperator.class));
   }
 
   @Override

--- a/gen/org/elixir_lang/psi/impl/ElixirMatchedArrowOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMatchedArrowOperationImpl.java
@@ -33,7 +33,7 @@ public class ElixirMatchedArrowOperationImpl extends ElixirMatchedExpressionImpl
   @Override
   @NotNull
   public ElixirArrowInfixOperator getArrowInfixOperator() {
-    return findNotNullChildByClass(ElixirArrowInfixOperator.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirArrowInfixOperator.class));
   }
 
   @Override

--- a/gen/org/elixir_lang/psi/impl/ElixirMatchedAtNonNumericOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMatchedAtNonNumericOperationImpl.java
@@ -5,6 +5,7 @@ import com.ericsson.otp.erlang.OtpErlangObject;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.PsiReference;
+import com.intellij.psi.util.PsiTreeUtil;
 import org.elixir_lang.psi.*;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -27,13 +28,13 @@ public class ElixirMatchedAtNonNumericOperationImpl extends ElixirMatchedExpress
   @Override
   @NotNull
   public ElixirAtPrefixOperator getAtPrefixOperator() {
-    return findNotNullChildByClass(ElixirAtPrefixOperator.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirAtPrefixOperator.class));
   }
 
   @Override
   @Nullable
   public ElixirMatchedExpression getMatchedExpression() {
-    return findChildByClass(ElixirMatchedExpression.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirMatchedExpression.class);
   }
 
   @Nullable

--- a/gen/org/elixir_lang/psi/impl/ElixirMatchedAtUnqualifiedBracketOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMatchedAtUnqualifiedBracketOperationImpl.java
@@ -4,6 +4,7 @@ package org.elixir_lang.psi.impl;
 import com.ericsson.otp.erlang.OtpErlangObject;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElementVisitor;
+import com.intellij.psi.util.PsiTreeUtil;
 import org.elixir_lang.psi.ElixirAtPrefixOperator;
 import org.elixir_lang.psi.ElixirBracketArguments;
 import org.elixir_lang.psi.ElixirMatchedAtUnqualifiedBracketOperation;
@@ -28,13 +29,13 @@ public class ElixirMatchedAtUnqualifiedBracketOperationImpl extends ElixirMatche
   @Override
   @NotNull
   public ElixirAtPrefixOperator getAtPrefixOperator() {
-    return findNotNullChildByClass(ElixirAtPrefixOperator.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirAtPrefixOperator.class));
   }
 
   @Override
   @NotNull
   public ElixirBracketArguments getBracketArguments() {
-    return findNotNullChildByClass(ElixirBracketArguments.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirBracketArguments.class));
   }
 
   @NotNull

--- a/gen/org/elixir_lang/psi/impl/ElixirMatchedAtUnqualifiedNoParenthesesCallImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMatchedAtUnqualifiedNoParenthesesCallImpl.java
@@ -10,6 +10,7 @@ import com.intellij.psi.ResolveState;
 import com.intellij.psi.scope.PsiScopeProcessor;
 import com.intellij.psi.search.SearchScope;
 import com.intellij.psi.stubs.IStubElementType;
+import com.intellij.psi.util.PsiTreeUtil;
 import org.apache.commons.lang.math.IntRange;
 import org.elixir_lang.psi.*;
 import org.elixir_lang.psi.stub.MatchedAtUnqualifiedNoParenthesesCall;
@@ -38,13 +39,13 @@ public class ElixirMatchedAtUnqualifiedNoParenthesesCallImpl extends NamedStubbe
   @Override
   @NotNull
   public ElixirAtIdentifier getAtIdentifier() {
-    return findNotNullChildByClass(ElixirAtIdentifier.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirAtIdentifier.class));
   }
 
   @Override
   @NotNull
   public ElixirNoParenthesesOneArgument getNoParenthesesOneArgument() {
-    return findNotNullChildByClass(ElixirNoParenthesesOneArgument.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirNoParenthesesOneArgument.class));
   }
 
   @Nullable

--- a/gen/org/elixir_lang/psi/impl/ElixirMatchedBracketOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMatchedBracketOperationImpl.java
@@ -4,6 +4,7 @@ package org.elixir_lang.psi.impl;
 import com.ericsson.otp.erlang.OtpErlangObject;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElementVisitor;
+import com.intellij.psi.util.PsiTreeUtil;
 import org.elixir_lang.psi.ElixirBracketArguments;
 import org.elixir_lang.psi.ElixirMatchedBracketOperation;
 import org.elixir_lang.psi.ElixirMatchedExpression;
@@ -28,13 +29,13 @@ public class ElixirMatchedBracketOperationImpl extends ElixirMatchedExpressionIm
   @Override
   @NotNull
   public ElixirBracketArguments getBracketArguments() {
-    return findNotNullChildByClass(ElixirBracketArguments.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirBracketArguments.class));
   }
 
   @Override
   @NotNull
   public ElixirMatchedExpression getMatchedExpression() {
-    return findNotNullChildByClass(ElixirMatchedExpression.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirMatchedExpression.class));
   }
 
   @NotNull

--- a/gen/org/elixir_lang/psi/impl/ElixirMatchedCaptureNonNumericOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMatchedCaptureNonNumericOperationImpl.java
@@ -5,6 +5,7 @@ import com.ericsson.otp.erlang.OtpErlangObject;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
+import com.intellij.psi.util.PsiTreeUtil;
 import org.apache.commons.lang.math.IntRange;
 import org.elixir_lang.psi.*;
 import org.jetbrains.annotations.NotNull;
@@ -28,13 +29,13 @@ public class ElixirMatchedCaptureNonNumericOperationImpl extends ElixirMatchedEx
   @Override
   @NotNull
   public ElixirCapturePrefixOperator getCapturePrefixOperator() {
-    return findNotNullChildByClass(ElixirCapturePrefixOperator.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirCapturePrefixOperator.class));
   }
 
   @Override
   @Nullable
   public ElixirMatchedExpression getMatchedExpression() {
-    return findChildByClass(ElixirMatchedExpression.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirMatchedExpression.class);
   }
 
   @Nullable

--- a/gen/org/elixir_lang/psi/impl/ElixirMatchedComparisonOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMatchedComparisonOperationImpl.java
@@ -33,7 +33,7 @@ public class ElixirMatchedComparisonOperationImpl extends ElixirMatchedExpressio
   @Override
   @NotNull
   public ElixirComparisonInfixOperator getComparisonInfixOperator() {
-    return findNotNullChildByClass(ElixirComparisonInfixOperator.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirComparisonInfixOperator.class));
   }
 
   @Override

--- a/gen/org/elixir_lang/psi/impl/ElixirMatchedDotCallImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMatchedDotCallImpl.java
@@ -40,13 +40,13 @@ public class ElixirMatchedDotCallImpl extends NamedStubbedPsiElementBase<Matched
   @Override
   @NotNull
   public ElixirDotInfixOperator getDotInfixOperator() {
-    return findNotNullChildByClass(ElixirDotInfixOperator.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirDotInfixOperator.class));
   }
 
   @Override
   @NotNull
   public ElixirMatchedExpression getMatchedExpression() {
-    return findNotNullChildByClass(ElixirMatchedExpression.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirMatchedExpression.class));
   }
 
   @Override

--- a/gen/org/elixir_lang/psi/impl/ElixirMatchedInMatchOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMatchedInMatchOperationImpl.java
@@ -33,7 +33,7 @@ public class ElixirMatchedInMatchOperationImpl extends ElixirMatchedExpressionIm
   @Override
   @NotNull
   public ElixirInMatchInfixOperator getInMatchInfixOperator() {
-    return findNotNullChildByClass(ElixirInMatchInfixOperator.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirInMatchInfixOperator.class));
   }
 
   @Override

--- a/gen/org/elixir_lang/psi/impl/ElixirMatchedInOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMatchedInOperationImpl.java
@@ -33,7 +33,7 @@ public class ElixirMatchedInOperationImpl extends ElixirMatchedExpressionImpl im
   @Override
   @NotNull
   public ElixirInInfixOperator getInInfixOperator() {
-    return findNotNullChildByClass(ElixirInInfixOperator.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirInInfixOperator.class));
   }
 
   @Override

--- a/gen/org/elixir_lang/psi/impl/ElixirMatchedMatchOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMatchedMatchOperationImpl.java
@@ -34,7 +34,7 @@ public class ElixirMatchedMatchOperationImpl extends ElixirMatchedExpressionImpl
   @Override
   @NotNull
   public ElixirMatchInfixOperator getMatchInfixOperator() {
-    return findNotNullChildByClass(ElixirMatchInfixOperator.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirMatchInfixOperator.class));
   }
 
   @Override

--- a/gen/org/elixir_lang/psi/impl/ElixirMatchedMultiplicationOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMatchedMultiplicationOperationImpl.java
@@ -39,7 +39,7 @@ public class ElixirMatchedMultiplicationOperationImpl extends ElixirMatchedExpre
   @Override
   @NotNull
   public ElixirMultiplicationInfixOperator getMultiplicationInfixOperator() {
-    return findNotNullChildByClass(ElixirMultiplicationInfixOperator.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirMultiplicationInfixOperator.class));
   }
 
   @Nullable

--- a/gen/org/elixir_lang/psi/impl/ElixirMatchedOrOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMatchedOrOperationImpl.java
@@ -39,7 +39,7 @@ public class ElixirMatchedOrOperationImpl extends ElixirMatchedExpressionImpl im
   @Override
   @NotNull
   public ElixirOrInfixOperator getOrInfixOperator() {
-    return findNotNullChildByClass(ElixirOrInfixOperator.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirOrInfixOperator.class));
   }
 
   @Nullable

--- a/gen/org/elixir_lang/psi/impl/ElixirMatchedPipeOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMatchedPipeOperationImpl.java
@@ -39,7 +39,7 @@ public class ElixirMatchedPipeOperationImpl extends ElixirMatchedExpressionImpl 
   @Override
   @NotNull
   public ElixirPipeInfixOperator getPipeInfixOperator() {
-    return findNotNullChildByClass(ElixirPipeInfixOperator.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirPipeInfixOperator.class));
   }
 
   @Nullable

--- a/gen/org/elixir_lang/psi/impl/ElixirMatchedQualifiedAliasImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMatchedQualifiedAliasImpl.java
@@ -8,6 +8,7 @@ import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.PsiReference;
 import com.intellij.psi.ResolveState;
 import com.intellij.psi.scope.PsiScopeProcessor;
+import com.intellij.psi.util.PsiTreeUtil;
 import org.elixir_lang.psi.*;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -30,19 +31,19 @@ public class ElixirMatchedQualifiedAliasImpl extends ElixirMatchedExpressionImpl
   @Override
   @NotNull
   public ElixirAlias getAlias() {
-    return findNotNullChildByClass(ElixirAlias.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirAlias.class));
   }
 
   @Override
   @NotNull
   public ElixirDotInfixOperator getDotInfixOperator() {
-    return findNotNullChildByClass(ElixirDotInfixOperator.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirDotInfixOperator.class));
   }
 
   @Override
   @NotNull
   public ElixirMatchedExpression getMatchedExpression() {
-    return findNotNullChildByClass(ElixirMatchedExpression.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirMatchedExpression.class));
   }
 
   @Nullable

--- a/gen/org/elixir_lang/psi/impl/ElixirMatchedQualifiedBracketOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMatchedQualifiedBracketOperationImpl.java
@@ -4,6 +4,7 @@ package org.elixir_lang.psi.impl;
 import com.ericsson.otp.erlang.OtpErlangObject;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElementVisitor;
+import com.intellij.psi.util.PsiTreeUtil;
 import org.elixir_lang.psi.*;
 import org.jetbrains.annotations.NotNull;
 
@@ -25,25 +26,25 @@ public class ElixirMatchedQualifiedBracketOperationImpl extends ElixirMatchedExp
   @Override
   @NotNull
   public ElixirBracketArguments getBracketArguments() {
-    return findNotNullChildByClass(ElixirBracketArguments.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirBracketArguments.class));
   }
 
   @Override
   @NotNull
   public ElixirDotInfixOperator getDotInfixOperator() {
-    return findNotNullChildByClass(ElixirDotInfixOperator.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirDotInfixOperator.class));
   }
 
   @Override
   @NotNull
   public ElixirMatchedExpression getMatchedExpression() {
-    return findNotNullChildByClass(ElixirMatchedExpression.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirMatchedExpression.class));
   }
 
   @Override
   @NotNull
   public ElixirRelativeIdentifier getRelativeIdentifier() {
-    return findNotNullChildByClass(ElixirRelativeIdentifier.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirRelativeIdentifier.class));
   }
 
   @NotNull

--- a/gen/org/elixir_lang/psi/impl/ElixirMatchedQualifiedNoArgumentsCallImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMatchedQualifiedNoArgumentsCallImpl.java
@@ -9,6 +9,7 @@ import com.intellij.psi.PsiReference;
 import com.intellij.psi.ResolveState;
 import com.intellij.psi.scope.PsiScopeProcessor;
 import com.intellij.psi.stubs.IStubElementType;
+import com.intellij.psi.util.PsiTreeUtil;
 import org.apache.commons.lang.math.IntRange;
 import org.elixir_lang.psi.*;
 import org.elixir_lang.psi.stub.MatchedQualifiedNoArgumentsCall;
@@ -37,19 +38,19 @@ public class ElixirMatchedQualifiedNoArgumentsCallImpl extends NamedStubbedPsiEl
   @Override
   @NotNull
   public ElixirDotInfixOperator getDotInfixOperator() {
-    return findNotNullChildByClass(ElixirDotInfixOperator.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirDotInfixOperator.class));
   }
 
   @Override
   @NotNull
   public ElixirMatchedExpression getMatchedExpression() {
-    return findNotNullChildByClass(ElixirMatchedExpression.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirMatchedExpression.class));
   }
 
   @Override
   @NotNull
   public ElixirRelativeIdentifier getRelativeIdentifier() {
-    return findNotNullChildByClass(ElixirRelativeIdentifier.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirRelativeIdentifier.class));
   }
 
   @Nullable

--- a/gen/org/elixir_lang/psi/impl/ElixirMatchedQualifiedNoParenthesesCallImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMatchedQualifiedNoParenthesesCallImpl.java
@@ -9,6 +9,7 @@ import com.intellij.psi.PsiReference;
 import com.intellij.psi.ResolveState;
 import com.intellij.psi.scope.PsiScopeProcessor;
 import com.intellij.psi.stubs.IStubElementType;
+import com.intellij.psi.util.PsiTreeUtil;
 import org.apache.commons.lang.math.IntRange;
 import org.elixir_lang.psi.*;
 import org.elixir_lang.psi.stub.MatchedQualifiedNoParenthesesCall;
@@ -37,25 +38,25 @@ public class ElixirMatchedQualifiedNoParenthesesCallImpl extends NamedStubbedPsi
   @Override
   @NotNull
   public ElixirDotInfixOperator getDotInfixOperator() {
-    return findNotNullChildByClass(ElixirDotInfixOperator.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirDotInfixOperator.class));
   }
 
   @Override
   @NotNull
   public ElixirMatchedExpression getMatchedExpression() {
-    return findNotNullChildByClass(ElixirMatchedExpression.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirMatchedExpression.class));
   }
 
   @Override
   @NotNull
   public ElixirNoParenthesesOneArgument getNoParenthesesOneArgument() {
-    return findNotNullChildByClass(ElixirNoParenthesesOneArgument.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirNoParenthesesOneArgument.class));
   }
 
   @Override
   @NotNull
   public ElixirRelativeIdentifier getRelativeIdentifier() {
-    return findNotNullChildByClass(ElixirRelativeIdentifier.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirRelativeIdentifier.class));
   }
 
   @Nullable

--- a/gen/org/elixir_lang/psi/impl/ElixirMatchedQualifiedParenthesesCallImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMatchedQualifiedParenthesesCallImpl.java
@@ -9,6 +9,7 @@ import com.intellij.psi.PsiReference;
 import com.intellij.psi.ResolveState;
 import com.intellij.psi.scope.PsiScopeProcessor;
 import com.intellij.psi.stubs.IStubElementType;
+import com.intellij.psi.util.PsiTreeUtil;
 import org.apache.commons.lang.math.IntRange;
 import org.elixir_lang.psi.*;
 import org.elixir_lang.psi.stub.MatchedQualifiedParenthesesCall;
@@ -37,25 +38,25 @@ public class ElixirMatchedQualifiedParenthesesCallImpl extends NamedStubbedPsiEl
   @Override
   @NotNull
   public ElixirDotInfixOperator getDotInfixOperator() {
-    return findNotNullChildByClass(ElixirDotInfixOperator.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirDotInfixOperator.class));
   }
 
   @Override
   @NotNull
   public ElixirMatchedExpression getMatchedExpression() {
-    return findNotNullChildByClass(ElixirMatchedExpression.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirMatchedExpression.class));
   }
 
   @Override
   @NotNull
   public ElixirMatchedParenthesesArguments getMatchedParenthesesArguments() {
-    return findNotNullChildByClass(ElixirMatchedParenthesesArguments.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirMatchedParenthesesArguments.class));
   }
 
   @Override
   @NotNull
   public ElixirRelativeIdentifier getRelativeIdentifier() {
-    return findNotNullChildByClass(ElixirRelativeIdentifier.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirRelativeIdentifier.class));
   }
 
   @Nullable

--- a/gen/org/elixir_lang/psi/impl/ElixirMatchedRelationalOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMatchedRelationalOperationImpl.java
@@ -39,7 +39,7 @@ public class ElixirMatchedRelationalOperationImpl extends ElixirMatchedExpressio
   @Override
   @NotNull
   public ElixirRelationalInfixOperator getRelationalInfixOperator() {
-    return findNotNullChildByClass(ElixirRelationalInfixOperator.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirRelationalInfixOperator.class));
   }
 
   @Nullable

--- a/gen/org/elixir_lang/psi/impl/ElixirMatchedTwoOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMatchedTwoOperationImpl.java
@@ -39,7 +39,7 @@ public class ElixirMatchedTwoOperationImpl extends ElixirMatchedExpressionImpl i
   @Override
   @NotNull
   public ElixirTwoInfixOperator getTwoInfixOperator() {
-    return findNotNullChildByClass(ElixirTwoInfixOperator.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirTwoInfixOperator.class));
   }
 
   @Nullable

--- a/gen/org/elixir_lang/psi/impl/ElixirMatchedTypeOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMatchedTypeOperationImpl.java
@@ -39,7 +39,7 @@ public class ElixirMatchedTypeOperationImpl extends ElixirMatchedExpressionImpl 
   @Override
   @NotNull
   public ElixirTypeInfixOperator getTypeInfixOperator() {
-    return findNotNullChildByClass(ElixirTypeInfixOperator.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirTypeInfixOperator.class));
   }
 
   @Nullable

--- a/gen/org/elixir_lang/psi/impl/ElixirMatchedUnaryNonNumericOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMatchedUnaryNonNumericOperationImpl.java
@@ -5,6 +5,7 @@ import com.ericsson.otp.erlang.OtpErlangObject;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
+import com.intellij.psi.util.PsiTreeUtil;
 import org.apache.commons.lang.math.IntRange;
 import org.elixir_lang.psi.*;
 import org.jetbrains.annotations.NotNull;
@@ -28,13 +29,13 @@ public class ElixirMatchedUnaryNonNumericOperationImpl extends ElixirMatchedExpr
   @Override
   @Nullable
   public ElixirMatchedExpression getMatchedExpression() {
-    return findChildByClass(ElixirMatchedExpression.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirMatchedExpression.class);
   }
 
   @Override
   @NotNull
   public ElixirUnaryPrefixOperator getUnaryPrefixOperator() {
-    return findNotNullChildByClass(ElixirUnaryPrefixOperator.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirUnaryPrefixOperator.class));
   }
 
   @Nullable

--- a/gen/org/elixir_lang/psi/impl/ElixirMatchedUnqualifiedBracketOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMatchedUnqualifiedBracketOperationImpl.java
@@ -4,6 +4,7 @@ package org.elixir_lang.psi.impl;
 import com.ericsson.otp.erlang.OtpErlangObject;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElementVisitor;
+import com.intellij.psi.util.PsiTreeUtil;
 import org.elixir_lang.psi.ElixirBracketArguments;
 import org.elixir_lang.psi.ElixirIdentifier;
 import org.elixir_lang.psi.ElixirMatchedUnqualifiedBracketOperation;
@@ -28,13 +29,13 @@ public class ElixirMatchedUnqualifiedBracketOperationImpl extends ElixirMatchedE
   @Override
   @NotNull
   public ElixirBracketArguments getBracketArguments() {
-    return findNotNullChildByClass(ElixirBracketArguments.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirBracketArguments.class));
   }
 
   @Override
   @NotNull
   public ElixirIdentifier getIdentifier() {
-    return findNotNullChildByClass(ElixirIdentifier.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirIdentifier.class));
   }
 
   @NotNull

--- a/gen/org/elixir_lang/psi/impl/ElixirMatchedUnqualifiedNoArgumentsCallImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMatchedUnqualifiedNoArgumentsCallImpl.java
@@ -10,6 +10,7 @@ import com.intellij.psi.ResolveState;
 import com.intellij.psi.scope.PsiScopeProcessor;
 import com.intellij.psi.search.SearchScope;
 import com.intellij.psi.stubs.IStubElementType;
+import com.intellij.psi.util.PsiTreeUtil;
 import org.apache.commons.lang.math.IntRange;
 import org.elixir_lang.psi.ElixirDoBlock;
 import org.elixir_lang.psi.ElixirIdentifier;
@@ -41,7 +42,7 @@ public class ElixirMatchedUnqualifiedNoArgumentsCallImpl extends NamedStubbedPsi
   @Override
   @NotNull
   public ElixirIdentifier getIdentifier() {
-    return findNotNullChildByClass(ElixirIdentifier.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirIdentifier.class));
   }
 
   @Nullable

--- a/gen/org/elixir_lang/psi/impl/ElixirMatchedUnqualifiedNoParenthesesCallImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMatchedUnqualifiedNoParenthesesCallImpl.java
@@ -9,6 +9,7 @@ import com.intellij.psi.PsiReference;
 import com.intellij.psi.ResolveState;
 import com.intellij.psi.scope.PsiScopeProcessor;
 import com.intellij.psi.stubs.IStubElementType;
+import com.intellij.psi.util.PsiTreeUtil;
 import org.apache.commons.lang.math.IntRange;
 import org.elixir_lang.psi.*;
 import org.elixir_lang.psi.stub.MatchedUnqualifiedNoParenthesesCall;
@@ -37,13 +38,13 @@ public class ElixirMatchedUnqualifiedNoParenthesesCallImpl extends NamedStubbedP
   @Override
   @NotNull
   public ElixirIdentifier getIdentifier() {
-    return findNotNullChildByClass(ElixirIdentifier.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirIdentifier.class));
   }
 
   @Override
   @NotNull
   public ElixirNoParenthesesOneArgument getNoParenthesesOneArgument() {
-    return findNotNullChildByClass(ElixirNoParenthesesOneArgument.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirNoParenthesesOneArgument.class));
   }
 
   @Nullable

--- a/gen/org/elixir_lang/psi/impl/ElixirMatchedUnqualifiedParenthesesCallImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMatchedUnqualifiedParenthesesCallImpl.java
@@ -9,6 +9,7 @@ import com.intellij.psi.PsiReference;
 import com.intellij.psi.ResolveState;
 import com.intellij.psi.scope.PsiScopeProcessor;
 import com.intellij.psi.stubs.IStubElementType;
+import com.intellij.psi.util.PsiTreeUtil;
 import org.apache.commons.lang.math.IntRange;
 import org.elixir_lang.psi.*;
 import org.elixir_lang.psi.stub.MatchedUnqualifiedParenthesesCall;
@@ -37,13 +38,13 @@ public class ElixirMatchedUnqualifiedParenthesesCallImpl extends NamedStubbedPsi
   @Override
   @NotNull
   public ElixirIdentifier getIdentifier() {
-    return findNotNullChildByClass(ElixirIdentifier.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirIdentifier.class));
   }
 
   @Override
   @NotNull
   public ElixirMatchedParenthesesArguments getMatchedParenthesesArguments() {
-    return findNotNullChildByClass(ElixirMatchedParenthesesArguments.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirMatchedParenthesesArguments.class));
   }
 
   @Nullable

--- a/gen/org/elixir_lang/psi/impl/ElixirMatchedWhenOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMatchedWhenOperationImpl.java
@@ -39,7 +39,7 @@ public class ElixirMatchedWhenOperationImpl extends ElixirMatchedExpressionImpl 
   @Override
   @NotNull
   public ElixirWhenInfixOperator getWhenInfixOperator() {
-    return findNotNullChildByClass(ElixirWhenInfixOperator.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirWhenInfixOperator.class));
   }
 
   @Nullable

--- a/gen/org/elixir_lang/psi/impl/ElixirNoParenthesesArgumentsImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirNoParenthesesArgumentsImpl.java
@@ -42,7 +42,7 @@ public class ElixirNoParenthesesArgumentsImpl extends ASTWrapperPsiElement imple
   @Override
   @Nullable
   public ElixirNoParenthesesKeywords getNoParenthesesKeywords() {
-    return findChildByClass(ElixirNoParenthesesKeywords.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirNoParenthesesKeywords.class);
   }
 
   @Override
@@ -54,7 +54,7 @@ public class ElixirNoParenthesesArgumentsImpl extends ASTWrapperPsiElement imple
   @Override
   @Nullable
   public ElixirNoParenthesesOneArgument getNoParenthesesOneArgument() {
-    return findChildByClass(ElixirNoParenthesesOneArgument.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirNoParenthesesOneArgument.class);
   }
 
   @NotNull

--- a/gen/org/elixir_lang/psi/impl/ElixirNoParenthesesKeywordPairImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirNoParenthesesKeywordPairImpl.java
@@ -5,6 +5,7 @@ import com.ericsson.otp.erlang.OtpErlangObject;
 import com.intellij.extapi.psi.ASTWrapperPsiElement;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElementVisitor;
+import com.intellij.psi.util.PsiTreeUtil;
 import org.elixir_lang.psi.*;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -27,25 +28,25 @@ public class ElixirNoParenthesesKeywordPairImpl extends ASTWrapperPsiElement imp
   @Override
   @Nullable
   public ElixirEmptyParentheses getEmptyParentheses() {
-    return findChildByClass(ElixirEmptyParentheses.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirEmptyParentheses.class);
   }
 
   @Override
   @NotNull
   public ElixirKeywordKey getKeywordKey() {
-    return findNotNullChildByClass(ElixirKeywordKey.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirKeywordKey.class));
   }
 
   @Override
   @Nullable
   public ElixirMatchedExpression getMatchedExpression() {
-    return findChildByClass(ElixirMatchedExpression.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirMatchedExpression.class);
   }
 
   @Override
   @Nullable
   public ElixirNoParenthesesManyStrictNoParenthesesExpression getNoParenthesesManyStrictNoParenthesesExpression() {
-    return findChildByClass(ElixirNoParenthesesManyStrictNoParenthesesExpression.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirNoParenthesesManyStrictNoParenthesesExpression.class);
   }
 
   public Quotable getKeywordValue() {

--- a/gen/org/elixir_lang/psi/impl/ElixirNoParenthesesManyStrictNoParenthesesExpressionImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirNoParenthesesManyStrictNoParenthesesExpressionImpl.java
@@ -5,6 +5,7 @@ import com.ericsson.otp.erlang.OtpErlangObject;
 import com.intellij.extapi.psi.ASTWrapperPsiElement;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElementVisitor;
+import com.intellij.psi.util.PsiTreeUtil;
 import org.elixir_lang.psi.ElixirNoParenthesesManyStrictNoParenthesesExpression;
 import org.elixir_lang.psi.ElixirUnqualifiedNoParenthesesManyArgumentsCall;
 import org.elixir_lang.psi.ElixirVisitor;
@@ -28,7 +29,7 @@ public class ElixirNoParenthesesManyStrictNoParenthesesExpressionImpl extends AS
   @Override
   @NotNull
   public ElixirUnqualifiedNoParenthesesManyArgumentsCall getUnqualifiedNoParenthesesManyArgumentsCall() {
-    return findNotNullChildByClass(ElixirUnqualifiedNoParenthesesManyArgumentsCall.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirUnqualifiedNoParenthesesManyArgumentsCall.class));
   }
 
   @NotNull

--- a/gen/org/elixir_lang/psi/impl/ElixirNoParenthesesOneArgumentImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirNoParenthesesOneArgumentImpl.java
@@ -43,7 +43,7 @@ public class ElixirNoParenthesesOneArgumentImpl extends ASTWrapperPsiElement imp
   @Override
   @Nullable
   public ElixirNoParenthesesKeywords getNoParenthesesKeywords() {
-    return findChildByClass(ElixirNoParenthesesKeywords.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirNoParenthesesKeywords.class);
   }
 
   @Override
@@ -55,13 +55,13 @@ public class ElixirNoParenthesesOneArgumentImpl extends ASTWrapperPsiElement imp
   @Override
   @Nullable
   public ElixirNoParenthesesStrict getNoParenthesesStrict() {
-    return findChildByClass(ElixirNoParenthesesStrict.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirNoParenthesesStrict.class);
   }
 
   @Override
   @Nullable
   public ElixirUnqualifiedNoParenthesesManyArgumentsCall getUnqualifiedNoParenthesesManyArgumentsCall() {
-    return findChildByClass(ElixirUnqualifiedNoParenthesesManyArgumentsCall.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirUnqualifiedNoParenthesesManyArgumentsCall.class);
   }
 
   @NotNull

--- a/gen/org/elixir_lang/psi/impl/ElixirNoParenthesesStrictImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirNoParenthesesStrictImpl.java
@@ -43,7 +43,7 @@ public class ElixirNoParenthesesStrictImpl extends ASTWrapperPsiElement implemen
   @Override
   @Nullable
   public ElixirNoParenthesesKeywords getNoParenthesesKeywords() {
-    return findChildByClass(ElixirNoParenthesesKeywords.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirNoParenthesesKeywords.class);
   }
 
   @Override

--- a/gen/org/elixir_lang/psi/impl/ElixirParenthesesArgumentsImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirParenthesesArgumentsImpl.java
@@ -37,7 +37,7 @@ public class ElixirParenthesesArgumentsImpl extends ASTWrapperPsiElement impleme
   @Override
   @Nullable
   public ElixirKeywords getKeywords() {
-    return findChildByClass(ElixirKeywords.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirKeywords.class);
   }
 
   @Override
@@ -49,7 +49,7 @@ public class ElixirParenthesesArgumentsImpl extends ASTWrapperPsiElement impleme
   @Override
   @Nullable
   public ElixirUnqualifiedNoParenthesesManyArgumentsCall getUnqualifiedNoParenthesesManyArgumentsCall() {
-    return findChildByClass(ElixirUnqualifiedNoParenthesesManyArgumentsCall.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirUnqualifiedNoParenthesesManyArgumentsCall.class);
   }
 
   @NotNull

--- a/gen/org/elixir_lang/psi/impl/ElixirParentheticalStabImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirParentheticalStabImpl.java
@@ -5,6 +5,7 @@ import com.ericsson.otp.erlang.OtpErlangObject;
 import com.intellij.extapi.psi.ASTWrapperPsiElement;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElementVisitor;
+import com.intellij.psi.util.PsiTreeUtil;
 import org.elixir_lang.psi.ElixirParentheticalStab;
 import org.elixir_lang.psi.ElixirStab;
 import org.elixir_lang.psi.ElixirVisitor;
@@ -29,7 +30,7 @@ public class ElixirParentheticalStabImpl extends ASTWrapperPsiElement implements
   @Override
   @Nullable
   public ElixirStab getStab() {
-    return findChildByClass(ElixirStab.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirStab.class);
   }
 
   @NotNull

--- a/gen/org/elixir_lang/psi/impl/ElixirQuoteHexadecimalEscapeSequenceImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirQuoteHexadecimalEscapeSequenceImpl.java
@@ -4,6 +4,7 @@ package org.elixir_lang.psi.impl;
 import com.intellij.extapi.psi.ASTWrapperPsiElement;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElementVisitor;
+import com.intellij.psi.util.PsiTreeUtil;
 import org.elixir_lang.psi.*;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -26,19 +27,19 @@ public class ElixirQuoteHexadecimalEscapeSequenceImpl extends ASTWrapperPsiEleme
   @Override
   @Nullable
   public ElixirEnclosedHexadecimalEscapeSequence getEnclosedHexadecimalEscapeSequence() {
-    return findChildByClass(ElixirEnclosedHexadecimalEscapeSequence.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirEnclosedHexadecimalEscapeSequence.class);
   }
 
   @Override
   @NotNull
   public ElixirHexadecimalEscapePrefix getHexadecimalEscapePrefix() {
-    return findNotNullChildByClass(ElixirHexadecimalEscapePrefix.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirHexadecimalEscapePrefix.class));
   }
 
   @Override
   @Nullable
   public ElixirOpenHexadecimalEscapeSequence getOpenHexadecimalEscapeSequence() {
-    return findChildByClass(ElixirOpenHexadecimalEscapeSequence.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirOpenHexadecimalEscapeSequence.class);
   }
 
   public int codePoint() {

--- a/gen/org/elixir_lang/psi/impl/ElixirRelativeIdentifierImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirRelativeIdentifierImpl.java
@@ -5,6 +5,7 @@ import com.ericsson.otp.erlang.OtpErlangObject;
 import com.intellij.extapi.psi.ASTWrapperPsiElement;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElementVisitor;
+import com.intellij.psi.util.PsiTreeUtil;
 import org.elixir_lang.psi.*;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -27,19 +28,19 @@ public class ElixirRelativeIdentifierImpl extends ASTWrapperPsiElement implement
   @Override
   @Nullable
   public ElixirAtomKeyword getAtomKeyword() {
-    return findChildByClass(ElixirAtomKeyword.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirAtomKeyword.class);
   }
 
   @Override
   @Nullable
   public ElixirCharListLine getCharListLine() {
-    return findChildByClass(ElixirCharListLine.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirCharListLine.class);
   }
 
   @Override
   @Nullable
   public ElixirStringLine getStringLine() {
-    return findChildByClass(ElixirStringLine.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirStringLine.class);
   }
 
   @NotNull

--- a/gen/org/elixir_lang/psi/impl/ElixirSigilHexadecimalEscapeSequenceImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirSigilHexadecimalEscapeSequenceImpl.java
@@ -4,6 +4,7 @@ package org.elixir_lang.psi.impl;
 import com.intellij.extapi.psi.ASTWrapperPsiElement;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElementVisitor;
+import com.intellij.psi.util.PsiTreeUtil;
 import org.elixir_lang.psi.*;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -26,19 +27,19 @@ public class ElixirSigilHexadecimalEscapeSequenceImpl extends ASTWrapperPsiEleme
   @Override
   @Nullable
   public ElixirEnclosedHexadecimalEscapeSequence getEnclosedHexadecimalEscapeSequence() {
-    return findChildByClass(ElixirEnclosedHexadecimalEscapeSequence.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirEnclosedHexadecimalEscapeSequence.class);
   }
 
   @Override
   @NotNull
   public ElixirHexadecimalEscapePrefix getHexadecimalEscapePrefix() {
-    return findNotNullChildByClass(ElixirHexadecimalEscapePrefix.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirHexadecimalEscapePrefix.class));
   }
 
   @Override
   @Nullable
   public ElixirOpenHexadecimalEscapeSequence getOpenHexadecimalEscapeSequence() {
-    return findChildByClass(ElixirOpenHexadecimalEscapeSequence.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirOpenHexadecimalEscapeSequence.class);
   }
 
   public int codePoint() {

--- a/gen/org/elixir_lang/psi/impl/ElixirStabImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirStabImpl.java
@@ -36,7 +36,7 @@ public class ElixirStabImpl extends ASTWrapperPsiElement implements ElixirStab {
   @Override
   @Nullable
   public ElixirStabBody getStabBody() {
-    return findChildByClass(ElixirStabBody.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirStabBody.class);
   }
 
   @Override

--- a/gen/org/elixir_lang/psi/impl/ElixirStabNoParenthesesSignatureImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirStabNoParenthesesSignatureImpl.java
@@ -5,6 +5,7 @@ import com.ericsson.otp.erlang.OtpErlangObject;
 import com.intellij.extapi.psi.ASTWrapperPsiElement;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElementVisitor;
+import com.intellij.psi.util.PsiTreeUtil;
 import org.elixir_lang.psi.ElixirNoParenthesesArguments;
 import org.elixir_lang.psi.ElixirStabNoParenthesesSignature;
 import org.elixir_lang.psi.ElixirVisitor;
@@ -28,7 +29,7 @@ public class ElixirStabNoParenthesesSignatureImpl extends ASTWrapperPsiElement i
   @Override
   @NotNull
   public ElixirNoParenthesesArguments getNoParenthesesArguments() {
-    return findNotNullChildByClass(ElixirNoParenthesesArguments.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirNoParenthesesArguments.class));
   }
 
   @NotNull

--- a/gen/org/elixir_lang/psi/impl/ElixirStabOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirStabOperationImpl.java
@@ -8,6 +8,7 @@ import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.ResolveState;
 import com.intellij.psi.scope.PsiScopeProcessor;
+import com.intellij.psi.util.PsiTreeUtil;
 import org.elixir_lang.psi.*;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -30,25 +31,25 @@ public class ElixirStabOperationImpl extends ASTWrapperPsiElement implements Eli
   @Override
   @Nullable
   public ElixirStabBody getStabBody() {
-    return findChildByClass(ElixirStabBody.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirStabBody.class);
   }
 
   @Override
   @NotNull
   public ElixirStabInfixOperator getStabInfixOperator() {
-    return findNotNullChildByClass(ElixirStabInfixOperator.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirStabInfixOperator.class));
   }
 
   @Override
   @Nullable
   public ElixirStabNoParenthesesSignature getStabNoParenthesesSignature() {
-    return findChildByClass(ElixirStabNoParenthesesSignature.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirStabNoParenthesesSignature.class);
   }
 
   @Override
   @Nullable
   public ElixirStabParenthesesSignature getStabParenthesesSignature() {
-    return findChildByClass(ElixirStabParenthesesSignature.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirStabParenthesesSignature.class);
   }
 
   @Nullable

--- a/gen/org/elixir_lang/psi/impl/ElixirStabParenthesesSignatureImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirStabParenthesesSignatureImpl.java
@@ -5,6 +5,7 @@ import com.ericsson.otp.erlang.OtpErlangObject;
 import com.intellij.extapi.psi.ASTWrapperPsiElement;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElementVisitor;
+import com.intellij.psi.util.PsiTreeUtil;
 import org.elixir_lang.psi.*;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -27,31 +28,31 @@ public class ElixirStabParenthesesSignatureImpl extends ASTWrapperPsiElement imp
   @Override
   @Nullable
   public ElixirEmptyParentheses getEmptyParentheses() {
-    return findChildByClass(ElixirEmptyParentheses.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirEmptyParentheses.class);
   }
 
   @Override
   @NotNull
   public ElixirParenthesesArguments getParenthesesArguments() {
-    return findNotNullChildByClass(ElixirParenthesesArguments.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirParenthesesArguments.class));
   }
 
   @Override
   @Nullable
   public ElixirUnmatchedExpression getUnmatchedExpression() {
-    return findChildByClass(ElixirUnmatchedExpression.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirUnmatchedExpression.class);
   }
 
   @Override
   @Nullable
   public ElixirUnqualifiedNoParenthesesManyArgumentsCall getUnqualifiedNoParenthesesManyArgumentsCall() {
-    return findChildByClass(ElixirUnqualifiedNoParenthesesManyArgumentsCall.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirUnqualifiedNoParenthesesManyArgumentsCall.class);
   }
 
   @Override
   @Nullable
   public ElixirWhenInfixOperator getWhenInfixOperator() {
-    return findChildByClass(ElixirWhenInfixOperator.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirWhenInfixOperator.class);
   }
 
   @Nullable

--- a/gen/org/elixir_lang/psi/impl/ElixirStringHeredocImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirStringHeredocImpl.java
@@ -32,7 +32,7 @@ public class ElixirStringHeredocImpl extends ASTWrapperPsiElement implements Eli
   @Override
   @Nullable
   public ElixirHeredocPrefix getHeredocPrefix() {
-    return findChildByClass(ElixirHeredocPrefix.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirHeredocPrefix.class);
   }
 
   @Override

--- a/gen/org/elixir_lang/psi/impl/ElixirStringHeredocLineImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirStringHeredocLineImpl.java
@@ -5,6 +5,7 @@ import com.ericsson.otp.erlang.OtpErlangObject;
 import com.intellij.extapi.psi.ASTWrapperPsiElement;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElementVisitor;
+import com.intellij.psi.util.PsiTreeUtil;
 import org.elixir_lang.psi.*;
 import org.jetbrains.annotations.NotNull;
 
@@ -26,13 +27,13 @@ public class ElixirStringHeredocLineImpl extends ASTWrapperPsiElement implements
   @Override
   @NotNull
   public ElixirHeredocLinePrefix getHeredocLinePrefix() {
-    return findNotNullChildByClass(ElixirHeredocLinePrefix.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirHeredocLinePrefix.class));
   }
 
   @Override
   @NotNull
   public ElixirQuoteStringBody getQuoteStringBody() {
-    return findNotNullChildByClass(ElixirQuoteStringBody.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirQuoteStringBody.class));
   }
 
   public Body getBody() {

--- a/gen/org/elixir_lang/psi/impl/ElixirStringLineImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirStringLineImpl.java
@@ -7,6 +7,7 @@ import com.intellij.extapi.psi.ASTWrapperPsiElement;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.tree.IElementType;
+import com.intellij.psi.util.PsiTreeUtil;
 import org.elixir_lang.psi.Body;
 import org.elixir_lang.psi.ElixirQuoteStringBody;
 import org.elixir_lang.psi.ElixirStringLine;
@@ -33,7 +34,7 @@ public class ElixirStringLineImpl extends ASTWrapperPsiElement implements Elixir
   @Override
   @NotNull
   public ElixirQuoteStringBody getQuoteStringBody() {
-    return findNotNullChildByClass(ElixirQuoteStringBody.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirQuoteStringBody.class));
   }
 
   @NotNull

--- a/gen/org/elixir_lang/psi/impl/ElixirStructOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirStructOperationImpl.java
@@ -5,6 +5,7 @@ import com.ericsson.otp.erlang.OtpErlangObject;
 import com.intellij.extapi.psi.ASTWrapperPsiElement;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElementVisitor;
+import com.intellij.psi.util.PsiTreeUtil;
 import org.elixir_lang.psi.*;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -27,37 +28,37 @@ public class ElixirStructOperationImpl extends ASTWrapperPsiElement implements E
   @Override
   @Nullable
   public ElixirAlias getAlias() {
-    return findChildByClass(ElixirAlias.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirAlias.class);
   }
 
   @Override
   @Nullable
   public ElixirAtom getAtom() {
-    return findChildByClass(ElixirAtom.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirAtom.class);
   }
 
   @Override
   @NotNull
   public ElixirMapArguments getMapArguments() {
-    return findNotNullChildByClass(ElixirMapArguments.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirMapArguments.class));
   }
 
   @Override
   @NotNull
   public ElixirMapPrefixOperator getMapPrefixOperator() {
-    return findNotNullChildByClass(ElixirMapPrefixOperator.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirMapPrefixOperator.class));
   }
 
   @Override
   @Nullable
   public ElixirMatchedExpression getMatchedExpression() {
-    return findChildByClass(ElixirMatchedExpression.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirMatchedExpression.class);
   }
 
   @Override
   @Nullable
   public ElixirVariable getVariable() {
-    return findChildByClass(ElixirVariable.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirVariable.class);
   }
 
   @NotNull

--- a/gen/org/elixir_lang/psi/impl/ElixirTupleImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirTupleImpl.java
@@ -36,7 +36,7 @@ public class ElixirTupleImpl extends ASTWrapperPsiElement implements ElixirTuple
   @Override
   @Nullable
   public ElixirKeywords getKeywords() {
-    return findChildByClass(ElixirKeywords.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirKeywords.class);
   }
 
   @Override

--- a/gen/org/elixir_lang/psi/impl/ElixirUnaryNumericOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnaryNumericOperationImpl.java
@@ -6,6 +6,7 @@ import com.intellij.extapi.psi.ASTWrapperPsiElement;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
+import com.intellij.psi.util.PsiTreeUtil;
 import org.apache.commons.lang.math.IntRange;
 import org.elixir_lang.psi.*;
 import org.jetbrains.annotations.NotNull;
@@ -29,49 +30,49 @@ public class ElixirUnaryNumericOperationImpl extends ASTWrapperPsiElement implem
   @Override
   @Nullable
   public ElixirBinaryWholeNumber getBinaryWholeNumber() {
-    return findChildByClass(ElixirBinaryWholeNumber.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirBinaryWholeNumber.class);
   }
 
   @Override
   @Nullable
   public ElixirCharToken getCharToken() {
-    return findChildByClass(ElixirCharToken.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirCharToken.class);
   }
 
   @Override
   @Nullable
   public ElixirDecimalFloat getDecimalFloat() {
-    return findChildByClass(ElixirDecimalFloat.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirDecimalFloat.class);
   }
 
   @Override
   @Nullable
   public ElixirDecimalWholeNumber getDecimalWholeNumber() {
-    return findChildByClass(ElixirDecimalWholeNumber.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirDecimalWholeNumber.class);
   }
 
   @Override
   @Nullable
   public ElixirHexadecimalWholeNumber getHexadecimalWholeNumber() {
-    return findChildByClass(ElixirHexadecimalWholeNumber.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirHexadecimalWholeNumber.class);
   }
 
   @Override
   @Nullable
   public ElixirOctalWholeNumber getOctalWholeNumber() {
-    return findChildByClass(ElixirOctalWholeNumber.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirOctalWholeNumber.class);
   }
 
   @Override
   @NotNull
   public ElixirUnaryPrefixOperator getUnaryPrefixOperator() {
-    return findNotNullChildByClass(ElixirUnaryPrefixOperator.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirUnaryPrefixOperator.class));
   }
 
   @Override
   @Nullable
   public ElixirUnknownBaseWholeNumber getUnknownBaseWholeNumber() {
-    return findChildByClass(ElixirUnknownBaseWholeNumber.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirUnknownBaseWholeNumber.class);
   }
 
   @Nullable

--- a/gen/org/elixir_lang/psi/impl/ElixirUnmatchedAdditionOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnmatchedAdditionOperationImpl.java
@@ -33,7 +33,7 @@ public class ElixirUnmatchedAdditionOperationImpl extends ElixirUnmatchedExpress
   @Override
   @NotNull
   public ElixirAdditionInfixOperator getAdditionInfixOperator() {
-    return findNotNullChildByClass(ElixirAdditionInfixOperator.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirAdditionInfixOperator.class));
   }
 
   @Override

--- a/gen/org/elixir_lang/psi/impl/ElixirUnmatchedAndOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnmatchedAndOperationImpl.java
@@ -34,7 +34,7 @@ public class ElixirUnmatchedAndOperationImpl extends ElixirUnmatchedExpressionIm
   @Override
   @NotNull
   public ElixirAndInfixOperator getAndInfixOperator() {
-    return findNotNullChildByClass(ElixirAndInfixOperator.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirAndInfixOperator.class));
   }
 
   @Override

--- a/gen/org/elixir_lang/psi/impl/ElixirUnmatchedArrowOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnmatchedArrowOperationImpl.java
@@ -33,7 +33,7 @@ public class ElixirUnmatchedArrowOperationImpl extends ElixirUnmatchedExpression
   @Override
   @NotNull
   public ElixirArrowInfixOperator getArrowInfixOperator() {
-    return findNotNullChildByClass(ElixirArrowInfixOperator.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirArrowInfixOperator.class));
   }
 
   @Override

--- a/gen/org/elixir_lang/psi/impl/ElixirUnmatchedAtNonNumericOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnmatchedAtNonNumericOperationImpl.java
@@ -5,6 +5,7 @@ import com.ericsson.otp.erlang.OtpErlangObject;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.PsiReference;
+import com.intellij.psi.util.PsiTreeUtil;
 import org.elixir_lang.psi.*;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -27,13 +28,13 @@ public class ElixirUnmatchedAtNonNumericOperationImpl extends ElixirUnmatchedExp
   @Override
   @NotNull
   public ElixirAtPrefixOperator getAtPrefixOperator() {
-    return findNotNullChildByClass(ElixirAtPrefixOperator.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirAtPrefixOperator.class));
   }
 
   @Override
   @Nullable
   public ElixirUnmatchedExpression getUnmatchedExpression() {
-    return findChildByClass(ElixirUnmatchedExpression.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirUnmatchedExpression.class);
   }
 
   @Nullable

--- a/gen/org/elixir_lang/psi/impl/ElixirUnmatchedAtUnqualifiedBracketOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnmatchedAtUnqualifiedBracketOperationImpl.java
@@ -4,6 +4,7 @@ package org.elixir_lang.psi.impl;
 import com.ericsson.otp.erlang.OtpErlangObject;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElementVisitor;
+import com.intellij.psi.util.PsiTreeUtil;
 import org.elixir_lang.psi.ElixirAtPrefixOperator;
 import org.elixir_lang.psi.ElixirBracketArguments;
 import org.elixir_lang.psi.ElixirUnmatchedAtUnqualifiedBracketOperation;
@@ -28,13 +29,13 @@ public class ElixirUnmatchedAtUnqualifiedBracketOperationImpl extends ElixirUnma
   @Override
   @NotNull
   public ElixirAtPrefixOperator getAtPrefixOperator() {
-    return findNotNullChildByClass(ElixirAtPrefixOperator.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirAtPrefixOperator.class));
   }
 
   @Override
   @NotNull
   public ElixirBracketArguments getBracketArguments() {
-    return findNotNullChildByClass(ElixirBracketArguments.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirBracketArguments.class));
   }
 
   @NotNull

--- a/gen/org/elixir_lang/psi/impl/ElixirUnmatchedAtUnqualifiedNoParenthesesCallImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnmatchedAtUnqualifiedNoParenthesesCallImpl.java
@@ -10,6 +10,7 @@ import com.intellij.psi.ResolveState;
 import com.intellij.psi.scope.PsiScopeProcessor;
 import com.intellij.psi.search.SearchScope;
 import com.intellij.psi.stubs.IStubElementType;
+import com.intellij.psi.util.PsiTreeUtil;
 import org.apache.commons.lang.math.IntRange;
 import org.elixir_lang.psi.*;
 import org.elixir_lang.psi.stub.UnmatchedAtUnqualifiedNoParenthesesCall;
@@ -38,19 +39,19 @@ public class ElixirUnmatchedAtUnqualifiedNoParenthesesCallImpl extends NamedStub
   @Override
   @NotNull
   public ElixirAtIdentifier getAtIdentifier() {
-    return findNotNullChildByClass(ElixirAtIdentifier.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirAtIdentifier.class));
   }
 
   @Override
   @Nullable
   public ElixirDoBlock getDoBlock() {
-    return findChildByClass(ElixirDoBlock.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirDoBlock.class);
   }
 
   @Override
   @NotNull
   public ElixirNoParenthesesOneArgument getNoParenthesesOneArgument() {
-    return findNotNullChildByClass(ElixirNoParenthesesOneArgument.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirNoParenthesesOneArgument.class));
   }
 
   @Nullable

--- a/gen/org/elixir_lang/psi/impl/ElixirUnmatchedBracketOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnmatchedBracketOperationImpl.java
@@ -4,6 +4,7 @@ package org.elixir_lang.psi.impl;
 import com.ericsson.otp.erlang.OtpErlangObject;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElementVisitor;
+import com.intellij.psi.util.PsiTreeUtil;
 import org.elixir_lang.psi.ElixirBracketArguments;
 import org.elixir_lang.psi.ElixirUnmatchedBracketOperation;
 import org.elixir_lang.psi.ElixirUnmatchedExpression;
@@ -28,13 +29,13 @@ public class ElixirUnmatchedBracketOperationImpl extends ElixirUnmatchedExpressi
   @Override
   @NotNull
   public ElixirBracketArguments getBracketArguments() {
-    return findNotNullChildByClass(ElixirBracketArguments.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirBracketArguments.class));
   }
 
   @Override
   @NotNull
   public ElixirUnmatchedExpression getUnmatchedExpression() {
-    return findNotNullChildByClass(ElixirUnmatchedExpression.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirUnmatchedExpression.class));
   }
 
   @NotNull

--- a/gen/org/elixir_lang/psi/impl/ElixirUnmatchedCaptureNonNumericOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnmatchedCaptureNonNumericOperationImpl.java
@@ -5,6 +5,7 @@ import com.ericsson.otp.erlang.OtpErlangObject;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
+import com.intellij.psi.util.PsiTreeUtil;
 import org.apache.commons.lang.math.IntRange;
 import org.elixir_lang.psi.*;
 import org.jetbrains.annotations.NotNull;
@@ -28,13 +29,13 @@ public class ElixirUnmatchedCaptureNonNumericOperationImpl extends ElixirUnmatch
   @Override
   @NotNull
   public ElixirCapturePrefixOperator getCapturePrefixOperator() {
-    return findNotNullChildByClass(ElixirCapturePrefixOperator.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirCapturePrefixOperator.class));
   }
 
   @Override
   @Nullable
   public ElixirUnmatchedExpression getUnmatchedExpression() {
-    return findChildByClass(ElixirUnmatchedExpression.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirUnmatchedExpression.class);
   }
 
   @Nullable

--- a/gen/org/elixir_lang/psi/impl/ElixirUnmatchedComparisonOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnmatchedComparisonOperationImpl.java
@@ -33,7 +33,7 @@ public class ElixirUnmatchedComparisonOperationImpl extends ElixirUnmatchedExpre
   @Override
   @NotNull
   public ElixirComparisonInfixOperator getComparisonInfixOperator() {
-    return findNotNullChildByClass(ElixirComparisonInfixOperator.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirComparisonInfixOperator.class));
   }
 
   @Override

--- a/gen/org/elixir_lang/psi/impl/ElixirUnmatchedDotCallImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnmatchedDotCallImpl.java
@@ -40,13 +40,13 @@ public class ElixirUnmatchedDotCallImpl extends NamedStubbedPsiElementBase<Unmat
   @Override
   @Nullable
   public ElixirDoBlock getDoBlock() {
-    return findChildByClass(ElixirDoBlock.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirDoBlock.class);
   }
 
   @Override
   @NotNull
   public ElixirDotInfixOperator getDotInfixOperator() {
-    return findNotNullChildByClass(ElixirDotInfixOperator.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirDotInfixOperator.class));
   }
 
   @Override
@@ -58,7 +58,7 @@ public class ElixirUnmatchedDotCallImpl extends NamedStubbedPsiElementBase<Unmat
   @Override
   @NotNull
   public ElixirUnmatchedExpression getUnmatchedExpression() {
-    return findNotNullChildByClass(ElixirUnmatchedExpression.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirUnmatchedExpression.class));
   }
 
   @Nullable

--- a/gen/org/elixir_lang/psi/impl/ElixirUnmatchedInMatchOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnmatchedInMatchOperationImpl.java
@@ -33,7 +33,7 @@ public class ElixirUnmatchedInMatchOperationImpl extends ElixirUnmatchedExpressi
   @Override
   @NotNull
   public ElixirInMatchInfixOperator getInMatchInfixOperator() {
-    return findNotNullChildByClass(ElixirInMatchInfixOperator.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirInMatchInfixOperator.class));
   }
 
   @Override

--- a/gen/org/elixir_lang/psi/impl/ElixirUnmatchedInOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnmatchedInOperationImpl.java
@@ -33,7 +33,7 @@ public class ElixirUnmatchedInOperationImpl extends ElixirUnmatchedExpressionImp
   @Override
   @NotNull
   public ElixirInInfixOperator getInInfixOperator() {
-    return findNotNullChildByClass(ElixirInInfixOperator.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirInInfixOperator.class));
   }
 
   @Override

--- a/gen/org/elixir_lang/psi/impl/ElixirUnmatchedMatchOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnmatchedMatchOperationImpl.java
@@ -34,7 +34,7 @@ public class ElixirUnmatchedMatchOperationImpl extends ElixirUnmatchedExpression
   @Override
   @NotNull
   public ElixirMatchInfixOperator getMatchInfixOperator() {
-    return findNotNullChildByClass(ElixirMatchInfixOperator.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirMatchInfixOperator.class));
   }
 
   @Override

--- a/gen/org/elixir_lang/psi/impl/ElixirUnmatchedMultiplicationOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnmatchedMultiplicationOperationImpl.java
@@ -33,7 +33,7 @@ public class ElixirUnmatchedMultiplicationOperationImpl extends ElixirUnmatchedE
   @Override
   @NotNull
   public ElixirMultiplicationInfixOperator getMultiplicationInfixOperator() {
-    return findNotNullChildByClass(ElixirMultiplicationInfixOperator.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirMultiplicationInfixOperator.class));
   }
 
   @Override

--- a/gen/org/elixir_lang/psi/impl/ElixirUnmatchedOrOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnmatchedOrOperationImpl.java
@@ -33,7 +33,7 @@ public class ElixirUnmatchedOrOperationImpl extends ElixirUnmatchedExpressionImp
   @Override
   @NotNull
   public ElixirOrInfixOperator getOrInfixOperator() {
-    return findNotNullChildByClass(ElixirOrInfixOperator.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirOrInfixOperator.class));
   }
 
   @Override

--- a/gen/org/elixir_lang/psi/impl/ElixirUnmatchedPipeOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnmatchedPipeOperationImpl.java
@@ -33,7 +33,7 @@ public class ElixirUnmatchedPipeOperationImpl extends ElixirUnmatchedExpressionI
   @Override
   @NotNull
   public ElixirPipeInfixOperator getPipeInfixOperator() {
-    return findNotNullChildByClass(ElixirPipeInfixOperator.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirPipeInfixOperator.class));
   }
 
   @Override

--- a/gen/org/elixir_lang/psi/impl/ElixirUnmatchedQualifiedAliasImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnmatchedQualifiedAliasImpl.java
@@ -8,6 +8,7 @@ import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.PsiReference;
 import com.intellij.psi.ResolveState;
 import com.intellij.psi.scope.PsiScopeProcessor;
+import com.intellij.psi.util.PsiTreeUtil;
 import org.elixir_lang.psi.*;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -30,19 +31,19 @@ public class ElixirUnmatchedQualifiedAliasImpl extends ElixirUnmatchedExpression
   @Override
   @NotNull
   public ElixirAlias getAlias() {
-    return findNotNullChildByClass(ElixirAlias.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirAlias.class));
   }
 
   @Override
   @NotNull
   public ElixirDotInfixOperator getDotInfixOperator() {
-    return findNotNullChildByClass(ElixirDotInfixOperator.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirDotInfixOperator.class));
   }
 
   @Override
   @NotNull
   public ElixirUnmatchedExpression getUnmatchedExpression() {
-    return findNotNullChildByClass(ElixirUnmatchedExpression.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirUnmatchedExpression.class));
   }
 
   @Nullable

--- a/gen/org/elixir_lang/psi/impl/ElixirUnmatchedQualifiedBracketOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnmatchedQualifiedBracketOperationImpl.java
@@ -4,6 +4,7 @@ package org.elixir_lang.psi.impl;
 import com.ericsson.otp.erlang.OtpErlangObject;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElementVisitor;
+import com.intellij.psi.util.PsiTreeUtil;
 import org.elixir_lang.psi.*;
 import org.jetbrains.annotations.NotNull;
 
@@ -25,25 +26,25 @@ public class ElixirUnmatchedQualifiedBracketOperationImpl extends ElixirUnmatche
   @Override
   @NotNull
   public ElixirBracketArguments getBracketArguments() {
-    return findNotNullChildByClass(ElixirBracketArguments.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirBracketArguments.class));
   }
 
   @Override
   @NotNull
   public ElixirDotInfixOperator getDotInfixOperator() {
-    return findNotNullChildByClass(ElixirDotInfixOperator.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirDotInfixOperator.class));
   }
 
   @Override
   @NotNull
   public ElixirRelativeIdentifier getRelativeIdentifier() {
-    return findNotNullChildByClass(ElixirRelativeIdentifier.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirRelativeIdentifier.class));
   }
 
   @Override
   @NotNull
   public ElixirUnmatchedExpression getUnmatchedExpression() {
-    return findNotNullChildByClass(ElixirUnmatchedExpression.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirUnmatchedExpression.class));
   }
 
   @NotNull

--- a/gen/org/elixir_lang/psi/impl/ElixirUnmatchedQualifiedNoArgumentsCallImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnmatchedQualifiedNoArgumentsCallImpl.java
@@ -9,6 +9,7 @@ import com.intellij.psi.PsiReference;
 import com.intellij.psi.ResolveState;
 import com.intellij.psi.scope.PsiScopeProcessor;
 import com.intellij.psi.stubs.IStubElementType;
+import com.intellij.psi.util.PsiTreeUtil;
 import org.apache.commons.lang.math.IntRange;
 import org.elixir_lang.psi.*;
 import org.elixir_lang.psi.stub.UnmatchedQualifiedNoArgumentsCall;
@@ -37,25 +38,25 @@ public class ElixirUnmatchedQualifiedNoArgumentsCallImpl extends NamedStubbedPsi
   @Override
   @Nullable
   public ElixirDoBlock getDoBlock() {
-    return findChildByClass(ElixirDoBlock.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirDoBlock.class);
   }
 
   @Override
   @NotNull
   public ElixirDotInfixOperator getDotInfixOperator() {
-    return findNotNullChildByClass(ElixirDotInfixOperator.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirDotInfixOperator.class));
   }
 
   @Override
   @NotNull
   public ElixirRelativeIdentifier getRelativeIdentifier() {
-    return findNotNullChildByClass(ElixirRelativeIdentifier.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirRelativeIdentifier.class));
   }
 
   @Override
   @NotNull
   public ElixirUnmatchedExpression getUnmatchedExpression() {
-    return findNotNullChildByClass(ElixirUnmatchedExpression.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirUnmatchedExpression.class));
   }
 
   @Nullable

--- a/gen/org/elixir_lang/psi/impl/ElixirUnmatchedQualifiedNoParenthesesCallImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnmatchedQualifiedNoParenthesesCallImpl.java
@@ -9,6 +9,7 @@ import com.intellij.psi.PsiReference;
 import com.intellij.psi.ResolveState;
 import com.intellij.psi.scope.PsiScopeProcessor;
 import com.intellij.psi.stubs.IStubElementType;
+import com.intellij.psi.util.PsiTreeUtil;
 import org.apache.commons.lang.math.IntRange;
 import org.elixir_lang.psi.*;
 import org.elixir_lang.psi.stub.UnmatchedQualifiedNoParenthesesCall;
@@ -37,31 +38,31 @@ public class ElixirUnmatchedQualifiedNoParenthesesCallImpl extends NamedStubbedP
   @Override
   @Nullable
   public ElixirDoBlock getDoBlock() {
-    return findChildByClass(ElixirDoBlock.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirDoBlock.class);
   }
 
   @Override
   @NotNull
   public ElixirDotInfixOperator getDotInfixOperator() {
-    return findNotNullChildByClass(ElixirDotInfixOperator.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirDotInfixOperator.class));
   }
 
   @Override
   @NotNull
   public ElixirNoParenthesesOneArgument getNoParenthesesOneArgument() {
-    return findNotNullChildByClass(ElixirNoParenthesesOneArgument.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirNoParenthesesOneArgument.class));
   }
 
   @Override
   @NotNull
   public ElixirRelativeIdentifier getRelativeIdentifier() {
-    return findNotNullChildByClass(ElixirRelativeIdentifier.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirRelativeIdentifier.class));
   }
 
   @Override
   @NotNull
   public ElixirUnmatchedExpression getUnmatchedExpression() {
-    return findNotNullChildByClass(ElixirUnmatchedExpression.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirUnmatchedExpression.class));
   }
 
   @Nullable

--- a/gen/org/elixir_lang/psi/impl/ElixirUnmatchedQualifiedParenthesesCallImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnmatchedQualifiedParenthesesCallImpl.java
@@ -9,6 +9,7 @@ import com.intellij.psi.PsiReference;
 import com.intellij.psi.ResolveState;
 import com.intellij.psi.scope.PsiScopeProcessor;
 import com.intellij.psi.stubs.IStubElementType;
+import com.intellij.psi.util.PsiTreeUtil;
 import org.apache.commons.lang.math.IntRange;
 import org.elixir_lang.psi.*;
 import org.elixir_lang.psi.stub.UnmatchedQualifiedParenthesesCall;
@@ -37,31 +38,31 @@ public class ElixirUnmatchedQualifiedParenthesesCallImpl extends NamedStubbedPsi
   @Override
   @Nullable
   public ElixirDoBlock getDoBlock() {
-    return findChildByClass(ElixirDoBlock.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirDoBlock.class);
   }
 
   @Override
   @NotNull
   public ElixirDotInfixOperator getDotInfixOperator() {
-    return findNotNullChildByClass(ElixirDotInfixOperator.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirDotInfixOperator.class));
   }
 
   @Override
   @NotNull
   public ElixirMatchedParenthesesArguments getMatchedParenthesesArguments() {
-    return findNotNullChildByClass(ElixirMatchedParenthesesArguments.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirMatchedParenthesesArguments.class));
   }
 
   @Override
   @NotNull
   public ElixirRelativeIdentifier getRelativeIdentifier() {
-    return findNotNullChildByClass(ElixirRelativeIdentifier.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirRelativeIdentifier.class));
   }
 
   @Override
   @NotNull
   public ElixirUnmatchedExpression getUnmatchedExpression() {
-    return findNotNullChildByClass(ElixirUnmatchedExpression.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirUnmatchedExpression.class));
   }
 
   @Nullable

--- a/gen/org/elixir_lang/psi/impl/ElixirUnmatchedRelationalOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnmatchedRelationalOperationImpl.java
@@ -33,7 +33,7 @@ public class ElixirUnmatchedRelationalOperationImpl extends ElixirUnmatchedExpre
   @Override
   @NotNull
   public ElixirRelationalInfixOperator getRelationalInfixOperator() {
-    return findNotNullChildByClass(ElixirRelationalInfixOperator.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirRelationalInfixOperator.class));
   }
 
   @Override

--- a/gen/org/elixir_lang/psi/impl/ElixirUnmatchedTwoOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnmatchedTwoOperationImpl.java
@@ -33,7 +33,7 @@ public class ElixirUnmatchedTwoOperationImpl extends ElixirUnmatchedExpressionIm
   @Override
   @NotNull
   public ElixirTwoInfixOperator getTwoInfixOperator() {
-    return findNotNullChildByClass(ElixirTwoInfixOperator.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirTwoInfixOperator.class));
   }
 
   @Override

--- a/gen/org/elixir_lang/psi/impl/ElixirUnmatchedTypeOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnmatchedTypeOperationImpl.java
@@ -33,7 +33,7 @@ public class ElixirUnmatchedTypeOperationImpl extends ElixirUnmatchedExpressionI
   @Override
   @NotNull
   public ElixirTypeInfixOperator getTypeInfixOperator() {
-    return findNotNullChildByClass(ElixirTypeInfixOperator.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirTypeInfixOperator.class));
   }
 
   @Override

--- a/gen/org/elixir_lang/psi/impl/ElixirUnmatchedUnaryNonNumericOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnmatchedUnaryNonNumericOperationImpl.java
@@ -5,6 +5,7 @@ import com.ericsson.otp.erlang.OtpErlangObject;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
+import com.intellij.psi.util.PsiTreeUtil;
 import org.apache.commons.lang.math.IntRange;
 import org.elixir_lang.psi.*;
 import org.jetbrains.annotations.NotNull;
@@ -28,13 +29,13 @@ public class ElixirUnmatchedUnaryNonNumericOperationImpl extends ElixirUnmatched
   @Override
   @NotNull
   public ElixirUnaryPrefixOperator getUnaryPrefixOperator() {
-    return findNotNullChildByClass(ElixirUnaryPrefixOperator.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirUnaryPrefixOperator.class));
   }
 
   @Override
   @Nullable
   public ElixirUnmatchedExpression getUnmatchedExpression() {
-    return findChildByClass(ElixirUnmatchedExpression.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirUnmatchedExpression.class);
   }
 
   @Nullable

--- a/gen/org/elixir_lang/psi/impl/ElixirUnmatchedUnqualifiedBracketOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnmatchedUnqualifiedBracketOperationImpl.java
@@ -4,6 +4,7 @@ package org.elixir_lang.psi.impl;
 import com.ericsson.otp.erlang.OtpErlangObject;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElementVisitor;
+import com.intellij.psi.util.PsiTreeUtil;
 import org.elixir_lang.psi.ElixirBracketArguments;
 import org.elixir_lang.psi.ElixirIdentifier;
 import org.elixir_lang.psi.ElixirUnmatchedUnqualifiedBracketOperation;
@@ -28,13 +29,13 @@ public class ElixirUnmatchedUnqualifiedBracketOperationImpl extends ElixirUnmatc
   @Override
   @NotNull
   public ElixirBracketArguments getBracketArguments() {
-    return findNotNullChildByClass(ElixirBracketArguments.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirBracketArguments.class));
   }
 
   @Override
   @NotNull
   public ElixirIdentifier getIdentifier() {
-    return findNotNullChildByClass(ElixirIdentifier.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirIdentifier.class));
   }
 
   @NotNull

--- a/gen/org/elixir_lang/psi/impl/ElixirUnmatchedUnqualifiedNoArgumentsCallImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnmatchedUnqualifiedNoArgumentsCallImpl.java
@@ -10,6 +10,7 @@ import com.intellij.psi.ResolveState;
 import com.intellij.psi.scope.PsiScopeProcessor;
 import com.intellij.psi.search.SearchScope;
 import com.intellij.psi.stubs.IStubElementType;
+import com.intellij.psi.util.PsiTreeUtil;
 import org.apache.commons.lang.math.IntRange;
 import org.elixir_lang.psi.ElixirDoBlock;
 import org.elixir_lang.psi.ElixirIdentifier;
@@ -41,13 +42,13 @@ public class ElixirUnmatchedUnqualifiedNoArgumentsCallImpl extends NamedStubbedP
   @Override
   @Nullable
   public ElixirDoBlock getDoBlock() {
-    return findChildByClass(ElixirDoBlock.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirDoBlock.class);
   }
 
   @Override
   @NotNull
   public ElixirIdentifier getIdentifier() {
-    return findNotNullChildByClass(ElixirIdentifier.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirIdentifier.class));
   }
 
   @Nullable

--- a/gen/org/elixir_lang/psi/impl/ElixirUnmatchedUnqualifiedNoParenthesesCallImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnmatchedUnqualifiedNoParenthesesCallImpl.java
@@ -9,6 +9,7 @@ import com.intellij.psi.PsiReference;
 import com.intellij.psi.ResolveState;
 import com.intellij.psi.scope.PsiScopeProcessor;
 import com.intellij.psi.stubs.IStubElementType;
+import com.intellij.psi.util.PsiTreeUtil;
 import org.apache.commons.lang.math.IntRange;
 import org.elixir_lang.psi.*;
 import org.elixir_lang.psi.stub.UnmatchedUnqualifiedNoParenthesesCall;
@@ -37,19 +38,19 @@ public class ElixirUnmatchedUnqualifiedNoParenthesesCallImpl extends NamedStubbe
   @Override
   @Nullable
   public ElixirDoBlock getDoBlock() {
-    return findChildByClass(ElixirDoBlock.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirDoBlock.class);
   }
 
   @Override
   @NotNull
   public ElixirIdentifier getIdentifier() {
-    return findNotNullChildByClass(ElixirIdentifier.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirIdentifier.class));
   }
 
   @Override
   @NotNull
   public ElixirNoParenthesesOneArgument getNoParenthesesOneArgument() {
-    return findNotNullChildByClass(ElixirNoParenthesesOneArgument.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirNoParenthesesOneArgument.class));
   }
 
   @Nullable

--- a/gen/org/elixir_lang/psi/impl/ElixirUnmatchedUnqualifiedParenthesesCallImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnmatchedUnqualifiedParenthesesCallImpl.java
@@ -9,6 +9,7 @@ import com.intellij.psi.PsiReference;
 import com.intellij.psi.ResolveState;
 import com.intellij.psi.scope.PsiScopeProcessor;
 import com.intellij.psi.stubs.IStubElementType;
+import com.intellij.psi.util.PsiTreeUtil;
 import org.apache.commons.lang.math.IntRange;
 import org.elixir_lang.psi.*;
 import org.elixir_lang.psi.stub.UnmatchedUnqualifiedParenthesesCall;
@@ -37,19 +38,19 @@ public class ElixirUnmatchedUnqualifiedParenthesesCallImpl extends NamedStubbedP
   @Override
   @Nullable
   public ElixirDoBlock getDoBlock() {
-    return findChildByClass(ElixirDoBlock.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirDoBlock.class);
   }
 
   @Override
   @NotNull
   public ElixirIdentifier getIdentifier() {
-    return findNotNullChildByClass(ElixirIdentifier.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirIdentifier.class));
   }
 
   @Override
   @NotNull
   public ElixirMatchedParenthesesArguments getMatchedParenthesesArguments() {
-    return findNotNullChildByClass(ElixirMatchedParenthesesArguments.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirMatchedParenthesesArguments.class));
   }
 
   @Nullable

--- a/gen/org/elixir_lang/psi/impl/ElixirUnmatchedWhenOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnmatchedWhenOperationImpl.java
@@ -39,7 +39,7 @@ public class ElixirUnmatchedWhenOperationImpl extends ElixirUnmatchedExpressionI
   @Override
   @NotNull
   public ElixirWhenInfixOperator getWhenInfixOperator() {
-    return findNotNullChildByClass(ElixirWhenInfixOperator.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirWhenInfixOperator.class));
   }
 
   @Nullable

--- a/gen/org/elixir_lang/psi/impl/ElixirUnqualifiedNoParenthesesManyArgumentsCallImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnqualifiedNoParenthesesManyArgumentsCallImpl.java
@@ -46,7 +46,7 @@ public class ElixirUnqualifiedNoParenthesesManyArgumentsCallImpl extends NamedSt
   @Override
   @NotNull
   public ElixirIdentifier getIdentifier() {
-    return findNotNullChildByClass(ElixirIdentifier.class);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirIdentifier.class));
   }
 
   @Override
@@ -58,7 +58,7 @@ public class ElixirUnqualifiedNoParenthesesManyArgumentsCallImpl extends NamedSt
   @Override
   @Nullable
   public ElixirNoParenthesesKeywords getNoParenthesesKeywords() {
-    return findChildByClass(ElixirNoParenthesesKeywords.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirNoParenthesesKeywords.class);
   }
 
   @Override
@@ -70,7 +70,7 @@ public class ElixirUnqualifiedNoParenthesesManyArgumentsCallImpl extends NamedSt
   @Override
   @Nullable
   public ElixirNoParenthesesStrict getNoParenthesesStrict() {
-    return findChildByClass(ElixirNoParenthesesStrict.class);
+    return PsiTreeUtil.getChildOfType(this, ElixirNoParenthesesStrict.class);
   }
 
   @Nullable


### PR DESCRIPTION

# Changelog
## Enhancements
* Regenerate `gen` folder using Grammar Kit 1.4.1 and fix some bugs (including https://github.com/JetBrains/Grammar-Kit/issues/126) manually.