### PR TITLE
Multiresolve to alias and defmodule

### DIFF
--- a/gen/org/elixir_lang/psi/ElixirUnmatchedQualifiedAlias.java
+++ b/gen/org/elixir_lang/psi/ElixirUnmatchedQualifiedAlias.java
@@ -23,6 +23,9 @@ public interface ElixirUnmatchedQualifiedAlias extends ElixirUnmatchedExpression
   @Nullable
   String fullyQualifiedName();
 
+  @NotNull
+  String getName();
+
   @Nullable
   PsiElement getNameIdentifier();
 

--- a/gen/org/elixir_lang/psi/impl/ElixirMatchedQualifiedAliasImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMatchedQualifiedAliasImpl.java
@@ -53,7 +53,7 @@ public class ElixirMatchedQualifiedAliasImpl extends ElixirMatchedExpressionImpl
 
   @NotNull
   public String getName() {
-    return ElixirPsiImplUtil.getName(this);
+    return ElixirPsiImplUtil.getName((QualifiedAlias) this);
   }
 
   @Nullable

--- a/gen/org/elixir_lang/psi/impl/ElixirUnmatchedQualifiedAliasImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnmatchedQualifiedAliasImpl.java
@@ -51,6 +51,11 @@ public class ElixirUnmatchedQualifiedAliasImpl extends ElixirUnmatchedExpression
     return ElixirPsiImplUtil.fullyQualifiedName(this);
   }
 
