### PR TITLE
Completion of multiples aliases inside curly braces

### DIFF
--- a/gen/org/elixir_lang/psi/ElixirMatchedAtUnqualifiedNoParenthesesCall.java
+++ b/gen/org/elixir_lang/psi/ElixirMatchedAtUnqualifiedNoParenthesesCall.java
@@ -26,7 +26,7 @@ public interface ElixirMatchedAtUnqualifiedNoParenthesesCall extends ElixirMatch
   @Nullable
   String canonicalName();
 
-  @Nullable
+  @NotNull
   Set<String> canonicalNameSet();
 
   @Nullable

--- a/gen/org/elixir_lang/psi/ElixirMatchedDotCall.java
+++ b/gen/org/elixir_lang/psi/ElixirMatchedDotCall.java
@@ -29,7 +29,7 @@ public interface ElixirMatchedDotCall extends ElixirMatchedExpression, DotCall<M
   @Nullable
   String canonicalName();
 
-  @Nullable
+  @NotNull
   Set<String> canonicalNameSet();
 
   @Nullable

--- a/gen/org/elixir_lang/psi/ElixirMatchedQualifiedNoArgumentsCall.java
+++ b/gen/org/elixir_lang/psi/ElixirMatchedQualifiedNoArgumentsCall.java
@@ -28,7 +28,7 @@ public interface ElixirMatchedQualifiedNoArgumentsCall extends ElixirMatchedExpr
   @Nullable
   String canonicalName();
 
-  @Nullable
+  @NotNull
   Set<String> canonicalNameSet();
 
   @Nullable

--- a/gen/org/elixir_lang/psi/ElixirMatchedQualifiedNoParenthesesCall.java
+++ b/gen/org/elixir_lang/psi/ElixirMatchedQualifiedNoParenthesesCall.java
@@ -31,7 +31,7 @@ public interface ElixirMatchedQualifiedNoParenthesesCall extends ElixirMatchedEx
   @Nullable
   String canonicalName();
 
-  @Nullable
+  @NotNull
   Set<String> canonicalNameSet();
 
   @Nullable

--- a/gen/org/elixir_lang/psi/ElixirMatchedQualifiedParenthesesCall.java
+++ b/gen/org/elixir_lang/psi/ElixirMatchedQualifiedParenthesesCall.java
@@ -31,7 +31,7 @@ public interface ElixirMatchedQualifiedParenthesesCall extends ElixirMatchedExpr
   @Nullable
   String canonicalName();
 
-  @Nullable
+  @NotNull
   Set<String> canonicalNameSet();
 
   @Nullable

--- a/gen/org/elixir_lang/psi/ElixirMatchedUnqualifiedNoArgumentsCall.java
+++ b/gen/org/elixir_lang/psi/ElixirMatchedUnqualifiedNoArgumentsCall.java
@@ -23,7 +23,7 @@ public interface ElixirMatchedUnqualifiedNoArgumentsCall extends ElixirMatchedEx
   @Nullable
   String canonicalName();
 
-  @Nullable
+  @NotNull
   Set<String> canonicalNameSet();
 
   @Nullable

--- a/gen/org/elixir_lang/psi/ElixirMatchedUnqualifiedNoParenthesesCall.java
+++ b/gen/org/elixir_lang/psi/ElixirMatchedUnqualifiedNoParenthesesCall.java
@@ -25,7 +25,7 @@ public interface ElixirMatchedUnqualifiedNoParenthesesCall extends ElixirMatched
   @Nullable
   String canonicalName();
 
-  @Nullable
+  @NotNull
   Set<String> canonicalNameSet();
 
   @Nullable

--- a/gen/org/elixir_lang/psi/ElixirMatchedUnqualifiedParenthesesCall.java
+++ b/gen/org/elixir_lang/psi/ElixirMatchedUnqualifiedParenthesesCall.java
@@ -25,7 +25,7 @@ public interface ElixirMatchedUnqualifiedParenthesesCall extends ElixirMatchedEx
   @Nullable
   String canonicalName();
 
