### PR TITLE
Allow folding of Module directive groups to be configured

### DIFF
--- a/src/META-INF/plugin.xml
+++ b/src/META-INF/plugin.xml
@@ -1606,7 +1606,10 @@
     <lang.braceMatcher language="Elixir" implementationClass="org.elixir_lang.BraceMatcher"/>
     <lang.commenter language="Elixir" implementationClass="org.elixir_lang.ElixirCommenter"/>
     <lang.findUsagesProvider language="Elixir" implementationClass="org.elixir_lang.FindUsagesProvider"/>
-    <lang.foldingBuilder language="Elixir" implementationClass="org.elixir_lang.psi.FoldingBuilder"/>
+
+    <!-- folding -->
+    <lang.foldingBuilder language="Elixir" implementationClass="org.elixir_lang.folding.Builder"/>
+
     <lang.parserDefinition language="Elixir" implementationClass="org.elixir_lang.ElixirParserDefinition"/>
     <lang.psiStructureViewFactory language="Elixir" implementationClass="org.elixir_lang.structure_view.Factory"/>
     <lang.quoteHandler language="Elixir" implementationClass="org.elixir_lang.QuoteHandler"/>

--- a/src/META-INF/plugin.xml
+++ b/src/META-INF/plugin.xml
@@ -1608,6 +1608,9 @@
     <lang.findUsagesProvider language="Elixir" implementationClass="org.elixir_lang.FindUsagesProvider"/>
 
     <!-- folding -->
+    <applicationService serviceInterface="org.elixir_lang.folding.ElixirFoldingSettings"
+                        serviceImplementation="org.elixir_lang.folding.ElixirFoldingSettings"/>
+    <codeFoldingOptionsProvider instance="org.elixir_lang.folding.OptionsProvider"/>
     <lang.foldingBuilder language="Elixir" implementationClass="org.elixir_lang.folding.Builder"/>
 
     <lang.parserDefinition language="Elixir" implementationClass="org.elixir_lang.ElixirParserDefinition"/>

--- a/src/org/elixir_lang/folding/Builder.java
+++ b/src/org/elixir_lang/folding/Builder.java
@@ -358,6 +358,29 @@ public class Builder extends FoldingBuilderEx {
     public boolean isCollapsedByDefault(@NotNull ASTNode node) {
         PsiElement element = node.getPsi();
 
-        return element instanceof AtNonNumericOperation || element instanceof ElixirStabBody;
+        boolean isCollapsedByDefault = false;
+
+        if (element instanceof AtNonNumericOperation) {
+            isCollapsedByDefault = true;
+        } else {
+            PsiElement[] children = element.getChildren();
+
+            for (PsiElement child : children) {
+                if (child instanceof Call) {
+                    Call call = (Call) child;
+
+                    for (String resolvedFunctionName : RESOLVED_FUNCTION_NAMES) {
+                        if (call.isCalling(KERNEL, resolvedFunctionName)) {
+                            isCollapsedByDefault = ElixirFoldingSettings
+                                    .getInstance()
+                                    .isCollapseElixirModuleDirectiveGroups();
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
+        return isCollapsedByDefault;
     }
 }

--- a/src/org/elixir_lang/folding/Builder.java
+++ b/src/org/elixir_lang/folding/Builder.java
@@ -1,4 +1,4 @@
-package org.elixir_lang.psi;
+package org.elixir_lang.folding;
 
 import com.intellij.lang.ASTNode;
 import com.intellij.lang.folding.FoldingBuilderEx;
@@ -11,6 +11,7 @@ import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiReference;
 import com.intellij.psi.search.PsiElementProcessor;
 import com.intellij.psi.util.PsiTreeUtil;
+import org.elixir_lang.psi.*;
 import org.elixir_lang.psi.call.Call;
 import org.elixir_lang.psi.operation.Type;
 import org.elixir_lang.psi.operation.infix.Normalized;
@@ -24,7 +25,7 @@ import static org.elixir_lang.psi.call.name.Function.*;
 import static org.elixir_lang.psi.call.name.Module.KERNEL;
 import static org.elixir_lang.psi.impl.ElixirPsiImplUtil.*;
 
-public class FoldingBuilder extends FoldingBuilderEx {
+public class Builder extends FoldingBuilderEx {
     /*
      * CONSTANTS
      */

--- a/src/org/elixir_lang/folding/ElixirFoldingSettings.java
+++ b/src/org/elixir_lang/folding/ElixirFoldingSettings.java
@@ -1,0 +1,43 @@
+package org.elixir_lang.folding;
+
+import com.intellij.openapi.components.PersistentStateComponent;
+import com.intellij.openapi.components.ServiceManager;
+import com.intellij.openapi.components.State;
+import com.intellij.openapi.components.Storage;
+import com.intellij.util.xmlb.XmlSerializerUtil;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * @see <a href="https://github.com/JetBrains/intellij-community/blob/22ad327271fbf0953803463ab132ba8253c1b496/python/src/com/jetbrains/python/PythonFoldingSettings.java">com.jetbrains.python.PythonFoldingSettings</a>
+ */
+@State(
+  name = "ElixirFoldingSettings",
+  storages = @Storage(file = "editor.codeinsight.xml")
+)
+public class ElixirFoldingSettings implements PersistentStateComponent<ElixirFoldingSettings> {
+    /*
+     * Fields
+     */
+    public boolean COLLAPSE_ELIXIR_MODULE_DIRECTIVE_GROUPS = false;
+
+    @Nullable
+    @Override
+    public ElixirFoldingSettings getState() {
+        return this;
+    }
+
+    @NotNull
+    public static ElixirFoldingSettings getInstance() {
+        return ServiceManager.getService(ElixirFoldingSettings.class);
+    }
+
+    @Override
+    public void loadState(ElixirFoldingSettings state) {
+        XmlSerializerUtil.copyBean(state, this);
+    }
+
+    public boolean isCollapseElixirModuleDirectiveGroups() {
+        return COLLAPSE_ELIXIR_MODULE_DIRECTIVE_GROUPS;
+    }
+}

--- a/src/org/elixir_lang/folding/OptionsProvider.java
+++ b/src/org/elixir_lang/folding/OptionsProvider.java
@@ -1,0 +1,14 @@
+package org.elixir_lang.folding;
+
+import com.intellij.application.options.editor.CodeFoldingOptionsProvider;
+import com.intellij.openapi.options.BeanConfigurable;
+
+public class OptionsProvider extends BeanConfigurable<ElixirFoldingSettings> implements CodeFoldingOptionsProvider {
+    public OptionsProvider() {
+        super(ElixirFoldingSettings.getInstance());
+        checkBox(
+                "COLLAPSE_ELIXIR_MODULE_DIRECTIVE_GROUPS",
+                "Elixir Module directive (`alias`, `import`, `require` or `use`) groups"
+        );
+    }
+}


### PR DESCRIPTION
Resolves #368 

# Changelog
## Enhancements
* By user request, the folding will be off-by-default now, but can be re-enabled, like the old behavior by checking the checkbox in Preferences > Editor > General > Code Folding > Elixir Module directive (`alias`, `import`, `require` or `use`) groups.