### PR TITLE
Check if parent isParameter for ElixirNoParenthesesManyStrictNoParenthesesExpression

### DIFF
--- a/src/org/elixir_lang/reference/Callable.java
+++ b/src/org/elixir_lang/reference/Callable.java
@@ -234,6 +234,9 @@ public class Callable extends PsiReferenceBase<Call> implements PsiPolyVariantRe
                 parent instanceof ElixirNoParenthesesArguments ||
                 parent instanceof ElixirNoParenthesesKeywordPair ||
                 parent instanceof ElixirNoParenthesesKeywords ||
+                /* ElixirNoParenthesesManyStrictNoParenthesesExpression indicates a syntax error where no parentheses
+                   calls are nested, so it's invalid, but try to still resolve parameters to have highlighting */
+                parent instanceof ElixirNoParenthesesManyStrictNoParenthesesExpression ||
                 parent instanceof ElixirNoParenthesesOneArgument ||
                 /* handles `(conn, %{})` in `def (conn, %{})`, which can occur in def templates.
                    See https://github.com/KronicDeth/intellij-elixir/issues/367#issuecomment-244214975 */

--- a/testData/org/elixir_lang/reference/callable/issue_431/planet.ex
+++ b/testData/org/elixir_lang/reference/callable/issue_431/planet.ex
@@ -1,0 +1,46 @@
+defmodule Physics.Planet do
+
+  alias Physics.Utils.{Laws, Convert, Calculate}
+
+  defstruct [
+    ev: 0,
+    mass: 0,
+    radius: 0,
+    name: nil,
+    type: :rocky
+  ]
+
+  def planets do
+    alias Physics.Planet
+    [
+      {:mars,    %Planet{name: "Mars",    type: :rocky,   mass: 6.41e23,  radius: 3.37e6}},
+      {:moon,    %Planet{name: "Moon",    type: :rocky,   mass: 7.35e22,  radius: 1.738e6}},
+      {:venus,   %Planet{name: "Venus",   type: :rocky,   mass: 4.86e24,  radius: 6.05e6}},
+      {:earth,   %Planet{name: "Earth",   type: :rocky,   mass: 5.972e24, radius: 6.37e6}},
+      {:saturn,  %Planet{name: "Saturn",  type: :gaseous, mass: 5.68e26,  radius: 6.02e7}},
+      {:uranus,  %Planet{name: "Uranus",  type: :gaseous, mass: 8.68e25,  radius: 2.55e7}},
+      {:mercury, %Planet{name: "Mercury", type: :rocky,   mass: 3.3e23,   radius: 2.439e6}},
+      {:jupiter, %Planet{name: "Jupiter", type: :gaseous, mass: 1.89e27,  radius: 7.14e7}},
+      {:neptune, %Planet{name: "Neptune", type: :gaseous, mass: 1.02e26,  radius: 2.47e7}}
+    ]
+  end
+
+  def select, do: for planet<caret> <- planets, do: planet |> set_ev
+
+  def escape_velocity(planet) when is_map(planet) do
+    planet
+    |> calculate_escape_velocity
+    |> Convert.to_km
+    |> Convert.to_nearest_tenth
+  end
+
+  defp set_ev({name, planet}) do
+    {name, %{ planet | ev: escape_velocity(planet) }}
+  end
+
+  defp calculate_escape_velocity(%{mass: mass, radius: radius}) do
+    2 * Laws.newtons_gravitational_constant * mass / radius
+      |> Calculate.square_root
+  end
+
+end

--- a/tests/org/elixir_lang/reference/callable/Issue431Test.java
+++ b/tests/org/elixir_lang/reference/callable/Issue431Test.java
@@ -1,0 +1,33 @@
+package org.elixir_lang.reference.callable;
+
+import com.intellij.psi.PsiElement;
+import com.intellij.testFramework.fixtures.LightCodeInsightFixtureTestCase;
+import org.elixir_lang.psi.UnqualifiedNoArgumentsCall;
+
+import static org.elixir_lang.reference.Callable.isParameter;
+
+public class Issue431Test extends LightCodeInsightFixtureTestCase {
+    /*
+     * Tests
+     */
+
+    public void testIsParameter() {
+        myFixture.configureByFiles("planet.ex");
+        PsiElement parameter = myFixture
+                .getFile()
+                .findElementAt(myFixture.getCaretOffset())
+                .getPrevSibling();
+
+        assertInstanceOf(parameter, UnqualifiedNoArgumentsCall.class);
+        assertTrue("planet is not marked as a parameter", isParameter(parameter));
+    }
+
+    /*
+     * Protected Instance Methods
+     */
+
+    @Override
+    protected String getTestDataPath() {
+        return "testData/org/elixir_lang/reference/callable/issue_431";
+    }
+}


### PR DESCRIPTION
Fixes #431

# Changelog
## Enhancements
* Failing regression test for #431

## Bug Fixes
* `ElixirNoParenthesesManyStrictNoParenthesesExpression` indicates an ambigious no parentheses nesting, but the highlighting should not error and do a best effort instead.