-  @Nullable
+  @NotNull
   Set<String> canonicalNameSet();
 
   @Nullable

--- a/gen/org/elixir_lang/psi/ElixirMultipleAliases.java
+++ b/gen/org/elixir_lang/psi/ElixirMultipleAliases.java
@@ -2,6 +2,9 @@
 package org.elixir_lang.psi;
 
 import com.ericsson.otp.erlang.OtpErlangObject;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.ResolveState;
+import com.intellij.psi.scope.PsiScopeProcessor;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -17,6 +20,8 @@ public interface ElixirMultipleAliases extends Quotable {
 
   @NotNull
   List<ElixirUnmatchedExpression> getUnmatchedExpressionList();
+
+  boolean processDeclarations(PsiScopeProcessor processor, ResolveState state, PsiElement lastParent, PsiElement entrance);
 
   @NotNull
   OtpErlangObject quote();

--- a/gen/org/elixir_lang/psi/ElixirUnmatchedAtUnqualifiedNoParenthesesCall.java
+++ b/gen/org/elixir_lang/psi/ElixirUnmatchedAtUnqualifiedNoParenthesesCall.java
@@ -29,7 +29,7 @@ public interface ElixirUnmatchedAtUnqualifiedNoParenthesesCall extends ElixirUnm
   @Nullable
   String canonicalName();
 
-  @Nullable
+  @NotNull
   Set<String> canonicalNameSet();
 
   @Nullable

--- a/gen/org/elixir_lang/psi/ElixirUnmatchedDotCall.java
+++ b/gen/org/elixir_lang/psi/ElixirUnmatchedDotCall.java
@@ -32,7 +32,7 @@ public interface ElixirUnmatchedDotCall extends ElixirUnmatchedExpression, DotCa
   @Nullable
   String canonicalName();
 
-  @Nullable
+  @NotNull
   Set<String> canonicalNameSet();
 
   @Nullable

--- a/gen/org/elixir_lang/psi/ElixirUnmatchedQualifiedNoArgumentsCall.java
+++ b/gen/org/elixir_lang/psi/ElixirUnmatchedQualifiedNoArgumentsCall.java
@@ -31,7 +31,7 @@ public interface ElixirUnmatchedQualifiedNoArgumentsCall extends ElixirUnmatched
   @Nullable
   String canonicalName();
 
-  @Nullable
+  @NotNull
   Set<String> canonicalNameSet();
 
   @Nullable

--- a/gen/org/elixir_lang/psi/ElixirUnmatchedQualifiedNoParenthesesCall.java
+++ b/gen/org/elixir_lang/psi/ElixirUnmatchedQualifiedNoParenthesesCall.java
@@ -34,7 +34,7 @@ public interface ElixirUnmatchedQualifiedNoParenthesesCall extends ElixirUnmatch
   @Nullable
   String canonicalName();
 
-  @Nullable
+  @NotNull
   Set<String> canonicalNameSet();
 
   @Nullable

--- a/gen/org/elixir_lang/psi/ElixirUnmatchedQualifiedParenthesesCall.java
+++ b/gen/org/elixir_lang/psi/ElixirUnmatchedQualifiedParenthesesCall.java
@@ -34,7 +34,7 @@ public interface ElixirUnmatchedQualifiedParenthesesCall extends ElixirUnmatched
   @Nullable
   String canonicalName();
 
-  @Nullable
+  @NotNull
   Set<String> canonicalNameSet();
 
   @Nullable

--- a/gen/org/elixir_lang/psi/ElixirUnmatchedUnqualifiedNoArgumentsCall.java
+++ b/gen/org/elixir_lang/psi/ElixirUnmatchedUnqualifiedNoArgumentsCall.java
@@ -26,7 +26,7 @@ public interface ElixirUnmatchedUnqualifiedNoArgumentsCall extends ElixirUnmatch
   @Nullable
   String canonicalName();
 
-  @Nullable
+  @NotNull
   Set<String> canonicalNameSet();
 
   @Nullable

--- a/gen/org/elixir_lang/psi/ElixirUnmatchedUnqualifiedNoParenthesesCall.java
+++ b/gen/org/elixir_lang/psi/ElixirUnmatchedUnqualifiedNoParenthesesCall.java
@@ -28,7 +28,7 @@ public interface ElixirUnmatchedUnqualifiedNoParenthesesCall extends ElixirUnmat
   @Nullable
   String canonicalName();
 
-  @Nullable
+  @NotNull
   Set<String> canonicalNameSet();
 
   @Nullable

--- a/gen/org/elixir_lang/psi/ElixirUnmatchedUnqualifiedParenthesesCall.java
+++ b/gen/org/elixir_lang/psi/ElixirUnmatchedUnqualifiedParenthesesCall.java
@@ -28,7 +28,7 @@ public interface ElixirUnmatchedUnqualifiedParenthesesCall extends ElixirUnmatch
   @Nullable
   String canonicalName();
 
-  @Nullable
+  @NotNull
   Set<String> canonicalNameSet();
 
   @Nullable

--- a/gen/org/elixir_lang/psi/ElixirUnqualifiedNoParenthesesManyArgumentsCall.java
+++ b/gen/org/elixir_lang/psi/ElixirUnqualifiedNoParenthesesManyArgumentsCall.java
@@ -41,7 +41,7 @@ public interface ElixirUnqualifiedNoParenthesesManyArgumentsCall extends PsiElem
   @Nullable
   String canonicalName();
 
-  @Nullable
+  @NotNull
   Set<String> canonicalNameSet();
 
   @Nullable

--- a/gen/org/elixir_lang/psi/impl/ElixirMatchedAtUnqualifiedNoParenthesesCallImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMatchedAtUnqualifiedNoParenthesesCallImpl.java
@@ -55,7 +55,7 @@ public class ElixirMatchedAtUnqualifiedNoParenthesesCallImpl extends NamedStubbe
     return ElixirPsiImplUtil.canonicalName(this);
   }
 
