### PR TITLE
Auto-insert matching delimiters

### DIFF
--- a/src/META-INF/plugin.xml
+++ b/src/META-INF/plugin.xml
@@ -1411,6 +1411,7 @@
     <codeInsight.lineMarkerProvider implementationClass="org.elixir_lang.code_insight.line_marker_provider.CallDefinition" language="Elixir"/>
     <elementDescriptionProvider implementation="org.elixir_lang.psi.ElementDescriptionProvider"/>
     <gotoSymbolContributor implementation="org.elixir_lang.navigation.GotoSymbolContributor"/>
+    <lang.braceMatcher language="Elixir" implementationClass="org.elixir_lang.BraceMatcher"/>
     <lang.commenter language="Elixir" implementationClass="org.elixir_lang.ElixirCommenter"/>
     <lang.findUsagesProvider language="Elixir" implementationClass="org.elixir_lang.FindUsagesProvider"/>
     <lang.foldingBuilder language="Elixir" implementationClass="org.elixir_lang.psi.FoldingBuilder"/>

--- a/src/META-INF/plugin.xml
+++ b/src/META-INF/plugin.xml
@@ -1417,6 +1417,7 @@
     <lang.foldingBuilder language="Elixir" implementationClass="org.elixir_lang.psi.FoldingBuilder"/>
     <lang.parserDefinition language="Elixir" implementationClass="org.elixir_lang.ElixirParserDefinition"/>
     <lang.psiStructureViewFactory language="Elixir" implementationClass="org.elixir_lang.structure_view.Factory"/>
+    <lang.quoteHandler language="Elixir" implementationClass="org.elixir_lang.QuoteHandler"/>
     <lang.syntaxHighlighterFactory key="Elixir" implementationClass="org.elixir_lang.ElixirSyntaxHighlighterFactory"/>
     <localInspection displayName="Ambiguous nested calls" enabledByDefault="true" groupName="Elixir"
                      implementationClass="org.elixir_lang.inspection.NoParenthesesManyStrict" language="Elixir"

--- a/src/META-INF/plugin.xml
+++ b/src/META-INF/plugin.xml
@@ -1440,6 +1440,7 @@
     <renamePsiElementProcessor implementation="org.elixir_lang.refactoring.variable.rename.Processor"/>
 
     <stubIndex implementation="org.elixir_lang.psi.stub.index.AllName"/>
+    <typedHandler implementation="org.elixir_lang.TypedHandler"/>
   </extensions>
 
   <application-components>

--- a/src/org/elixir_lang/BraceMatcher.java
+++ b/src/org/elixir_lang/BraceMatcher.java
@@ -2,9 +2,12 @@ package org.elixir_lang;
 
 import com.intellij.lang.BracePair;
 import com.intellij.lang.PairedBraceMatcher;
+import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
 import com.intellij.psi.tree.IElementType;
+import org.elixir_lang.psi.ElixirDoBlock;
 import org.elixir_lang.psi.ElixirTypes;
