### PR TITLE
Look through NoParenthesesStrict for parameters

### DIFF
--- a/src/org/elixir_lang/reference/Callable.java
+++ b/src/org/elixir_lang/reference/Callable.java
@@ -256,7 +256,7 @@ public class Callable extends PsiReferenceBase<Call> implements PsiPolyVariantRe
                     parent instanceof PsiFile ||
                     parent instanceof QualifiedAlias ||
                     parent instanceof QualifiedMultipleAliases)) {
-                Logger.error(Callable.class, "Don't know how to check if parameter", parent);
+                error("Don't know how to check if parameter", parent);
             }
         }
 
@@ -339,7 +339,7 @@ public class Callable extends PsiReferenceBase<Call> implements PsiPolyVariantRe
                     ancestor instanceof BracketOperation ||
                     ancestor instanceof PsiFile ||
                     ancestor instanceof QualifiedMultipleAliases)) {
-                Logger.error(Callable.class, "Don't know how to check if variable", ancestor);
+                error("Don't know how to check if variable", ancestor);
             }
         }
 
@@ -462,6 +462,10 @@ public class Callable extends PsiReferenceBase<Call> implements PsiPolyVariantRe
         );
 
         return lookupElementList;
+    }
+
+    private static void error(@NotNull String message, @NotNull PsiElement element) {
+        Logger.error(Callable.class, message + " (when element class is " + element.getClass().getName() + ")", element);
     }
 
     /**
@@ -679,7 +683,7 @@ public class Callable extends PsiReferenceBase<Call> implements PsiPolyVariantRe
                so it has no use scope */
             useScope = LocalSearchScope.EMPTY;
         } else {
-            Logger.error(Callable.class, "Don't know how to find variable use scope for ", ancestor);
+            error("Don't know how to find variable use scope", ancestor);
         }
 
         return useScope;
@@ -693,7 +697,7 @@ public class Callable extends PsiReferenceBase<Call> implements PsiPolyVariantRe
             if (!(element instanceof ElixirStabBody ||
                     element instanceof ElixirEndOfExpression ||
                     element instanceof PsiWhiteSpace)) {
-                Logger.error(Callable.class, "Don't know how to find variables in ", element);
+                error("Don't know how to find variables", element);
             }
         }
 

--- a/src/org/elixir_lang/reference/Callable.java
+++ b/src/org/elixir_lang/reference/Callable.java
@@ -234,6 +234,9 @@ public class Callable extends PsiReferenceBase<Call> implements PsiPolyVariantRe
                 parent instanceof ElixirNoParenthesesKeywordPair ||
                 parent instanceof ElixirNoParenthesesKeywords ||
                 parent instanceof ElixirNoParenthesesOneArgument ||
+                /* handles `(conn, %{})` in `def (conn, %{})`, which can occur in def templates.
+                   See https://github.com/KronicDeth/intellij-elixir/issues/367#issuecomment-244214975 */
+                parent instanceof ElixirNoParenthesesStrict ||
                 parent instanceof ElixirParenthesesArguments ||
                 parent instanceof ElixirParentheticalStab ||
                 parent instanceof ElixirStab ||


### PR DESCRIPTION
Fixes #367

# Changelog
## Enhancements
* Include element class in Callable logged errors because sometimes, the excerpt doesn't have enough context, and it's not safe to search for more context (as those PSI walking methods have also had errors before), so include the element class in the message, which has the benefit that most times the bugs are fixed by adding that class or an interface of that class to one of the methods AND it will make the error message different, so that users don't think other users have the same error and jump on the issue instead of opening a new one.

## Bug Fixes
* `ElixirNoParenthesesStrict` can occur in `def (conn, %{}) do\nend` when a template is used, so there is no name for `def`.  Since the intent is known, mark `conn` as a parameter by checking the parent of the `ElixirNoParenthesesStrict`, which eventually gets to the `def`.