-  @Nullable
+  @NotNull
   public Set<String> canonicalNameSet() {
     return ElixirPsiImplUtil.canonicalNameSet(this);
   }

--- a/gen/org/elixir_lang/psi/impl/ElixirMatchedDotCallImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMatchedDotCallImpl.java
@@ -61,7 +61,7 @@ public class ElixirMatchedDotCallImpl extends NamedStubbedPsiElementBase<Matched
     return ElixirPsiImplUtil.canonicalName(this);
   }
 
-  @Nullable
+  @NotNull
   public Set<String> canonicalNameSet() {
     return ElixirPsiImplUtil.canonicalNameSet(this);
   }

--- a/gen/org/elixir_lang/psi/impl/ElixirMatchedQualifiedNoArgumentsCallImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMatchedQualifiedNoArgumentsCallImpl.java
@@ -60,7 +60,7 @@ public class ElixirMatchedQualifiedNoArgumentsCallImpl extends NamedStubbedPsiEl
     return ElixirPsiImplUtil.canonicalName(this);
   }
 
-  @Nullable
+  @NotNull
   public Set<String> canonicalNameSet() {
     return ElixirPsiImplUtil.canonicalNameSet(this);
   }

--- a/gen/org/elixir_lang/psi/impl/ElixirMatchedQualifiedNoParenthesesCallImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMatchedQualifiedNoParenthesesCallImpl.java
@@ -66,7 +66,7 @@ public class ElixirMatchedQualifiedNoParenthesesCallImpl extends NamedStubbedPsi
     return ElixirPsiImplUtil.canonicalName(this);
   }
 