+import org.elixir_lang.psi.call.Call;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -38,7 +41,23 @@ public class BraceMatcher implements PairedBraceMatcher {
      */
     @Override
     public int getCodeConstructStart(PsiFile file, int openingBraceOffset) {
-        return 0;
+        int offset = openingBraceOffset;
+
+        PsiElement element = file.findElementAt(openingBraceOffset);
+
+        if (element != null) {
+            PsiElement parent = element.getParent();
+
+            if (parent instanceof ElixirDoBlock) {
+                PsiElement grandParent = parent.getParent();
+
+                if (grandParent instanceof Call) {
+                    offset = grandParent.getTextOffset();
+                }
+            }
+        }
+
+        return offset;
     }
 
     /**

--- a/src/org/elixir_lang/BraceMatcher.java
+++ b/src/org/elixir_lang/BraceMatcher.java
@@ -22,8 +22,8 @@ public class BraceMatcher implements PairedBraceMatcher {
             new BracePair(ElixirTypes.OPENING_BRACKET,     ElixirTypes.CLOSING_BRACKET,     false),
             new BracePair(ElixirTypes.OPENING_CURLY,       ElixirTypes.CLOSING_CURLY,       false),
             new BracePair(ElixirTypes.OPENING_PARENTHESIS, ElixirTypes.CLOSING_PARENTHESIS, false),
-            new BracePair(ElixirTypes.FN,                  ElixirTypes.END,                 true),
-            new BracePair(ElixirTypes.DO,                  ElixirTypes.END,                 true)
+            new BracePair(ElixirTypes.DO,                  ElixirTypes.END,                 true),
+            new BracePair(ElixirTypes.FN,                  ElixirTypes.END,                 true)
     };
 
     /*

--- a/src/org/elixir_lang/BraceMatcher.java
+++ b/src/org/elixir_lang/BraceMatcher.java
@@ -1,0 +1,69 @@
+package org.elixir_lang;
+
+import com.intellij.lang.BracePair;
+import com.intellij.lang.PairedBraceMatcher;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.tree.IElementType;
+import org.elixir_lang.psi.ElixirTypes;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class BraceMatcher implements PairedBraceMatcher {
+    /*
+     * CONSTANTS
+     */
+
+    private final static BracePair[] BRACE_PAIRS = new BracePair[]{
+            new BracePair(ElixirTypes.OPENING_BIT,         ElixirTypes.CLOSING_BIT,         false),
+            new BracePair(ElixirTypes.OPENING_BRACKET,     ElixirTypes.CLOSING_BRACKET,     false),
+            new BracePair(ElixirTypes.OPENING_CURLY,       ElixirTypes.CLOSING_CURLY,       false),
+            new BracePair(ElixirTypes.OPENING_PARENTHESIS, ElixirTypes.CLOSING_PARENTHESIS, false),
+            new BracePair(ElixirTypes.FN,                  ElixirTypes.END,                 true),
+            new BracePair(ElixirTypes.DO,                  ElixirTypes.END,                 true)
+    };
+
+    /*
+     * Instance Methods
+     */
+
+    /**
+     * Returns the start offset of the code construct which owns the opening structural brace at the specified offset.
+     * For example, if the opening brace belongs to an 'if' statement, returns the start offset of the 'if' statement.
+     * This is used for the scope highlighting.
+     *
+     * @param file               the file in which brace matching is performed.
+     * @param openingBraceOffset the offset of an opening structural brace.
+     * @return the offset of corresponding code construct, or the same offset if not defined.
+     */
+    @Override
+    public int getCodeConstructStart(PsiFile file, int openingBraceOffset) {
+        return 0;
+    }
+
+    /**
+     * Returns the array of definitions for brace pairs that need to be matched when
+     * editing code in the language.
+     *
+     * @return the array of brace pair definitions.
+     */
+    @Contract(pure = true)
+    @Override
+    public BracePair[] getPairs() {
+        return BRACE_PAIRS;
+    }
+
+    /**
+     * Returns true if paired rbrace should be inserted after lbrace of given type when lbrace is encountered before
+     * contextType token. It is safe to always return true, then paired brace will be inserted anyway.
+     *
+     * @param lbraceType  lbrace for which information is queried
+     * @param contextType token type that follows lbrace
+     * @return true / false as described
+     */
+    @Override
+    public boolean isPairedBracesAllowedBeforeType(@NotNull IElementType lbraceType, @Nullable IElementType contextType) {
+        return true;
+    }
+
+}

