### PR TITLE
Highlight @type without :: 

### DIFF
--- a/src/org/elixir_lang/annonator/ModuleAttribute.java
+++ b/src/org/elixir_lang/annonator/ModuleAttribute.java
@@ -378,7 +378,34 @@ public class ModuleAttribute implements Annotator, DumbAware {
                             ElixirSyntaxHighlighter.TYPE
                     );
                 }
+            } else if (grandChild instanceof UnqualifiedNoParenthesesCall) {
+                /* Pretend that `::` separates the functionNameElement from the arguments, so that
+                   ```
+                   @type coefficient non_neg_integer | :qNaN | :sNaN | :inf
+                   ```
+                   is retreated like
+                   ```
+                   @type coefficient :: non_neg_integer | :qNaN | :sNaN | :inf
+                   ```
+                 */
+                UnqualifiedNoParenthesesCall unqualifiedNoParenthesesCall = (UnqualifiedNoParenthesesCall) grandChild;
 
+                PsiElement functionNameElement = unqualifiedNoParenthesesCall.functionNameElement();
+
+                if (functionNameElement != null) {
+                    highlight(
+                            functionNameElement.getTextRange(),
+                            annotationHolder,
+                            ElixirSyntaxHighlighter.TYPE
+                    );
+                }
+
+                highlightTypesAndTypeParameterUsages(
+                        unqualifiedNoParenthesesCall.getNoParenthesesOneArgument(),
+                        Collections.<String>emptySet(),
+                        annotationHolder,
+                        ElixirSyntaxHighlighter.TYPE
+                );
             } else {
                 cannotHighlightTypes(grandChild);
             }

--- a/testData/org/elixir_lang/annotator/module_attribute/missing_type_operator.ex
+++ b/testData/org/elixir_lang/annotator/module_attribute/missing_type_operator.ex
@@ -1,0 +1,1 @@
+@type coefficient non_neg_integer | :qNaN | :sNaN | :inf

--- a/tests/org/elixir_lang/annotator/ModuleAttributeTest.java
+++ b/tests/org/elixir_lang/annotator/ModuleAttributeTest.java
@@ -16,6 +16,14 @@ public class ModuleAttributeTest extends LightCodeInsightFixtureTestCase {
         myFixture.checkHighlighting(false, false, true);
     }
 
+    /**
+     * See https://github.com/KronicDeth/intellij-elixir/issues/438
+     */
+    public void testIssue438() {
+        myFixture.configureByFiles("missing_type_operator.ex");
+        myFixture.checkHighlighting(false, false, true);
+    }
+
     /*
      * Protected Instance Methods
      */


### PR DESCRIPTION
Fixes #438

# Changelog
## Enhancements
* Failing regression test for #438

## Bug Fixes
* Highlight `@type` without `::`