-  @Nullable
+  @NotNull
   public Set<String> canonicalNameSet() {
     return ElixirPsiImplUtil.canonicalNameSet(this);
   }

--- a/gen/org/elixir_lang/psi/impl/ElixirMatchedQualifiedParenthesesCallImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMatchedQualifiedParenthesesCallImpl.java
@@ -66,7 +66,7 @@ public class ElixirMatchedQualifiedParenthesesCallImpl extends NamedStubbedPsiEl
     return ElixirPsiImplUtil.canonicalName(this);
   }
 
-  @Nullable
+  @NotNull
   public Set<String> canonicalNameSet() {
     return ElixirPsiImplUtil.canonicalNameSet(this);
   }

--- a/gen/org/elixir_lang/psi/impl/ElixirMatchedUnqualifiedNoArgumentsCallImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMatchedUnqualifiedNoArgumentsCallImpl.java
@@ -52,7 +52,7 @@ public class ElixirMatchedUnqualifiedNoArgumentsCallImpl extends NamedStubbedPsi
     return ElixirPsiImplUtil.canonicalName(this);
   }
 
-  @Nullable
+  @NotNull
   public Set<String> canonicalNameSet() {
     return ElixirPsiImplUtil.canonicalNameSet(this);
   }

--- a/gen/org/elixir_lang/psi/impl/ElixirMatchedUnqualifiedNoParenthesesCallImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMatchedUnqualifiedNoParenthesesCallImpl.java
@@ -54,7 +54,7 @@ public class ElixirMatchedUnqualifiedNoParenthesesCallImpl extends NamedStubbedP
     return ElixirPsiImplUtil.canonicalName(this);
   }
 
-  @Nullable
+  @NotNull
   public Set<String> canonicalNameSet() {
     return ElixirPsiImplUtil.canonicalNameSet(this);
   }

--- a/gen/org/elixir_lang/psi/impl/ElixirMatchedUnqualifiedParenthesesCallImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMatchedUnqualifiedParenthesesCallImpl.java
@@ -54,7 +54,7 @@ public class ElixirMatchedUnqualifiedParenthesesCallImpl extends NamedStubbedPsi
     return ElixirPsiImplUtil.canonicalName(this);
   }
 
-  @Nullable
+  @NotNull
   public Set<String> canonicalNameSet() {
     return ElixirPsiImplUtil.canonicalNameSet(this);
   }

--- a/gen/org/elixir_lang/psi/impl/ElixirMultipleAliasesImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMultipleAliasesImpl.java
@@ -4,7 +4,10 @@ package org.elixir_lang.psi.impl;
 import com.ericsson.otp.erlang.OtpErlangObject;
 import com.intellij.extapi.psi.ASTWrapperPsiElement;
 import com.intellij.lang.ASTNode;
+import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
+import com.intellij.psi.ResolveState;
+import com.intellij.psi.scope.PsiScopeProcessor;
 import com.intellij.psi.util.PsiTreeUtil;
 import org.elixir_lang.psi.*;
 import org.jetbrains.annotations.NotNull;
@@ -43,6 +46,10 @@ public class ElixirMultipleAliasesImpl extends ASTWrapperPsiElement implements E
   @NotNull
   public List<ElixirUnmatchedExpression> getUnmatchedExpressionList() {
     return PsiTreeUtil.getChildrenOfTypeAsList(this, ElixirUnmatchedExpression.class);
+  }
+
+  public boolean processDeclarations(PsiScopeProcessor processor, ResolveState state, PsiElement lastParent, PsiElement entrance) {
+    return ElixirPsiImplUtil.processDeclarations(this, processor, state, lastParent, entrance);
   }
 
   @NotNull

--- a/gen/org/elixir_lang/psi/impl/ElixirUnmatchedAtUnqualifiedNoParenthesesCallImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnmatchedAtUnqualifiedNoParenthesesCallImpl.java
@@ -61,7 +61,7 @@ public class ElixirUnmatchedAtUnqualifiedNoParenthesesCallImpl extends NamedStub
     return ElixirPsiImplUtil.canonicalName(this);
   }
 
