### PR TITLE
Resolve aliased modules

### DIFF
--- a/src/org/elixir_lang/Module.java
+++ b/src/org/elixir_lang/Module.java
@@ -9,6 +9,16 @@ import java.util.Arrays;
 import java.util.Collection;
 
 public class Module {
+    /*
+     * Constants
+     */
+
+    private static final String SEPARATOR = ".";
+
+    /*
+     * Public Static Methods
+     */
+
     /**
      * Emulates Module.concat/1
      * @return
@@ -16,19 +26,22 @@ public class Module {
     @Contract(pure = true)
     @NotNull
     public static String concat(@NotNull String... aliases) {
-        return StringUtil.join(aliases, ".");
+        return StringUtil.join(aliases, SEPARATOR);
     }
 
     @Contract(pure = true)
     @NotNull
     public static String concat(@NotNull Collection<String> aliases) {
-        return StringUtil.join(aliases, ".");
+        return StringUtil.join(aliases, SEPARATOR);
     }
 
-    public static String[] reverse(@NotNull String... forward) {
-        String[] reversed = Arrays.copyOf(forward, 0);
-        ArrayUtils.reverse(reversed);
-
-        return reversed;
+    /**
+     * Emulates Module.split/1
+     */
+    @Contract(pure = true)
+    @NotNull
+    public static java.util.List<String> split(@NotNull String name) {
+        return StringUtil.split(name, SEPARATOR);
     }
+
 }

