### PR TITLE
Add support for `else` (or `after`, `catch`, or `rescue`) to enclosingMacroCall

### DIFF
--- a/src/org/elixir_lang/psi/impl/ElixirPsiImplUtil.java
+++ b/src/org/elixir_lang/psi/impl/ElixirPsiImplUtil.java
@@ -1887,7 +1887,21 @@ public class ElixirPsiImplUtil {
             if (grandParent instanceof ElixirStab) {
                 PsiElement greatGrandParent = grandParent.getParent();
 
-                if (greatGrandParent instanceof ElixirDoBlock) {
+                if (greatGrandParent instanceof ElixirBlockItem) {
+                    PsiElement greatGreatGrandParent = greatGrandParent.getParent();
+
+                    if (greatGreatGrandParent instanceof ElixirBlockList) {
+                        PsiElement greatGreatGreatGrandParent = greatGreatGrandParent.getParent();
+
+                        if (greatGreatGreatGrandParent instanceof ElixirDoBlock) {
+                            PsiElement greatGreatGreatGreatGrandParent = greatGreatGreatGrandParent.getParent();
+
+                            if (greatGreatGreatGreatGrandParent instanceof Call) {
+                                enclosingMacroCall = (Call) greatGreatGreatGreatGrandParent;
+                            }
+                        }
+                    }
+                } else if (greatGrandParent instanceof ElixirDoBlock) {
                     PsiElement greatGreatGrandParent = greatGrandParent.getParent();
 
                     if (greatGreatGrandParent instanceof Call) {


### PR DESCRIPTION
Fixes #369

# Changelog
## Bug Fixes
* `enclosingMacroCall` could climb out the stab after a `do`, but not the `else` in an `if`, which is used for defined functions conditionally in [`Phoenix.Endpoint.server/0`](https://github.com/phoenixframework/phoenix/blob/v1.2.0/lib/phoenix/endpoint.ex#L542-L548)