-  @Nullable
+  @NotNull
   public Set<String> canonicalNameSet() {
     return ElixirPsiImplUtil.canonicalNameSet(this);
   }

--- a/gen/org/elixir_lang/psi/impl/ElixirUnmatchedDotCallImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnmatchedDotCallImpl.java
@@ -67,7 +67,7 @@ public class ElixirUnmatchedDotCallImpl extends NamedStubbedPsiElementBase<Unmat
     return ElixirPsiImplUtil.canonicalName(this);
   }
 
-  @Nullable
+  @NotNull
   public Set<String> canonicalNameSet() {
     return ElixirPsiImplUtil.canonicalNameSet(this);
   }

--- a/gen/org/elixir_lang/psi/impl/ElixirUnmatchedQualifiedNoArgumentsCallImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnmatchedQualifiedNoArgumentsCallImpl.java
@@ -66,7 +66,7 @@ public class ElixirUnmatchedQualifiedNoArgumentsCallImpl extends NamedStubbedPsi
     return ElixirPsiImplUtil.canonicalName(this);
   }
 
-  @Nullable
+  @NotNull
   public Set<String> canonicalNameSet() {
     return ElixirPsiImplUtil.canonicalNameSet(this);
   }

--- a/gen/org/elixir_lang/psi/impl/ElixirUnmatchedQualifiedNoParenthesesCallImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnmatchedQualifiedNoParenthesesCallImpl.java
@@ -72,7 +72,7 @@ public class ElixirUnmatchedQualifiedNoParenthesesCallImpl extends NamedStubbedP
     return ElixirPsiImplUtil.canonicalName(this);
   }
 
-  @Nullable
+  @NotNull
   public Set<String> canonicalNameSet() {
     return ElixirPsiImplUtil.canonicalNameSet(this);
   }

--- a/gen/org/elixir_lang/psi/impl/ElixirUnmatchedQualifiedParenthesesCallImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnmatchedQualifiedParenthesesCallImpl.java
@@ -72,7 +72,7 @@ public class ElixirUnmatchedQualifiedParenthesesCallImpl extends NamedStubbedPsi
     return ElixirPsiImplUtil.canonicalName(this);
   }
 
-  @Nullable
+  @NotNull
   public Set<String> canonicalNameSet() {
     return ElixirPsiImplUtil.canonicalNameSet(this);
   }

--- a/gen/org/elixir_lang/psi/impl/ElixirUnmatchedUnqualifiedNoArgumentsCallImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnmatchedUnqualifiedNoArgumentsCallImpl.java
@@ -58,7 +58,7 @@ public class ElixirUnmatchedUnqualifiedNoArgumentsCallImpl extends NamedStubbedP
     return ElixirPsiImplUtil.canonicalName(this);
   }
 
-  @Nullable
+  @NotNull
   public Set<String> canonicalNameSet() {
     return ElixirPsiImplUtil.canonicalNameSet(this);
   }

--- a/gen/org/elixir_lang/psi/impl/ElixirUnmatchedUnqualifiedNoParenthesesCallImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnmatchedUnqualifiedNoParenthesesCallImpl.java
@@ -60,7 +60,7 @@ public class ElixirUnmatchedUnqualifiedNoParenthesesCallImpl extends NamedStubbe
     return ElixirPsiImplUtil.canonicalName(this);
   }
 
-  @Nullable
+  @NotNull
   public Set<String> canonicalNameSet() {
     return ElixirPsiImplUtil.canonicalNameSet(this);
   }

--- a/gen/org/elixir_lang/psi/impl/ElixirUnmatchedUnqualifiedParenthesesCallImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnmatchedUnqualifiedParenthesesCallImpl.java
@@ -60,7 +60,7 @@ public class ElixirUnmatchedUnqualifiedParenthesesCallImpl extends NamedStubbedP
     return ElixirPsiImplUtil.canonicalName(this);
   }
 
