### PR TITLE
Check parent `isVariable` for `ElixirNoParenthesesManyStrictNoParenthesesExpression`

### DIFF
--- a/src/org/elixir_lang/reference/Callable.java
+++ b/src/org/elixir_lang/reference/Callable.java
@@ -327,6 +327,9 @@ public class Callable extends PsiReferenceBase<Call> implements PsiPolyVariantRe
                 ancestor instanceof ElixirNoParenthesesArguments ||
                 ancestor instanceof ElixirNoParenthesesKeywordPair ||
                 ancestor instanceof ElixirNoParenthesesKeywords ||
+                /* ElixirNoParenthesesManyStrictNoParenthesesExpression indicates a syntax error, but it can also occur
+                   during typing, so try searching above the syntax error to resolve whether a variable */
+                ancestor instanceof ElixirNoParenthesesManyStrictNoParenthesesExpression ||
                 ancestor instanceof ElixirParenthesesArguments ||
                 ancestor instanceof ElixirParentheticalStab ||
                 ancestor instanceof ElixirStab ||

--- a/testData/org/elixir_lang/reference/callable/issue_422/is_variable.ex
+++ b/testData/org/elixir_lang/reference/callable/issue_422/is_variable.ex
@@ -1,0 +1,11 @@
+defmodule InfraTg.Query.AssociateUserNotification.Crud do
+  import Ecto.Query
+  alias InfraTg.Schema
+  alias Schema.AssociateUserNotification
+  alias Schema.Notification
+
+  def list_messages do
+    from associate_user_notification in AssociateUserNotification,
+    inner_join notifications, assoc<caret>   # <- **_wrong syntax raises this error_**
+  end
+end

--- a/tests/org/elixir_lang/reference/callable/Issue422Test.java
+++ b/tests/org/elixir_lang/reference/callable/Issue422Test.java
@@ -1,0 +1,41 @@
+package org.elixir_lang.reference.callable;
+
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.search.LocalSearchScope;
+import com.intellij.psi.search.SearchScope;
+import com.intellij.testFramework.fixtures.LightCodeInsightFixtureTestCase;
+import org.elixir_lang.psi.call.Call;
+
+import static org.elixir_lang.reference.Callable.isVariable;
+
+public class Issue422Test extends LightCodeInsightFixtureTestCase {
+    /*
+     * Tests
+     */
+
+    public void testIsVariable() {
+        myFixture.configureByFiles("is_variable.ex");
+        PsiElement callable = myFixture
+                .getFile()
+                .findElementAt(myFixture.getCaretOffset())
+                .getPrevSibling()
+                .getLastChild()
+                .getLastChild()
+                .getLastChild()
+                .getLastChild()
+                .getLastChild()
+                .getLastChild();
+
+        assertInstanceOf(callable, Call.class);
+        assertFalse("assoc is incorrectly marked as a variable", isVariable(callable));
+    }
+
+    /*
+     * Protected Instance Methods
+     */
+
+    @Override
+    protected String getTestDataPath() {
+        return "testData/org/elixir_lang/reference/callable/issue_422";
+    }
+}


### PR DESCRIPTION
# Changelog
## Enhancements
* Failing regression test for #422

## Bug Fixes
* Check parent `isVariable` for `ElixirNoParenthesesManyStrictNoParenthesesExpression`