### PR TITLE
BracketOperations no longer break isParameter or isVariable

### DIFF
--- a/src/org/elixir_lang/psi/BracketOperation.java
+++ b/src/org/elixir_lang/psi/BracketOperation.java
@@ -4,4 +4,5 @@ package org.elixir_lang.psi;
  * <expression> bracketArguments
  */
 public interface BracketOperation extends Quotable {
+    Quotable getBracketArguments();
 }

--- a/src/org/elixir_lang/psi/QualifiedBracketOperation.java
+++ b/src/org/elixir_lang/psi/QualifiedBracketOperation.java
@@ -5,6 +5,5 @@ import org.elixir_lang.psi.qualification.Qualified;
 /**
  * <expression> dotInfixOperator relativeIdentifier CALL bracketArguments
  */
-public interface QualifiedBracketOperation extends Qualified, Quotable {
-    Quotable getBracketArguments();
+public interface QualifiedBracketOperation extends BracketOperation, Qualified, Quotable {
 }

--- a/src/org/elixir_lang/psi/UnqualifiedBracketOperation.java
+++ b/src/org/elixir_lang/psi/UnqualifiedBracketOperation.java
@@ -5,6 +5,5 @@ import org.elixir_lang.psi.qualification.Unqualified;
 /**
  * IDENTIFIER CALL bracketArguments
  */
-public interface UnqualifiedBracketOperation extends Quotable, Unqualified {
-    Quotable getBracketArguments();
+public interface UnqualifiedBracketOperation extends BracketOperation, Unqualified {
 }

--- a/src/org/elixir_lang/reference/Callable.java
+++ b/src/org/elixir_lang/reference/Callable.java
@@ -333,7 +333,9 @@ public class Callable extends PsiReferenceBase<Call> implements PsiPolyVariantRe
             // MUST be after any operations because operations also implement Call
             isVariable = isVariable((Call) ancestor);
         } else {
-            if (!(ancestor instanceof AtNonNumericOperation || ancestor instanceof PsiFile)) {
+            if (!(ancestor instanceof AtNonNumericOperation ||
+                    ancestor instanceof BracketOperation ||
+                    ancestor instanceof PsiFile)) {
                 Logger.error(Callable.class, "Don't know how to check if variable", ancestor);
             }
         }

--- a/src/org/elixir_lang/reference/Callable.java
+++ b/src/org/elixir_lang/reference/Callable.java
@@ -247,7 +247,8 @@ public class Callable extends PsiReferenceBase<Call> implements PsiPolyVariantRe
         } else if (parent instanceof ElixirAnonymousFunction || parent instanceof InMatch) {
             isParameter = true;
         } else {
-            if (!(parent instanceof ElixirBlockItem ||
+            if (!(parent instanceof BracketOperation ||
+                    parent instanceof ElixirBlockItem ||
                     parent instanceof ElixirDoBlock ||
                     parent instanceof ElixirInterpolation ||
                     parent instanceof ElixirMapUpdateArguments ||


### PR DESCRIPTION
Fixes #346

# Changelog

## Enhancements
* Have both `QualifiedBracketOperation` and `UnqualifiedBracketOperation` extend `BracketOperation`, so that `BracketOperation` can be used to match both when the qualification does not matter.

## Bug Fixes
* `BracketOperations` are neither parameters nor variables.