-  @Nullable
+  @NotNull
   public Set<String> canonicalNameSet() {
     return ElixirPsiImplUtil.canonicalNameSet(this);
   }

--- a/gen/org/elixir_lang/psi/impl/ElixirUnqualifiedNoParenthesesManyArgumentsCallImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnqualifiedNoParenthesesManyArgumentsCallImpl.java
@@ -79,7 +79,7 @@ public class ElixirUnqualifiedNoParenthesesManyArgumentsCallImpl extends NamedSt
     return ElixirPsiImplUtil.canonicalName(this);
   }
 
-  @Nullable
+  @NotNull
   public Set<String> canonicalNameSet() {
     return ElixirPsiImplUtil.canonicalNameSet(this);
   }

--- a/src/org/elixir_lang/Elixir.bnf
+++ b/src/org/elixir_lang/Elixir.bnf
@@ -1834,7 +1834,13 @@ matchedQualifiedMultipleAliases ::= matchedExpression dotInfixOperator multipleA
 multipleAliases ::= OPENING_CURLY EOL*
                     containerArguments? EOL*
                     CLOSING_CURLY
-                    { implements = "org.elixir_lang.psi.Quotable" methods = [quote] }
+                    {
+                      implements = "org.elixir_lang.psi.Quotable"
+                      methods = [
+                        processDeclarations
+                        quote
+                      ]
+                    }
 
 
 /*

--- a/src/org/elixir_lang/psi/impl/ElixirPsiImplUtil.java
+++ b/src/org/elixir_lang/psi/impl/ElixirPsiImplUtil.java
@@ -1521,6 +1521,20 @@ public class ElixirPsiImplUtil {
         );
     }
 
+    public static boolean processDeclarations(@NotNull final ElixirMultipleAliases multipleAliases,
+                                              @NotNull PsiScopeProcessor processor,
+                                              @NotNull ResolveState state,
+                                              PsiElement lastParent,
+                                              @NotNull PsiElement entrance) {
+        return processDeclarationsRecursively(
+                multipleAliases,
+                processor,
+                state,
+                lastParent,
+                entrance
+        );
+    }
+
     public static boolean processDeclarations(@NotNull final ElixirStabBody scope,
                                               @NotNull PsiScopeProcessor processor,
                                               @NotNull ResolveState state,

--- a/src/org/elixir_lang/psi/scope/Module.java
+++ b/src/org/elixir_lang/psi/scope/Module.java
@@ -21,17 +21,6 @@ public abstract class Module implements PsiScopeProcessor {
      * Public Instance Methods
      */
 
