### PR TITLE
Don't skip Call's parent when checking types in isParameter

### DIFF
--- a/src/org/elixir_lang/reference/Callable.java
+++ b/src/org/elixir_lang/reference/Callable.java
@@ -545,9 +545,8 @@ public class Callable extends PsiReferenceBase<Call> implements PsiPolyVariantRe
         if (CallDefinitionClause.is(call) || Delegation.is(call) || call.hasDoBlockOrKeyword()) {
             isParameter = true;
         } else {
-            PsiElement parent = call.getParent();
-
-            isParameter = parent != null && !(parent instanceof PsiFile) && isParameter(parent);
+            // use generic handling, so that parent is checked
+            isParameter = isParameter((PsiElement) call);
         }
 
         return isParameter;

--- a/testData/org/elixir_lang/reference/callable/issue_436/is_parameter.ex
+++ b/testData/org/elixir_lang/reference/callable/issue_436/is_parameter.ex
@@ -1,0 +1,1 @@
+~s|<a href="#{source}#{enc_h(inspect alias<caret>)}.html#t:#{n}/#{length(args)}">#{h(string)}</a>|

--- a/tests/org/elixir_lang/reference/callable/Issue436Test.java
+++ b/tests/org/elixir_lang/reference/callable/Issue436Test.java
@@ -1,0 +1,37 @@
+package org.elixir_lang.reference.callable;
+
+import com.intellij.psi.PsiElement;
+import com.intellij.testFramework.fixtures.LightCodeInsightFixtureTestCase;
+import org.elixir_lang.psi.UnqualifiedNoArgumentsCall;
+
+import static org.elixir_lang.reference.Callable.isParameter;
+import static org.elixir_lang.reference.Callable.isVariable;
+
+public class Issue436Test extends LightCodeInsightFixtureTestCase {
+    /*
+     * Tests
+     */
+
+    public void testIsParameter() {
+        myFixture.configureByFiles("is_parameter.ex");
+        PsiElement variable = myFixture
+                .getFile()
+                .findElementAt(myFixture.getCaretOffset())
+                .getPrevSibling()
+                .getLastChild()
+                .getLastChild();
+
+        assertInstanceOf(variable, UnqualifiedNoArgumentsCall.class);
+        assertFalse("alias is marked as a parameter", isParameter(variable));
+        assertTrue("alias is not marked as a variable", isVariable(variable));
+    }
+
+    /*
+     * Protected Instance Methods
+     */
+
+    @Override
+    protected String getTestDataPath() {
+        return "testData/org/elixir_lang/reference/callable/issue_436";
+    }
+}


### PR DESCRIPTION
Fixes #436

# Changelog
## Enhancements
* Regression test for #436

## Bug Fixes
* `isParameter(Call)` called `isParameter` on its parent if it wasn't a call definition clause, delegation or macro, but `isParameter(PsiElement)` immediately calls `getParent()` and does all the `instanceof` tests on the parent.  So, instead of `isParameter(Call)` calling `isParameter(PsiElement)` on its parent, it should just call it on itself, this way the check for `ElixirInterpolation` will not be skipped and there's no need to handle `ElixirInterpolatedString`.