--- a/src/org/elixir_lang/annonator/Kernel.java
+++ b/src/org/elixir_lang/annonator/Kernel.java
@@ -144,7 +144,7 @@ public class Kernel implements Annotator, DumbAware {
                             "__CALLER__",
                             "__DIR__",
                             "__ENV__",
-                            "__MODULE__",
+                            __MODULE__,
                             "__aliases__",
                             "__block__",
                             ALIAS,

--- a/src/org/elixir_lang/psi/ElementDescriptionProvider.java
+++ b/src/org/elixir_lang/psi/ElementDescriptionProvider.java
@@ -15,6 +15,10 @@ import org.elixir_lang.structure_view.element.structure.Structure;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import static org.elixir_lang.psi.call.name.Function.ALIAS;
+import static org.elixir_lang.psi.call.name.Module.KERNEL;
+import static org.elixir_lang.reference.module.ResolvableName.resolvableName;
+
 /**
  * Dual to {@link org.elixir_lang.FindUsagesProvider}, where instead of each location being a separate method, they
  * are all one method, which means the same code can be used to detect the type of an element and then group all the
@@ -103,8 +107,21 @@ public class ElementDescriptionProvider implements com.intellij.psi.ElementDescr
                                          @NotNull ElementDescriptionLocation location) {
         String elementDescription = null;
 
+        if (maybeModuleName instanceof QualifiableAlias) {
+            QualifiableAlias qualifiableAlias = (QualifiableAlias) maybeModuleName;
+
+            if (location == UsageViewShortNameLocation.INSTANCE) {
+                elementDescription = resolvableName(qualifiableAlias);
+            }
+        }
+
         if (location == UsageViewTypeLocation.INSTANCE) {
-            elementDescription = "module";
+            if (isAliasCallArgument(maybeModuleName)) {
+                elementDescription = "alias";
+            } else {
+                elementDescription = "module";
+            }
+
         }
 
         return elementDescription;
@@ -172,5 +189,25 @@ public class ElementDescriptionProvider implements com.intellij.psi.ElementDescr
         }
 
         return elementDescription;
+    }
+
+    private boolean isAliasCallArgument(@NotNull Call element) {
+        return element.isCalling(KERNEL, ALIAS);
+    }
+
+    private boolean isAliasCallArgument(@NotNull PsiElement element) {
+        boolean isAliasCallArgument = false;
+
+        if (element instanceof Call) {
+            isAliasCallArgument = isAliasCallArgument((Call) element);
+        } else if (element instanceof Arguments ||
+                element instanceof ElixirAccessExpression ||
+                element instanceof ElixirMultipleAliases ||
+                element instanceof QualifiableAlias ||
+                element instanceof QualifiedMultipleAliases) {
+            isAliasCallArgument = isAliasCallArgument(element.getParent());
+        }
+
+        return isAliasCallArgument;
     }
 }

--- a/src/org/elixir_lang/psi/call/name/Function.java
+++ b/src/org/elixir_lang/psi/call/name/Function.java
@@ -16,14 +16,15 @@ public class Function {
     public static final String DEFPROTOCOL = "defprotocol";
     public static final String DEFSTRUCT = "defstruct";
     public static final String DESTRUCTURE = "destructure";
+    public static final String FOR = "for";
     public static final String IF = "if";
     public static final String IMPORT = "import";
-    public static final String FOR = "for";
     public static final String QUOTE = Quote.FUNCTION;
     public static final String RECEIVE = "receive";
     public static final String REQUIRE = "require";
     public static final String UNLESS = "unless";
-    public static final String USE = "use";
     public static final String UNQUOTE = "unquote";
+    public static final String USE = "use";
     public static final String VAR_BANG = "var!";
+    public static final String __MODULE__ = "__MODULE__";
 }

--- a/src/org/elixir_lang/psi/impl/ElixirPsiImplUtil.java
+++ b/src/org/elixir_lang/psi/impl/ElixirPsiImplUtil.java
@@ -1571,9 +1571,10 @@ public class ElixirPsiImplUtil {
         boolean keepProcessing = processor.execute(psiElement, state);
 
         if (keepProcessing) {
+            @Nullable
             PsiElement child = psiElement.getFirstChild();
 
-            while (child != lastParent) {
+            while (child != null && child != lastParent) {
                 if (!child.processDeclarations(processor, state, lastParent, place)) {
                     keepProcessing = false;
 

--- a/src/org/elixir_lang/psi/impl/ElixirPsiImplUtil.java
+++ b/src/org/elixir_lang/psi/impl/ElixirPsiImplUtil.java
@@ -57,6 +57,7 @@ import java.util.*;
 import static org.elixir_lang.errorreport.Logger.error;
 import static org.elixir_lang.intellij_elixir.Quoter.*;
 import static org.elixir_lang.psi.call.name.Function.*;
+import static org.elixir_lang.psi.call.name.Module.KERNEL;
 import static org.elixir_lang.psi.call.name.Module.prependElixirPrefix;
 import static org.elixir_lang.psi.call.name.Module.stripElixirPrefix;
 import static org.elixir_lang.psi.stub.type.call.Stub.isModular;
@@ -488,12 +489,12 @@ public class ElixirPsiImplUtil {
         } else if (element instanceof Call) {
             Call call = (Call) element;
 
-            if (call.isCalling(org.elixir_lang.psi.call.name.Module.KERNEL, CASE) ||
-                    call.isCalling(org.elixir_lang.psi.call.name.Module.KERNEL, COND) ||
-                    call.isCalling(org.elixir_lang.psi.call.name.Module.KERNEL, IF) ||
-                    call.isCalling(org.elixir_lang.psi.call.name.Module.KERNEL, RECEIVE) ||
-                    call.isCalling(org.elixir_lang.psi.call.name.Module.KERNEL, UNLESS) ||
-                    call.isCalling(org.elixir_lang.psi.call.name.Module.KERNEL, VAR_BANG)
+            if (call.isCalling(KERNEL, CASE) ||
+                    call.isCalling(KERNEL, COND) ||
+                    call.isCalling(KERNEL, IF) ||
+                    call.isCalling(KERNEL, RECEIVE) ||
+                    call.isCalling(KERNEL, UNLESS) ||
+                    call.isCalling(KERNEL, VAR_BANG)
                     ) {
                useScopeSelector = UseScopeSelector.SELF_AND_FOLLOWING_SIBLINGS;
             } else if (CallDefinitionClause.is(call) || isModular(call) || hasDoBlockOrKeyword(call)) {
@@ -822,7 +823,7 @@ public class ElixirPsiImplUtil {
             } else if (grandParent instanceof ElixirDoBlock) {
                 Call call = (Call) grandParent.getParent();
 
-                if (call.isCalling(org.elixir_lang.psi.call.name.Module.KERNEL, COND)) {
+                if (call.isCalling(KERNEL, COND)) {
                     declaringScope = false;
                 }
             }
@@ -892,7 +893,7 @@ public class ElixirPsiImplUtil {
         if (parent instanceof ElixirUnmatchedUnqualifiedNoParenthesesCall) {
             ElixirUnmatchedUnqualifiedNoParenthesesCall unmatchedUnqualifiedNoParenthesesCall = (ElixirUnmatchedUnqualifiedNoParenthesesCall) parent;
 
-            isModuleName = unmatchedUnqualifiedNoParenthesesCall.isCallingMacro(org.elixir_lang.psi.call.name.Module.KERNEL, DEFMODULE, 2);
+            isModuleName = unmatchedUnqualifiedNoParenthesesCall.isCallingMacro(KERNEL, DEFMODULE, 2);
         }
 
         return isModuleName;
@@ -1406,11 +1407,11 @@ public class ElixirPsiImplUtil {
             if (CallDefinitionClause.is(call) || // call parameters
                     Delegation.is(call) || // delegation call parameters
                     Module.is(call) || // module Alias
-                    call.isCalling(org.elixir_lang.psi.call.name.Module.KERNEL, DESTRUCTURE) || // left operand
-                    call.isCallingMacro(org.elixir_lang.psi.call.name.Module.KERNEL, IF) || // match in condition
-                    call.isCallingMacro(org.elixir_lang.psi.call.name.Module.KERNEL, Function.FOR) || // comprehension match variable
-                    call.isCallingMacro(org.elixir_lang.psi.call.name.Module.KERNEL, UNLESS) || // match in condition
-                    call.isCallingMacro(org.elixir_lang.psi.call.name.Module.KERNEL, "with") // <- or = variable
+                    call.isCalling(KERNEL, DESTRUCTURE) || // left operand
+                    call.isCallingMacro(KERNEL, IF) || // match in condition
+                    call.isCallingMacro(KERNEL, Function.FOR) || // comprehension match variable
+                    call.isCallingMacro(KERNEL, UNLESS) || // match in condition
+                    call.isCallingMacro(KERNEL, "with") // <- or = variable
                     ) {
                 keepProcessing = processor.execute(call, state);
             } else if (org.elixir_lang.structure_view.element.Quote.is(call)) { // quote :bind_quoted keys{
@@ -1881,8 +1882,13 @@ public class ElixirPsiImplUtil {
         Call enclosingMacroCall = null;
         PsiElement parent = element.getParent();
 
-        // Reverse of {@link ElixirPsiImplUtil#macroChildCalls}
-        if (parent instanceof ElixirStabBody) {
+        if (parent instanceof Call) {
+            Call parentCall = (Call) parent;
+
+            if (parentCall.isCalling(KERNEL, ALIAS)) {
+                enclosingMacroCall = parentCall;
+            }
+        } else if (parent instanceof ElixirStabBody) {
             PsiElement grandParent = parent.getParent();
 
             if (grandParent instanceof ElixirStab) {
@@ -1916,7 +1922,10 @@ public class ElixirPsiImplUtil {
                     }
                 }
             }
-        } else if (parent instanceof Match) {
+        } else if (parent instanceof Arguments ||
+                parent instanceof Match ||
+                parent instanceof QualifiedAlias ||
+                parent instanceof QualifiedMultipleAliases) {
             enclosingMacroCall = enclosingMacroCall(parent);
         } else if (parent instanceof QuotableKeywordPair) {
             QuotableKeywordPair parentKeywordPair = (QuotableKeywordPair) parent;
@@ -2018,7 +2027,18 @@ public class ElixirPsiImplUtil {
         PsiElement qualifier = children[0];
         String qualifierName = null;
 
-        if (qualifier instanceof QualifiableAlias) {
+        if (qualifier instanceof Call) {
+            Call qualifierCall = (Call) qualifier;
+
+            if (qualifierCall.isCalling(KERNEL, __MODULE__, 0)) {
+                Call enclosingCall = enclosingModularMacroCall(qualifierCall);
+
+                if (enclosingCall != null && enclosingCall instanceof StubBased) {
+                    StubBased enclosingStubBasedCall = (StubBased) enclosingCall;
+                    qualifierName = enclosingStubBasedCall.canonicalName();
+                }
+            }
+        } else if (qualifier instanceof QualifiableAlias) {
             QualifiableAlias qualifiableQualifier = (QualifiableAlias) qualifier;
 
             qualifierName = qualifiableQualifier.fullyQualifiedName();
@@ -2961,7 +2981,7 @@ public class ElixirPsiImplUtil {
         OtpErlangList interpolationMetadata = metadata(interpolation);
 
         OtpErlangObject quotedKernelToStringCall = quotedFunctionCall(
-                prependElixirPrefix(org.elixir_lang.psi.call.name.Module.KERNEL),
+                prependElixirPrefix(KERNEL),
                 "to_string",
                 interpolationMetadata,
                 quotedChildren
@@ -4681,14 +4701,14 @@ if (quoted == null) {
     public static String resolvedModuleName(@NotNull final Infix infix) {
         /* TODO handle resolving module name from imports.  Assume KERNEL for now, but some are actually from
            Bitwise */
-        return org.elixir_lang.psi.call.name.Module.KERNEL;
+        return KERNEL;
     }
 
     @Contract(pure = true)
     @NotNull
     public static String resolvedModuleName(@NotNull final Prefix prefix) {
         /* TODO handle resolving module name from imports.  Assume KERNEL for now. */
-        return org.elixir_lang.psi.call.name.Module.KERNEL;
+        return KERNEL;
     }
 
     /**
@@ -4742,7 +4762,7 @@ if (quoted == null) {
             resolvedModuleName = stub.resolvedModuleName();
         } else {
             // TODO handle `import`s
-            resolvedModuleName = org.elixir_lang.psi.call.name.Module.KERNEL;
+            resolvedModuleName = KERNEL;
         }
 
         //noinspection ConstantConditions
@@ -4759,7 +4779,7 @@ if (quoted == null) {
     @NotNull
     public static String resolvedModuleName(@NotNull @SuppressWarnings("unused") final UnqualifiedNoArgumentsCall unqualifiedNoArgumentsCall) {
         // TODO handle `import`s and determine whether actually a local variable
-        return org.elixir_lang.psi.call.name.Module.KERNEL;
+        return KERNEL;
     }
 
     @Contract(pure = true)

--- a/src/org/elixir_lang/psi/impl/ElixirPsiImplUtil.java
+++ b/src/org/elixir_lang/psi/impl/ElixirPsiImplUtil.java
@@ -1404,7 +1404,9 @@ public class ElixirPsiImplUtil {
 
         // need to check if call is place because lastParent is set to place at start of treeWalkUp
         if (!call.isEquivalentTo(lastParent) || call.isEquivalentTo(place)) {
-            if (CallDefinitionClause.is(call) || // call parameters
+            if (call.isCalling(KERNEL, ALIAS)) {
+                keepProcessing = processor.execute(call, state);
+            } else if (CallDefinitionClause.is(call) || // call parameters
                     Delegation.is(call) || // delegation call parameters
                     Module.is(call) || // module Alias
                     call.isCalling(KERNEL, DESTRUCTURE) || // left operand

--- a/src/org/elixir_lang/psi/scope/Module.java
+++ b/src/org/elixir_lang/psi/scope/Module.java
@@ -5,10 +5,15 @@ import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiNamedElement;
 import com.intellij.psi.ResolveState;
 import com.intellij.psi.scope.PsiScopeProcessor;
+import org.elixir_lang.psi.*;
 import org.elixir_lang.psi.call.Named;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import static org.elixir_lang.psi.call.name.Function.ALIAS;
+import static org.elixir_lang.psi.call.name.Module.KERNEL;
+import static org.elixir_lang.psi.impl.ElixirPsiImplUtil.finalArguments;
+import static org.elixir_lang.psi.impl.ElixirPsiImplUtil.keywordArgument;
 import static org.elixir_lang.psi.stub.type.call.Stub.isModular;
 
 public abstract class Module implements PsiScopeProcessor {
@@ -47,19 +52,240 @@ public abstract class Module implements PsiScopeProcessor {
      *
      * @return {@code true} to keep processing; {@code false} to stop processing.
      */