--- a/src/org/elixir_lang/BraceMatcher.java
+++ b/src/org/elixir_lang/BraceMatcher.java
@@ -18,12 +18,26 @@ public class BraceMatcher implements PairedBraceMatcher {
      */
 
     private final static BracePair[] BRACE_PAIRS = new BracePair[]{
-            new BracePair(ElixirTypes.DO,                  ElixirTypes.END,                 true),
-            new BracePair(ElixirTypes.FN,                  ElixirTypes.END,                 true),
-            new BracePair(ElixirTypes.OPENING_BIT,         ElixirTypes.CLOSING_BIT,         false),
-            new BracePair(ElixirTypes.OPENING_BRACKET,     ElixirTypes.CLOSING_BRACKET,     false),
-            new BracePair(ElixirTypes.OPENING_CURLY,       ElixirTypes.CLOSING_CURLY,       false),
-            new BracePair(ElixirTypes.OPENING_PARENTHESIS, ElixirTypes.CLOSING_PARENTHESIS, false)
+            new BracePair(ElixirTypes.DO,                               ElixirTypes.END,                                true),
+            new BracePair(ElixirTypes.FN,                               ElixirTypes.END,                                true),
+            new BracePair(ElixirTypes.CHAR_LIST_HEREDOC_PROMOTER,       ElixirTypes.CHAR_LIST_HEREDOC_TERMINATOR,       false),
+            new BracePair(ElixirTypes.CHAR_LIST_SIGIL_HEREDOC_PROMOTER, ElixirTypes.CHAR_LIST_SIGIL_HEREDOC_TERMINATOR, false),
+            new BracePair(ElixirTypes.CHAR_LIST_SIGIL_PROMOTER,         ElixirTypes.CHAR_LIST_SIGIL_TERMINATOR,         false),
+            new BracePair(ElixirTypes.CHAR_LIST_PROMOTER,               ElixirTypes.CHAR_LIST_PROMOTER,                 false),
+            new BracePair(ElixirTypes.REGEX_HEREDOC_PROMOTER,           ElixirTypes.REGEX_HEREDOC_TERMINATOR,           false),
+            new BracePair(ElixirTypes.REGEX_PROMOTER,                   ElixirTypes.REGEX_TERMINATOR,                   false),
+            new BracePair(ElixirTypes.SIGIL_HEREDOC_PROMOTER,           ElixirTypes.SIGIL_HEREDOC_TERMINATOR,           false),
+            new BracePair(ElixirTypes.SIGIL_PROMOTER,                   ElixirTypes.SIGIL_TERMINATOR,                   false),
+            new BracePair(ElixirTypes.STRING_HEREDOC_PROMOTER,          ElixirTypes.STRING_HEREDOC_TERMINATOR,          false),
+            new BracePair(ElixirTypes.STRING_SIGIL_HEREDOC_PROMOTER,    ElixirTypes.STRING_SIGIL_HEREDOC_TERMINATOR,    false),
+            new BracePair(ElixirTypes.STRING_SIGIL_PROMOTER,            ElixirTypes.STRING_SIGIL_TERMINATOR,            false),
+            new BracePair(ElixirTypes.STRING_PROMOTER,                  ElixirTypes.STRING_TERMINATOR,                  false),
+            new BracePair(ElixirTypes.WORDS_HEREDOC_PROMOTER,           ElixirTypes.WORDS_HEREDOC_TERMINATOR,           false),
+            new BracePair(ElixirTypes.WORDS_PROMOTER,                   ElixirTypes.WORDS_TERMINATOR,                   false),
+            new BracePair(ElixirTypes.OPENING_BIT,                      ElixirTypes.CLOSING_BIT,                        false),
+            new BracePair(ElixirTypes.OPENING_BRACKET,                  ElixirTypes.CLOSING_BRACKET,                    false),
+            new BracePair(ElixirTypes.OPENING_CURLY,                    ElixirTypes.CLOSING_CURLY,                      false),
+            new BracePair(ElixirTypes.OPENING_PARENTHESIS,              ElixirTypes.CLOSING_PARENTHESIS,                false)
     };
 
     /*

--- a/src/org/elixir_lang/BraceMatcher.java
+++ b/src/org/elixir_lang/BraceMatcher.java
@@ -18,12 +18,12 @@ public class BraceMatcher implements PairedBraceMatcher {
      */
 
     private final static BracePair[] BRACE_PAIRS = new BracePair[]{
+            new BracePair(ElixirTypes.DO,                  ElixirTypes.END,                 true),
+            new BracePair(ElixirTypes.FN,                  ElixirTypes.END,                 true),
             new BracePair(ElixirTypes.OPENING_BIT,         ElixirTypes.CLOSING_BIT,         false),
             new BracePair(ElixirTypes.OPENING_BRACKET,     ElixirTypes.CLOSING_BRACKET,     false),
             new BracePair(ElixirTypes.OPENING_CURLY,       ElixirTypes.CLOSING_CURLY,       false),
-            new BracePair(ElixirTypes.OPENING_PARENTHESIS, ElixirTypes.CLOSING_PARENTHESIS, false),
-            new BracePair(ElixirTypes.DO,                  ElixirTypes.END,                 true),
-            new BracePair(ElixirTypes.FN,                  ElixirTypes.END,                 true)
+            new BracePair(ElixirTypes.OPENING_PARENTHESIS, ElixirTypes.CLOSING_PARENTHESIS, false)
     };
 
     /*

--- a/src/org/elixir_lang/QuoteHandler.java
+++ b/src/org/elixir_lang/QuoteHandler.java
@@ -1,0 +1,145 @@
+package org.elixir_lang;
+
+import com.google.common.collect.ImmutableMap;
+import com.intellij.codeInsight.editorActions.MultiCharQuoteHandler;
+import com.intellij.openapi.editor.Document;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.editor.highlighter.HighlighterIterator;
+import com.intellij.openapi.util.TextRange;
+import com.intellij.psi.tree.IElementType;
+import com.intellij.psi.tree.TokenSet;
+import org.elixir_lang.lexer.StackFrame;
+import org.elixir_lang.psi.ElixirTypes;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Map;
+
+public class QuoteHandler implements MultiCharQuoteHandler {
+    /*
+     * CONSTANTS
+     */
+
+    private final static Map<IElementType, IElementType> CLOSING_QUOTE_BY_OPENING_QUOTE = ImmutableMap
+            .<IElementType, IElementType>builder()
+            .put(ElixirTypes.CHAR_LIST_HEREDOC_PROMOTER, ElixirTypes.CHAR_LIST_HEREDOC_TERMINATOR)
+            .put(ElixirTypes.CHAR_LIST_SIGIL_HEREDOC_PROMOTER, ElixirTypes.CHAR_LIST_SIGIL_HEREDOC_TERMINATOR)
+            .put(ElixirTypes.CHAR_LIST_SIGIL_PROMOTER, ElixirTypes.CHAR_LIST_SIGIL_TERMINATOR)
+            .put(ElixirTypes.CHAR_LIST_PROMOTER, ElixirTypes.CHAR_LIST_PROMOTER)
+            .put(ElixirTypes.REGEX_HEREDOC_PROMOTER, ElixirTypes.REGEX_HEREDOC_TERMINATOR)
+            .put(ElixirTypes.REGEX_PROMOTER, ElixirTypes.REGEX_TERMINATOR)
+            .put(ElixirTypes.SIGIL_HEREDOC_PROMOTER, ElixirTypes.SIGIL_HEREDOC_TERMINATOR)
+            .put(ElixirTypes.SIGIL_PROMOTER, ElixirTypes.SIGIL_TERMINATOR)
+            .put(ElixirTypes.STRING_HEREDOC_PROMOTER, ElixirTypes.STRING_HEREDOC_TERMINATOR)
+            .put(ElixirTypes.STRING_SIGIL_HEREDOC_PROMOTER, ElixirTypes.STRING_SIGIL_HEREDOC_TERMINATOR)
+            .put(ElixirTypes.STRING_SIGIL_PROMOTER, ElixirTypes.STRING_SIGIL_TERMINATOR)
+            .put(ElixirTypes.STRING_PROMOTER, ElixirTypes.STRING_TERMINATOR)
+            .put(ElixirTypes.WORDS_HEREDOC_PROMOTER, ElixirTypes.WORDS_HEREDOC_TERMINATOR)
+            .put(ElixirTypes.WORDS_PROMOTER, ElixirTypes.WORDS_TERMINATOR)
+            .build();
+
+    private final static TokenSet CLOSING_QUOTES = TokenSet.create(
+            CLOSING_QUOTE_BY_OPENING_QUOTE
+                    .values()
+                    .toArray(new IElementType[0])
+    );
+
+    private final static TokenSet LITERALS = TokenSet.create(
+            ElixirTypes.ATOM_FRAGMENT,
+            ElixirTypes.CHAR_LIST_FRAGMENT,
+            ElixirTypes.REGEX_FRAGMENT,
+            ElixirTypes.SIGIL_FRAGMENT,
+            ElixirTypes.STRING_FRAGMENT,
+            ElixirTypes.WORDS_FRAGMENT
+    );
+
+    private final static TokenSet OPENING_QUOTES = TokenSet.create(
+            CLOSING_QUOTE_BY_OPENING_QUOTE
+                    .keySet()
+                    .toArray(new IElementType[0])
+    );
+
+    /*
+     * Instance Methods
+     */
+
+    @Nullable
+    @Override
+    public CharSequence getClosingQuote(HighlighterIterator highlighterIterator, int offset) {
+        Document document = highlighterIterator.getDocument();
+        CharSequence closingQuote = null;
+
+        if (document != null) {
+            if (offset >= 3) {
+                String openingQuote = document.getText(new TextRange(offset - 3, offset));
+
+                closingQuote = StackFrame.TERMINATOR_BY_PROMOTER.get(openingQuote);
+
+                if (closingQuote != null) {
+                    closingQuote = "\n" + closingQuote;
+                }
+            }
+
+            if (closingQuote == null && offset >= 1) {
+                String openingQuote = document.getText(new TextRange(offset - 1, offset));
+
+                closingQuote = StackFrame.TERMINATOR_BY_PROMOTER.get(openingQuote);
+            }
+        }
+
+        return closingQuote;
+    }
+
+    /**
+     *
+     * @param editor
+     * @param highlighterIterator
+     * @param offset the offset of the element with {@link HighlighterIterator#getTokenType()}
+     * @return {@code true} to automatically insert a closing quote
+     *   (from {@link #getClosingQuote(HighlighterIterator, int)}
+     * @see <a href="https://github.com/JetBrains/intellij-community/blob/eeefa20d7c43856143c825ca65de6d5089241b35/platform/lang-impl/src/com/intellij/codeInsight/editorActions/TypedHandler.java#L472-L478">TypeHandler#handleQuote</a>
+     * @see <a href="https://github.com/JetBrains/intellij-community/blob/eeefa20d7c43856143c825ca65de6d5089241b35/platform/lang-impl/src/com/intellij/codeInsight/editorActions/TypedHandler.java#L529">TypeHandler#hasNonClosedLiterals</a>
+     */
+    @Override
+    public boolean hasNonClosedLiteral(Editor editor, HighlighterIterator highlighterIterator, int offset) {
+        /* it is safe to always return true based on XMLQuoteHandler
+           @see https://github.com/JetBrains/intellij-community/blob/eeefa20d7c43856143c825ca65de6d5089241b35/xml/impl/src/com/intellij/codeInsight/editorActions/XmlQuoteHandler.java#L38 */
+        return true;
+    }
+
+    /**
+     *
+     * @param highlighterIterator
+     * @param offset the current offset in the file of the {@code highlighterIterator}
+     * @return {@code true} if {@link HighlighterIterator#getTokenType()} is one of {@link #CLOSING_QUOTES} and
+     *   {@code offset} is {@link HighlighterIterator#getStart()}
+     */
+    @Override
+    public boolean isClosingQuote(HighlighterIterator highlighterIterator, int offset) {
+        boolean isClosingQuote = false;
+
+        if (CLOSING_QUOTES.contains(highlighterIterator.getTokenType())) {
+            int start = highlighterIterator.getStart();
+            int end = highlighterIterator.getEnd();
+            isClosingQuote = end - start >= 1 && offset == end - 1;
+        }
+
+        return isClosingQuote;
+    }
+
+    @Override
+    public boolean isInsideLiteral(HighlighterIterator highlighterIterator) {
+        return LITERALS.contains(highlighterIterator.getTokenType());
+    }
+
+    @Override
+    public boolean isOpeningQuote(HighlighterIterator highlighterIterator, int offset) {
+        boolean isOpeningQuote = false;
+
+        if (OPENING_QUOTES.contains(highlighterIterator.getTokenType())){
+            int start = highlighterIterator.getStart();
+            isOpeningQuote = offset == start;
+        }
+
+        return isOpeningQuote;
+    }
+}

