### PR TITLE
Module completion for file aliases and project modules

### DIFF
--- a/src/org/elixir_lang/psi/scope/module/MultiResolve.java
+++ b/src/org/elixir_lang/psi/scope/module/MultiResolve.java
@@ -6,7 +6,6 @@ import org.elixir_lang.psi.scope.Module;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import static org.elixir_lang.Module.split;

--- a/src/org/elixir_lang/psi/scope/module/Variants.java
+++ b/src/org/elixir_lang/psi/scope/module/Variants.java
@@ -1,0 +1,78 @@
+package org.elixir_lang.psi.scope.module;
+
+import com.intellij.codeInsight.lookup.LookupElement;
+import com.intellij.codeInsight.lookup.LookupElementBuilder;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiNamedElement;
+import com.intellij.psi.ResolveState;
+import org.elixir_lang.psi.scope.Module;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.intellij.psi.util.PsiTreeUtil.treeWalkUp;
+import static org.elixir_lang.psi.impl.ElixirPsiImplUtil.ENTRANCE;
+
+public class Variants extends Module {
+    /*
+     * Public Static Methods
+     */
+
+    @Nullable
+    public static List<LookupElement> lookupElementList(@NotNull PsiElement entrance) {
+        Variants variants = new Variants();
+        treeWalkUp(
+                variants,
+                entrance,
+                entrance.getContainingFile(),
+                ResolveState.initial().put(ENTRANCE, entrance)
+        );
+
+        return variants.getLookupElementList();
+    }
+
+    /*
+     * Fields
+     */
+
+    private List<LookupElement> lookupElementList = null;
+
+    /*
+     * Protected Instance Methods
+     */
+
+    /**
+     * Decides whether {@code match} matches the criteria being searched for.  All other {@link #execute} methods
+     * eventually end here.
+     *
+     * @param match
+     * @param aliasedName
+     * @param state
+     * @return {@code true} to keep processing; {@code false} to stop processing.
+     */
+    @Override
+    protected boolean executeOnAliasedName(@NotNull PsiNamedElement match, @NotNull String aliasedName, @NotNull ResolveState state) {
+        if (lookupElementList == null) {
+            lookupElementList = new ArrayList<LookupElement>();
+        }
+
+        lookupElementList.add(
+                LookupElementBuilder.createWithSmartPointer(
+                        aliasedName,
+                        match
+                )
+        );
+
+        return true;
+    }
+
+    /*
+     * Private Instance Methods
+     */
+
+    private List<LookupElement> getLookupElementList() {
+        return lookupElementList;
+    }
+}

--- a/src/org/elixir_lang/reference/Module.java
+++ b/src/org/elixir_lang/reference/Module.java
@@ -9,6 +9,7 @@ import com.intellij.psi.stubs.StubIndex;
 import org.elixir_lang.psi.*;
 import org.elixir_lang.psi.call.Named;
 import org.elixir_lang.psi.scope.module.MultiResolve;
+import org.elixir_lang.psi.scope.module.Variants;
 import org.elixir_lang.psi.stub.index.AllName;
 import org.elixir_lang.reference.module.ResolvableName;
 import org.jetbrains.annotations.NotNull;
@@ -112,7 +113,16 @@ public class Module extends PsiReferenceBase<QualifiableAlias> implements PsiPol
     @NotNull
     @Override
     public Object[] getVariants() {
-        List<LookupElement> variants = new ArrayList<LookupElement>();
-        return variants.toArray();
+        List<LookupElement> lookupElementList = Variants.lookupElementList(myElement);
+
+        Object[] variants;
+
+        if (lookupElementList == null) {
+            variants = new Object[0];
+        } else {
+            variants = lookupElementList.toArray(new Object[lookupElementList.size()]);
+        }
+
+        return variants;
     }
 }

--- a/src/org/elixir_lang/reference/Module.java
+++ b/src/org/elixir_lang/reference/Module.java
@@ -1,6 +1,7 @@
 package org.elixir_lang.reference;
 
 import com.intellij.codeInsight.lookup.LookupElement;
+import com.intellij.codeInsight.lookup.LookupElementBuilder;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.TextRange;
 import com.intellij.psi.*;
@@ -115,14 +116,22 @@ public class Module extends PsiReferenceBase<QualifiableAlias> implements PsiPol
     public Object[] getVariants() {
         List<LookupElement> lookupElementList = Variants.lookupElementList(myElement);
 
-        Object[] variants;
-
         if (lookupElementList == null) {
-            variants = new Object[0];
-        } else {
-            variants = lookupElementList.toArray(new Object[lookupElementList.size()]);
+            lookupElementList = new ArrayList<LookupElement>();
         }
 
-        return variants;
+
+        Collection<String> projectModuleCollection  = StubIndex.getInstance().getAllKeys(
+                AllName.KEY,
+                myElement.getProject()
+        );
+
+        for (String projectModule : projectModuleCollection) {
+            lookupElementList.add(
+                    LookupElementBuilder.create(projectModule)
+            );
+        }
+
+        return lookupElementList.toArray(new Object[lookupElementList.size()]);
     }
 }

--- a/src/org/elixir_lang/reference/Module.java
+++ b/src/org/elixir_lang/reference/Module.java
@@ -21,6 +21,7 @@ import java.util.Collection;
 import java.util.List;
 
 import static org.elixir_lang.Module.concat;
+import static org.elixir_lang.psi.call.name.Function.__MODULE__;
 import static org.elixir_lang.psi.stub.type.call.Stub.isModular;
 import static org.elixir_lang.reference.module.ResolvableName.resolvableName;
 
@@ -120,7 +121,6 @@ public class Module extends PsiReferenceBase<QualifiableAlias> implements PsiPol
             lookupElementList = new ArrayList<LookupElement>();
         }
 
-
         Collection<String> projectModuleCollection  = StubIndex.getInstance().getAllKeys(
                 AllName.KEY,
                 myElement.getProject()
@@ -131,6 +131,11 @@ public class Module extends PsiReferenceBase<QualifiableAlias> implements PsiPol
                     LookupElementBuilder.create(projectModule)
             );
         }
+
+        lookupElementList.add(
+                // not really module, but it acts like one, so include it here for completion
+                LookupElementBuilder.create(__MODULE__)
+        );
 
         return lookupElementList.toArray(new Object[lookupElementList.size()]);
     }


### PR DESCRIPTION
Resolves #88

# Changelog
## Enhancements
* Completion for module aliases
  * From in-file aliases
  * `__MODULE__`
  * In project modules (using index already used for Go To Declaration)