-    protected abstract boolean executeOnModular(@NotNull final PsiNamedElement match, @NotNull ResolveState state);
+    protected abstract boolean executeOnAliasedName(@NotNull final PsiNamedElement match,
+                                                    @NotNull String aliasedName,
+                                                    @NotNull ResolveState state);
 
     /*
      * Private Instance Methods
      */
 
+    @Nullable
+    private String aliasedName(@NotNull ElixirAlias element) {
+        return element.getName();
+    }
+
+    @Nullable
+    private String aliasedName(@NotNull PsiElement element) {
+        String aliasedName = null;
+
+        if (element instanceof ElixirAlias) {
+            aliasedName = aliasedName((ElixirAlias) element);
+        } else if (element instanceof QualifiedAlias) {
+            aliasedName = aliasedName((QualifiedAlias) element);
+        }
+
+        return aliasedName;
+    }
+
+    @Nullable
+    private String aliasedName(@NotNull QualifiedAlias element) {
+        String aliasedName = null;
+
+        PsiElement[] children = element.getChildren();
+        int operatorIndex = org.elixir_lang.psi.operation.Normalized.operatorIndex(children);
+        PsiElement unqualified = org.elixir_lang.psi.operation.infix.Normalized.rightOperand(children, operatorIndex);        assert children.length == 3;
+
+        if (unqualified instanceof PsiNamedElement) {
+            PsiNamedElement namedElement = (PsiNamedElement) unqualified;
+            aliasedName = namedElement.getName();
+        }
+
+        return aliasedName;
+    }
+
+
     private boolean execute(@NotNull Named match, @NotNull ResolveState state) {
         boolean keepProcessing = true;
 
         if (isModular(match)) {
-            keepProcessing = executeOnModular(match, state);
+            keepProcessing = executeOnMaybeAliasedName(match, match.getName(), state);
+        } else if (match.isCalling(KERNEL, ALIAS)) {
+            keepProcessing = executeOnAliasCall(match, state);
         }
 
         return keepProcessing;
     }
