### PR TITLE
Revert incorrect find-replace when Unknown was introduced

### DIFF
--- a/src/org/elixir_lang/navigation/item_presentation/modular/Module.java
+++ b/src/org/elixir_lang/navigation/item_presentation/modular/Module.java
@@ -1,6 +1,5 @@
 package org.elixir_lang.navigation.item_presentation.modular;
 
-import com.intellij.icons.AllIcons;
 import com.intellij.navigation.ItemPresentation;
 import com.intellij.psi.PsiElement;
 import org.elixir_lang.icons.ElixirIcons;
@@ -100,13 +99,13 @@ public class Module implements ItemPresentation, Parent {
     }
 
     /**
-     * Question mark icon
+     * The module icon.
      *
      * @param unused Used to mean if open/close icons for tree renderer. No longer in use. The parameter is only there for API compatibility reason.
      */
     @Override
     @NotNull
     public Icon getIcon(boolean unused) {
-        return AllIcons.General.QuestionDialog;
+        return ElixirIcons.MODULE;
     }
 }


### PR DESCRIPTION
Fixes #255

# Changelog
## Bug Fixes
* The `Module` icon got the same icon as `Unknown` when creating `Unknown` somehow, I assume due to find-replace.