### PR TITLE
Check if rightOperand is null when highlighting types

### DIFF
--- a/src/org/elixir_lang/annonator/ModuleAttribute.java
+++ b/src/org/elixir_lang/annonator/ModuleAttribute.java
@@ -504,12 +504,14 @@ public class ModuleAttribute implements Annotator, DumbAware {
 
                 PsiElement rightOperand = infix.rightOperand();
 
-                highlightTypesAndTypeParameterUsages(
-                        rightOperand,
-                        Collections.EMPTY_SET,
-                        annotationHolder,
-                        ElixirSyntaxHighlighter.TYPE
-                );
+                if (rightOperand != null) {
+                    highlightTypesAndTypeParameterUsages(
+                            rightOperand,
+                            Collections.EMPTY_SET,
+                            annotationHolder,
+                            ElixirSyntaxHighlighter.TYPE
+                    );
+                }
             } else if (grandChild instanceof ElixirMatchedWhenOperation) {
                 ElixirMatchedWhenOperation matchedWhenOperation = (ElixirMatchedWhenOperation) grandChild;
                 Set<String> typeParameterNameSet = specificationTypeParameterNameSet(matchedWhenOperation.rightOperand());


### PR DESCRIPTION
# Changelog
## Bug Fixes
* Check if `rightOperand` is `null` when highlighting types for `Type`, which can occur when typing `:` for an atom after the `::` for a `Type`.