+
+    private boolean executeOnAliasCall(@NotNull Named aliasCall, @NotNull ResolveState state) {
+        boolean keepProcessing = true;
+
+        PsiElement asKeywordValue = keywordArgument(aliasCall, "as");
+
+        if (asKeywordValue != null) {
+            keepProcessing = executeOnAs(asKeywordValue, state);
+        } else {
+            PsiElement[] finalArguments = finalArguments(aliasCall);
+
+            if (finalArguments != null && finalArguments.length > 0) {
+                keepProcessing = executeOnAliasCallArgument(finalArguments[0], state);
+            }
+        }
+
+        return keepProcessing;
+    }
+
+    private boolean executeOnAliasCallArgument(@NotNull ElixirAccessExpression accessExpression,
+                                               @NotNull ResolveState state) {
+        return executeOnAliasCallArgument(accessExpression.getChildren(), state);
+    }
+
+    private boolean executeOnAliasCallArgument(@NotNull ElixirMultipleAliases multipleAliases,
+                                               @NotNull ResolveState state) {
+        return executeOnMultipleAliasChildren(multipleAliases.getChildren(), state);
+    }
+
+
+    private boolean executeOnAliasCallArgument(@Nullable PsiElement element, @NotNull ResolveState state) {
+        boolean keepProcessing = true;
+
+        if (element instanceof ElixirAccessExpression) {
+            keepProcessing = executeOnAliasCallArgument((ElixirAccessExpression) element, state);
+        } else if (element instanceof QualifiableAlias) {
+            keepProcessing = executeOnAliasCallArgument((QualifiableAlias) element, state);
+        } else if (element instanceof QualifiedMultipleAliases) {
+            keepProcessing = executeOnAliasCallArgument((QualifiedMultipleAliases) element, state);
+        }
+
+        return keepProcessing;
+    }
+
+    private boolean executeOnAliasCallArgument(@NotNull PsiElement[] children, @NotNull ResolveState state) {
+        boolean keepProcessing = true;
+
+        for (@Nullable PsiElement child : children) {
+            if (child != null) {
+                keepProcessing = executeOnAliasCallArgument(child, state);
+
+                if (!keepProcessing) {
+                    break;
+                }
+            }
+        }
+
+        return keepProcessing;
+    }
+
+    private boolean executeOnMultipleAliasChild(@NotNull ElixirAccessExpression child, ResolveState state) {
+        PsiElement[] accessChildren = child.getChildren();
+        boolean keepProcessing = true;
+
+        if (accessChildren != null) {
+            keepProcessing = executeOnMultipleAliasChild(accessChildren, state);
+        }
+
+        return keepProcessing;
+    }
+
+    private boolean executeOnMultipleAliasChild(@NotNull PsiElement child, @NotNull ResolveState state) {
+        boolean keepProcessing = true;
+
+        if (child instanceof ElixirAccessExpression) {
+            keepProcessing = executeOnMultipleAliasChild((ElixirAccessExpression) child, state);
+        } else if (child instanceof QualifiableAlias) {
+            keepProcessing = executeOnMultipleAliasChild((QualifiableAlias) child, state);
+        }
+
+        return keepProcessing;
+    }
+
+    private boolean executeOnMultipleAliasChild(@NotNull PsiElement[] elements, @NotNull ResolveState state) {
+        boolean keepProcessing = true;
+
+        for (PsiElement element : elements) {
+            if (element != null) {
+                keepProcessing = executeOnMultipleAliasChild(element, state);
+
+                if (!keepProcessing) {
+                    break;
+                }
+            }
+        }
+
+        return keepProcessing;
+    }
+
+    private boolean executeOnMultipleAliasChild(@NotNull QualifiableAlias element, @NotNull ResolveState state) {
+        return executeOnMaybeAliasedName(element, aliasedName(element), state);
+    }
+
+    private boolean executeOnMultipleAliasChildren(@Nullable PsiElement[] elements, @NotNull ResolveState state) {
+        boolean keepProcessing = true;
+
+        if (elements != null) {
+            for (PsiElement element : elements) {
+                if (element != null) {
+                    keepProcessing = executeOnMultipleAliasChild(element, state);
+
+                    if (!keepProcessing) {
+                        break;
+                    }
+                }
+            }
+        }
+
+        return keepProcessing;
+    }
+
+    private boolean executeOnAliasCallArgument(@NotNull QualifiableAlias qualifiableAlias,
+                                               @NotNull ResolveState state) {
+        return executeOnMaybeAliasedName(qualifiableAlias, aliasedName(qualifiableAlias), state);
+    }
+
+    private boolean executeOnAliasCallArgument(@NotNull QualifiedMultipleAliases qualifiedMultipleAliases,
+                                               @NotNull ResolveState state) {
+        PsiElement[] children = qualifiedMultipleAliases.getChildren();
+        int operatorIndex = org.elixir_lang.psi.operation.Normalized.operatorIndex(children);
+        PsiElement unqualified = org.elixir_lang.psi.operation.infix.Normalized.rightOperand(children, operatorIndex);
+        boolean keepProcessing = true;
+
+        if (unqualified instanceof ElixirMultipleAliases) {
+            keepProcessing = executeOnAliasCallArgument((ElixirMultipleAliases) unqualified, state);
+        }
+
+        return keepProcessing;
+    }
+
+    private boolean executeOnAs(ElixirAccessExpression asKeywordValue, @NotNull ResolveState state) {
+        PsiElement[] children = asKeywordValue.getChildren();
+        boolean keepProcessing = true;
+
+        if (children.length > 0) {
+            PsiElement child = children[0];
+
+            keepProcessing = executeOnAs(child, state);
+        }
+
+        return keepProcessing;
+    }
+
+    private boolean executeOnAs(PsiElement asKeywordValue, @NotNull ResolveState state) {
+        boolean keepProcessing = true;
+
+        if (asKeywordValue instanceof ElixirAccessExpression) {
+            keepProcessing = executeOnAs((ElixirAccessExpression) asKeywordValue, state);
+        } else if (asKeywordValue instanceof PsiNamedElement) {
+            PsiNamedElement namedElement = (PsiNamedElement) asKeywordValue;
+            keepProcessing = executeOnMaybeAliasedName(
+                    namedElement,
+                    namedElement.getName(),
+                    state
+            );
+        }
+
+        return keepProcessing;
+    }
+
+    private boolean executeOnMaybeAliasedName(@NotNull PsiNamedElement named,
+                                                 @Nullable String aliasedName,
+                                                 @NotNull ResolveState state) {
+        boolean keepProcessing = true;
+
+        if (aliasedName != null) {
+            keepProcessing = executeOnAliasedName(named, aliasedName, state);
+        }
+
+        return keepProcessing;
+    }
+
 }

--- a/src/org/elixir_lang/psi/scope/Module.java
+++ b/src/org/elixir_lang/psi/scope/Module.java
@@ -1,0 +1,65 @@
+package org.elixir_lang.psi.scope;
+
+import com.intellij.openapi.util.Key;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiNamedElement;
+import com.intellij.psi.ResolveState;
+import com.intellij.psi.scope.PsiScopeProcessor;
+import org.elixir_lang.psi.call.Named;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import static org.elixir_lang.psi.stub.type.call.Stub.isModular;
+
+public abstract class Module implements PsiScopeProcessor {
+    /*
+     * Public Instance Methods
+     */
+
+    @Override
+    public boolean execute(@NotNull PsiElement match, @NotNull ResolveState state) {
+        boolean keepProcessing = true;
+
+        if (match instanceof Named) {
+            keepProcessing = execute((Named) match, state);
+        }
+
+        return keepProcessing;
+    }
+
+    @Nullable
+    @Override
+    public <T> T getHint(@NotNull Key<T> hintKey) {
+        return null;
+    }
+
+    @Override
+    public void handleEvent(@NotNull Event event, @Nullable Object associated) {
+    }
+
+    /*
+     * Protected Instance Methods
+     */
+
+    /**
+     * Decides whether {@code match} matches the criteria being searched for.  All other {@link #execute} methods
+     * eventually end here.
+     *
+     * @return {@code true} to keep processing; {@code false} to stop processing.
+     */
+    protected abstract boolean executeOnModular(@NotNull final PsiNamedElement match, @NotNull ResolveState state);
+
+    /*
+     * Private Instance Methods
+     */
+
+    private boolean execute(@NotNull Named match, @NotNull ResolveState state) {
+        boolean keepProcessing = true;
+
+        if (isModular(match)) {
+            keepProcessing = executeOnModular(match, state);
+        }
+
+        return keepProcessing;
+    }
+}

