### PR TITLE
defimpl with `for: list` indexes name for each list entry

### DIFF
--- a/gen/org/elixir_lang/psi/ElixirMatchedAtUnqualifiedNoParenthesesCall.java
+++ b/gen/org/elixir_lang/psi/ElixirMatchedAtUnqualifiedNoParenthesesCall.java
@@ -13,6 +13,8 @@ import org.elixir_lang.psi.stub.MatchedAtUnqualifiedNoParenthesesCall;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Collection;
+
 public interface ElixirMatchedAtUnqualifiedNoParenthesesCall extends ElixirMatchedExpression, AtUnqualifiedNoParenthesesCall<MatchedAtUnqualifiedNoParenthesesCall>, MatchedCall, StubBasedPsiElement<MatchedAtUnqualifiedNoParenthesesCall> {
 
   @NotNull
@@ -23,6 +25,9 @@ public interface ElixirMatchedAtUnqualifiedNoParenthesesCall extends ElixirMatch
 
   @Nullable
   String canonicalName();
+
+  @Nullable
+  Collection<String> canonicalNameCollection();
 
   @Nullable
   String functionName();

--- a/gen/org/elixir_lang/psi/ElixirMatchedDotCall.java
+++ b/gen/org/elixir_lang/psi/ElixirMatchedDotCall.java
@@ -12,6 +12,7 @@ import org.elixir_lang.psi.stub.MatchedDotCall;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Collection;
 import java.util.List;
 
 public interface ElixirMatchedDotCall extends ElixirMatchedExpression, DotCall<MatchedDotCall>, MatchedCall, StubBasedPsiElement<MatchedDotCall> {
@@ -27,6 +28,9 @@ public interface ElixirMatchedDotCall extends ElixirMatchedExpression, DotCall<M
 
   @Nullable
   String canonicalName();
+
+  @Nullable
+  Collection<String> canonicalNameCollection();
 
   @Nullable
   String functionName();

--- a/gen/org/elixir_lang/psi/ElixirMatchedQualifiedNoArgumentsCall.java
+++ b/gen/org/elixir_lang/psi/ElixirMatchedQualifiedNoArgumentsCall.java
@@ -12,6 +12,8 @@ import org.elixir_lang.psi.stub.MatchedQualifiedNoArgumentsCall;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Collection;
+
 public interface ElixirMatchedQualifiedNoArgumentsCall extends ElixirMatchedExpression, MatchedCall, QualifiedNoArgumentsCall<MatchedQualifiedNoArgumentsCall>, StubBasedPsiElement<MatchedQualifiedNoArgumentsCall> {
 
   @NotNull
@@ -25,6 +27,9 @@ public interface ElixirMatchedQualifiedNoArgumentsCall extends ElixirMatchedExpr
 
   @Nullable
   String canonicalName();
+
+  @Nullable
+  Collection<String> canonicalNameCollection();
 
   @Nullable
   String functionName();

--- a/gen/org/elixir_lang/psi/ElixirMatchedQualifiedNoParenthesesCall.java
+++ b/gen/org/elixir_lang/psi/ElixirMatchedQualifiedNoParenthesesCall.java
@@ -12,6 +12,8 @@ import org.elixir_lang.psi.stub.MatchedQualifiedNoParenthesesCall;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Collection;
+
 public interface ElixirMatchedQualifiedNoParenthesesCall extends ElixirMatchedExpression, MatchedCall, QualifiedNoParenthesesCall<MatchedQualifiedNoParenthesesCall>, StubBasedPsiElement<MatchedQualifiedNoParenthesesCall> {
 
   @NotNull
@@ -28,6 +30,9 @@ public interface ElixirMatchedQualifiedNoParenthesesCall extends ElixirMatchedEx
 
   @Nullable
   String canonicalName();
+
+  @Nullable
+  Collection<String> canonicalNameCollection();
 
   @Nullable
   String functionName();

--- a/gen/org/elixir_lang/psi/ElixirMatchedQualifiedParenthesesCall.java
+++ b/gen/org/elixir_lang/psi/ElixirMatchedQualifiedParenthesesCall.java
@@ -12,6 +12,8 @@ import org.elixir_lang.psi.stub.MatchedQualifiedParenthesesCall;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Collection;
+
 public interface ElixirMatchedQualifiedParenthesesCall extends ElixirMatchedExpression, MatchedCall, QualifiedParenthesesCall<MatchedQualifiedParenthesesCall>, StubBasedPsiElement<MatchedQualifiedParenthesesCall> {
 
   @NotNull
@@ -28,6 +30,9 @@ public interface ElixirMatchedQualifiedParenthesesCall extends ElixirMatchedExpr
 
   @Nullable
   String canonicalName();
+
+  @Nullable
+  Collection<String> canonicalNameCollection();
 
   @Nullable
   String functionName();

--- a/gen/org/elixir_lang/psi/ElixirMatchedUnqualifiedNoArgumentsCall.java
+++ b/gen/org/elixir_lang/psi/ElixirMatchedUnqualifiedNoArgumentsCall.java
@@ -13,6 +13,8 @@ import org.elixir_lang.psi.stub.MatchedUnqualifiedNoArgumentsCall;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Collection;
+
 public interface ElixirMatchedUnqualifiedNoArgumentsCall extends ElixirMatchedExpression, MatchedCall, UnqualifiedNoArgumentsCall<MatchedUnqualifiedNoArgumentsCall>, StubBasedPsiElement<MatchedUnqualifiedNoArgumentsCall> {
 
   @NotNull
@@ -20,6 +22,9 @@ public interface ElixirMatchedUnqualifiedNoArgumentsCall extends ElixirMatchedEx
 
   @Nullable
   String canonicalName();
+
+  @Nullable
+  Collection<String> canonicalNameCollection();
 
   @Nullable
   String functionName();

--- a/gen/org/elixir_lang/psi/ElixirMatchedUnqualifiedNoParenthesesCall.java
+++ b/gen/org/elixir_lang/psi/ElixirMatchedUnqualifiedNoParenthesesCall.java
@@ -12,6 +12,8 @@ import org.elixir_lang.psi.stub.MatchedUnqualifiedNoParenthesesCall;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Collection;
+
 public interface ElixirMatchedUnqualifiedNoParenthesesCall extends ElixirMatchedExpression, MatchedCall, UnqualifiedNoParenthesesCall<MatchedUnqualifiedNoParenthesesCall>, StubBasedPsiElement<MatchedUnqualifiedNoParenthesesCall> {
 
   @NotNull
@@ -22,6 +24,9 @@ public interface ElixirMatchedUnqualifiedNoParenthesesCall extends ElixirMatched
 
   @Nullable
   String canonicalName();
+
+  @Nullable
+  Collection<String> canonicalNameCollection();
 
   @Nullable
   String functionName();

--- a/gen/org/elixir_lang/psi/ElixirMatchedUnqualifiedParenthesesCall.java
+++ b/gen/org/elixir_lang/psi/ElixirMatchedUnqualifiedParenthesesCall.java
@@ -12,6 +12,8 @@ import org.elixir_lang.psi.stub.MatchedUnqualifiedParenthesesCall;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Collection;
+
 public interface ElixirMatchedUnqualifiedParenthesesCall extends ElixirMatchedExpression, MatchedCall, UnqualifiedParenthesesCall<MatchedUnqualifiedParenthesesCall>, StubBasedPsiElement<MatchedUnqualifiedParenthesesCall> {
 
   @NotNull
@@ -22,6 +24,9 @@ public interface ElixirMatchedUnqualifiedParenthesesCall extends ElixirMatchedEx
 
   @Nullable
   String canonicalName();
+
+  @Nullable
+  Collection<String> canonicalNameCollection();
 
   @Nullable
   String functionName();

--- a/gen/org/elixir_lang/psi/ElixirUnmatchedAtUnqualifiedNoParenthesesCall.java
+++ b/gen/org/elixir_lang/psi/ElixirUnmatchedAtUnqualifiedNoParenthesesCall.java
@@ -13,6 +13,8 @@ import org.elixir_lang.psi.stub.UnmatchedAtUnqualifiedNoParenthesesCall;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Collection;
+
 public interface ElixirUnmatchedAtUnqualifiedNoParenthesesCall extends ElixirUnmatchedExpression, AtUnqualifiedNoParenthesesCall<UnmatchedAtUnqualifiedNoParenthesesCall>, StubBasedPsiElement<UnmatchedAtUnqualifiedNoParenthesesCall> {
 
   @NotNull
@@ -26,6 +28,9 @@ public interface ElixirUnmatchedAtUnqualifiedNoParenthesesCall extends ElixirUnm
 
   @Nullable
   String canonicalName();
+
+  @Nullable
+  Collection<String> canonicalNameCollection();
 
   @Nullable
   String functionName();

--- a/gen/org/elixir_lang/psi/ElixirUnmatchedDotCall.java
+++ b/gen/org/elixir_lang/psi/ElixirUnmatchedDotCall.java
@@ -12,6 +12,7 @@ import org.elixir_lang.psi.stub.UnmatchedDotCall;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Collection;
 import java.util.List;
 
 public interface ElixirUnmatchedDotCall extends ElixirUnmatchedExpression, DotCall<UnmatchedDotCall>, StubBasedPsiElement<UnmatchedDotCall> {
@@ -30,6 +31,9 @@ public interface ElixirUnmatchedDotCall extends ElixirUnmatchedExpression, DotCa
 
   @Nullable
   String canonicalName();
+
+  @Nullable
+  Collection<String> canonicalNameCollection();
 
   @Nullable
   String functionName();

--- a/gen/org/elixir_lang/psi/ElixirUnmatchedQualifiedNoArgumentsCall.java
+++ b/gen/org/elixir_lang/psi/ElixirUnmatchedQualifiedNoArgumentsCall.java
@@ -12,6 +12,8 @@ import org.elixir_lang.psi.stub.UnmatchedQualifiedNoArgumentsCall;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Collection;
+
 public interface ElixirUnmatchedQualifiedNoArgumentsCall extends ElixirUnmatchedExpression, QualifiedNoArgumentsCall<UnmatchedQualifiedNoArgumentsCall>, StubBasedPsiElement<UnmatchedQualifiedNoArgumentsCall> {
 
   @Nullable
@@ -28,6 +30,9 @@ public interface ElixirUnmatchedQualifiedNoArgumentsCall extends ElixirUnmatched
 
   @Nullable
   String canonicalName();
+
+  @Nullable
+  Collection<String> canonicalNameCollection();
 
   @Nullable
   String functionName();

--- a/gen/org/elixir_lang/psi/ElixirUnmatchedQualifiedNoParenthesesCall.java
+++ b/gen/org/elixir_lang/psi/ElixirUnmatchedQualifiedNoParenthesesCall.java
@@ -12,6 +12,8 @@ import org.elixir_lang.psi.stub.UnmatchedQualifiedNoParenthesesCall;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Collection;
+
 public interface ElixirUnmatchedQualifiedNoParenthesesCall extends ElixirUnmatchedExpression, QualifiedNoParenthesesCall<UnmatchedQualifiedNoParenthesesCall>, StubBasedPsiElement<UnmatchedQualifiedNoParenthesesCall> {
 
   @Nullable
@@ -31,6 +33,9 @@ public interface ElixirUnmatchedQualifiedNoParenthesesCall extends ElixirUnmatch
 
   @Nullable
   String canonicalName();
+
+  @Nullable
+  Collection<String> canonicalNameCollection();
 
   @Nullable
   String functionName();

--- a/gen/org/elixir_lang/psi/ElixirUnmatchedQualifiedParenthesesCall.java
+++ b/gen/org/elixir_lang/psi/ElixirUnmatchedQualifiedParenthesesCall.java
@@ -12,6 +12,8 @@ import org.elixir_lang.psi.stub.UnmatchedQualifiedParenthesesCall;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Collection;
+
 public interface ElixirUnmatchedQualifiedParenthesesCall extends ElixirUnmatchedExpression, QualifiedParenthesesCall<UnmatchedQualifiedParenthesesCall>, StubBasedPsiElement<UnmatchedQualifiedParenthesesCall> {
 
   @Nullable
@@ -31,6 +33,9 @@ public interface ElixirUnmatchedQualifiedParenthesesCall extends ElixirUnmatched
 
   @Nullable
   String canonicalName();
+
+  @Nullable
+  Collection<String> canonicalNameCollection();
 
   @Nullable
   String functionName();

--- a/gen/org/elixir_lang/psi/ElixirUnmatchedUnqualifiedNoArgumentsCall.java
+++ b/gen/org/elixir_lang/psi/ElixirUnmatchedUnqualifiedNoArgumentsCall.java
@@ -13,6 +13,8 @@ import org.elixir_lang.psi.stub.UnmatchedUnqualifiedNoArgumentsCall;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Collection;
+
 public interface ElixirUnmatchedUnqualifiedNoArgumentsCall extends ElixirUnmatchedExpression, UnqualifiedNoArgumentsCall<UnmatchedUnqualifiedNoArgumentsCall>, StubBasedPsiElement<UnmatchedUnqualifiedNoArgumentsCall> {
 
   @Nullable
@@ -23,6 +25,9 @@ public interface ElixirUnmatchedUnqualifiedNoArgumentsCall extends ElixirUnmatch
 
   @Nullable
   String canonicalName();
+
+  @Nullable
+  Collection<String> canonicalNameCollection();
 
   @Nullable
   String functionName();

--- a/gen/org/elixir_lang/psi/ElixirUnmatchedUnqualifiedNoParenthesesCall.java
+++ b/gen/org/elixir_lang/psi/ElixirUnmatchedUnqualifiedNoParenthesesCall.java
@@ -12,6 +12,8 @@ import org.elixir_lang.psi.stub.UnmatchedUnqualifiedNoParenthesesCall;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Collection;
+
 public interface ElixirUnmatchedUnqualifiedNoParenthesesCall extends ElixirUnmatchedExpression, UnqualifiedNoParenthesesCall<UnmatchedUnqualifiedNoParenthesesCall>, StubBasedPsiElement<UnmatchedUnqualifiedNoParenthesesCall> {
 
   @Nullable
@@ -25,6 +27,9 @@ public interface ElixirUnmatchedUnqualifiedNoParenthesesCall extends ElixirUnmat
 
   @Nullable
   String canonicalName();
+
+  @Nullable
+  Collection<String> canonicalNameCollection();
 
   @Nullable
   String functionName();

--- a/gen/org/elixir_lang/psi/ElixirUnmatchedUnqualifiedParenthesesCall.java
+++ b/gen/org/elixir_lang/psi/ElixirUnmatchedUnqualifiedParenthesesCall.java
@@ -12,6 +12,8 @@ import org.elixir_lang.psi.stub.UnmatchedUnqualifiedParenthesesCall;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Collection;
+
 public interface ElixirUnmatchedUnqualifiedParenthesesCall extends ElixirUnmatchedExpression, UnqualifiedParenthesesCall<UnmatchedUnqualifiedParenthesesCall>, StubBasedPsiElement<UnmatchedUnqualifiedParenthesesCall> {
 
   @Nullable
@@ -25,6 +27,9 @@ public interface ElixirUnmatchedUnqualifiedParenthesesCall extends ElixirUnmatch
 
   @Nullable
   String canonicalName();
+
+  @Nullable
+  Collection<String> canonicalNameCollection();
 
   @Nullable
   String functionName();

--- a/gen/org/elixir_lang/psi/ElixirUnqualifiedNoParenthesesManyArgumentsCall.java
+++ b/gen/org/elixir_lang/psi/ElixirUnqualifiedNoParenthesesManyArgumentsCall.java
@@ -15,6 +15,7 @@ import org.elixir_lang.psi.stub.UnqualifiedNoParenthesesManyArgumentsCall;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Collection;
 import java.util.List;
 
 public interface ElixirUnqualifiedNoParenthesesManyArgumentsCall extends PsiElement, StubBased<UnqualifiedNoParenthesesManyArgumentsCall>, NoParentheses, Unqualified, Quotable, StubBasedPsiElement<UnqualifiedNoParenthesesManyArgumentsCall> {
@@ -39,6 +40,9 @@ public interface ElixirUnqualifiedNoParenthesesManyArgumentsCall extends PsiElem
 
   @Nullable
   String canonicalName();
+
+  @Nullable
+  Collection<String> canonicalNameCollection();
 
   @Nullable
   String functionName();

--- a/gen/org/elixir_lang/psi/impl/ElixirMatchedAtUnqualifiedNoParenthesesCallImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMatchedAtUnqualifiedNoParenthesesCallImpl.java
@@ -17,6 +17,8 @@ import org.elixir_lang.psi.stub.MatchedAtUnqualifiedNoParenthesesCall;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Collection;
+
 public class ElixirMatchedAtUnqualifiedNoParenthesesCallImpl extends NamedStubbedPsiElementBase<MatchedAtUnqualifiedNoParenthesesCall> implements ElixirMatchedAtUnqualifiedNoParenthesesCall {
 
   public ElixirMatchedAtUnqualifiedNoParenthesesCallImpl(MatchedAtUnqualifiedNoParenthesesCall stub, IStubElementType nodeType) {
@@ -51,6 +53,11 @@ public class ElixirMatchedAtUnqualifiedNoParenthesesCallImpl extends NamedStubbe
   @Nullable
   public String canonicalName() {
     return ElixirPsiImplUtil.canonicalName(this);
+  }
+
+  @Nullable
+  public Collection<String> canonicalNameCollection() {
+    return ElixirPsiImplUtil.canonicalNameCollection(this);
   }
 
   @Nullable

--- a/gen/org/elixir_lang/psi/impl/ElixirMatchedDotCallImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMatchedDotCallImpl.java
@@ -16,6 +16,7 @@ import org.elixir_lang.psi.stub.MatchedDotCall;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Collection;
 import java.util.List;
 
 public class ElixirMatchedDotCallImpl extends NamedStubbedPsiElementBase<MatchedDotCall> implements ElixirMatchedDotCall {
@@ -58,6 +59,11 @@ public class ElixirMatchedDotCallImpl extends NamedStubbedPsiElementBase<Matched
   @Nullable
   public String canonicalName() {
     return ElixirPsiImplUtil.canonicalName(this);
+  }
+
+  @Nullable
+  public Collection<String> canonicalNameCollection() {
+    return ElixirPsiImplUtil.canonicalNameCollection(this);
   }
 
   @Nullable

--- a/gen/org/elixir_lang/psi/impl/ElixirMatchedQualifiedNoArgumentsCallImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMatchedQualifiedNoArgumentsCallImpl.java
@@ -16,6 +16,8 @@ import org.elixir_lang.psi.stub.MatchedQualifiedNoArgumentsCall;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Collection;
+
 public class ElixirMatchedQualifiedNoArgumentsCallImpl extends NamedStubbedPsiElementBase<MatchedQualifiedNoArgumentsCall> implements ElixirMatchedQualifiedNoArgumentsCall {
 
   public ElixirMatchedQualifiedNoArgumentsCallImpl(MatchedQualifiedNoArgumentsCall stub, IStubElementType nodeType) {
@@ -56,6 +58,11 @@ public class ElixirMatchedQualifiedNoArgumentsCallImpl extends NamedStubbedPsiEl
   @Nullable
   public String canonicalName() {
     return ElixirPsiImplUtil.canonicalName(this);
+  }
+
+  @Nullable
+  public Collection<String> canonicalNameCollection() {
+    return ElixirPsiImplUtil.canonicalNameCollection(this);
   }
 
   @Nullable

--- a/gen/org/elixir_lang/psi/impl/ElixirMatchedQualifiedNoParenthesesCallImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMatchedQualifiedNoParenthesesCallImpl.java
@@ -16,6 +16,8 @@ import org.elixir_lang.psi.stub.MatchedQualifiedNoParenthesesCall;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Collection;
+
 public class ElixirMatchedQualifiedNoParenthesesCallImpl extends NamedStubbedPsiElementBase<MatchedQualifiedNoParenthesesCall> implements ElixirMatchedQualifiedNoParenthesesCall {
 
   public ElixirMatchedQualifiedNoParenthesesCallImpl(MatchedQualifiedNoParenthesesCall stub, IStubElementType nodeType) {
@@ -62,6 +64,11 @@ public class ElixirMatchedQualifiedNoParenthesesCallImpl extends NamedStubbedPsi
   @Nullable
   public String canonicalName() {
     return ElixirPsiImplUtil.canonicalName(this);
+  }
+
+  @Nullable
+  public Collection<String> canonicalNameCollection() {
+    return ElixirPsiImplUtil.canonicalNameCollection(this);
   }
 
   @Nullable

--- a/gen/org/elixir_lang/psi/impl/ElixirMatchedQualifiedParenthesesCallImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMatchedQualifiedParenthesesCallImpl.java
@@ -16,6 +16,8 @@ import org.elixir_lang.psi.stub.MatchedQualifiedParenthesesCall;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Collection;
+
 public class ElixirMatchedQualifiedParenthesesCallImpl extends NamedStubbedPsiElementBase<MatchedQualifiedParenthesesCall> implements ElixirMatchedQualifiedParenthesesCall {
 
   public ElixirMatchedQualifiedParenthesesCallImpl(MatchedQualifiedParenthesesCall stub, IStubElementType nodeType) {
@@ -62,6 +64,11 @@ public class ElixirMatchedQualifiedParenthesesCallImpl extends NamedStubbedPsiEl
   @Nullable
   public String canonicalName() {
     return ElixirPsiImplUtil.canonicalName(this);
+  }
+
+  @Nullable
+  public Collection<String> canonicalNameCollection() {
+    return ElixirPsiImplUtil.canonicalNameCollection(this);
   }
 
   @Nullable

--- a/gen/org/elixir_lang/psi/impl/ElixirMatchedUnqualifiedNoArgumentsCallImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMatchedUnqualifiedNoArgumentsCallImpl.java
@@ -20,6 +20,8 @@ import org.elixir_lang.psi.stub.MatchedUnqualifiedNoArgumentsCall;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Collection;
+
 public class ElixirMatchedUnqualifiedNoArgumentsCallImpl extends NamedStubbedPsiElementBase<MatchedUnqualifiedNoArgumentsCall> implements ElixirMatchedUnqualifiedNoArgumentsCall {
 
   public ElixirMatchedUnqualifiedNoArgumentsCallImpl(MatchedUnqualifiedNoArgumentsCall stub, IStubElementType nodeType) {
@@ -48,6 +50,11 @@ public class ElixirMatchedUnqualifiedNoArgumentsCallImpl extends NamedStubbedPsi
   @Nullable
   public String canonicalName() {
     return ElixirPsiImplUtil.canonicalName(this);
+  }
+
+  @Nullable
+  public Collection<String> canonicalNameCollection() {
+    return ElixirPsiImplUtil.canonicalNameCollection(this);
   }
 
   @Nullable

--- a/gen/org/elixir_lang/psi/impl/ElixirMatchedUnqualifiedNoParenthesesCallImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMatchedUnqualifiedNoParenthesesCallImpl.java
@@ -16,6 +16,8 @@ import org.elixir_lang.psi.stub.MatchedUnqualifiedNoParenthesesCall;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Collection;
+
 public class ElixirMatchedUnqualifiedNoParenthesesCallImpl extends NamedStubbedPsiElementBase<MatchedUnqualifiedNoParenthesesCall> implements ElixirMatchedUnqualifiedNoParenthesesCall {
 
   public ElixirMatchedUnqualifiedNoParenthesesCallImpl(MatchedUnqualifiedNoParenthesesCall stub, IStubElementType nodeType) {
@@ -50,6 +52,11 @@ public class ElixirMatchedUnqualifiedNoParenthesesCallImpl extends NamedStubbedP
   @Nullable
   public String canonicalName() {
     return ElixirPsiImplUtil.canonicalName(this);
+  }
+
+  @Nullable
+  public Collection<String> canonicalNameCollection() {
+    return ElixirPsiImplUtil.canonicalNameCollection(this);
   }
 
   @Nullable

--- a/gen/org/elixir_lang/psi/impl/ElixirMatchedUnqualifiedParenthesesCallImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMatchedUnqualifiedParenthesesCallImpl.java
@@ -16,6 +16,8 @@ import org.elixir_lang.psi.stub.MatchedUnqualifiedParenthesesCall;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Collection;
+
 public class ElixirMatchedUnqualifiedParenthesesCallImpl extends NamedStubbedPsiElementBase<MatchedUnqualifiedParenthesesCall> implements ElixirMatchedUnqualifiedParenthesesCall {
 
   public ElixirMatchedUnqualifiedParenthesesCallImpl(MatchedUnqualifiedParenthesesCall stub, IStubElementType nodeType) {
@@ -50,6 +52,11 @@ public class ElixirMatchedUnqualifiedParenthesesCallImpl extends NamedStubbedPsi
   @Nullable
   public String canonicalName() {
     return ElixirPsiImplUtil.canonicalName(this);
+  }
+
+  @Nullable
+  public Collection<String> canonicalNameCollection() {
+    return ElixirPsiImplUtil.canonicalNameCollection(this);
   }
 
   @Nullable

--- a/gen/org/elixir_lang/psi/impl/ElixirUnmatchedAtUnqualifiedNoParenthesesCallImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnmatchedAtUnqualifiedNoParenthesesCallImpl.java
@@ -17,6 +17,8 @@ import org.elixir_lang.psi.stub.UnmatchedAtUnqualifiedNoParenthesesCall;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Collection;
+
 public class ElixirUnmatchedAtUnqualifiedNoParenthesesCallImpl extends NamedStubbedPsiElementBase<UnmatchedAtUnqualifiedNoParenthesesCall> implements ElixirUnmatchedAtUnqualifiedNoParenthesesCall {
 
   public ElixirUnmatchedAtUnqualifiedNoParenthesesCallImpl(UnmatchedAtUnqualifiedNoParenthesesCall stub, IStubElementType nodeType) {
@@ -57,6 +59,11 @@ public class ElixirUnmatchedAtUnqualifiedNoParenthesesCallImpl extends NamedStub
   @Nullable
   public String canonicalName() {
     return ElixirPsiImplUtil.canonicalName(this);
+  }
+
+  @Nullable
+  public Collection<String> canonicalNameCollection() {
+    return ElixirPsiImplUtil.canonicalNameCollection(this);
   }
 
   @Nullable

--- a/gen/org/elixir_lang/psi/impl/ElixirUnmatchedDotCallImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnmatchedDotCallImpl.java
@@ -16,6 +16,7 @@ import org.elixir_lang.psi.stub.UnmatchedDotCall;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Collection;
 import java.util.List;
 
 public class ElixirUnmatchedDotCallImpl extends NamedStubbedPsiElementBase<UnmatchedDotCall> implements ElixirUnmatchedDotCall {
@@ -64,6 +65,11 @@ public class ElixirUnmatchedDotCallImpl extends NamedStubbedPsiElementBase<Unmat
   @Nullable
   public String canonicalName() {
     return ElixirPsiImplUtil.canonicalName(this);
+  }
+
+  @Nullable
+  public Collection<String> canonicalNameCollection() {
+    return ElixirPsiImplUtil.canonicalNameCollection(this);
   }
 
   @Nullable

--- a/gen/org/elixir_lang/psi/impl/ElixirUnmatchedQualifiedNoArgumentsCallImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnmatchedQualifiedNoArgumentsCallImpl.java
@@ -16,6 +16,8 @@ import org.elixir_lang.psi.stub.UnmatchedQualifiedNoArgumentsCall;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Collection;
+
 public class ElixirUnmatchedQualifiedNoArgumentsCallImpl extends NamedStubbedPsiElementBase<UnmatchedQualifiedNoArgumentsCall> implements ElixirUnmatchedQualifiedNoArgumentsCall {
 
   public ElixirUnmatchedQualifiedNoArgumentsCallImpl(UnmatchedQualifiedNoArgumentsCall stub, IStubElementType nodeType) {
@@ -62,6 +64,11 @@ public class ElixirUnmatchedQualifiedNoArgumentsCallImpl extends NamedStubbedPsi
   @Nullable
   public String canonicalName() {
     return ElixirPsiImplUtil.canonicalName(this);
+  }
+
+  @Nullable
+  public Collection<String> canonicalNameCollection() {
+    return ElixirPsiImplUtil.canonicalNameCollection(this);
   }
 
   @Nullable

--- a/gen/org/elixir_lang/psi/impl/ElixirUnmatchedQualifiedNoParenthesesCallImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnmatchedQualifiedNoParenthesesCallImpl.java
@@ -16,6 +16,8 @@ import org.elixir_lang.psi.stub.UnmatchedQualifiedNoParenthesesCall;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Collection;
+
 public class ElixirUnmatchedQualifiedNoParenthesesCallImpl extends NamedStubbedPsiElementBase<UnmatchedQualifiedNoParenthesesCall> implements ElixirUnmatchedQualifiedNoParenthesesCall {
 
   public ElixirUnmatchedQualifiedNoParenthesesCallImpl(UnmatchedQualifiedNoParenthesesCall stub, IStubElementType nodeType) {
@@ -68,6 +70,11 @@ public class ElixirUnmatchedQualifiedNoParenthesesCallImpl extends NamedStubbedP
   @Nullable
   public String canonicalName() {
     return ElixirPsiImplUtil.canonicalName(this);
+  }
+
+  @Nullable
+  public Collection<String> canonicalNameCollection() {
+    return ElixirPsiImplUtil.canonicalNameCollection(this);
   }
 
   @Nullable

--- a/gen/org/elixir_lang/psi/impl/ElixirUnmatchedQualifiedParenthesesCallImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnmatchedQualifiedParenthesesCallImpl.java
@@ -16,6 +16,8 @@ import org.elixir_lang.psi.stub.UnmatchedQualifiedParenthesesCall;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Collection;
+
 public class ElixirUnmatchedQualifiedParenthesesCallImpl extends NamedStubbedPsiElementBase<UnmatchedQualifiedParenthesesCall> implements ElixirUnmatchedQualifiedParenthesesCall {
 
   public ElixirUnmatchedQualifiedParenthesesCallImpl(UnmatchedQualifiedParenthesesCall stub, IStubElementType nodeType) {
@@ -68,6 +70,11 @@ public class ElixirUnmatchedQualifiedParenthesesCallImpl extends NamedStubbedPsi
   @Nullable
   public String canonicalName() {
     return ElixirPsiImplUtil.canonicalName(this);
+  }
+
+  @Nullable
+  public Collection<String> canonicalNameCollection() {
+    return ElixirPsiImplUtil.canonicalNameCollection(this);
   }
 
   @Nullable

--- a/gen/org/elixir_lang/psi/impl/ElixirUnmatchedUnqualifiedNoArgumentsCallImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnmatchedUnqualifiedNoArgumentsCallImpl.java
@@ -20,6 +20,8 @@ import org.elixir_lang.psi.stub.UnmatchedUnqualifiedNoArgumentsCall;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Collection;
+
 public class ElixirUnmatchedUnqualifiedNoArgumentsCallImpl extends NamedStubbedPsiElementBase<UnmatchedUnqualifiedNoArgumentsCall> implements ElixirUnmatchedUnqualifiedNoArgumentsCall {
 
   public ElixirUnmatchedUnqualifiedNoArgumentsCallImpl(UnmatchedUnqualifiedNoArgumentsCall stub, IStubElementType nodeType) {
@@ -54,6 +56,11 @@ public class ElixirUnmatchedUnqualifiedNoArgumentsCallImpl extends NamedStubbedP
   @Nullable
   public String canonicalName() {
     return ElixirPsiImplUtil.canonicalName(this);
+  }
+
+  @Nullable
+  public Collection<String> canonicalNameCollection() {
+    return ElixirPsiImplUtil.canonicalNameCollection(this);
   }
 
   @Nullable

--- a/gen/org/elixir_lang/psi/impl/ElixirUnmatchedUnqualifiedNoParenthesesCallImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnmatchedUnqualifiedNoParenthesesCallImpl.java
@@ -16,6 +16,8 @@ import org.elixir_lang.psi.stub.UnmatchedUnqualifiedNoParenthesesCall;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Collection;
+
 public class ElixirUnmatchedUnqualifiedNoParenthesesCallImpl extends NamedStubbedPsiElementBase<UnmatchedUnqualifiedNoParenthesesCall> implements ElixirUnmatchedUnqualifiedNoParenthesesCall {
 
   public ElixirUnmatchedUnqualifiedNoParenthesesCallImpl(UnmatchedUnqualifiedNoParenthesesCall stub, IStubElementType nodeType) {
@@ -56,6 +58,11 @@ public class ElixirUnmatchedUnqualifiedNoParenthesesCallImpl extends NamedStubbe
   @Nullable
   public String canonicalName() {
     return ElixirPsiImplUtil.canonicalName(this);
+  }
+
+  @Nullable
+  public Collection<String> canonicalNameCollection() {
+    return ElixirPsiImplUtil.canonicalNameCollection(this);
   }
 
   @Nullable

--- a/gen/org/elixir_lang/psi/impl/ElixirUnmatchedUnqualifiedParenthesesCallImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnmatchedUnqualifiedParenthesesCallImpl.java
@@ -16,6 +16,8 @@ import org.elixir_lang.psi.stub.UnmatchedUnqualifiedParenthesesCall;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Collection;
+
 public class ElixirUnmatchedUnqualifiedParenthesesCallImpl extends NamedStubbedPsiElementBase<UnmatchedUnqualifiedParenthesesCall> implements ElixirUnmatchedUnqualifiedParenthesesCall {
 
   public ElixirUnmatchedUnqualifiedParenthesesCallImpl(UnmatchedUnqualifiedParenthesesCall stub, IStubElementType nodeType) {
@@ -56,6 +58,11 @@ public class ElixirUnmatchedUnqualifiedParenthesesCallImpl extends NamedStubbedP
   @Nullable
   public String canonicalName() {
     return ElixirPsiImplUtil.canonicalName(this);
+  }
+
+  @Nullable
+  public Collection<String> canonicalNameCollection() {
+    return ElixirPsiImplUtil.canonicalNameCollection(this);
   }
 
   @Nullable

--- a/gen/org/elixir_lang/psi/impl/ElixirUnqualifiedNoParenthesesManyArgumentsCallImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnqualifiedNoParenthesesManyArgumentsCallImpl.java
@@ -16,6 +16,7 @@ import org.elixir_lang.psi.stub.UnqualifiedNoParenthesesManyArgumentsCall;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Collection;
 import java.util.List;
 
 public class ElixirUnqualifiedNoParenthesesManyArgumentsCallImpl extends NamedStubbedPsiElementBase<UnqualifiedNoParenthesesManyArgumentsCall> implements ElixirUnqualifiedNoParenthesesManyArgumentsCall {
@@ -76,6 +77,11 @@ public class ElixirUnqualifiedNoParenthesesManyArgumentsCallImpl extends NamedSt
   @Nullable
   public String canonicalName() {
     return ElixirPsiImplUtil.canonicalName(this);
+  }
+
+  @Nullable
+  public Collection<String> canonicalNameCollection() {
+    return ElixirPsiImplUtil.canonicalNameCollection(this);
   }
 
   @Nullable

--- a/src/org/elixir_lang/Elixir.bnf
+++ b/src/org/elixir_lang/Elixir.bnf
@@ -11,6 +11,7 @@
   elementTypeFactory("((un)?matched((((At)?Unq)|Q)ualified(No)?(Argument|Parenthese)s|Dot)||unqualifiedNoParenthesesManyArguments)Call")="org.elixir_lang.ElementTypeFactory.factory"
   methods(           "((un)?matched((((At)?Unq)|Q)ualified(No)?(Argument|Parenthese)s|Dot)||unqualifiedNoParenthesesManyArguments)Call")=[
     canonicalName
+    canonicalNameCollection
     functionName
     functionNameElement
     getDoBlock

--- a/src/org/elixir_lang/navigation/GotoSymbolContributor.java
+++ b/src/org/elixir_lang/navigation/GotoSymbolContributor.java
@@ -184,8 +184,23 @@ public class GotoSymbolContributor implements ChooseByNameContributor {
                 } else if (Implementation.is(call)) {
                     Modular modular = enclosingModularByCall.putNew(call);
 
-                    Implementation implementation = new Implementation(modular, call);
-                    items.add(implementation);
+                    Collection<String> forNameCollection = Implementation.forNameCollection(modular, call);
+
+                    if (forNameCollection != null) {
+                        for (String forName : forNameCollection) {
+                            Implementation forNameOverriddenImplementation = new Implementation(modular, call, forName);
+                            String implementationName = forNameOverriddenImplementation.getName();
+
+                            if (implementationName != null && implementationName.contains(name)) {
+                                items.add(forNameOverriddenImplementation);
+                            }
+                        }
+                    }
+
+                    if (forNameCollection == null || forNameCollection.size() < 2) {
+                        Implementation implementation = new Implementation(modular, call);
+                        items.add(implementation);
+                    }
                 } else if (Module.is(call)) {
                     Modular modular = enclosingModularByCall.putNew(call);
 

--- a/src/org/elixir_lang/psi/call/StubBased.java
+++ b/src/org/elixir_lang/psi/call/StubBased.java
@@ -1,9 +1,21 @@
 package org.elixir_lang.psi.call;
 
 import com.intellij.psi.StubBasedPsiElement;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Collection;
+
 public interface StubBased<Stub extends org.elixir_lang.psi.stub.call.Stub> extends Named, StubBasedPsiElement<Stub> {
+    /**
+     * @return {@code null} if it does not have a canonical name OR if it has more than one canonical name
+     */
     @Nullable
     String canonicalName();
+
+    /**
+     * @return empty collection if no canonical names
+     */
+    @NotNull
+    Collection<String> canonicalNameCollection();
 }

--- a/src/org/elixir_lang/psi/stub/MatchedAtUnqualifiedNoParenthesesCall.java
+++ b/src/org/elixir_lang/psi/stub/MatchedAtUnqualifiedNoParenthesesCall.java
@@ -8,6 +8,8 @@ import org.elixir_lang.psi.stub.call.Stub;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Collection;
+
 public class MatchedAtUnqualifiedNoParenthesesCall extends Stub<ElixirMatchedAtUnqualifiedNoParenthesesCall> {
     public MatchedAtUnqualifiedNoParenthesesCall(
             StubElement parent,
@@ -17,7 +19,7 @@ public class MatchedAtUnqualifiedNoParenthesesCall extends Stub<ElixirMatchedAtU
             int resolvedFinalArity,
             boolean hasDoBlockOrKeyword,
             @NotNull StringRef name,
-            @NotNull StringRef canonicalName
+            @NotNull Collection<StringRef> canonicalNameCollection
     ) {
         super(parent,
                 elementType,
@@ -26,7 +28,7 @@ public class MatchedAtUnqualifiedNoParenthesesCall extends Stub<ElixirMatchedAtU
                 resolvedFinalArity,
                 hasDoBlockOrKeyword,
                 name,
-                canonicalName);
+                canonicalNameCollection);
     }
 
     public MatchedAtUnqualifiedNoParenthesesCall(
@@ -37,7 +39,7 @@ public class MatchedAtUnqualifiedNoParenthesesCall extends Stub<ElixirMatchedAtU
             int resolvedFinalArity,
             boolean hasDoBlockOrKeyword,
             @NotNull String name,
-            @NotNull String canonicalName
+            @NotNull Collection<String> canonicalNameCollection
     ) {
         super(
                 parent,
@@ -47,7 +49,7 @@ public class MatchedAtUnqualifiedNoParenthesesCall extends Stub<ElixirMatchedAtU
                 resolvedFinalArity,
                 hasDoBlockOrKeyword,
                 name,
-                canonicalName
+                canonicalNameCollection
         );
     }
 }

--- a/src/org/elixir_lang/psi/stub/MatchedDotCall.java
+++ b/src/org/elixir_lang/psi/stub/MatchedDotCall.java
@@ -8,6 +8,8 @@ import org.elixir_lang.psi.stub.call.Stub;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Collection;
+
 public class MatchedDotCall extends Stub<ElixirMatchedDotCall> {
     public MatchedDotCall(
             StubElement parent,
@@ -17,7 +19,7 @@ public class MatchedDotCall extends Stub<ElixirMatchedDotCall> {
             int resolvedFinalArity,
             boolean hasDoBlockOrKeyword,
             @NotNull StringRef name,
-            @NotNull StringRef canonicalName
+            @NotNull Collection<StringRef> canonicalNameCollection
     ) {
         super(
                 parent,
@@ -27,7 +29,7 @@ public class MatchedDotCall extends Stub<ElixirMatchedDotCall> {
                 resolvedFinalArity,
                 hasDoBlockOrKeyword,
                 name,
-                canonicalName
+                canonicalNameCollection
         );
     }
 
@@ -39,7 +41,7 @@ public class MatchedDotCall extends Stub<ElixirMatchedDotCall> {
             int resolvedFinalArity,
             boolean hasDoBlockOrKeyword,
             @NotNull String name,
-            @NotNull String canonicalName
+            @NotNull Collection<String> canonicalNameCollection
     ) {
         super(
                 parent,
@@ -49,7 +51,7 @@ public class MatchedDotCall extends Stub<ElixirMatchedDotCall> {
                 resolvedFinalArity,
                 hasDoBlockOrKeyword,
                 name,
-                canonicalName
+                canonicalNameCollection
         );
     }
 }

--- a/src/org/elixir_lang/psi/stub/MatchedQualifiedNoArgumentsCall.java
+++ b/src/org/elixir_lang/psi/stub/MatchedQualifiedNoArgumentsCall.java
@@ -8,6 +8,8 @@ import org.elixir_lang.psi.stub.call.Stub;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Collection;
+
 public class MatchedQualifiedNoArgumentsCall extends Stub<ElixirMatchedQualifiedNoArgumentsCall> {
     public MatchedQualifiedNoArgumentsCall(
             StubElement parent,
@@ -17,7 +19,7 @@ public class MatchedQualifiedNoArgumentsCall extends Stub<ElixirMatchedQualified
             int resolvedFinalArity,
             boolean hasDoBlockOrKeyword,
             @NotNull StringRef name,
-            @NotNull StringRef canonicalName
+            @NotNull Collection<StringRef> canonicalNameCollection
     ) {
         super(
                 parent,
@@ -27,7 +29,7 @@ public class MatchedQualifiedNoArgumentsCall extends Stub<ElixirMatchedQualified
                 resolvedFinalArity,
                 hasDoBlockOrKeyword,
                 name,
-                canonicalName
+                canonicalNameCollection
         );
     }
 
@@ -39,7 +41,7 @@ public class MatchedQualifiedNoArgumentsCall extends Stub<ElixirMatchedQualified
             int resolvedFinalArity,
             boolean hasDoBlockOrKeyword,
             @NotNull String name,
-            @NotNull String canonicalName
+            @NotNull Collection<String> canonicalNameCollection
     ) {
         super(
                 parent,
@@ -49,7 +51,7 @@ public class MatchedQualifiedNoArgumentsCall extends Stub<ElixirMatchedQualified
                 resolvedFinalArity,
                 hasDoBlockOrKeyword,
                 name,
-                canonicalName
+                canonicalNameCollection
         );
     }
 }

--- a/src/org/elixir_lang/psi/stub/MatchedQualifiedNoParenthesesCall.java
+++ b/src/org/elixir_lang/psi/stub/MatchedQualifiedNoParenthesesCall.java
@@ -8,6 +8,8 @@ import org.elixir_lang.psi.stub.call.Stub;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Collection;
+
 public class MatchedQualifiedNoParenthesesCall extends Stub<ElixirMatchedQualifiedNoParenthesesCall> {
     public MatchedQualifiedNoParenthesesCall(
             StubElement parent,
@@ -17,7 +19,7 @@ public class MatchedQualifiedNoParenthesesCall extends Stub<ElixirMatchedQualifi
             int resolvedFinalArity,
             boolean hasDoBlockOrKeyword,
             @NotNull StringRef name,
-            @NotNull StringRef canonicalName
+            @NotNull Collection<StringRef> canonicalNameCollection
     ) {
         super(
                 parent,
@@ -27,7 +29,7 @@ public class MatchedQualifiedNoParenthesesCall extends Stub<ElixirMatchedQualifi
                 resolvedFinalArity,
                 hasDoBlockOrKeyword,
                 name,
-                canonicalName
+                canonicalNameCollection
         );
     }
 
@@ -39,7 +41,7 @@ public class MatchedQualifiedNoParenthesesCall extends Stub<ElixirMatchedQualifi
             int resolvedFinalArity,
             boolean hasDoBlockOrKeyword,
             @NotNull String name,
-            @NotNull String canonicalName
+            @NotNull Collection<String> canonicalNameCollection
     ) {
         super(
                 parent,
@@ -49,7 +51,7 @@ public class MatchedQualifiedNoParenthesesCall extends Stub<ElixirMatchedQualifi
                 resolvedFinalArity,
                 hasDoBlockOrKeyword,
                 name,
-                canonicalName
+                canonicalNameCollection
         );
     }
 }

--- a/src/org/elixir_lang/psi/stub/MatchedQualifiedParenthesesCall.java
+++ b/src/org/elixir_lang/psi/stub/MatchedQualifiedParenthesesCall.java
@@ -8,6 +8,8 @@ import org.elixir_lang.psi.stub.call.Stub;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Collection;
+
 public class MatchedQualifiedParenthesesCall extends Stub<ElixirMatchedQualifiedParenthesesCall> {
     public MatchedQualifiedParenthesesCall(
             StubElement parent,
@@ -17,7 +19,7 @@ public class MatchedQualifiedParenthesesCall extends Stub<ElixirMatchedQualified
             int resolvedFinalArity,
             boolean hasDoBlockOrKeyword,
             @NotNull StringRef name,
-            @NotNull StringRef canonicalName
+            @NotNull Collection<StringRef> canonicalNameCollection
     ) {
         super(
                 parent,
@@ -27,7 +29,7 @@ public class MatchedQualifiedParenthesesCall extends Stub<ElixirMatchedQualified
                 resolvedFinalArity,
                 hasDoBlockOrKeyword,
                 name,
-                canonicalName
+                canonicalNameCollection
         );
     }
 
@@ -39,7 +41,7 @@ public class MatchedQualifiedParenthesesCall extends Stub<ElixirMatchedQualified
             int resolvedFinalArity,
             boolean hasDoBlockOrKeyword,
             @NotNull String name,
-            @NotNull String canonicalName
+            @NotNull Collection<String> canonicalNameCollection
     ) {
         super(
                 parent,
@@ -49,7 +51,7 @@ public class MatchedQualifiedParenthesesCall extends Stub<ElixirMatchedQualified
                 resolvedFinalArity,
                 hasDoBlockOrKeyword,
                 name,
-                canonicalName
+                canonicalNameCollection
         );
     }
 }

--- a/src/org/elixir_lang/psi/stub/MatchedUnqualifiedNoArgumentsCall.java
+++ b/src/org/elixir_lang/psi/stub/MatchedUnqualifiedNoArgumentsCall.java
@@ -8,6 +8,8 @@ import org.elixir_lang.psi.stub.call.Stub;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Collection;
+
 public class MatchedUnqualifiedNoArgumentsCall extends Stub<ElixirMatchedUnqualifiedNoArgumentsCall> {
     public MatchedUnqualifiedNoArgumentsCall(
             StubElement parent,
@@ -17,7 +19,7 @@ public class MatchedUnqualifiedNoArgumentsCall extends Stub<ElixirMatchedUnquali
             int resolvedFinalArity,
             boolean hasDoBlockOrKeyword,
             @NotNull StringRef name,
-            @NotNull StringRef canonicalName
+            @NotNull Collection<StringRef> canonicalNameCollection
     ) {
         super(
                 parent,
@@ -27,7 +29,7 @@ public class MatchedUnqualifiedNoArgumentsCall extends Stub<ElixirMatchedUnquali
                 resolvedFinalArity,
                 hasDoBlockOrKeyword,
                 name,
-                canonicalName
+                canonicalNameCollection
         );
     }
 
@@ -39,7 +41,7 @@ public class MatchedUnqualifiedNoArgumentsCall extends Stub<ElixirMatchedUnquali
             int resolvedFinalArity,
             boolean hasDoBlockOrKeyword,
             @NotNull String name,
-            @NotNull String canonicalName
+            @NotNull Collection<String> canonicalNameCollection
     ) {
         super(
                 parent,
@@ -49,7 +51,7 @@ public class MatchedUnqualifiedNoArgumentsCall extends Stub<ElixirMatchedUnquali
                 resolvedFinalArity,
                 hasDoBlockOrKeyword,
                 name,
-                canonicalName
+                canonicalNameCollection
         );
     }
 }

--- a/src/org/elixir_lang/psi/stub/MatchedUnqualifiedNoParenthesesCall.java
+++ b/src/org/elixir_lang/psi/stub/MatchedUnqualifiedNoParenthesesCall.java
@@ -8,6 +8,8 @@ import org.elixir_lang.psi.stub.call.Stub;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Collection;
+
 public class MatchedUnqualifiedNoParenthesesCall extends Stub<ElixirMatchedUnqualifiedNoParenthesesCall> {
     public MatchedUnqualifiedNoParenthesesCall(
             StubElement parent,
@@ -17,7 +19,7 @@ public class MatchedUnqualifiedNoParenthesesCall extends Stub<ElixirMatchedUnqua
             int resolvedFinalArity,
             boolean hasDoBlockOrKeyword,
             @NotNull StringRef name,
-            @NotNull StringRef canonicalName
+            @NotNull Collection<StringRef> canonicalNameCollection
     ) {
         super(
                 parent,
@@ -27,7 +29,7 @@ public class MatchedUnqualifiedNoParenthesesCall extends Stub<ElixirMatchedUnqua
                 resolvedFinalArity,
                 hasDoBlockOrKeyword,
                 name,
-                canonicalName
+                canonicalNameCollection
         );
     }
 
@@ -39,7 +41,7 @@ public class MatchedUnqualifiedNoParenthesesCall extends Stub<ElixirMatchedUnqua
             int resolvedFinalArity,
             boolean hasDoBlockOrKeyword,
             @NotNull String name,
-            @NotNull String canonicalName
+            @NotNull Collection<String> canonicalNameCollection
     ) {
         super(
                 parent,
@@ -49,7 +51,7 @@ public class MatchedUnqualifiedNoParenthesesCall extends Stub<ElixirMatchedUnqua
                 resolvedFinalArity,
                 hasDoBlockOrKeyword,
                 name,
-                canonicalName
+                canonicalNameCollection
         );
     }
 }

--- a/src/org/elixir_lang/psi/stub/MatchedUnqualifiedParenthesesCall.java
+++ b/src/org/elixir_lang/psi/stub/MatchedUnqualifiedParenthesesCall.java
@@ -8,6 +8,8 @@ import org.elixir_lang.psi.stub.call.Stub;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Collection;
+
 public class MatchedUnqualifiedParenthesesCall extends Stub<ElixirMatchedUnqualifiedParenthesesCall> {
     public MatchedUnqualifiedParenthesesCall(
             StubElement parent,
@@ -17,7 +19,7 @@ public class MatchedUnqualifiedParenthesesCall extends Stub<ElixirMatchedUnquali
             int resolvedFinalArity,
             boolean hasDoBlockOrKeyword,
             @NotNull StringRef name,
-            @NotNull StringRef canonicalName
+            @NotNull Collection<StringRef> canonicalNameCollection
     ) {
         super(
                 parent,
@@ -27,7 +29,7 @@ public class MatchedUnqualifiedParenthesesCall extends Stub<ElixirMatchedUnquali
                 resolvedFinalArity,
                 hasDoBlockOrKeyword,
                 name,
-                canonicalName
+                canonicalNameCollection
         );
     }
 
@@ -39,7 +41,7 @@ public class MatchedUnqualifiedParenthesesCall extends Stub<ElixirMatchedUnquali
             int resolvedFinalArity,
             boolean hasDoBlockOrKeyword,
             @NotNull String name,
-            @NotNull String canonicalName
+            @NotNull Collection<String> canonicalNameCollection
     ) {
         super(
                 parent,
@@ -49,7 +51,7 @@ public class MatchedUnqualifiedParenthesesCall extends Stub<ElixirMatchedUnquali
                 resolvedFinalArity,
                 hasDoBlockOrKeyword,
                 name,
-                canonicalName
+                canonicalNameCollection
         );
     }
 }

--- a/src/org/elixir_lang/psi/stub/UnmatchedAtUnqualifiedNoParenthesesCall.java
+++ b/src/org/elixir_lang/psi/stub/UnmatchedAtUnqualifiedNoParenthesesCall.java
@@ -8,6 +8,8 @@ import org.elixir_lang.psi.stub.call.Stub;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Collection;
+
 public class UnmatchedAtUnqualifiedNoParenthesesCall extends Stub<ElixirUnmatchedAtUnqualifiedNoParenthesesCall> {
     public UnmatchedAtUnqualifiedNoParenthesesCall(
             StubElement parent,
@@ -17,7 +19,7 @@ public class UnmatchedAtUnqualifiedNoParenthesesCall extends Stub<ElixirUnmatche
             int resolvedFinalArity,
             boolean hasDoBlockOrKeyword,
             @NotNull StringRef name,
-            @NotNull StringRef canonicalName
+            @NotNull Collection<StringRef> canonicalNameCollection
     ) {
         super(
                 parent,
@@ -27,7 +29,7 @@ public class UnmatchedAtUnqualifiedNoParenthesesCall extends Stub<ElixirUnmatche
                 resolvedFinalArity,
                 hasDoBlockOrKeyword,
                 name,
-                canonicalName
+                canonicalNameCollection
         );
     }
 
@@ -39,7 +41,7 @@ public class UnmatchedAtUnqualifiedNoParenthesesCall extends Stub<ElixirUnmatche
             int resolvedFinalArity,
             boolean hasDoBlockOrKeyword,
             @NotNull String name,
-            @NotNull String canonicalName
+            @NotNull Collection<String> canonicalNameCollection
     ) {
         super(
                 parent,
@@ -49,7 +51,7 @@ public class UnmatchedAtUnqualifiedNoParenthesesCall extends Stub<ElixirUnmatche
                 resolvedFinalArity,
                 hasDoBlockOrKeyword,
                 name,
-                canonicalName
+                canonicalNameCollection
         );
     }
 }

--- a/src/org/elixir_lang/psi/stub/UnmatchedDotCall.java
+++ b/src/org/elixir_lang/psi/stub/UnmatchedDotCall.java
@@ -8,6 +8,8 @@ import org.elixir_lang.psi.stub.call.Stub;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Collection;
+
 public class UnmatchedDotCall extends Stub<ElixirUnmatchedDotCall> {
     public UnmatchedDotCall(
             StubElement parent,
@@ -17,7 +19,7 @@ public class UnmatchedDotCall extends Stub<ElixirUnmatchedDotCall> {
             int resolvedFinalArity,
             boolean hasDoBlockOrKeyword,
             @NotNull StringRef name,
-            @NotNull StringRef canonicalName
+            @NotNull Collection<StringRef> canonicalNameColection
     ) {
         super(
                 parent,
@@ -27,7 +29,7 @@ public class UnmatchedDotCall extends Stub<ElixirUnmatchedDotCall> {
                 resolvedFinalArity,
                 hasDoBlockOrKeyword,
                 name,
-                canonicalName
+                canonicalNameColection
         );
     }
 
@@ -39,7 +41,7 @@ public class UnmatchedDotCall extends Stub<ElixirUnmatchedDotCall> {
             int resolvedFinalArity,
             boolean hasDoBlockOrKeyword,
             @NotNull String name,
-            @NotNull String canonicalName
+            @NotNull Collection<String> canonicalNameCollection
     ) {
         super(
                 parent,
@@ -49,7 +51,7 @@ public class UnmatchedDotCall extends Stub<ElixirUnmatchedDotCall> {
                 resolvedFinalArity,
                 hasDoBlockOrKeyword,
                 name,
-                canonicalName
+                canonicalNameCollection
         );
     }
 }

--- a/src/org/elixir_lang/psi/stub/UnmatchedQualifiedNoArgumentsCall.java
+++ b/src/org/elixir_lang/psi/stub/UnmatchedQualifiedNoArgumentsCall.java
@@ -8,6 +8,8 @@ import org.elixir_lang.psi.stub.call.Stub;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Collection;
+
 public class UnmatchedQualifiedNoArgumentsCall extends Stub<ElixirUnmatchedQualifiedNoArgumentsCall> {
     public UnmatchedQualifiedNoArgumentsCall(
             StubElement parent,
@@ -17,7 +19,7 @@ public class UnmatchedQualifiedNoArgumentsCall extends Stub<ElixirUnmatchedQuali
             int resolvedFinalArity,
             boolean hasDoBlockOrKeyword,
             @NotNull StringRef name,
-            @NotNull StringRef canonicalName
+            @NotNull Collection<StringRef> canonicalNameCollection
     ) {
         super(
                 parent,
@@ -27,7 +29,7 @@ public class UnmatchedQualifiedNoArgumentsCall extends Stub<ElixirUnmatchedQuali
                 resolvedFinalArity,
                 hasDoBlockOrKeyword,
                 name,
-                canonicalName
+                canonicalNameCollection
         );
     }
 
@@ -39,7 +41,7 @@ public class UnmatchedQualifiedNoArgumentsCall extends Stub<ElixirUnmatchedQuali
             int resolvedFinalArity,
             boolean hasDoBlockOrKeyword,
             @NotNull String name,
-            @NotNull String canonicalName
+            @NotNull Collection<String> canonicalNameCollection
     ) {
         super(
                 parent,
@@ -49,7 +51,7 @@ public class UnmatchedQualifiedNoArgumentsCall extends Stub<ElixirUnmatchedQuali
                 resolvedFinalArity,
                 hasDoBlockOrKeyword,
                 name,
-                canonicalName
+                canonicalNameCollection
         );
     }
 }

--- a/src/org/elixir_lang/psi/stub/UnmatchedQualifiedNoParenthesesCall.java
+++ b/src/org/elixir_lang/psi/stub/UnmatchedQualifiedNoParenthesesCall.java
@@ -8,6 +8,8 @@ import org.elixir_lang.psi.stub.call.Stub;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Collection;
+
 public class UnmatchedQualifiedNoParenthesesCall extends Stub<ElixirUnmatchedQualifiedNoParenthesesCall> {
     public UnmatchedQualifiedNoParenthesesCall(
             StubElement parent,
@@ -17,7 +19,7 @@ public class UnmatchedQualifiedNoParenthesesCall extends Stub<ElixirUnmatchedQua
             int resolvedFinalArity,
             boolean hasDoBlockOrKeyword,
             @NotNull StringRef name,
-            @NotNull StringRef canonicalName
+            @NotNull Collection<StringRef> canonicalNameCollection
     ) {
         super(
                 parent,
@@ -27,7 +29,7 @@ public class UnmatchedQualifiedNoParenthesesCall extends Stub<ElixirUnmatchedQua
                 resolvedFinalArity,
                 hasDoBlockOrKeyword,
                 name,
-                canonicalName
+                canonicalNameCollection
         );
     }
 
@@ -39,7 +41,7 @@ public class UnmatchedQualifiedNoParenthesesCall extends Stub<ElixirUnmatchedQua
             int resolvedFinalArity,
             boolean hasDoBlockOrKeyword,
             @NotNull String name,
-            @NotNull String canonicalName
+            @NotNull Collection<String> canonicalNameCollection
     ) {
         super(
                 parent,
@@ -49,7 +51,7 @@ public class UnmatchedQualifiedNoParenthesesCall extends Stub<ElixirUnmatchedQua
                 resolvedFinalArity,
                 hasDoBlockOrKeyword,
                 name,
-                canonicalName
+                canonicalNameCollection
         );
     }
 }

--- a/src/org/elixir_lang/psi/stub/UnmatchedQualifiedParenthesesCall.java
+++ b/src/org/elixir_lang/psi/stub/UnmatchedQualifiedParenthesesCall.java
@@ -8,6 +8,8 @@ import org.elixir_lang.psi.stub.call.Stub;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Collection;
+
 public class UnmatchedQualifiedParenthesesCall extends Stub<ElixirUnmatchedQualifiedParenthesesCall> {
     public UnmatchedQualifiedParenthesesCall(
             StubElement parent,
@@ -17,7 +19,7 @@ public class UnmatchedQualifiedParenthesesCall extends Stub<ElixirUnmatchedQuali
             int resolvedFinalArity,
             boolean hasDoBlockOrKeyword,
             @NotNull StringRef name,
-            @NotNull StringRef canonicalName
+            @NotNull Collection<StringRef> canonicalNameCollection
     ) {
         super(
                 parent,
@@ -27,7 +29,7 @@ public class UnmatchedQualifiedParenthesesCall extends Stub<ElixirUnmatchedQuali
                 resolvedFinalArity,
                 hasDoBlockOrKeyword,
                 name,
-                canonicalName
+                canonicalNameCollection
         );
     }
 
@@ -39,7 +41,7 @@ public class UnmatchedQualifiedParenthesesCall extends Stub<ElixirUnmatchedQuali
             int resolvedFinalArity,
             boolean hasDoBlockOrKeyword,
             @NotNull String name,
-            @NotNull String canonicalName
+            @NotNull Collection<String> canonicalNameCollection
     ) {
         super(
                 parent,
@@ -49,7 +51,7 @@ public class UnmatchedQualifiedParenthesesCall extends Stub<ElixirUnmatchedQuali
                 resolvedFinalArity,
                 hasDoBlockOrKeyword,
                 name,
-                canonicalName
+                canonicalNameCollection
         );
     }
 }

--- a/src/org/elixir_lang/psi/stub/UnmatchedUnqualifiedNoArgumentsCall.java
+++ b/src/org/elixir_lang/psi/stub/UnmatchedUnqualifiedNoArgumentsCall.java
@@ -8,6 +8,8 @@ import org.elixir_lang.psi.stub.call.Stub;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Collection;
+
 public class UnmatchedUnqualifiedNoArgumentsCall extends Stub<ElixirUnmatchedUnqualifiedNoArgumentsCall> {
     public UnmatchedUnqualifiedNoArgumentsCall(
             StubElement parent,
@@ -17,7 +19,7 @@ public class UnmatchedUnqualifiedNoArgumentsCall extends Stub<ElixirUnmatchedUnq
             int resolvedFinalArity,
             boolean hasDoBlockOrKeyword,
             @NotNull StringRef name,
-            @NotNull StringRef canonicalName
+            @NotNull Collection<StringRef> canonicalNameCollection
     ) {
         super(
                 parent,
@@ -27,7 +29,7 @@ public class UnmatchedUnqualifiedNoArgumentsCall extends Stub<ElixirUnmatchedUnq
                 resolvedFinalArity,
                 hasDoBlockOrKeyword,
                 name,
-                canonicalName);
+                canonicalNameCollection);
     }
 
     public UnmatchedUnqualifiedNoArgumentsCall(
@@ -38,7 +40,7 @@ public class UnmatchedUnqualifiedNoArgumentsCall extends Stub<ElixirUnmatchedUnq
             int resolvedFinalArity,
             boolean hasDoBlockOrKeyword,
             @NotNull String name,
-            @NotNull String canonicalName
+            @NotNull Collection<String> canonicalNameCollection
     ) {
         super(parent,
                 elementType,
@@ -47,6 +49,6 @@ public class UnmatchedUnqualifiedNoArgumentsCall extends Stub<ElixirUnmatchedUnq
                 resolvedFinalArity,
                 hasDoBlockOrKeyword,
                 name,
-                canonicalName);
+                canonicalNameCollection);
     }
 }

--- a/src/org/elixir_lang/psi/stub/UnmatchedUnqualifiedNoParenthesesCall.java
+++ b/src/org/elixir_lang/psi/stub/UnmatchedUnqualifiedNoParenthesesCall.java
@@ -8,6 +8,8 @@ import org.elixir_lang.psi.stub.call.Stub;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Collection;
+
 public class UnmatchedUnqualifiedNoParenthesesCall extends Stub<ElixirUnmatchedUnqualifiedNoParenthesesCall> {
     public UnmatchedUnqualifiedNoParenthesesCall(
             StubElement parent,
@@ -17,7 +19,7 @@ public class UnmatchedUnqualifiedNoParenthesesCall extends Stub<ElixirUnmatchedU
             int resolvedFinalArity,
             boolean hasDoBlockOrKeyword,
             @NotNull StringRef name,
-            @NotNull StringRef canonicalName
+            @NotNull Collection<StringRef> canonicalNameCollection
     ) {
         super(
                 parent,
@@ -27,7 +29,7 @@ public class UnmatchedUnqualifiedNoParenthesesCall extends Stub<ElixirUnmatchedU
                 resolvedFinalArity,
                 hasDoBlockOrKeyword,
                 name,
-                canonicalName
+                canonicalNameCollection
         );
     }
 
@@ -39,7 +41,7 @@ public class UnmatchedUnqualifiedNoParenthesesCall extends Stub<ElixirUnmatchedU
             int resolvedFinalArity,
             boolean hasDoBlockOrKeyword,
             @NotNull String name,
-            @NotNull String canonicalName
+            @NotNull Collection<String> canonicalNameCollection
     ) {
         super(
                 parent,
@@ -49,7 +51,7 @@ public class UnmatchedUnqualifiedNoParenthesesCall extends Stub<ElixirUnmatchedU
                 resolvedFinalArity,
                 hasDoBlockOrKeyword,
                 name,
-                canonicalName
+                canonicalNameCollection
         );
     }
 }

--- a/src/org/elixir_lang/psi/stub/UnmatchedUnqualifiedParenthesesCall.java
+++ b/src/org/elixir_lang/psi/stub/UnmatchedUnqualifiedParenthesesCall.java
@@ -8,6 +8,8 @@ import org.elixir_lang.psi.stub.call.Stub;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Collection;
+
 public class UnmatchedUnqualifiedParenthesesCall extends Stub<ElixirUnmatchedUnqualifiedParenthesesCall> {
     public UnmatchedUnqualifiedParenthesesCall(
             StubElement parent,
@@ -17,7 +19,7 @@ public class UnmatchedUnqualifiedParenthesesCall extends Stub<ElixirUnmatchedUnq
             int resolvedFinalArity,
             boolean hasDoBlockOrKeyword,
             @NotNull StringRef name,
-            @NotNull StringRef canonicalName
+            @NotNull Collection<StringRef> canonicalNameCollection
     ) {
         super(
                 parent,
@@ -27,7 +29,7 @@ public class UnmatchedUnqualifiedParenthesesCall extends Stub<ElixirUnmatchedUnq
                 resolvedFinalArity,
                 hasDoBlockOrKeyword,
                 name,
-                canonicalName
+                canonicalNameCollection
         );
     }
 
@@ -39,7 +41,7 @@ public class UnmatchedUnqualifiedParenthesesCall extends Stub<ElixirUnmatchedUnq
             int resolvedFinalArity,
             boolean hasDoBlockOrKeyword,
             @NotNull String name,
-            @NotNull String canonicalName
+            @NotNull Collection<String> canonicalNameCollection
     ) {
         super(
                 parent,
@@ -49,7 +51,7 @@ public class UnmatchedUnqualifiedParenthesesCall extends Stub<ElixirUnmatchedUnq
                 resolvedFinalArity,
                 hasDoBlockOrKeyword,
                 name,
-                canonicalName
+                canonicalNameCollection
         );
     }
 }

--- a/src/org/elixir_lang/psi/stub/UnqualifiedNoParenthesesManyArgumentsCall.java
+++ b/src/org/elixir_lang/psi/stub/UnqualifiedNoParenthesesManyArgumentsCall.java
@@ -8,6 +8,8 @@ import org.elixir_lang.psi.stub.call.Stub;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Collection;
+
 public class UnqualifiedNoParenthesesManyArgumentsCall extends Stub<ElixirUnqualifiedNoParenthesesManyArgumentsCall> {
     public UnqualifiedNoParenthesesManyArgumentsCall(
             StubElement parent,
@@ -17,7 +19,7 @@ public class UnqualifiedNoParenthesesManyArgumentsCall extends Stub<ElixirUnqual
             int resolvedFinalArity,
             boolean hasDoBlockOrKeyword,
             @NotNull StringRef name,
-            @NotNull StringRef canonicalName
+            @NotNull Collection<StringRef> canonicalNameCollection
     ) {
         super(
                 parent,
@@ -27,7 +29,7 @@ public class UnqualifiedNoParenthesesManyArgumentsCall extends Stub<ElixirUnqual
                 resolvedFinalArity,
                 hasDoBlockOrKeyword,
                 name,
-                canonicalName
+                canonicalNameCollection
         );
     }
 
@@ -39,7 +41,7 @@ public class UnqualifiedNoParenthesesManyArgumentsCall extends Stub<ElixirUnqual
             int resolvedFinalArity,
             boolean hasDoBlockOrKeyword,
             @NotNull String name,
-            @NotNull String canonicalName
+            @NotNull Collection<String> canonicalNameCollection
     ) {
         super(
                 parent,
@@ -49,7 +51,7 @@ public class UnqualifiedNoParenthesesManyArgumentsCall extends Stub<ElixirUnqual
                 resolvedFinalArity,
                 hasDoBlockOrKeyword,
                 name,
-                canonicalName
+                canonicalNameCollection
         );
     }
 }

--- a/src/org/elixir_lang/psi/stub/call/Stub.java
+++ b/src/org/elixir_lang/psi/stub/call/Stub.java
@@ -9,13 +9,40 @@ import org.elixir_lang.psi.call.Call;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.ArrayList;
+import java.util.Collection;
+
 // I normally wouldn't add the redundant StubBased prefix, but it makes generating from Elixir.bnf work
 public class Stub<T extends org.elixir_lang.psi.call.StubBased> extends NamedStubBase<T> {
+    private static Collection<String> collectionStringRefToCollectionString(
+            Collection<StringRef> canonicalNameCollection
+    ) {
+        Collection<String> stringCollection = new ArrayList<String>(canonicalNameCollection.size());
+
+        for (StringRef canonicalName : canonicalNameCollection) {
+            stringCollection.add(StringRef.toString(canonicalName));
+        }
+
+        return stringCollection;
+    }
+
+    private static Collection<StringRef> collectionStringToCollectionStringRef(
+            Collection<String> canonicalNameCollection
+    ) {
+        Collection<StringRef> stringRefCollection = new ArrayList<StringRef>(canonicalNameCollection.size());
+
+        for (String canonicalName : canonicalNameCollection) {
+            stringRefCollection.add(StringRef.fromString(canonicalName));
+        }
+
+        return stringRefCollection;
+    }
+
     /*
      * Fields
      */
 
-    private final StringRef canonicalName;
+    private final Collection<StringRef> canonicalNameCollection;
     private final boolean hasDoBlockOrKeyword;
     private final int resolvedFinalArity;
     private final StringRef resolvedFunctionName;
@@ -33,7 +60,7 @@ public class Stub<T extends org.elixir_lang.psi.call.StubBased> extends NamedStu
                 int resolvedFinalArity,
                 boolean hasDoBlockOrKeyword,
                 @NotNull String name,
-                @NotNull String canonicalName) {
+                @NotNull Collection<String> canonicalNameCollection) {
         this(
                 parent,
                 elementType,
@@ -42,7 +69,7 @@ public class Stub<T extends org.elixir_lang.psi.call.StubBased> extends NamedStu
                 resolvedFinalArity,
                 hasDoBlockOrKeyword,
                 StringRef.fromString(name),
-                StringRef.fromString(canonicalName)
+                collectionStringToCollectionStringRef(canonicalNameCollection)
         );
     }
 
@@ -53,9 +80,9 @@ public class Stub<T extends org.elixir_lang.psi.call.StubBased> extends NamedStu
                 int resolvedFinalArity,
                 boolean hasDoBlockOrKeyword,
                 @NotNull StringRef name,
-                @NotNull StringRef canonicalName) {
+                @NotNull Collection<StringRef> canonicalNameCollection) {
         super(parent, elementType, name);
-        this.canonicalName = canonicalName;
+        this.canonicalNameCollection = canonicalNameCollection;
         this.hasDoBlockOrKeyword = hasDoBlockOrKeyword;
         this.resolvedFinalArity = resolvedFinalArity;
         this.resolvedFunctionName = resolvedFunctionName;
@@ -67,13 +94,13 @@ public class Stub<T extends org.elixir_lang.psi.call.StubBased> extends NamedStu
      */
 
     /**
-     * The name does not depend on aliases or nested modules
+     * These names do not depend on aliases or nested modules.
      *
-     * @return the canonical text of the reference.
+     * @return the canonical texts of the reference
      * @see PsiReference#getCanonicalText()
      */
-    public String canonicalName() {
-        return StringRef.toString(canonicalName);
+    public Collection<String> canonicalNameCollection() {
+        return collectionStringRefToCollectionString(canonicalNameCollection);
     }
 
     /**

--- a/src/org/elixir_lang/psi/stub/index/AllName.java
+++ b/src/org/elixir_lang/psi/stub/index/AllName.java
@@ -7,7 +7,7 @@ import org.jetbrains.annotations.NotNull;
 
 public class AllName extends StringStubIndexExtension<NamedElement> {
     public static final StubIndexKey<String, NamedElement> KEY = StubIndexKey.createIndexKey("elixir.all.name");
-    public static final int VERSION = 1;
+    public static final int VERSION = 2;
 
     @Override
     public int getVersion() {

--- a/src/org/elixir_lang/psi/stub/type/MatchedAtUnqualifiedNoParenthesesCall.java
+++ b/src/org/elixir_lang/psi/stub/type/MatchedAtUnqualifiedNoParenthesesCall.java
@@ -38,7 +38,7 @@ public class MatchedAtUnqualifiedNoParenthesesCall extends Stub<org.elixir_lang.
                 psi.resolvedFinalArity(),
                 psi.hasDoBlockOrKeyword(),
                 StringUtil.notNullize(psi.getName(), "?"),
-                StringUtil.notNullize(psi.canonicalName(), "?")
+                psi.canonicalNameCollection()
         );
     }
 
@@ -53,7 +53,7 @@ public class MatchedAtUnqualifiedNoParenthesesCall extends Stub<org.elixir_lang.
                 dataStream.readInt(),
                 dataStream.readBoolean(),
                 dataStream.readName(),
-                dataStream.readName()
+                readNameCollection(dataStream)
         );
     }
 }

--- a/src/org/elixir_lang/psi/stub/type/MatchedDotCall.java
+++ b/src/org/elixir_lang/psi/stub/type/MatchedDotCall.java
@@ -38,7 +38,7 @@ public class MatchedDotCall extends Stub<org.elixir_lang.psi.stub.MatchedDotCall
                 psi.resolvedFinalArity(),
                 psi.hasDoBlockOrKeyword(),
                 StringUtil.notNullize(psi.getName(), "?"),
-                StringUtil.notNullize(psi.canonicalName(), "?")
+                psi.canonicalNameCollection()
         );
     }
 
@@ -53,7 +53,7 @@ public class MatchedDotCall extends Stub<org.elixir_lang.psi.stub.MatchedDotCall
                 dataStream.readInt(),
                 dataStream.readBoolean(),
                 dataStream.readName(),
-                dataStream.readName()
+                readNameCollection(dataStream)
         );
     }
 }

--- a/src/org/elixir_lang/psi/stub/type/MatchedQualifiedNoArgumentsCall.java
+++ b/src/org/elixir_lang/psi/stub/type/MatchedQualifiedNoArgumentsCall.java
@@ -38,7 +38,7 @@ public class MatchedQualifiedNoArgumentsCall extends Stub<org.elixir_lang.psi.st
                 psi.resolvedFinalArity(),
                 psi.hasDoBlockOrKeyword(),
                 StringUtil.notNullize(psi.getName(), "?"),
-                StringUtil.notNullize(psi.canonicalName(), "?")
+                psi.canonicalNameCollection()
         );
     }
 
@@ -53,7 +53,7 @@ public class MatchedQualifiedNoArgumentsCall extends Stub<org.elixir_lang.psi.st
                 dataStream.readInt(),
                 dataStream.readBoolean(),
                 dataStream.readName(),
-                dataStream.readName()
+                readNameCollection(dataStream)
         );
     }
 }

--- a/src/org/elixir_lang/psi/stub/type/MatchedQualifiedNoParenthesesCall.java
+++ b/src/org/elixir_lang/psi/stub/type/MatchedQualifiedNoParenthesesCall.java
@@ -38,7 +38,7 @@ public class MatchedQualifiedNoParenthesesCall extends Stub<org.elixir_lang.psi.
                 psi.resolvedFinalArity(),
                 psi.hasDoBlockOrKeyword(),
                 StringUtil.notNullize(psi.getName(), "?"),
-                StringUtil.notNullize(psi.canonicalName(), "?")
+                psi.canonicalNameCollection()
         );
     }
 
@@ -53,7 +53,7 @@ public class MatchedQualifiedNoParenthesesCall extends Stub<org.elixir_lang.psi.
                 dataStream.readInt(),
                 dataStream.readBoolean(),
                 dataStream.readName(),
-                dataStream.readName()
+                readNameCollection(dataStream)
         );
     }
 }

--- a/src/org/elixir_lang/psi/stub/type/MatchedQualifiedParenthesesCall.java
+++ b/src/org/elixir_lang/psi/stub/type/MatchedQualifiedParenthesesCall.java
@@ -38,7 +38,7 @@ public class MatchedQualifiedParenthesesCall extends Stub<org.elixir_lang.psi.st
                 psi.resolvedFinalArity(),
                 psi.hasDoBlockOrKeyword(),
                 StringUtil.notNullize(psi.getName(), "?"),
-                StringUtil.notNullize(psi.canonicalName(), "?")
+                psi.canonicalNameCollection()
         );
     }
 
@@ -53,7 +53,7 @@ public class MatchedQualifiedParenthesesCall extends Stub<org.elixir_lang.psi.st
                 dataStream.readInt(),
                 dataStream.readBoolean(),
                 dataStream.readName(),
-                dataStream.readName()
+                readNameCollection(dataStream)
         );
     }
 }

--- a/src/org/elixir_lang/psi/stub/type/MatchedUnqualifiedNoArgumentsCall.java
+++ b/src/org/elixir_lang/psi/stub/type/MatchedUnqualifiedNoArgumentsCall.java
@@ -38,7 +38,7 @@ public class MatchedUnqualifiedNoArgumentsCall extends Stub<org.elixir_lang.psi.
                 psi.resolvedFinalArity(),
                 psi.hasDoBlockOrKeyword(),
                 StringUtil.notNullize(psi.getName(), "?"),
-                StringUtil.notNullize(psi.canonicalName(), "?")
+                psi.canonicalNameCollection()
         );
     }
 
@@ -53,7 +53,7 @@ public class MatchedUnqualifiedNoArgumentsCall extends Stub<org.elixir_lang.psi.
                 dataStream.readInt(),
                 dataStream.readBoolean(),
                 dataStream.readName(),
-                dataStream.readName()
+                readNameCollection(dataStream)
         );
     }
 }

--- a/src/org/elixir_lang/psi/stub/type/MatchedUnqualifiedNoParenthesesCall.java
+++ b/src/org/elixir_lang/psi/stub/type/MatchedUnqualifiedNoParenthesesCall.java
@@ -38,7 +38,7 @@ public class MatchedUnqualifiedNoParenthesesCall extends Stub<org.elixir_lang.ps
                 psi.resolvedFinalArity(),
                 psi.hasDoBlockOrKeyword(),
                 StringUtil.notNullize(psi.getName(), "?"),
-                StringUtil.notNullize(psi.canonicalName(), "?")
+                psi.canonicalNameCollection()
         );
     }
 
@@ -53,7 +53,7 @@ public class MatchedUnqualifiedNoParenthesesCall extends Stub<org.elixir_lang.ps
                 dataStream.readInt(),
                 dataStream.readBoolean(),
                 dataStream.readName(),
-                dataStream.readName()
+                readNameCollection(dataStream)
         );
     }
 }

--- a/src/org/elixir_lang/psi/stub/type/MatchedUnqualifiedParenthesesCall.java
+++ b/src/org/elixir_lang/psi/stub/type/MatchedUnqualifiedParenthesesCall.java
@@ -38,7 +38,7 @@ public class MatchedUnqualifiedParenthesesCall extends Stub<org.elixir_lang.psi.
                 psi.resolvedFinalArity(),
                 psi.hasDoBlockOrKeyword(),
                 StringUtil.notNullize(psi.getName(), "?"),
-                StringUtil.notNullize(psi.canonicalName(), "?")
+                psi.canonicalNameCollection()
         );
     }
 
@@ -53,7 +53,7 @@ public class MatchedUnqualifiedParenthesesCall extends Stub<org.elixir_lang.psi.
                 dataStream.readInt(),
                 dataStream.readBoolean(),
                 dataStream.readName(),
-                dataStream.readName()
+                readNameCollection(dataStream)
         );
     }
 }

--- a/src/org/elixir_lang/psi/stub/type/Named.java
+++ b/src/org/elixir_lang/psi/stub/type/Named.java
@@ -8,6 +8,8 @@ import org.elixir_lang.psi.stub.index.AllName;
 import org.jetbrains.annotations.NonNls;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.Collection;
+
 public abstract class Named<S extends NamedStubBase<T>, T extends PsiNameIdentifierOwner> extends Element<S, T> {
     public Named(@NonNls @NotNull String debugName) {
         super(debugName);
@@ -23,9 +25,9 @@ public abstract class Named<S extends NamedStubBase<T>, T extends PsiNameIdentif
 
         if (stub instanceof org.elixir_lang.psi.stub.call.Stub) {
             org.elixir_lang.psi.stub.call.Stub callStub = (org.elixir_lang.psi.stub.call.Stub) stub;
-            String canonicalName = callStub.canonicalName();
+            Collection<String> canonicalNameCollection = callStub.canonicalNameCollection();
 
-            if (canonicalName != null) {
+            for (String canonicalName : canonicalNameCollection) {
                 sink.occurrence(AllName.KEY, canonicalName);
             }
         }

--- a/src/org/elixir_lang/psi/stub/type/UnmatchedAtUnqualifiedNoParenthesesCall.java
+++ b/src/org/elixir_lang/psi/stub/type/UnmatchedAtUnqualifiedNoParenthesesCall.java
@@ -38,7 +38,7 @@ public class UnmatchedAtUnqualifiedNoParenthesesCall extends Stub<org.elixir_lan
                 psi.resolvedFinalArity(),
                 psi.hasDoBlockOrKeyword(),
                 StringUtil.notNullize(psi.getName(), "?"),
-                StringUtil.notNullize(psi.canonicalName(), "?")
+                psi.canonicalNameCollection()
         );
     }
 
@@ -53,7 +53,7 @@ public class UnmatchedAtUnqualifiedNoParenthesesCall extends Stub<org.elixir_lan
                 dataStream.readInt(),
                 dataStream.readBoolean(),
                 dataStream.readName(),
-                dataStream.readName()
+                readNameCollection(dataStream)
         );
     }
 }

--- a/src/org/elixir_lang/psi/stub/type/UnmatchedDotCall.java
+++ b/src/org/elixir_lang/psi/stub/type/UnmatchedDotCall.java
@@ -38,7 +38,7 @@ public class UnmatchedDotCall extends Stub<org.elixir_lang.psi.stub.UnmatchedDot
                 psi.resolvedFinalArity(),
                 psi.hasDoBlockOrKeyword(),
                 StringUtil.notNullize(psi.getName(), "?"),
-                StringUtil.notNullize(psi.canonicalName(), "?")
+                psi.canonicalNameCollection()
         );
     }
 
@@ -53,7 +53,7 @@ public class UnmatchedDotCall extends Stub<org.elixir_lang.psi.stub.UnmatchedDot
                 dataStream.readInt(),
                 dataStream.readBoolean(),
                 dataStream.readName(),
-                dataStream.readName()
+                readNameCollection(dataStream)
         );
     }
 }

--- a/src/org/elixir_lang/psi/stub/type/UnmatchedQualifiedNoArgumentsCall.java
+++ b/src/org/elixir_lang/psi/stub/type/UnmatchedQualifiedNoArgumentsCall.java
@@ -38,7 +38,7 @@ public class UnmatchedQualifiedNoArgumentsCall extends Stub<org.elixir_lang.psi.
                 psi.resolvedFinalArity(),
                 psi.hasDoBlockOrKeyword(),
                 StringUtil.notNullize(psi.getName(), "?"),
-                StringUtil.notNullize(psi.canonicalName(), "?")
+                psi.canonicalNameCollection()
         );
     }
 
@@ -53,7 +53,7 @@ public class UnmatchedQualifiedNoArgumentsCall extends Stub<org.elixir_lang.psi.
                 dataStream.readInt(),
                 dataStream.readBoolean(),
                 dataStream.readName(),
-                dataStream.readName()
+                readNameCollection(dataStream)
         );
     }
 }

--- a/src/org/elixir_lang/psi/stub/type/UnmatchedQualifiedNoParenthesesCall.java
+++ b/src/org/elixir_lang/psi/stub/type/UnmatchedQualifiedNoParenthesesCall.java
@@ -38,7 +38,7 @@ public class UnmatchedQualifiedNoParenthesesCall extends Stub<org.elixir_lang.ps
                 psi.resolvedFinalArity(),
                 psi.hasDoBlockOrKeyword(),
                 StringUtil.notNullize(psi.getName(), "?"),
-                StringUtil.notNullize(psi.canonicalName(), "?")
+                psi.canonicalNameCollection()
         );
     }
 
@@ -53,7 +53,7 @@ public class UnmatchedQualifiedNoParenthesesCall extends Stub<org.elixir_lang.ps
                 dataStream.readInt(),
                 dataStream.readBoolean(),
                 dataStream.readName(),
-                dataStream.readName()
+                readNameCollection(dataStream)
         );
     }
 }

--- a/src/org/elixir_lang/psi/stub/type/UnmatchedQualifiedParenthesesCall.java
+++ b/src/org/elixir_lang/psi/stub/type/UnmatchedQualifiedParenthesesCall.java
@@ -38,7 +38,7 @@ public class UnmatchedQualifiedParenthesesCall extends Stub<org.elixir_lang.psi.
                 psi.resolvedFinalArity(),
                 psi.hasDoBlockOrKeyword(),
                 StringUtil.notNullize(psi.getName(), "?"),
-                StringUtil.notNullize(psi.canonicalName(), "?")
+                psi.canonicalNameCollection()
         );
     }
 
@@ -53,7 +53,7 @@ public class UnmatchedQualifiedParenthesesCall extends Stub<org.elixir_lang.psi.
                 dataStream.readInt(),
                 dataStream.readBoolean(),
                 dataStream.readName(),
-                dataStream.readName()
+                readNameCollection(dataStream)
         );
     }
 }

--- a/src/org/elixir_lang/psi/stub/type/UnmatchedUnqualifiedNoArgumentsCall.java
+++ b/src/org/elixir_lang/psi/stub/type/UnmatchedUnqualifiedNoArgumentsCall.java
@@ -38,7 +38,7 @@ public class UnmatchedUnqualifiedNoArgumentsCall extends Stub<org.elixir_lang.ps
                 psi.resolvedFinalArity(),
                 psi.hasDoBlockOrKeyword(),
                 StringUtil.notNullize(psi.getName(), "?"),
-                StringUtil.notNullize(psi.canonicalName(), "?")
+                psi.canonicalNameCollection()
         );
     }
 
@@ -53,7 +53,7 @@ public class UnmatchedUnqualifiedNoArgumentsCall extends Stub<org.elixir_lang.ps
                 dataStream.readInt(),
                 dataStream.readBoolean(),
                 dataStream.readName(),
-                dataStream.readName()
+                readNameCollection(dataStream)
         );
     }
 }

--- a/src/org/elixir_lang/psi/stub/type/UnmatchedUnqualifiedNoParenthesesCall.java
+++ b/src/org/elixir_lang/psi/stub/type/UnmatchedUnqualifiedNoParenthesesCall.java
@@ -9,6 +9,7 @@ import org.elixir_lang.psi.stub.type.call.Stub;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
+import java.util.Collection;
 
 public class UnmatchedUnqualifiedNoParenthesesCall extends Stub<org.elixir_lang.psi.stub.UnmatchedUnqualifiedNoParenthesesCall, ElixirUnmatchedUnqualifiedNoParenthesesCall> {
     /*
@@ -30,6 +31,7 @@ public class UnmatchedUnqualifiedNoParenthesesCall extends Stub<org.elixir_lang.
 
     @Override
     public org.elixir_lang.psi.stub.UnmatchedUnqualifiedNoParenthesesCall createStub(@NotNull ElixirUnmatchedUnqualifiedNoParenthesesCall psi, StubElement parentStub) {
+        Collection<String> canonicalNameCollection = psi.canonicalNameCollection();
         return new org.elixir_lang.psi.stub.UnmatchedUnqualifiedNoParenthesesCall(
                 parentStub,
                 this,
@@ -38,7 +40,7 @@ public class UnmatchedUnqualifiedNoParenthesesCall extends Stub<org.elixir_lang.
                 psi.resolvedFinalArity(),
                 psi.hasDoBlockOrKeyword(),
                 StringUtil.notNullize(psi.getName(), "?"),
-                StringUtil.notNullize(psi.canonicalName(), "?")
+                psi.canonicalNameCollection()
         );
     }
 
@@ -53,7 +55,7 @@ public class UnmatchedUnqualifiedNoParenthesesCall extends Stub<org.elixir_lang.
                 dataStream.readInt(),
                 dataStream.readBoolean(),
                 dataStream.readName(),
-                dataStream.readName()
+                readNameCollection(dataStream)
         );
     }
 }

--- a/src/org/elixir_lang/psi/stub/type/UnmatchedUnqualifiedParenthesesCall.java
+++ b/src/org/elixir_lang/psi/stub/type/UnmatchedUnqualifiedParenthesesCall.java
@@ -2,12 +2,15 @@ package org.elixir_lang.psi.stub.type;
 
 import com.intellij.psi.stubs.StubElement;
 import com.intellij.psi.stubs.StubInputStream;
+import com.intellij.util.io.StringRef;
 import org.elixir_lang.psi.ElixirUnmatchedUnqualifiedParenthesesCall;
 import org.elixir_lang.psi.impl.ElixirUnmatchedUnqualifiedParenthesesCallImpl;
 import org.elixir_lang.psi.stub.type.call.Stub;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
 
 public class UnmatchedUnqualifiedParenthesesCall extends Stub<org.elixir_lang.psi.stub.UnmatchedUnqualifiedParenthesesCall, ElixirUnmatchedUnqualifiedParenthesesCall> {
     /*
@@ -37,13 +40,16 @@ public class UnmatchedUnqualifiedParenthesesCall extends Stub<org.elixir_lang.ps
                 psi.resolvedFinalArity(),
                 psi.hasDoBlockOrKeyword(),
                 psi.getName(),
-                psi.canonicalName()
+                psi.canonicalNameCollection()
         );
     }
 
     @NotNull
     @Override
-    public org.elixir_lang.psi.stub.UnmatchedUnqualifiedParenthesesCall deserialize(@NotNull StubInputStream dataStream, StubElement parentStub) throws IOException {
+    public org.elixir_lang.psi.stub.UnmatchedUnqualifiedParenthesesCall deserialize(
+            @NotNull StubInputStream dataStream,
+            StubElement parentStub
+    ) throws IOException {
         return new org.elixir_lang.psi.stub.UnmatchedUnqualifiedParenthesesCall(
                 parentStub,
                 this,
@@ -52,7 +58,7 @@ public class UnmatchedUnqualifiedParenthesesCall extends Stub<org.elixir_lang.ps
                 dataStream.readInt(),
                 dataStream.readBoolean(),
                 dataStream.readName(),
-                dataStream.readName()
+                readNameCollection(dataStream)
         );
     }
 }

--- a/src/org/elixir_lang/psi/stub/type/UnqualifiedNoParenthesesManyArgumentsCall.java
+++ b/src/org/elixir_lang/psi/stub/type/UnqualifiedNoParenthesesManyArgumentsCall.java
@@ -38,7 +38,7 @@ public class UnqualifiedNoParenthesesManyArgumentsCall extends Stub<org.elixir_l
                 psi.resolvedFinalArity(),
                 psi.hasDoBlockOrKeyword(),
                 StringUtil.notNullize(psi.getName(), "?"),
-                StringUtil.notNullize(psi.canonicalName(), "?")
+                psi.canonicalNameCollection()
         );
     }
 
@@ -53,7 +53,7 @@ public class UnqualifiedNoParenthesesManyArgumentsCall extends Stub<org.elixir_l
                 dataStream.readInt(),
                 dataStream.readBoolean(),
                 dataStream.readName(),
-                dataStream.readName()
+                readNameCollection(dataStream)
         );
     }
 }

--- a/src/org/elixir_lang/psi/stub/type/call/Stub.java
+++ b/src/org/elixir_lang/psi/stub/type/call/Stub.java
@@ -1,8 +1,12 @@
 package org.elixir_lang.psi.stub.type.call;
 
 import com.intellij.lang.ASTNode;
+import com.intellij.psi.stubs.StubIndex;
+import com.intellij.psi.stubs.StubInputStream;
 import com.intellij.psi.stubs.StubOutputStream;
+import com.intellij.util.io.StringRef;
 import org.elixir_lang.psi.call.Call;
+import org.elixir_lang.psi.call.StubBased;
 import org.elixir_lang.structure_view.element.*;
 import org.elixir_lang.structure_view.element.modular.Implementation;
 import org.elixir_lang.structure_view.element.modular.Module;
@@ -10,6 +14,8 @@ import org.elixir_lang.structure_view.element.modular.Protocol;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
 
 public abstract class Stub<Stub extends org.elixir_lang.psi.stub.call.Stub<Psi>,
         Psi extends org.elixir_lang.psi.call.StubBased> extends org.elixir_lang.psi.stub.type.Named<Stub, Psi> {
@@ -20,6 +26,35 @@ public abstract class Stub<Stub extends org.elixir_lang.psi.stub.call.Stub<Psi>,
 
     public static boolean isModular(Call call) {
         return Implementation.is(call) || Module.is(call) || Protocol.is(call);
+    }
+
+    /*
+     * Protected Static Methods
+     */
+
+    protected static Collection<StringRef> readNameCollection(@NotNull StubInputStream dataStream) throws IOException {
+        int nameCollectionSize = dataStream.readInt();
+
+        Collection<StringRef> canonicalNameCollection = new ArrayList<StringRef>(nameCollectionSize);
+
+        for (int i = 0; i < nameCollectionSize; i++) {
+            canonicalNameCollection.add(dataStream.readName());
+        }
+
+        return canonicalNameCollection;
+    }
+
+    /*
+     * Private Static Methods
+     */
+
+    private static void writeNameCollection(@NotNull StubOutputStream dataStream,
+                                            @NotNull Collection<String> nameCollection) throws IOException {
+        dataStream.writeInt(nameCollection.size());
+
+        for (String name : nameCollection) {
+            dataStream.writeName(name);
+        }
     }
 
     /*
@@ -42,22 +77,38 @@ public abstract class Stub<Stub extends org.elixir_lang.psi.stub.call.Stub<Psi>,
         dataStream.writeInt(stub.resolvedFinalArity());
         dataStream.writeBoolean(stub.hasDoBlockOrKeyword());
         dataStream.writeName(stub.getName());
-        dataStream.writeName(stub.canonicalName());
+        writeNameCollection(dataStream, stub.canonicalNameCollection());
     }
 
     @Override
     public boolean shouldCreateStub(ASTNode node) {
         Call call = (Call) node.getPsi();
 
-        return isNameable(call) && hasName(call);
+        return isNameable(call) && hasNameOrCanonicalNames(call);
     }
 
     /*
      * Private Instance Methods
      */
 
+    private boolean hasCanonicalNames(Call call) {
+        boolean hasCanonicalNames = false;
+
+        if (call instanceof StubBased) {
+            StubBased stubBased = (StubBased) call;
+
+            hasCanonicalNames = stubBased.canonicalNameCollection().size() > 0;
+        }
+
+        return hasCanonicalNames;
+    }
+
     private boolean hasName(Call call) {
         return call.getName() != null;
+    }
+
+    private boolean hasNameOrCanonicalNames(Call call) {
+        return hasName(call) || hasCanonicalNames(call);
     }
 
     private boolean isDelegationCallDefinitionHead(Call call) {


### PR DESCRIPTION
Fixes #388

# Changelog
## Enhancements
* In addtion to `StubBased#canonicalName`, there now also `StubBased#canonicalNames`, for when a call defines multiple canonical names, as is the case for `defimpl <PROTOCOL>, for: [<TYPE>, ...]`.
## Bug Fixes
* `defimpl <PROTOCOL>, for: [<TYPE>, ...]` generates multiple canonical names, which are stored in the stub index.
  * When retrieved from the `AllName` index, the `defimpl`'s Implementation will render as if only the `defimpl <PROTOCOL>, for: <TYPE>` was used for the `<TYPE>` matching the lookup name in the Goto Symbol dialog.  For example, if you search for `Tuple`, `JSX.Encoder.Tuple` will match for [`defimpl JSX.Encoder, for: for: [Tuple, PID, Port, Reference, Function, Any]`](https://github.com/talentdeficit/exjsx/blob/master/lib/jsx.ex#L152-L155).