### PR TITLE
Module names nested under aliases module names show up in completion

### DIFF
--- a/src/org/elixir_lang/psi/scope/module/CreateLookupElement.java
+++ b/src/org/elixir_lang/psi/scope/module/CreateLookupElement.java
@@ -1,0 +1,14 @@
+package org.elixir_lang.psi.scope.module;
+
+import com.intellij.codeInsight.lookup.LookupElement;
+import com.intellij.codeInsight.lookup.LookupElementBuilder;
+import com.intellij.util.Function;
+
+class CreateLookupElement implements Function<String, LookupElement> {
+    public static final CreateLookupElement INSTANCE = new CreateLookupElement();
+
+    @Override
+    public LookupElement fun(String lookupElementName) {
+        return LookupElementBuilder.create(lookupElementName);
+    }
+}

--- a/src/org/elixir_lang/psi/scope/module/Longer.java
+++ b/src/org/elixir_lang/psi/scope/module/Longer.java
@@ -1,0 +1,33 @@
+package org.elixir_lang.psi.scope.module;
+
+import com.intellij.openapi.util.Condition;
+import org.jetbrains.annotations.NotNull;
+
+class Longer implements Condition<String> {
+    /*
+     * Fields
+     */
+
+    private final int length;
+
+    /*
+     * Constructors
+     */
+
+    Longer(int length) {
+        this.length = length;
+    }
+
+    /*
+     * Public Instance Methods
+     */
+
+    /**
+     * @param string
+     * @return {@code true} if {@code string} is greather than {@link #length}
+     */
+    @Override
+    public boolean value(@NotNull String string) {
+        return string.length() > length;
+    }
+}

--- a/src/org/elixir_lang/psi/scope/module/ProperStartsWith.java
+++ b/src/org/elixir_lang/psi/scope/module/ProperStartsWith.java
@@ -1,0 +1,10 @@
+package org.elixir_lang.psi.scope.module;
+
+import com.intellij.openapi.util.Condition;
+import com.intellij.openapi.util.Conditions;
+
+class ProperStartsWith {
+    static Condition<String> properStartsWith(String prefix) {
+        return Conditions.or2(new StartsWith(prefix), new Longer(prefix.length()));
+    }
+}

--- a/src/org/elixir_lang/psi/scope/module/ReplaceFirst.java
+++ b/src/org/elixir_lang/psi/scope/module/ReplaceFirst.java
@@ -1,0 +1,33 @@
+package org.elixir_lang.psi.scope.module;
+
+import com.intellij.util.Function;
+import org.jetbrains.annotations.NotNull;
+
+public class ReplaceFirst implements Function<String, String> {
+    /*
+     * Fields
+     */
+
+    @NotNull
+    private final String original;
+    @NotNull
+    private final String replacement;
+
+    /*
+     * Constructor
+     */
+
+    ReplaceFirst(@NotNull String original, @NotNull String replacement) {
+        this.original = original;
+        this.replacement = replacement;
+    }
+
+    /*
+     * Public Instance Methods
+     */
+
+    @Override
+    public String fun(String originalPrefixed) {
+        return originalPrefixed.replaceFirst(original, replacement);
+    }
+}

--- a/src/org/elixir_lang/psi/scope/module/StartsWith.java
+++ b/src/org/elixir_lang/psi/scope/module/StartsWith.java
@@ -1,0 +1,35 @@
+package org.elixir_lang.psi.scope.module;
+
+import com.intellij.openapi.util.Condition;
+import org.jetbrains.annotations.NotNull;
+
+class StartsWith implements Condition<String> {
+    /*
+     * Fields
+     */
+
+    @NotNull
+    private final String prefix;
+
+    /*
+     * Constructors
+     */
+
+    StartsWith(@NotNull String prefix) {
+        this.prefix = prefix;
+    }
+
+
+    /*
+     * Public Instance Methods
+     */
+
+    /**
+     * @param full a full String
+     * @return {@code true} if {@code full} starts with {@link #prefix}
+     */
+    @Override
+    public boolean value(@NotNull String full) {
+        return full.startsWith(prefix);
+    }
+}

--- a/src/org/elixir_lang/psi/scope/module/Variants.java
+++ b/src/org/elixir_lang/psi/scope/module/Variants.java
@@ -2,14 +2,24 @@ package org.elixir_lang.psi.scope.module;
 
 import com.intellij.codeInsight.lookup.LookupElement;
 import com.intellij.codeInsight.lookup.LookupElementBuilder;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.Condition;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiNamedElement;
+import com.intellij.psi.PsiReference;
 import com.intellij.psi.ResolveState;
+import com.intellij.psi.search.GlobalSearchScope;
+import com.intellij.psi.stubs.StubIndex;
+import com.intellij.util.Function;
+import com.intellij.util.containers.ContainerUtil;
+import org.elixir_lang.psi.NamedElement;
 import org.elixir_lang.psi.scope.Module;