--- a/src/org/elixir_lang/psi/scope/MultiResolve.java
+++ b/src/org/elixir_lang/psi/scope/MultiResolve.java
@@ -1,0 +1,67 @@
+package org.elixir_lang.psi.scope;
+
+import com.intellij.openapi.util.Condition;
+import com.intellij.psi.ResolveResult;
+import com.intellij.util.containers.ContainerUtil;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class MultiResolve {
+    /*
+     * Constants
+     */
+
+    public static final Condition<ResolveResult> HAS_VALID_RESULT_CONDITION = new Condition<ResolveResult>() {
+        @Override
+        public boolean value(ResolveResult resolveResult) {
+            return resolveResult.isValidResult();
+        }
+    };
+
+    /*
+     * Public Static Methods
+     */
+
+    public static List<ResolveResult> addToResolveResultList(@Nullable List<ResolveResult> resolveResultList,
+                                                             @NotNull ResolveResult resolveResult) {
+        if (resolveResultList == null) {
+            resolveResultList = new ArrayList<ResolveResult>();
+        }
+
+        resolveResultList.add(resolveResult);
+
+        return resolveResultList;
+    }
+
+    /**
+     * Whether the {@code resolveResultList} has any {@link ResolveResult} where {@link ResolveResult#isValidResult()}
+     * is {@code true}.
+     *
+     * @return {@code false} if {@code resolveResultList} is {@code null}; otherwise, {@code true} if the
+     * {@code resolveResultList} has any {@link ResolveResult} where {@link ResolveResult#isValidResult()} is
+     * {@code true}.
+     */
+    public static boolean hasValidResult(@Nullable List<ResolveResult> resolveResultList) {
+        boolean hasValidResult = false;
+
+        if (resolveResultList != null) {
+            hasValidResult = ContainerUtil.exists(resolveResultList, HAS_VALID_RESULT_CONDITION);
+        }
+
+        return hasValidResult;
+    }
+
+    /**
+     * Keep trying to resolve the reference if {@code resolveResultList} does not have a valid result or the code is
+     * incomplete.
+     *
+     * @return {@code false} if {@link #hasValidResult(List)} or {@code incompleteCode} is {@code false}, so only one
+     * valid result is allowed.
+     */
+    public static boolean keepProcessing(boolean incompleteCode, @Nullable List<ResolveResult> resolveResultList) {
+        return incompleteCode || !hasValidResult(resolveResultList);
+    }
+}

--- a/src/org/elixir_lang/psi/scope/Variable.java
+++ b/src/org/elixir_lang/psi/scope/Variable.java
@@ -23,6 +23,9 @@ import java.util.List;
 import static com.intellij.lang.parser.GeneratedParserUtilBase.DUMMY_BLOCK;
 import static org.elixir_lang.psi.call.name.Function.*;
 import static org.elixir_lang.psi.impl.ElixirPsiImplUtil.*;
+import static org.elixir_lang.psi.operation.Normalized.operatorIndex;
+import static org.elixir_lang.psi.operation.infix.Normalized.leftOperand;
+import static org.elixir_lang.psi.operation.infix.Normalized.rightOperand;
 
 public abstract class Variable implements PsiScopeProcessor {
     /*
@@ -74,6 +77,8 @@ public abstract class Variable implements PsiScopeProcessor {
             keepProcessing = execute((ElixirMapOperation) element, state);
         } else if (element instanceof ElixirMatchedWhenOperation) {
             keepProcessing = execute((ElixirMatchedWhenOperation) element, state);
+        } else if (element instanceof ElixirStabOperation) {
+            keepProcessing = execute((ElixirStabOperation) element, state);
         } else if (element instanceof ElixirStabNoParenthesesSignature) {
             keepProcessing = execute((ElixirStabNoParenthesesSignature) element, state);
         } else if (element instanceof ElixirStabParenthesesSignature) {
@@ -387,6 +392,28 @@ public abstract class Variable implements PsiScopeProcessor {
 
     private boolean execute(@NotNull ElixirStabNoParenthesesSignature match, @NotNull ResolveState state) {
         return execute(match.getNoParenthesesArguments(), state);
+    }
+
+    private boolean execute(@NotNull ElixirStabOperation match, @NotNull ResolveState state) {
+        boolean keepProcessing = true;
+
+        PsiElement[] children = match.getChildren();
+        int operatorIndex = operatorIndex(children);
+        PsiElement leftOperand = leftOperand(children, operatorIndex);
+
+        if (leftOperand != null) {
+            keepProcessing = execute(leftOperand, state);
+        }
+
+        if (keepProcessing) {
+            PsiElement rightOperand = rightOperand(children, operatorIndex);
+
+            if (rightOperand != null) {
+                keepProcessing = execute(rightOperand, state);
+            }
+        }
+
+        return keepProcessing;
     }
 
     private boolean execute(@NotNull ElixirStabParenthesesSignature match, @NotNull ResolveState state) {

--- a/src/org/elixir_lang/psi/scope/module/MultiResolve.java
+++ b/src/org/elixir_lang/psi/scope/module/MultiResolve.java
@@ -1,0 +1,115 @@
+package org.elixir_lang.psi.scope.module;
+
+import com.intellij.psi.*;
+import com.intellij.psi.util.PsiTreeUtil;
+import org.elixir_lang.psi.scope.Module;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.elixir_lang.psi.impl.ElixirPsiImplUtil.ENTRANCE;
+
+public class MultiResolve extends Module {
+    /*
+     * Public Static Methods
+     */
+
+    @Nullable
+    public static List<ResolveResult> resolveResultList(@NotNull String name,
+                                                        boolean incompleteCode,
+                                                        @NotNull PsiElement entrance) {
+      return resolveResultList(name, incompleteCode, entrance, ResolveState.initial());
+    }
+
+    /*
+     * Private Static Methods
+     */
+
+    @Nullable
+    private static List<ResolveResult> resolveResultList(@NotNull String name,
+                                                         boolean incompleteCode,
+                                                         @NotNull PsiElement entrance,
+                                                         @NotNull ResolveState state) {
+        MultiResolve multiResolve = new MultiResolve(name, incompleteCode);
+        PsiTreeUtil.treeWalkUp(
+                multiResolve,
+                entrance,
+                entrance.getContainingFile(),
+                state.put(ENTRANCE, entrance)
+        );
+        return multiResolve.getResolveResultList();
+    }
+
+    /*
+     * Fields
+     */
+
+    @NotNull
+    private final String name;
+    private final boolean incompleteCode;
+    @Nullable
+    private List<ResolveResult> resolveResultList = null;
+
+    /*
+     * Constructors
+     */
+
+    MultiResolve(@NotNull String name, boolean incompleteCode) {
+        this.incompleteCode = incompleteCode;
+        this.name = name;
+    }
+
+    /*
+     * Public Instance Methods
+     */
+
+    @Nullable
+    public List<ResolveResult> getResolveResultList() {
+        return resolveResultList;
+    }
+
+    /*
+     * Protected Instance Methods
+     */
+
+    /**
+     * Decides whether {@code match} matches the criteria being searched for.  All other {@link #execute} methods
+     * eventually end here.
+     *
+     * @param match
+     * @param state
+     * @return {@code true} to keep processing; {@code false} to stop processing.
+     */
+    @Override
+    protected boolean executeOnModular(@NotNull PsiNamedElement match, @NotNull ResolveState state) {
+        String matchName = match.getName();
+
+        if (matchName != null) {
+            Boolean validResult = null;
+
+            if (matchName.equals(name)) {
+                validResult = true;
+            } else if (incompleteCode && matchName.startsWith(name)) {
+                validResult = false;
+            }
+
+            if (validResult != null) {
+                addToResolveResultList(match, validResult);
+            }
+        }
+
+        return org.elixir_lang.psi.scope.MultiResolve.keepProcessing(incompleteCode, resolveResultList);
+    }
+
+    /*
+     * Private Instance Methods
+     */
+
+    private void addToResolveResultList(@NotNull PsiElement element, boolean validResult) {
+        resolveResultList = org.elixir_lang.psi.scope.MultiResolve.addToResolveResultList(
+                resolveResultList, new PsiElementResolveResult(element, validResult)
+        );
+    }
+}

