### PR TITLE
Check all left or rigth operands instead of normalized operands in match

### DIFF
--- a/src/org/elixir_lang/psi/impl/ElixirPsiImplUtil.java
+++ b/src/org/elixir_lang/psi/impl/ElixirPsiImplUtil.java
@@ -32,6 +32,8 @@ import org.elixir_lang.psi.call.arguments.None;
 import org.elixir_lang.psi.call.arguments.star.Parentheses;
 import org.elixir_lang.psi.call.name.Function;
 import org.elixir_lang.psi.operation.*;
+import org.elixir_lang.psi.operation.infix.Position;
+import org.elixir_lang.psi.operation.infix.Triple;
 import org.elixir_lang.psi.qualification.Qualified;
 import org.elixir_lang.psi.qualification.Unqualified;
 import org.elixir_lang.psi.stub.call.Stub;
@@ -1429,15 +1431,24 @@ public class ElixirPsiImplUtil {
         boolean checkRight = false;
         boolean checkLeft = false;
 
-        if (match.isEquivalentTo(lastParent) || match.operator().isEquivalentTo(lastParent)) {
+        Triple triple = new Triple(match.getChildren());
+        Position position = triple.ancestorPosition(lastParent);
+
+        if (position != null) {
+            switch (position) {
+                case LEFT:
+                    checkLeft  = true;
+                    checkRight = false;
+                case OPERATOR:
+                    checkLeft  = true;
+                    checkRight = true;
+                case RIGHT:
+                    checkLeft  = false;
+                    checkRight = true;
+            }
+        } else if (PsiTreeUtil.isAncestor(match, lastParent, false)) {
+            checkLeft  = true;
             checkRight = true;
-            checkLeft = true;
-        } else if (PsiTreeUtil.isAncestor(rightOperand, lastParent, false)) {
-            checkRight = true;
-            checkLeft = false;
-        } else if (PsiTreeUtil.isAncestor(leftOperand, lastParent, false)) {
-            checkRight = false;
-            checkLeft = true;
         }
 
         boolean keepProcessing = true;

--- a/src/org/elixir_lang/psi/operation/infix/Position.java
+++ b/src/org/elixir_lang/psi/operation/infix/Position.java
@@ -1,0 +1,8 @@
+package org.elixir_lang.psi.operation.infix;
+
+/**
+ * The position of a child inside the {@link org.elixir_lang.psi.operation.Infix}.
+ */
+public enum Position {
+    LEFT, OPERATOR, RIGHT
+}

--- a/src/org/elixir_lang/psi/operation/infix/Triple.java
+++ b/src/org/elixir_lang/psi/operation/infix/Triple.java
@@ -1,0 +1,95 @@
+package org.elixir_lang.psi.operation.infix;
+
+import com.intellij.psi.PsiElement;
+import org.elixir_lang.psi.Operator;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Arrays;
+
+import static com.intellij.psi.util.PsiTreeUtil.isAncestor;
+import static org.elixir_lang.psi.operation.Normalized.operatorIndex;
+
+/**
+ * Partitions children into those left of the operator, the operator, and those right of the operator.  This will
+ * include any error elements and the left or right children may be empty if there are other parsing errors with
+ * recovery.
+ */
+public class Triple {
+    /*
+     * Fields
+     */
+
+    @NotNull
+    public final PsiElement[] leftOperands;
+    @NotNull
+    public final PsiElement operator;
+    @NotNull
+    public final PsiElement[] rightOperands;
+
+    /*
+     * Constructors
+     */
+
+    public Triple(@NotNull PsiElement[] children) {
+        this(children, operatorIndex(children));
+    }
+
+    private Triple(@NotNull PsiElement[] children, int operatorIndex) {
+        this(
+                Arrays.copyOfRange(children, 0, operatorIndex),
+                (Operator) children[operatorIndex],
+                Arrays.copyOfRange(children, operatorIndex + 1, children.length)
+        );
+    }
+
+    private Triple(@NotNull PsiElement[] leftOperands, @NotNull Operator operator, @NotNull PsiElement[] rightOperands) {
+        this.leftOperands = leftOperands;
+        this.operator = operator;
+        this.rightOperands = rightOperands;
+    }
+
+    /*
+     *
+     * Instance Methods
+     *
+     */
+
+    /**
+     *
+     * @param element an element that MAY be an descendant of a child of this triple
+     * @return {@code null} if element is not a descendant of any children in this Triple.
+     */
+    @Nullable
+    public Position ancestorPosition(@NotNull PsiElement element) {
+        Position position = null;
+
+        if (isAnyAncestor(leftOperands, element)) {
+            position = Position.LEFT;
+        } else if (isAnyAncestor(rightOperands, element)) {
+            position = Position.RIGHT;
+        } else if (isAncestor(operator, element, false)) {
+            position = Position.OPERATOR;
+        }
+
+        return position;
+    }
+
+    /*
+     * Private Instance Methods
+     */
+
+    private boolean isAnyAncestor(@NotNull PsiElement[] operands, @NotNull PsiElement element) {
+        boolean isAnyAncestor = false;
+
+        for (PsiElement operand : operands) {
+            if (isAncestor(operand, element, false)) {
+                isAnyAncestor = true;
+
+                break;
+            }
+        }
+
+        return isAnyAncestor;
+    }
+}


### PR DESCRIPTION
Fixes #352

# Changelog
## Bug Fixes
* Determine whether to check left, right, or both by doing isAncestor checks for all operands, not just the normalized operand.  The normalized operand is still used for PsiSceopProcessor#execute since execute is not expected to handle error elements.