### PR TITLE
Use resolvableName when completing aliases nested modules

### DIFF
--- a/src/org/elixir_lang/psi/scope/module/Variants.java
+++ b/src/org/elixir_lang/psi/scope/module/Variants.java
@@ -8,8 +8,10 @@ import com.intellij.psi.PsiNamedElement;
 import com.intellij.psi.ResolveState;
 import com.intellij.psi.stubs.StubIndex;
 import com.intellij.util.containers.ContainerUtil;
+import org.elixir_lang.psi.QualifiableAlias;
 import org.elixir_lang.psi.scope.Module;
 import org.elixir_lang.psi.stub.index.AllName;
+import org.elixir_lang.reference.module.ResolvableName;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
@@ -78,7 +80,15 @@ public class Variants extends Module {
                 )
         );
 
-        final String unaliasedName = match.getName();
+        final String unaliasedName;
+
+        if (match instanceof QualifiableAlias) {
+            QualifiableAlias matchQualfiableAlias = (QualifiableAlias) match;
+
+            unaliasedName = ResolvableName.resolvableName(matchQualfiableAlias);
+        } else {
+            unaliasedName = match.getName();
+        }
 
         if (unaliasedName != null) {
             List<String> unaliasedNestedNames = ContainerUtil.findAll(


### PR DESCRIPTION
Fixes #398 

# Changelog
## Enhancements
* `resolvableName` allows nested modules under multiple aliases to be completed.