### PR TITLE
Fix latent bugs causing bad file linking in stacktraces

### DIFF
--- a/src/org/elixir_lang/console/FileReferenceFilter.java
+++ b/src/org/elixir_lang/console/FileReferenceFilter.java
@@ -101,8 +101,8 @@ public final class FileReferenceFilter implements Filter {
     int fileLine = matchGroupToNumber(matcher, myLineMatchGroup);
     int fileColumn = matchGroupToNumber(matcher, myColumnMatchGroup);
 
-    int highlightStartOffset = entireLength - line.length() + matcher.start(0);
-    int highlightEndOffset = highlightStartOffset + matcher.end(0) - matcher.start(0);
+    int highlightStartOffset = entireLength - line.length() + matcher.start(0) + 1;
+    int highlightEndOffset = highlightStartOffset + matcher.end(0) - matcher.start(0) - 1;
 
     VirtualFile absolutePath = resolveAbsolutePath(filePath);
     HyperlinkInfo hyperlinkInfo = absolutePath != null ? new OpenFileHyperlinkInfo(myProject, absolutePath, fileLine, fileColumn) : null;

--- a/src/org/elixir_lang/console/FileReferenceFilter.java
+++ b/src/org/elixir_lang/console/FileReferenceFilter.java
@@ -30,7 +30,7 @@ public final class FileReferenceFilter implements Filter {
   public static final String LINE_MACROS = "$LINE$";
   public static final String COLUMN_MACROS = "$COLUMN$";
 
-  private static final String FILE_PATH_REGEXP = "((?:\\p{Alpha}\\:)?[0-9 a-z_A-Z\\-\\\\./]+)";
+  private static final String FILE_PATH_REGEXP = "\\s*([0-9 a-z_A-Z\\-\\\\./]+)";
   private static final String NUMBER_REGEXP = "([0-9]+)";
 
   private static final Pattern PATTERN_FILENAME = Pattern.compile("[/\\\\]?([^/\\\\]*?\\.ex)$");


### PR DESCRIPTION
Fixes #229

# Changelog
## Bug Fixes
* Strip spaces from front of file path in `mix` output, which allows file looks to work correctly.
* Ensure file reference highlight doesn't include the leading and trailing characters by fix off-by-one errors.