-    @Override
-    public boolean execute(@NotNull PsiElement match, @NotNull ResolveState state) {
-        boolean keepProcessing = true;
-
-        if (match instanceof Named) {
-            keepProcessing = execute((Named) match, state);
-        }
-
-        return keepProcessing;
-    }
-
     @Nullable
     @Override
     public <T> T getHint(@NotNull Key<T> hintKey) {
@@ -55,6 +44,22 @@ public abstract class Module implements PsiScopeProcessor {
     protected abstract boolean executeOnAliasedName(@NotNull final PsiNamedElement match,
                                                     @NotNull String aliasedName,
                                                     @NotNull ResolveState state);
+
+    /*
+     * Protected Instance Methods
+     */
+
+    protected boolean execute(@NotNull Named match, @NotNull ResolveState state) {
+        boolean keepProcessing = true;
+
+        if (isModular(match)) {
+            keepProcessing = executeOnMaybeAliasedName(match, match.getName(), state);
+        } else if (match.isCalling(KERNEL, ALIAS)) {
+            keepProcessing = executeOnAliasCall(match, state);
+        }
+
+        return keepProcessing;
+    }
 
     /*
      * Private Instance Methods
@@ -92,19 +97,6 @@ public abstract class Module implements PsiScopeProcessor {
         }
 
         return aliasedName;
-    }
-
-
-    private boolean execute(@NotNull Named match, @NotNull ResolveState state) {
-        boolean keepProcessing = true;
-
-        if (isModular(match)) {
-            keepProcessing = executeOnMaybeAliasedName(match, match.getName(), state);
-        } else if (match.isCalling(KERNEL, ALIAS)) {
-            keepProcessing = executeOnAliasCall(match, state);
-        }
-
-        return keepProcessing;
     }
 
     private boolean executeOnAliasCall(@NotNull Named aliasCall, @NotNull ResolveState state) {

--- a/src/org/elixir_lang/psi/scope/module/MultiResolve.java
+++ b/src/org/elixir_lang/psi/scope/module/MultiResolve.java
@@ -6,6 +6,7 @@ import com.intellij.psi.search.GlobalSearchScope;
 import com.intellij.psi.stubs.StubIndex;
 import com.intellij.psi.util.PsiTreeUtil;
 import org.elixir_lang.psi.NamedElement;
+import org.elixir_lang.psi.call.Named;
 import org.elixir_lang.psi.scope.Module;
 import org.elixir_lang.psi.stub.index.AllName;
 import org.elixir_lang.reference.module.UnaliasedName;
@@ -100,6 +101,17 @@ public class MultiResolve extends Module {
     /*
      * Public Instance Methods
      */
+
+    @Override
+    public boolean execute(@NotNull PsiElement match, @NotNull ResolveState state) {
+        boolean keepProcessing = true;
+
+        if (match instanceof Named) {
+            keepProcessing = execute((Named) match, state);
+        }
+
+        return keepProcessing;
+    }
 
     @Nullable
     public List<ResolveResult> getResolveResultList() {

--- a/testData/org/elixir_lang/reference/module/multiple_alias/completion_inside_curlies.ex
+++ b/testData/org/elixir_lang/reference/module/multiple_alias/completion_inside_curlies.ex
@@ -1,0 +1,3 @@
+defmodule Prefix.CompletionInsideCurlies do
+  alias Prefix.{Mu<caret>}
+end

--- a/tests/org/elixir_lang/reference/module/MultipleAliasTest.java
+++ b/tests/org/elixir_lang/reference/module/MultipleAliasTest.java
@@ -36,6 +36,21 @@ public class MultipleAliasTest extends LightCodeInsightFixtureTestCase {
         assertEquals(2, strings.size());
     }
 
+    public void testCompletionInSideCurlies() {
+        myFixture.configureByFiles("completion_inside_curlies.ex", "multiple_alias_aye.ex", "multiple_alias_bee.ex");
+        myFixture.complete(CompletionType.BASIC, 1);
+        List<String> strings = myFixture.getLookupElementStrings();
+        assertTrue(
+                strings.containsAll(
+                        Arrays.asList(
+                                "MultipleAliasAye",
+                                "MultipleAliasBee"
+                        )
+                )
+        );
+        assertEquals(2, strings.size());
+    }
+
     public void testReference() {
         myFixture.configureByFiles("reference.ex", "multiple_alias_aye.ex", "multiple_alias_bee.ex");
         PsiElement alias = myFixture


### PR DESCRIPTION
Resolves 411

# Changelog
## Enhancements
* [Completion of multiple aliases inside curly braces](https://www.youtube.com/watch?v=aOiJHZuudzg)
  * Override `ElixirMultipleAliases#processDeclarations`, so that `treeWalkUp` can stop at
`ElixirMultipleAliases` when determining how to do Alias completion.  If a multiple alias is encountered, then de-prefixed names should be returned.
## Bug Fixes
* Add missing `@Nullable` to `@NotNull` change when parser wasn't regenerated when `canonicalNameSet` was changed to `@NotNull` in the interface.