### PR TITLE
Add @doc template

### DIFF
--- a/res/liveTemplates/Elixir.xml
+++ b/res/liveTemplates/Elixir.xml
@@ -1,4 +1,9 @@
 <templateSet group="Elixir">
+  <template name="@doc" value="@doc &quot;&quot;&quot;&#10;$1$&#10;&quot;&quot;&quot;&#10;$END$" description="@doc &quot;&quot;&quot; ... &quot;&quot;&quot;" toReformat="true" toShortenFQNames="true" >
+    <context>
+      <option name="ELIXIR_CODE" value="true" />
+    </context>
+  </template>
   <template name="def" value="def $NAME$ do&#10;  $END$&#10;end" description="def name do end" toReformat="true" toShortenFQNames="true" >
     <variable name="NAME" expression="" defaultValue="" alwaysStopAt="true" />
     <context>


### PR DESCRIPTION
Resolves #294

# Changelog
## Bug Fixes
* A lot of ppl use the doc template after already typing @, but the `doc` template starts with `@`, so it ends up inserting `@@doc ...`.  The `@doc` is the same code, but since the name starts with `@`, it doesn't insert a second `@`.  Unfortunately, the template search code doesn't prompt when just typing `@`, so you end up having to type `@doc` before only one template is selected.  The `@doc` template will show in the lookup as soon as `@d` is typed, but you have to select it from the list then before tabbing to accept.