### PR TITLE
Ignore ElixirVariable in highlightTypesAndTypeParameterUsages

### DIFF
--- a/src/org/elixir_lang/annonator/ModuleAttribute.java
+++ b/src/org/elixir_lang/annonator/ModuleAttribute.java
@@ -833,7 +833,8 @@ public class ModuleAttribute implements Annotator, DumbAware {
                 /* happens when :: is typed in `@spec` above function clause that uses `do:` */
                 psiElement instanceof ElixirNoParenthesesKeywords ||
                 psiElement instanceof ElixirStringLine ||
-                psiElement instanceof ElixirUnaryNumericOperation) {
+                psiElement instanceof ElixirUnaryNumericOperation ||
+                psiElement instanceof ElixirVariable) {
             // leave normal highlighting
         }  else if (psiElement instanceof ElixirMapOperation) {
             highlightTypesAndTypeParameterUsages(


### PR DESCRIPTION
Fixes #375

# Changelog
## Bug Fixes
* Ignore `ElixirVariable` in `highlightTypesAndTypeParameterUsages`