--- a/src/org/elixir_lang/TypedHandler.java
+++ b/src/org/elixir_lang/TypedHandler.java
@@ -79,6 +79,19 @@ public class TypedHandler extends TypedHandlerDelegate {
                         result = Result.STOP;
                     }
                 }
+            } else if (charTyped == '/' || charTyped == '|') {
+                int caret = editor.getCaretModel().getOffset();
+
+                if (caret > 2) { // "~<sigil_name>(/|\|)"
+                    final EditorHighlighter highlighter = ((EditorEx)editor).getHighlighter();
+                    HighlighterIterator iterator = highlighter.createIterator(caret - 1);
+                    IElementType tokenType = iterator.getTokenType();
+
+                    if (SIGIL_PROMOTERS.contains(tokenType)) {
+                        editor.getDocument().insertString(caret, String.valueOf(charTyped));
+                        result = Result.STOP;
+                    }
+                }
             }
         }
 

--- a/src/org/elixir_lang/TypedHandler.java
+++ b/src/org/elixir_lang/TypedHandler.java
@@ -29,14 +29,25 @@ public class TypedHandler extends TypedHandlerDelegate {
             if (charTyped == ' ') {
                 int caret = editor.getCaretModel().getOffset();
 
-                // "(do|fn)<space><caret>"
-                if (caret > 2) {
+                if (caret > 2) { // "(do|fn)<space><caret>"
                     final EditorHighlighter highlighter = ((EditorEx)editor).getHighlighter();
                     HighlighterIterator iterator = highlighter.createIterator(caret - 3);
                     IElementType tokenType = iterator.getTokenType();
 
                     if (tokenType == ElixirTypes.DO || tokenType == ElixirTypes.FN) {
                         editor.getDocument().insertString(caret, " end");
+                        result = Result.STOP;
+                    }
+                }
+            } else if (charTyped == '<') {
+                int caret = editor.getCaretModel().getOffset();
+
+                if (caret > 1) { // "<<"
+                    final EditorHighlighter highlighter = ((EditorEx)editor).getHighlighter();
+                    HighlighterIterator iterator = highlighter.createIterator(caret - 2);
+
+                    if (iterator.getTokenType() == ElixirTypes.OPENING_BIT) {
+                        editor.getDocument().insertString(caret, ">>");
                         result = Result.STOP;
                     }
                 }

--- a/src/org/elixir_lang/TypedHandler.java
+++ b/src/org/elixir_lang/TypedHandler.java
@@ -7,6 +7,7 @@ import com.intellij.openapi.editor.highlighter.EditorHighlighter;
 import com.intellij.openapi.editor.highlighter.HighlighterIterator;
 import com.intellij.openapi.project.Project;
 import com.intellij.psi.PsiFile;
+import com.intellij.psi.tree.IElementType;
 import org.elixir_lang.psi.ElixirFile;
 import org.elixir_lang.psi.ElixirTypes;
 import org.jetbrains.annotations.NotNull;
@@ -28,12 +29,13 @@ public class TypedHandler extends TypedHandlerDelegate {
             if (charTyped == ' ') {
                 int caret = editor.getCaretModel().getOffset();
 
-                // "fn<space><caret>"
+                // "(do|fn)<space><caret>"
                 if (caret > 2) {
                     final EditorHighlighter highlighter = ((EditorEx)editor).getHighlighter();
                     HighlighterIterator iterator = highlighter.createIterator(caret - 3);
+                    IElementType tokenType = iterator.getTokenType();
 
-                    if (iterator.getTokenType() == ElixirTypes.FN) {
+                    if (tokenType == ElixirTypes.DO || tokenType == ElixirTypes.FN) {
                         editor.getDocument().insertString(caret, " end");
                         result = Result.STOP;
                     }

--- a/src/org/elixir_lang/TypedHandler.java
+++ b/src/org/elixir_lang/TypedHandler.java
@@ -1,0 +1,46 @@
+package org.elixir_lang;
+
+import com.intellij.codeInsight.editorActions.TypedHandlerDelegate;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.editor.ex.EditorEx;
+import com.intellij.openapi.editor.highlighter.EditorHighlighter;
+import com.intellij.openapi.editor.highlighter.HighlighterIterator;
+import com.intellij.openapi.project.Project;
+import com.intellij.psi.PsiFile;
+import org.elixir_lang.psi.ElixirFile;
+import org.elixir_lang.psi.ElixirTypes;
+import org.jetbrains.annotations.NotNull;
+
+public class TypedHandler extends TypedHandlerDelegate {
+    /**
+     * Called after the specified character typed by the user has been inserted in the editor.
+     *
+     * @param charTyped the character that was typed
+     * @param project the project in which the {@code file} exists
+     * @param editor the editor that has the {@code file} open
+     * @param file the file into which the {@code charTyped} was typed
+     */
+    @Override
+    public Result charTyped(char charTyped, Project project, @NotNull Editor editor, @NotNull PsiFile file) {
+        Result result = Result.CONTINUE;
+
+        if (file instanceof ElixirFile) {
+            if (charTyped == ' ') {
+                int caret = editor.getCaretModel().getOffset();
+
+                // "fn<space><caret>"
+                if (caret > 2) {
+                    final EditorHighlighter highlighter = ((EditorEx)editor).getHighlighter();
+                    HighlighterIterator iterator = highlighter.createIterator(caret - 3);
+
+                    if (iterator.getTokenType() == ElixirTypes.FN) {
+                        editor.getDocument().insertString(caret, " end");
+                        result = Result.STOP;
+                    }
+                }
+            }
+        }
+
+        return result;
+    }
+}

--- a/src/org/elixir_lang/lexer/StackFrame.java
+++ b/src/org/elixir_lang/lexer/StackFrame.java
@@ -17,19 +17,19 @@ public class StackFrame {
      * Static
      */
 
-    public static final Map<String, String> terminatorByPromoter = new HashMap<String, String>();
+    public static final Map<String, String> TERMINATOR_BY_PROMOTER = new HashMap<String, String>();
 
     static {
-        terminatorByPromoter.put("'", "'");
-        terminatorByPromoter.put("'''", "'''");
-        terminatorByPromoter.put("(", ")");
-        terminatorByPromoter.put("/", "/");
-        terminatorByPromoter.put("<", ">");
-        terminatorByPromoter.put("[", "]");
-        terminatorByPromoter.put("\"", "\"");
-        terminatorByPromoter.put("\"\"\"", "\"\"\"");
-        terminatorByPromoter.put("{", "}");
-        terminatorByPromoter.put("|", "|");
+        TERMINATOR_BY_PROMOTER.put("'", "'");
+        TERMINATOR_BY_PROMOTER.put("'''", "'''");
+        TERMINATOR_BY_PROMOTER.put("(", ")");
+        TERMINATOR_BY_PROMOTER.put("/", "/");
+        TERMINATOR_BY_PROMOTER.put("<", ">");
+        TERMINATOR_BY_PROMOTER.put("[", "]");
+        TERMINATOR_BY_PROMOTER.put("\"", "\"");
+        TERMINATOR_BY_PROMOTER.put("\"\"\"", "\"\"\"");
+        TERMINATOR_BY_PROMOTER.put("{", "}");
+        TERMINATOR_BY_PROMOTER.put("|", "|");
     }
 
     /*
@@ -204,11 +204,11 @@ public class StackFrame {
 
     public String getTerminator() {
         String promoter = getPromoter();
-        String terminator = terminatorByPromoter.get(promoter);
+        String terminator = TERMINATOR_BY_PROMOTER.get(promoter);
 
         // unregistered promoters are their own terminators
         if (terminator == null) {
-            terminatorByPromoter.put(promoter, promoter);
+            TERMINATOR_BY_PROMOTER.put(promoter, promoter);
             terminator = promoter;
         }
 


### PR DESCRIPTION
Resolves #357

# Changelog
## Enhancements
* `BraceMatcher`
  * Matches the following pairs:
    * `do` to `end`
    * `fn` to `end`
    * `"""` to `"""`
    *  `'''` to `'''`
    * `<<` to `>>`
    * `<` to `>`
    * `[` to `]`
    * `{` to `}`
    * `(` to `)`
  * Completes the following pairs:
    * `[` with `]`
    * `{` with `}`
    * `(` with `)`
* `QuoteHandler` completes standard quotes (that start with `"` or `'`)
  * `'` with `'`
  * `"` with `"`
  * `'''` with `'''`
  * `"""` with `"""`
* `TypedHandler` completes the non-standard quotes and braces
  * `do` with ` end`
  * `fn` with ` end`
  ` `<<` with `>>`
  * `<` with `>`  (for promoters)
  * `/` with `/`  (for promoters)
  * `|` with `|` (for promoters)