+  @NotNull
+  public String getName() {
+    return ElixirPsiImplUtil.getName(this);
+  }
+
   @Nullable
   public PsiElement getNameIdentifier() {
     return ElixirPsiImplUtil.getNameIdentifier(this);

--- a/src/org/elixir_lang/Elixir.bnf
+++ b/src/org/elixir_lang/Elixir.bnf
@@ -2531,6 +2531,7 @@ unmatchedQualifiedAlias ::= unmatchedExpression dotInfixOperator alias
                               implements = "org.elixir_lang.psi.QualifiedAlias"
                               methods = [
                                 fullyQualifiedName
+                                getName
                                 getNameIdentifier
                                 getReference
                                 isModuleName

--- a/src/org/elixir_lang/psi/impl/ElixirPsiImplUtil.java
+++ b/src/org/elixir_lang/psi/impl/ElixirPsiImplUtil.java
@@ -2590,8 +2590,8 @@ public class ElixirPsiImplUtil {
     }
 
     @NotNull
-    public static String getName(@NotNull ElixirMatchedQualifiedAlias matchedQualifiedAlias) {
-        return matchedQualifiedAlias.getText();
+    public static String getName(@NotNull QualifiedAlias qualifiedAlias) {
+        return qualifiedAlias.getText();
     }
 
     @Contract(pure = true)

--- a/src/org/elixir_lang/psi/scope/module/MultiResolve.java
+++ b/src/org/elixir_lang/psi/scope/module/MultiResolve.java
@@ -122,7 +122,13 @@ public class MultiResolve extends Module {
                                            @NotNull String aliasedName,
                                            @NotNull ResolveState state) {
         if (aliasedName.equals(name)) {
+            List<String> namePartList = split(name);
+
+            // adds `Foo.SSH` in `alias Foo.SSH`
             addToResolveResultList(match, true);
+
+            // adds `defmodule Foo.SSH` for `alias Foo.SSH`
+            addUnaliasedNamedElementsToResolveResultList(match, namePartList);
         } else {
             List<String> namePartList = split(name);
             String firstNamePart = namePartList.get(0);
@@ -131,12 +137,7 @@ public class MultiResolve extends Module {
             if (aliasedName.equals(firstNamePart)) {
                 addToResolveResultList(match, true);
 
-                String unaliasedName = unaliasedName(match, namePartList);
-                Collection<NamedElement> namedElementCollection = indexedNamedElements(match, unaliasedName);
-
-                for (PsiElement element : namedElementCollection) {
-                    addToResolveResultList(element, true);
-                }
+                addUnaliasedNamedElementsToResolveResultList(match, namePartList);
             } else if (incompleteCode && aliasedName.startsWith(name)) {
                 addToResolveResultList(match, false);
             }
@@ -153,5 +154,14 @@ public class MultiResolve extends Module {
         resolveResultList = org.elixir_lang.psi.scope.MultiResolve.addToResolveResultList(
                 resolveResultList, new PsiElementResolveResult(element, validResult)
         );
+    }
+
+    private void addUnaliasedNamedElementsToResolveResultList(@NotNull PsiNamedElement match, List<String> namePartList) {
+        String unaliasedName = unaliasedName(match, namePartList);
+        Collection<NamedElement> namedElementCollection = indexedNamedElements(match, unaliasedName);
+
+        for (PsiElement element : namedElementCollection) {
+            addToResolveResultList(element, true);
+        }
     }
 }

--- a/src/org/elixir_lang/psi/scope/module/MultiResolve.java
+++ b/src/org/elixir_lang/psi/scope/module/MultiResolve.java
@@ -6,10 +6,9 @@ import com.intellij.psi.search.GlobalSearchScope;
 import com.intellij.psi.stubs.StubIndex;
 import com.intellij.psi.util.PsiTreeUtil;
 import org.elixir_lang.psi.NamedElement;
-import org.elixir_lang.psi.QualifiableAlias;
 import org.elixir_lang.psi.scope.Module;
 import org.elixir_lang.psi.stub.index.AllName;
-import org.elixir_lang.reference.module.ResolvableName;
+import org.elixir_lang.reference.module.UnaliasedName;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -67,7 +66,7 @@ public class MultiResolve extends Module {
 
     @NotNull
     private static String unaliasedName(@NotNull PsiNamedElement match, @NotNull List<String> namePartList) {
-        String matchUnaliasedName = ResolvableName.resolvableName(match);
+        String matchUnaliasedName = UnaliasedName.unaliasedName(match);
 
         List<String> unaliasedNamePartList = new ArrayList<String>(namePartList.size());
         unaliasedNamePartList.add(matchUnaliasedName);

--- a/src/org/elixir_lang/psi/scope/module/Variants.java
+++ b/src/org/elixir_lang/psi/scope/module/Variants.java
@@ -8,10 +8,9 @@ import com.intellij.psi.PsiNamedElement;
 import com.intellij.psi.ResolveState;
 import com.intellij.psi.stubs.StubIndex;
 import com.intellij.util.containers.ContainerUtil;
-import org.elixir_lang.psi.QualifiableAlias;
 import org.elixir_lang.psi.scope.Module;
 import org.elixir_lang.psi.stub.index.AllName;
-import org.elixir_lang.reference.module.ResolvableName;
+import org.elixir_lang.reference.module.UnaliasedName;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
@@ -80,7 +79,7 @@ public class Variants extends Module {
                 )
         );
 
-        String unaliasedName = ResolvableName.resolvableName(match);
+        String unaliasedName = UnaliasedName.unaliasedName(match);
 
         if (unaliasedName != null) {
             List<String> unaliasedNestedNames = ContainerUtil.findAll(

--- a/src/org/elixir_lang/psi/scope/module/Variants.java
+++ b/src/org/elixir_lang/psi/scope/module/Variants.java
@@ -80,15 +80,7 @@ public class Variants extends Module {
                 )
         );
 
-        final String unaliasedName;
-
-        if (match instanceof QualifiableAlias) {
-            QualifiableAlias matchQualfiableAlias = (QualifiableAlias) match;
-
-            unaliasedName = ResolvableName.resolvableName(matchQualfiableAlias);
-        } else {
-            unaliasedName = match.getName();
-        }
+        String unaliasedName = ResolvableName.resolvableName(match);
 
         if (unaliasedName != null) {
             List<String> unaliasedNestedNames = ContainerUtil.findAll(

--- a/src/org/elixir_lang/reference/module/ResolvableName.java
+++ b/src/org/elixir_lang/reference/module/ResolvableName.java
@@ -1,6 +1,7 @@
 package org.elixir_lang.reference.module;
 
 import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiNamedElement;
 import org.elixir_lang.psi.ElixirAccessExpression;
 import org.elixir_lang.psi.ElixirMultipleAliases;
 import org.elixir_lang.psi.QualifiableAlias;
@@ -22,6 +23,19 @@ public class ResolvableName {
     /*
      * Public Static Methods
      */
+
+    @Nullable
+    public static String resolvableName(@NotNull PsiNamedElement namedElement) {
+        String resolvableName;
+
+        if (namedElement instanceof QualifiableAlias) {
+            resolvableName = resolvableName((QualifiableAlias) namedElement);
+        } else {
+            resolvableName = namedElement.getName();
+        }
+
+        return resolvableName;
+    }
 
     /**
      * The full name of the qualifiable alias, with any multiple aliases expanded

--- a/src/org/elixir_lang/reference/module/ResolvableName.java
+++ b/src/org/elixir_lang/reference/module/ResolvableName.java
@@ -1,7 +1,6 @@
 package org.elixir_lang.reference.module;
 
 import com.intellij.psi.PsiElement;
-import com.intellij.psi.PsiNamedElement;
 import org.elixir_lang.psi.ElixirAccessExpression;
 import org.elixir_lang.psi.ElixirMultipleAliases;
 import org.elixir_lang.psi.QualifiableAlias;
@@ -23,19 +22,6 @@ public class ResolvableName {
     /*
      * Public Static Methods
      */
-
-    @Nullable
-    public static String resolvableName(@NotNull PsiNamedElement namedElement) {
-        String resolvableName;
-
-        if (namedElement instanceof QualifiableAlias) {
-            resolvableName = resolvableName((QualifiableAlias) namedElement);
-        } else {
-            resolvableName = namedElement.getName();
-        }
-
-        return resolvableName;
-    }
 
     /**
      * The full name of the qualifiable alias, with any multiple aliases expanded

--- a/src/org/elixir_lang/reference/module/UnaliasedName.java
+++ b/src/org/elixir_lang/reference/module/UnaliasedName.java
@@ -1,0 +1,102 @@
+package org.elixir_lang.reference.module;
+
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiNamedElement;
+import org.elixir_lang.psi.*;
+import org.elixir_lang.psi.call.Call;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import static org.elixir_lang.psi.call.name.Function.ALIAS;
+import static org.elixir_lang.psi.call.name.Module.KERNEL;
+import static org.elixir_lang.psi.impl.ElixirPsiImplUtil.finalArguments;
+import static org.elixir_lang.psi.impl.ElixirPsiImplUtil.hasKeywordKey;
+
+public class UnaliasedName {
+    /*
+     * Public Static Methods
+     */
+
+    @Nullable
+    public static String unaliasedName(@NotNull PsiNamedElement namedElement) {
+        String unaliasedName;
+
+        if (namedElement instanceof QualifiableAlias) {
+            unaliasedName = unaliasedName((QualifiableAlias) namedElement);
+        } else {
+            unaliasedName = namedElement.getName();
+        }
+
+        return unaliasedName;
+    }
+
+    /*
+     * Private Static Methods
+     */
+
+    @Nullable
+    private static String down(@NotNull PsiElement element) {
+        String unaliasedName = null;
+
+        if (element instanceof QualifiableAlias) {
+            PsiNamedElement namedElement = (PsiNamedElement) element;
+
+            unaliasedName = namedElement.getName();
+        }
+
+        return unaliasedName;
+    }
+
+    @Nullable
+    private static String unaliasedName(@NotNull QualifiableAlias qualifiableAlias) {
+        return up(qualifiableAlias.getParent(), qualifiableAlias);
+    }
+
+    @Nullable
+    private static String up(@NotNull Call call, @NotNull QualifiableAlias entrance) {
+        String unaliasedName = null;
+
+        if (call.isCalling(KERNEL, ALIAS)) {
+            PsiElement[] finalArguments = finalArguments(call);
+
+            if (finalArguments != null && finalArguments.length > 0) {
+                PsiElement firstArgument = finalArguments[0];
+
+                unaliasedName = down(firstArgument);
+            }
+        }
+
+        return unaliasedName;
+    }
+
+    @Nullable
+    private static String up(@Nullable PsiElement element, @NotNull QualifiableAlias entrance) {
+        String unaliasedName = null;
+
+        if (element instanceof Call) {
+            unaliasedName = up((Call) element, entrance);
+        } else if (element instanceof ElixirAccessExpression ||
+                element instanceof QuotableArguments ||
+                element instanceof QuotableKeywordList) {
+            unaliasedName = up(element.getParent(), entrance);
+        } else if (element instanceof ElixirMultipleAliases) {
+            unaliasedName = down(entrance);
+        } else if (element instanceof QuotableKeywordPair) {
+            unaliasedName =up((QuotableKeywordPair) element, entrance);
+        }
+
+        return unaliasedName;
+    }
+
+    @Nullable
+    private static String up(@NotNull QuotableKeywordPair element, @NotNull QualifiableAlias entrance) {
+        String unaliasedName = null;
+
+        if (hasKeywordKey(element, "as")) {
+            unaliasedName = up(element.getParent(), entrance);
+        }
+
+        return  unaliasedName;
+    }
+
+}


### PR DESCRIPTION
Fixes #404

# Changelog
## Enhancements
* Resolve `as:` aliased name to both `alias` and `defmodule`
* Complete modules nested under `as:` aliased name.

## Bug Fixes
* Resolve alias nested under aliased modules to both the `alias` and `defmodule`, as resolving to only the `alias` loses the nested name, so it wasn't possible to jump to the nested name's `defmodule.
* Resolve aliased name to both the `alias` and the `defmodule`, so you can skip jumping to the `alias` before jumping to the `defmodule`.