+import org.elixir_lang.psi.stub.index.AllName;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 import static com.intellij.psi.util.PsiTreeUtil.treeWalkUp;
@@ -37,6 +47,8 @@ public class Variants extends Module {
      * Fields
      */
 
+    private Collection<String> nameCollection = null;
+    private Project project = null;
     private List<LookupElement> lookupElementList = null;
 
     /*
@@ -53,7 +65,7 @@ public class Variants extends Module {
      * @return {@code true} to keep processing; {@code false} to stop processing.
      */
     @Override
-    protected boolean executeOnAliasedName(@NotNull PsiNamedElement match, @NotNull String aliasedName, @NotNull ResolveState state) {
+    protected boolean executeOnAliasedName(@NotNull PsiNamedElement match, @NotNull final String aliasedName, @NotNull ResolveState state) {
         if (lookupElementList == null) {
             lookupElementList = new ArrayList<LookupElement>();
         }
@@ -65,6 +77,30 @@ public class Variants extends Module {
                 )
         );
 
+        final String unaliasedName = match.getName();
+
+        if (unaliasedName != null) {
+            List<String> unaliasedNestedNames = ContainerUtil.findAll(nameCollection(match.getProject()), new Condition<String>() {
+                @Override
+                public boolean value(String indexedName) {
+                    return indexedName.startsWith(unaliasedName) && indexedName.length() > unaliasedName.length();
+                }
+            });
+            List<String> aliasedNestedNames = ContainerUtil.map(unaliasedNestedNames, new Function<String, String>() {
+                @Override
+                public String fun(String unaliasedNestedName) {
+                    return unaliasedNestedName.replaceFirst(unaliasedName, aliasedName);
+                }
+            });
+            List<LookupElement> aliasedNesteNameLookElements = ContainerUtil.map(aliasedNestedNames, new Function<String, LookupElement>() {
+                @Override
+                public LookupElement fun(String aliasedNestedName) {
+                    return LookupElementBuilder.create(aliasedNestedName);
+                }
+            });
+            lookupElementList.addAll(aliasedNesteNameLookElements);
+        }
+
         return true;
     }
 
@@ -74,5 +110,17 @@ public class Variants extends Module {
 
     private List<LookupElement> getLookupElementList() {
         return lookupElementList;
+    }
+
+    /**
+     * Caches {@code StubIndex.getAllKeys(AllName.KEY, project)}
+     * @return
+     */
+    private Collection<String> nameCollection(Project project) {
+        if (project != this.project || nameCollection == null) {
+            nameCollection = StubIndex.getInstance().getAllKeys(AllName.KEY, project);
+        }
+
+        return nameCollection;
     }
 }

--- a/src/org/elixir_lang/reference/Module.java
+++ b/src/org/elixir_lang/reference/Module.java
@@ -1,18 +1,15 @@
 package org.elixir_lang.reference;
 
 import com.intellij.codeInsight.lookup.LookupElement;
-import com.intellij.codeInsight.lookup.LookupElementBuilder;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.TextRange;
 import com.intellij.psi.*;
 import com.intellij.psi.search.GlobalSearchScope;
 import com.intellij.psi.stubs.StubIndex;
 import org.elixir_lang.psi.*;
-import org.elixir_lang.psi.call.Named;
 import org.elixir_lang.psi.scope.module.MultiResolve;
 import org.elixir_lang.psi.scope.module.Variants;
 import org.elixir_lang.psi.stub.index.AllName;
-import org.elixir_lang.reference.module.ResolvableName;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -20,9 +17,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
-import static org.elixir_lang.Module.concat;
-import static org.elixir_lang.psi.call.name.Function.__MODULE__;
-import static org.elixir_lang.psi.stub.type.call.Stub.isModular;
 import static org.elixir_lang.reference.module.ResolvableName.resolvableName;
 
 public class Module extends PsiReferenceBase<QualifiableAlias> implements PsiPolyVariantReference {
@@ -116,26 +110,6 @@ public class Module extends PsiReferenceBase<QualifiableAlias> implements PsiPol
     @Override
     public Object[] getVariants() {
         List<LookupElement> lookupElementList = Variants.lookupElementList(myElement);
-
-        if (lookupElementList == null) {
-            lookupElementList = new ArrayList<LookupElement>();
-        }
-
-        Collection<String> projectModuleCollection  = StubIndex.getInstance().getAllKeys(
-                AllName.KEY,
-                myElement.getProject()
-        );
-
-        for (String projectModule : projectModuleCollection) {
-            lookupElementList.add(
-                    LookupElementBuilder.create(projectModule)
-            );
-        }
-
-        lookupElementList.add(
-                // not really module, but it acts like one, so include it here for completion
-                LookupElementBuilder.create(__MODULE__)
-        );
 
         return lookupElementList.toArray(new Object[lookupElementList.size()]);
     }


### PR DESCRIPTION
Fixes #394 

# Changelog
## Enhancements
* When a aliased name is added to the module list for completion, it's unaliased name is searched for in the `AllName` index, if any nested modules are found for the unaliased name, then those nested names are aliased and also shown for completion.