### PR TITLE
Look at end of `do` instead of start for `end` completion

### DIFF
--- a/src/org/elixir_lang/TypedHandler.java
+++ b/src/org/elixir_lang/TypedHandler.java
@@ -48,7 +48,7 @@ public class TypedHandler extends TypedHandlerDelegate {
 
                 if (caret > 2) { // "(do|fn)<space><caret>"
                     final EditorHighlighter highlighter = ((EditorEx)editor).getHighlighter();
-                    HighlighterIterator iterator = highlighter.createIterator(caret - 3);
+                    HighlighterIterator iterator = highlighter.createIterator(caret - 2);
                     IElementType tokenType = iterator.getTokenType();
 
                     if (tokenType == ElixirTypes.DO || tokenType == ElixirTypes.FN) {


### PR DESCRIPTION
Fixes #376

# Changelog
## Bug Fixes
* Look at end of `do` instead of start for `end` completion to stop ignoring the `:` in `do: `, when `caret - 3` would land on the `o`, now all tests are meant to land on the `o`, so `do: ` won't complete with `end` incorrectly anymore.