--- a/src/org/elixir_lang/psi/scope/module/MultiResolve.java
+++ b/src/org/elixir_lang/psi/scope/module/MultiResolve.java
@@ -78,26 +78,22 @@ public class MultiResolve extends Module {
      * Decides whether {@code match} matches the criteria being searched for.  All other {@link #execute} methods
      * eventually end here.
      *
-     * @param match
-     * @param state
      * @return {@code true} to keep processing; {@code false} to stop processing.
      */
     @Override
-    protected boolean executeOnModular(@NotNull PsiNamedElement match, @NotNull ResolveState state) {
-        String matchName = match.getName();
+    protected boolean executeOnAliasedName(@NotNull PsiNamedElement match,
+                                           @NotNull String aliasedName,
+                                           @NotNull ResolveState state) {
+        Boolean validResult = null;
 
-        if (matchName != null) {
-            Boolean validResult = null;
+        if (aliasedName.equals(name)) {
+            validResult = true;
+        } else if (incompleteCode && aliasedName.startsWith(name)) {
+            validResult = false;
+        }
 
-            if (matchName.equals(name)) {
-                validResult = true;
-            } else if (incompleteCode && matchName.startsWith(name)) {
-                validResult = false;
-            }
-
-            if (validResult != null) {
-                addToResolveResultList(match, validResult);
-            }
+        if (validResult != null) {
+            addToResolveResultList(match, validResult);
         }
 
         return org.elixir_lang.psi.scope.MultiResolve.keepProcessing(incompleteCode, resolveResultList);

--- a/src/org/elixir_lang/psi/scope/module/MultiResolve.java
+++ b/src/org/elixir_lang/psi/scope/module/MultiResolve.java
@@ -9,6 +9,7 @@ import org.jetbrains.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.elixir_lang.Module.split;
 import static org.elixir_lang.psi.impl.ElixirPsiImplUtil.ENTRANCE;
 
 public class MultiResolve extends Module {
@@ -88,8 +89,16 @@ public class MultiResolve extends Module {
 
         if (aliasedName.equals(name)) {
             validResult = true;
-        } else if (incompleteCode && aliasedName.startsWith(name)) {
-            validResult = false;
+        } else {
+            List<String> namePartList = split(name);
+            String firstNamePart = namePartList.get(0);
+
+            // alias Foo.SSH, then SSH.Key is name
+            if (aliasedName.equals(firstNamePart)) {
+                validResult = true;
+            } else if (incompleteCode && aliasedName.startsWith(name)) {
+                validResult = false;
+            }
         }
 
         if (validResult != null) {

--- a/src/org/elixir_lang/psi/scope/variable/MultiResolve.java
+++ b/src/org/elixir_lang/psi/scope/variable/MultiResolve.java
@@ -31,12 +31,6 @@ public class MultiResolve extends Variable {
      */
 
     private static final Key<PsiElement> LAST_BINDING_KEY = new Key<PsiElement>("LAST_BINDING_KEY");
-    public static final Condition<ResolveResult> HAS_VALID_RESULT_CONDITION = new Condition<ResolveResult>() {
-        @Override
-        public boolean value(ResolveResult resolveResult) {
-            return resolveResult.isValidResult();
-        }
-    };
 
     /*
      *
@@ -152,7 +146,7 @@ public class MultiResolve extends Variable {
     protected boolean executeOnVariable(@NotNull PsiNamedElement match, @NotNull ResolveState state) {
         addToResolveResultListIfMatchingName(match, state);
 
-        return keepProcessing();
+        return org.elixir_lang.psi.scope.MultiResolve.keepProcessing(incompleteCode, resolveResultList);
     }
 
     /*
@@ -242,34 +236,5 @@ public class MultiResolve extends Variable {
                 addToResolveResultList(match, state, false);
             }
         }
-    }
-
-    /**
-     * Whether the {@link #resolveResultList} has any {@link ResolveResult} where {@link ResolveResult#isValidResult()}
-     * is {@code true}.
-     *
-     * @return {@code false} if {@link #resolveResultList} is {@code null}; otherwise, {@code true} if the
-     * {@link #resolveResultList} has any {@link ResolveResult} where {@link ResolveResult#isValidResult()} is
-     * {@code true}.
-     */
-    private boolean hasValidResult() {
-        boolean hasValidResult = false;
-
-        if (resolveResultList != null) {
-            hasValidResult = ContainerUtil.exists(resolveResultList, HAS_VALID_RESULT_CONDITION);
-        }
-
-        return hasValidResult;
-    }
-
-    /**
-     * Keep trying to resolve the reference if {@code resolveResultList} does not have a valid result or the code is
-     * incomplete.
-     *
-     * @return {@code false} if {@link #hasValidResult()} or {@link #incompleteCode} is {@code false}, so only one
-     * valid result is allowed.
-     */
-    private boolean keepProcessing() {
-        return incompleteCode || !hasValidResult();
     }
 }

--- a/src/org/elixir_lang/reference/Callable.java
+++ b/src/org/elixir_lang/reference/Callable.java
@@ -254,7 +254,8 @@ public class Callable extends PsiReferenceBase<Call> implements PsiPolyVariantRe
                     parent instanceof ElixirMapUpdateArguments ||
                     parent instanceof ElixirQuoteStringBody ||
                     parent instanceof PsiFile ||
-                    parent instanceof QualifiedAlias)) {
+                    parent instanceof QualifiedAlias ||
+                    parent instanceof QualifiedMultipleAliases)) {
                 Logger.error(Callable.class, "Don't know how to check if parameter", parent);
             }
         }
@@ -336,7 +337,8 @@ public class Callable extends PsiReferenceBase<Call> implements PsiPolyVariantRe
         } else {
             if (!(ancestor instanceof AtNonNumericOperation ||
                     ancestor instanceof BracketOperation ||
-                    ancestor instanceof PsiFile)) {
+                    ancestor instanceof PsiFile ||
+                    ancestor instanceof QualifiedMultipleAliases)) {
                 Logger.error(Callable.class, "Don't know how to check if variable", ancestor);
             }
         }

--- a/src/org/elixir_lang/reference/Module.java
+++ b/src/org/elixir_lang/reference/Module.java
@@ -10,6 +10,7 @@ import org.elixir_lang.psi.*;
 import org.elixir_lang.psi.call.Named;
 import org.elixir_lang.psi.scope.module.MultiResolve;
 import org.elixir_lang.psi.stub.index.AllName;
+import org.elixir_lang.reference.module.ResolvableName;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -19,6 +20,7 @@ import java.util.List;
 
 import static org.elixir_lang.Module.concat;
 import static org.elixir_lang.psi.stub.type.call.Stub.isModular;
+import static org.elixir_lang.reference.module.ResolvableName.resolvableName;
 
 public class Module extends PsiReferenceBase<QualifiableAlias> implements PsiPolyVariantReference {
     /*
@@ -30,116 +32,6 @@ public class Module extends PsiReferenceBase<QualifiableAlias> implements PsiPol
     /*
      * Private Static Methods
      */
-
-    /**
-     * The full name of the qualifiable alias, with any multiple aliases expanded
-     */
-    @Nullable
-    private String resolvableName(@NotNull QualifiableAlias qualifiableAlias) {
-        String resolvableName = qualifiableAlias.fullyQualifiedName();
-        List<String> tail = null;
-
-        if (resolvableName != null) {
-            tail = new ArrayList<String>();
-            tail.add(resolvableName);
-        }
-
-        return resolvableNameUp(qualifiableAlias.getParent(), tail);
-    }
-
-    @Nullable
-    private List<String> resolvableNameDown(@NotNull QualifiableAlias qualifier) {
-        String resolvableName = qualifier.getName();
-        List<String> nameList = null;
-
-        if (resolvableName != null) {
-            nameList = new ArrayList<String>();
-            nameList.add(resolvableName);
-        }
-
-        return nameList;
-    }
-
-    @Nullable
-    private List<String> resolvableNameDown(@NotNull PsiElement qualifier) {
-        List<String> nameList = null;
-
-        if (qualifier instanceof ElixirAccessExpression) {
-            nameList = resolvableNameDown(qualifier.getChildren());
-        } else if (qualifier instanceof QualifiableAlias) {
-            nameList = resolvableNameDown((QualifiableAlias) qualifier);
-        }
-
-        return nameList;
-    }
-
-    @Nullable
-    private List<String> resolvableNameDown(@NotNull PsiElement[] qualifiers) {
-        List<String> nameList = null;
-
-        for (PsiElement qualifier : qualifiers) {
-            List<String> qualifierNameList = resolvableNameDown(qualifier);
-
-            if (qualifierNameList != null) {
-                if (nameList == null) {
-                    nameList = new ArrayList<String>(qualifierNameList.size());
-                }
-
-                nameList.addAll(qualifierNameList);
-            }
-        }
-
-        return nameList;
-    }
-
-    @Nullable
-    private String resolvableNameUp(@Nullable PsiElement ancestor, @Nullable List<String> tail) {
-        String resolvableName = null;
-
-        if (ancestor instanceof ElixirAccessExpression ||
-                ancestor instanceof ElixirMultipleAliases) {
-            resolvableName = resolvableNameUp(ancestor.getParent(), tail);
-        } else if (ancestor instanceof QualifiedMultipleAliases) {
-            resolvableName = resolvableNameUp((QualifiedMultipleAliases) ancestor, tail);
-        } else if (tail != null) {
-            resolvableName = concat(tail);
-        }
-
-        return resolvableName;
-    }
-
-    @Nullable
-    private String resolvableNameUp(@NotNull QualifiedMultipleAliases ancestor, @Nullable List<String> tail) {
-        PsiElement[] children = ancestor.getChildren();
-        int operatorIndex = org.elixir_lang.psi.operation.Normalized.operatorIndex(children);
-
-        PsiElement qualifier = org.elixir_lang.psi.operation.infix.Normalized.leftOperand(children, operatorIndex);
-        List<String> qualifierNameList = null;
-
-        if (qualifier != null) {
-            qualifierNameList = resolvableNameDown(qualifier);
-        }
-
-        List<String> nameList;
-
-        if (qualifierNameList != null) {
-            nameList = qualifierNameList;
-
-            if (tail != null) {
-                qualifierNameList.addAll(tail);
-            }
-        } else {
-            nameList = tail;
-        }
-
-        String resolvableName = null;
-
-        if (nameList != null) {
-            resolvableName = concat(nameList);
-        }
-
-        return resolvableName;
-    }
 
     /*
      * Constructors

--- a/src/org/elixir_lang/reference/Module.java
+++ b/src/org/elixir_lang/reference/Module.java
@@ -8,6 +8,7 @@ import com.intellij.psi.search.GlobalSearchScope;
 import com.intellij.psi.stubs.StubIndex;
 import org.elixir_lang.psi.*;
 import org.elixir_lang.psi.call.Named;
+import org.elixir_lang.psi.scope.module.MultiResolve;
 import org.elixir_lang.psi.stub.index.AllName;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -161,47 +162,36 @@ public class Module extends PsiReferenceBase<QualifiableAlias> implements PsiPol
     @NotNull
     @Override
     public ResolveResult[] multiResolve(boolean incompleteCode) {
-        List<ResolveResult> results = new ArrayList<ResolveResult>();
+        List<ResolveResult> resolveResultList = null;
         final String name = resolvableName(myElement);
 
         if (name != null) {
-            results.addAll(multiResolveUpFromElement(myElement, name));
+            resolveResultList = MultiResolve.resolveResultList(name, incompleteCode, myElement);
 
-            if (results.isEmpty()) {
-                results.addAll(
-                        multiResolveProject(
-                                myElement.getProject(),
-                                name
-                        )
+            if (resolveResultList == null || resolveResultList.isEmpty()) {
+                resolveResultList = multiResolveProject(
+                        myElement.getProject(),
+                        name
                 );
             }
         }
 
-        return results.toArray(new ResolveResult[results.size()]);
+        ResolveResult[] resolveResults;
+
+        if (resolveResultList == null) {
+            resolveResults = new ResolveResult[0];
+        } else {
+            resolveResults = resolveResultList.toArray(new ResolveResult[resolveResultList.size()]);
+        }
+
+        return resolveResults;
     }
 
     /*
      * Private Instance Methods
      */
 
-    private void addMatchingAsResolveResult(@NotNull List<ResolveResult> resultList,
-                                            @NotNull Named named,
-                                            @NotNull String targetName) {
-        String name = named.getName();
-
-        if (name != null && name.equals(targetName)) {
-            PsiElement nameIdentifier = named.getNameIdentifier();
-            PsiElement resolved = named;
-
-            if (nameIdentifier != null) {
-                resolved = nameIdentifier;
-            }
-
-            resultList.add(new PsiElementResolveResult(resolved));
-        }
-    }
-
-    private Collection<ResolveResult> multiResolveProject(@NotNull Project project,
+    private List<ResolveResult> multiResolveProject(@NotNull Project project,
                                                           @NotNull String name) {
         List<ResolveResult> results = new ArrayList<ResolveResult>();
 
@@ -215,36 +205,6 @@ public class Module extends PsiReferenceBase<QualifiableAlias> implements PsiPol
 
         for (NamedElement namedElement : namedElementCollection) {
             results.add(new PsiElementResolveResult(namedElement));
-        }
-
-        return results;
-    }
-
-    private List<ResolveResult> multiResolveUpFromElement(@NotNull final PsiElement element,
-                                                          @NotNull final String name) {
-        List<ResolveResult> results = new ArrayList<ResolveResult>();
-        PsiElement lastSibling = element;
-
-        while (results.isEmpty() && lastSibling != null) {
-            results.addAll(multiResolveSibling(lastSibling, name));
-
-            lastSibling = lastSibling.getParent();
-        }
-
-        return results;
-    }
-
-    private List<ResolveResult> multiResolveSibling(@NotNull final PsiElement lastSibling, @NotNull final String name) {
-        List<ResolveResult> results = new ArrayList<ResolveResult>();
-
-        for (PsiElement sibling = lastSibling; sibling != null; sibling = sibling.getPrevSibling()) {
-            if (sibling instanceof Named) {
-                Named named = (Named) sibling;
-
-                if (isModular(named)) {
-                    addMatchingAsResolveResult(results, named, name);
-                }
-            }
         }
 
         return results;

--- a/src/org/elixir_lang/reference/ModuleAttribute.java
+++ b/src/org/elixir_lang/reference/ModuleAttribute.java
@@ -16,11 +16,10 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
-import static org.elixir_lang.psi.scope.variable.MultiResolve.HAS_VALID_RESULT_CONDITION;
+import static org.elixir_lang.psi.scope.MultiResolve.HAS_VALID_RESULT_CONDITION;
 
 /**
  * Created by limhoff on 12/30/15.

--- a/src/org/elixir_lang/reference/module/ResolvableName.java
+++ b/src/org/elixir_lang/reference/module/ResolvableName.java
@@ -1,0 +1,135 @@
+package org.elixir_lang.reference.module;
+
+import com.intellij.psi.PsiElement;
+import org.elixir_lang.psi.ElixirAccessExpression;
+import org.elixir_lang.psi.ElixirMultipleAliases;
+import org.elixir_lang.psi.QualifiableAlias;
+import org.elixir_lang.psi.QualifiedMultipleAliases;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.elixir_lang.Module.concat;
+
+public class ResolvableName {
+    /*
+     * Public Static Methods
+     */
+
+    /**
+     * The full name of the qualifiable alias, with any multiple aliases expanded
+     */
+    @Nullable
+    public static String resolvableName(@NotNull QualifiableAlias qualifiableAlias) {
+        String resolvableName = qualifiableAlias.fullyQualifiedName();
+        List<String> tail = null;
+
+        if (resolvableName != null) {
+            tail = new ArrayList<String>();
+            tail.add(resolvableName);
+        }
+
+        return up(qualifiableAlias.getParent(), tail);
+    }
+
+    /*
+     * Private Static Methods
+     */
+
+    @Nullable
+    private static List<String> down(@NotNull QualifiableAlias qualifier) {
+        String resolvableName = qualifier.getName();
+        List<String> nameList = null;
+
+        if (resolvableName != null) {
+            nameList = new ArrayList<String>();
+            nameList.add(resolvableName);
+        }
+
+        return nameList;
+    }
+
+    @Nullable
+    private static List<String> down(@NotNull PsiElement qualifier) {
+        List<String> nameList = null;
+
+        if (qualifier instanceof ElixirAccessExpression) {
+            nameList = down(qualifier.getChildren());
+        } else if (qualifier instanceof QualifiableAlias) {
+            nameList = down((QualifiableAlias) qualifier);
+        }
+
+        return nameList;
+    }
+
+    @Nullable
+    private static List<String> down(@NotNull PsiElement[] qualifiers) {
+        List<String> nameList = null;
+
+        for (PsiElement qualifier : qualifiers) {
+            List<String> qualifierNameList = down(qualifier);
+
+            if (qualifierNameList != null) {
+                if (nameList == null) {
+                    nameList = new ArrayList<String>(qualifierNameList.size());
+                }
+
+                nameList.addAll(qualifierNameList);
+            }
+        }
+
+        return nameList;
+    }
+
+    @Nullable
+    private static String up(@Nullable PsiElement ancestor, @Nullable List<String> tail) {
+        String resolvableName = null;
+
+        if (ancestor instanceof ElixirAccessExpression ||
+                ancestor instanceof ElixirMultipleAliases) {
+            resolvableName = up(ancestor.getParent(), tail);
+        } else if (ancestor instanceof QualifiedMultipleAliases) {
+            resolvableName = up((QualifiedMultipleAliases) ancestor, tail);
+        } else if (tail != null) {
+            resolvableName = concat(tail);
+        }
+
+        return resolvableName;
+    }
+
+    @Nullable
+    private static String up(@NotNull QualifiedMultipleAliases ancestor, @Nullable List<String> tail) {
+        PsiElement[] children = ancestor.getChildren();
+        int operatorIndex = org.elixir_lang.psi.operation.Normalized.operatorIndex(children);
+
+        PsiElement qualifier = org.elixir_lang.psi.operation.infix.Normalized.leftOperand(children, operatorIndex);
+        List<String> qualifierNameList = null;
+
+        if (qualifier != null) {
+            qualifierNameList = down(qualifier);
+        }
+
+        List<String> nameList;
+
+        if (qualifierNameList != null) {
+            nameList = qualifierNameList;
+
+            if (tail != null) {
+                qualifierNameList.addAll(tail);
+            }
+        } else {
+            nameList = tail;
+        }
+
+        String resolvableName = null;
+
+        if (nameList != null) {
+            resolvableName = concat(nameList);
+        }
+
+        return resolvableName;
+    }
+
+}

--- a/src/org/elixir_lang/structure_view/element/CallDefinitionClause.java
+++ b/src/org/elixir_lang/structure_view/element/CallDefinitionClause.java
@@ -92,7 +92,9 @@ public class CallDefinitionClause extends Element<Call> implements Presentable, 
         while(true) {
             enclosingMacroCall = enclosingMacroCall(enclosedCall);
 
-            if (enclosingMacroCall != null && enclosingMacroCall.isCallingMacro(KERNEL, FOR, 2)) {
+            if (enclosingMacroCall != null &&
+                    (enclosingMacroCall.isCalling(KERNEL, ALIAS) ||
+                            enclosingMacroCall.isCallingMacro(KERNEL, FOR, 2))) {
                 enclosedCall = enclosingMacroCall;
             } else {
                 break;


### PR DESCRIPTION
Resolves #377

# Changelog
## Enhancements
* Resolve aliased modules to their `alias` call, from the alias call, you can Go To Declaration for the module itself.
  * Code structure
    * Module resolution uses the OpenAPI convention of `treeWalkUp` now instead of custom code.
    * Resolvable names has been extracted to its own class
  * Resolution use cases
    * `Suffix` resolves to `alias Prefix.Suffix`
    * `Suffix.Nested` resolves to `alias Prefix.Suffix`
    * `As` resolves `to `alias Prefix.Suffix, as: As`
    * `NestedSuffix` resolves to `alias __MODULE__.NestedSuffix`