### PR TITLE
Go To Function/Macro and Function/Macro completion for project and deps

### DIFF
--- a/.idea/runConfigurations/org_elixir_lang.xml
+++ b/.idea/runConfigurations/org_elixir_lang.xml
@@ -17,7 +17,7 @@
       <value defaultName="moduleWithDependencies" />
     </option>
     <envs>
-      <env name="ELIXIR_LANG_ELIXIR_PATH" value="/Users/limhoff/git/elixir-lang/elixir" />
+      <env name="ELIXIR_LANG_ELIXIR_PATH" value="$PROJECT_DIR$/../../elixir-lang/elixir" />
     </envs>
     <patterns />
     <RunnerSettings RunnerId="Debug">
@@ -28,6 +28,9 @@
     <RunnerSettings RunnerId="Run" />
     <ConfigurationWrapper RunnerId="Debug" />
     <ConfigurationWrapper RunnerId="Run" />
-    <method />
+    <method>
+      <option name="Make" enabled="true" />
+      <option name="ToolBeforeRunTask" enabled="true" actionId="Tool_External Tools_intellij_elixir" />
+    </method>
   </configuration>
 </component>

--- a/gen/org/elixir_lang/psi/ElixirAnonymousFunction.java
+++ b/gen/org/elixir_lang/psi/ElixirAnonymousFunction.java
@@ -2,11 +2,12 @@
 package org.elixir_lang.psi;
 
 import com.ericsson.otp.erlang.OtpErlangObject;
+import com.intellij.psi.NavigatablePsiElement;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
 
-public interface ElixirAnonymousFunction extends Quotable {
+public interface ElixirAnonymousFunction extends NavigatablePsiElement, Quotable {
 
   @NotNull
   List<ElixirEndOfExpression> getEndOfExpressionList();

--- a/gen/org/elixir_lang/psi/ElixirIdentifier.java
+++ b/gen/org/elixir_lang/psi/ElixirIdentifier.java
@@ -2,9 +2,14 @@
 package org.elixir_lang.psi;
 
 import com.ericsson.otp.erlang.OtpErlangObject;
+import com.intellij.navigation.ItemPresentation;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public interface ElixirIdentifier extends Quotable {
+
+  @Nullable
+  ItemPresentation getPresentation();
 
   @NotNull
   OtpErlangObject quote();

--- a/gen/org/elixir_lang/psi/ElixirVisitor.java
+++ b/gen/org/elixir_lang/psi/ElixirVisitor.java
@@ -29,7 +29,8 @@ public class ElixirVisitor extends PsiElementVisitor {
   }
 
   public void visitAnonymousFunction(@NotNull ElixirAnonymousFunction o) {
-    visitQuotable(o);
+    visitNavigatablePsiElement(o);
+    // visitQuotable(o);
   }
 
   public void visitArrowInfixOperator(@NotNull ElixirArrowInfixOperator o) {

--- a/gen/org/elixir_lang/psi/impl/ElixirIdentifierImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirIdentifierImpl.java
@@ -4,10 +4,12 @@ package org.elixir_lang.psi.impl;
 import com.ericsson.otp.erlang.OtpErlangObject;
 import com.intellij.extapi.psi.ASTWrapperPsiElement;
 import com.intellij.lang.ASTNode;
+import com.intellij.navigation.ItemPresentation;
 import com.intellij.psi.PsiElementVisitor;
 import org.elixir_lang.psi.ElixirIdentifier;
 import org.elixir_lang.psi.ElixirVisitor;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public class ElixirIdentifierImpl extends ASTWrapperPsiElement implements ElixirIdentifier {
 
@@ -22,6 +24,11 @@ public class ElixirIdentifierImpl extends ASTWrapperPsiElement implements Elixir
   public void accept(@NotNull PsiElementVisitor visitor) {
     if (visitor instanceof ElixirVisitor) accept((ElixirVisitor)visitor);
     else super.accept(visitor);
+  }
+
+  @Nullable
+  public ItemPresentation getPresentation() {
+    return ElixirPsiImplUtil.getPresentation(this);
   }
 
   @NotNull

--- a/src/META-INF/plugin.xml
+++ b/src/META-INF/plugin.xml
@@ -1762,6 +1762,8 @@
     <annotator implementationClass="org.elixir_lang.annonator.Map" language="Elixir"/>
     <annotator implementationClass="org.elixir_lang.annonator.ModuleAttribute" language="Elixir"/>
 
+    <completion.contributor implementationClass="org.elixir_lang.codeInsight.completion.contributor.CallDefinitionClause" language="Elixir"/>
+
     <codeInsight.lineMarkerProvider implementationClass="org.elixir_lang.code_insight.line_marker_provider.CallDefinition" language="Elixir"/>
     <elementDescriptionProvider implementation="org.elixir_lang.psi.ElementDescriptionProvider"/>
     <gotoSymbolContributor implementation="org.elixir_lang.navigation.GotoSymbolContributor"/>

--- a/src/org/elixir_lang/Elixir.bnf
+++ b/src/org/elixir_lang/Elixir.bnf
@@ -435,7 +435,13 @@ private noParenthesesManyArgumentsStrict ::= noParenthesesManyArguments |
 
 // A rule instead of a token so that there is a PsiElement to return from getNameIdentifier
 identifier ::= IDENTIFIER_TOKEN
-               { implements = "org.elixir_lang.psi.Quotable" methods = [quote] }
+               {
+                 implements = "org.elixir_lang.psi.Quotable"
+                 methods = [
+                   getPresentation
+                   quote
+                 ]
+               }
 
 // @see https://github.com/elixir-lang/elixir/blob/de39bbaca277002797e52ffbde617ace06233a2b/lib/elixir/src/elixir_parser.yrl#L124-L125
 unqualifiedNoParenthesesManyArgumentsCall ::= identifier !KEYWORD_PAIR_COLON

--- a/src/org/elixir_lang/Elixir.bnf
+++ b/src/org/elixir_lang/Elixir.bnf
@@ -2186,7 +2186,15 @@ stab ::= stabOperation (endOfExpression stabOperation)* |
 anonymousFunction ::= FN endOfExpression?
                       stab endOfExpression?
                       END
-                      { implements = "org.elixir_lang.psi.Quotable" methods = [quote] }
+                      {
+                        implements = [
+                          "com.intellij.psi.NavigatablePsiElement"
+                          "org.elixir_lang.psi.Quotable"
+                        ]
+                        methods = [
+                          quote
+                        ]
+                      }
 
 // @see https://github.com/elixir-lang/elixir/blob/de39bbaca277002797e52ffbde617ace06233a2b/lib/elixir/src/elixir_parser.yrl#L206-L210
 parentheticalStab ::= OPENING_PARENTHESIS EOL*

--- a/src/org/elixir_lang/ElixirSyntaxHighlighter.java
+++ b/src/org/elixir_lang/ElixirSyntaxHighlighter.java
@@ -98,6 +98,11 @@ public class ElixirSyntaxHighlighter extends SyntaxHighlighterBase {
             DefaultLanguageHighlighterColors.FUNCTION_CALL
     );
 
+    public static final TextAttributesKey FUNCTION_DECLARATION = createTextAttributesKey(
+            "ELIXIR_FUNCTION_DECLARATION",
+            DefaultLanguageHighlighterColors.FUNCTION_DECLARATION
+    );
+
     public static final TextAttributesKey IDENTIFIER = createTextAttributesKey(
             "ELIXIR_IDENTIFIER",
             DefaultLanguageHighlighterColors.IDENTIFIER
@@ -116,6 +121,11 @@ public class ElixirSyntaxHighlighter extends SyntaxHighlighterBase {
     public static final TextAttributesKey MACRO_CALL = createTextAttributesKey(
             "ELIXIR_MACRO_CALL",
             FUNCTION_CALL
+    );
+
+    public static final TextAttributesKey MACRO_DECLARATION = createTextAttributesKey(
+            "ELIXIR_MACRO_DECLARATION",
+            FUNCTION_DECLARATION
     );
 
     public static final TextAttributesKey MAP = createTextAttributesKey(

--- a/src/org/elixir_lang/annonator/Parameter.java
+++ b/src/org/elixir_lang/annonator/Parameter.java
@@ -1,0 +1,107 @@
+package org.elixir_lang.annonator;
+
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
+import org.elixir_lang.errorreport.Logger;
+import org.elixir_lang.psi.*;
+import org.elixir_lang.psi.call.Call;
+import org.elixir_lang.psi.operation.InMatch;
+import org.elixir_lang.structure_view.element.CallDefinitionClause;
+import org.elixir_lang.structure_view.element.Delegation;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class Parameter {
+    public static enum Type {
+        FUNCTION_NAME,
+        MACRO_NAME,
+        VARIABLE
+    }
+
+    @Contract(pure = true)
+    @Nullable
+    public static Type type(@NotNull PsiElement ancestor) {
+        PsiElement parent = ancestor.getParent();
+        Type type = null;
+
+        if (parent instanceof Call) {
+            type = type((Call) parent);
+        } else if (parent instanceof AtNonNumericOperation ||
+                parent instanceof ElixirAccessExpression ||
+                parent instanceof ElixirAssociations ||
+                parent instanceof ElixirAssociationsBase ||
+                parent instanceof ElixirBitString ||
+                parent instanceof ElixirBracketArguments ||
+                parent instanceof ElixirContainerAssociationOperation ||
+                parent instanceof ElixirKeywordPair ||
+                parent instanceof ElixirKeywords ||
+                parent instanceof ElixirList ||
+                parent instanceof ElixirMapArguments ||
+                parent instanceof ElixirMapConstructionArguments ||
+                parent instanceof ElixirMapOperation ||
+                parent instanceof ElixirMatchedParenthesesArguments ||
+                parent instanceof ElixirNoParenthesesArguments ||
+                parent instanceof ElixirNoParenthesesKeywordPair ||
+                parent instanceof ElixirNoParenthesesKeywords ||
+                /* ElixirNoParenthesesManyStrictNoParenthesesExpression indicates a syntax error where no parentheses
+                   calls are nested, so it's invalid, but try to still resolve parameters to have highlighting */
+                parent instanceof ElixirNoParenthesesManyStrictNoParenthesesExpression ||
+                parent instanceof ElixirNoParenthesesOneArgument ||
+                /* handles `(conn, %{})` in `def (conn, %{})`, which can occur in def templates.
+                   See https://github.com/KronicDeth/intellij-elixir/issues/367#issuecomment-244214975 */
+                parent instanceof ElixirNoParenthesesStrict ||
+                parent instanceof ElixirParenthesesArguments ||
+                parent instanceof ElixirParentheticalStab ||
+                parent instanceof ElixirStab ||
+                parent instanceof ElixirStabNoParenthesesSignature ||
+                parent instanceof ElixirStabBody ||
+                parent instanceof ElixirStabOperation ||
+                parent instanceof ElixirStabParenthesesSignature ||
+                parent instanceof ElixirStructOperation ||
+                parent instanceof ElixirTuple) {
+            type = type(parent);
+        } else if (parent instanceof ElixirAnonymousFunction || parent instanceof InMatch) {
+            type = Type.VARIABLE;
+        } else {
+            if (!(parent instanceof BracketOperation ||
+                    parent instanceof ElixirBlockItem ||
+                    parent instanceof ElixirDoBlock ||
+                    parent instanceof ElixirInterpolation ||
+                    parent instanceof ElixirMapUpdateArguments ||
+                    parent instanceof ElixirQuoteStringBody ||
+                    parent instanceof PsiFile ||
+                    parent instanceof QualifiedAlias ||
+                    parent instanceof QualifiedMultipleAliases)) {
+                error("Don't know how to check if parameter", parent);
+            }
+        }
+
+        return type;
+    }
+
+    /*
+     * Private Static Methods
+     */
+
+    private static void error(@NotNull String message, @NotNull PsiElement element) {
+        Logger.error(Parameter.class, message + " (when element class is " + element.getClass().getName() + ")", element);
+    }
+
+    private static Type type(@NotNull Call call) {
+        Type type;
+
+        if (CallDefinitionClause.isFunction(call) || Delegation.is(call)) {
+            type = Type.FUNCTION_NAME;
+        } else if (CallDefinitionClause.isMacro(call)) {
+            type = Type.MACRO_NAME;
+        } else if (call.hasDoBlockOrKeyword()) {
+            type = Type.VARIABLE;
+        } else {
+            // use generic handling, so that parent is checked
+            type = type((PsiElement) call);
+        }
+
+        return type;
+    }
+}

--- a/src/org/elixir_lang/codeInsight/completion/contributor/CallDefinitionClause.java
+++ b/src/org/elixir_lang/codeInsight/completion/contributor/CallDefinitionClause.java
@@ -1,0 +1,18 @@
+package org.elixir_lang.codeInsight.completion.contributor;
+
+import com.intellij.codeInsight.completion.CompletionContributor;
+import com.intellij.codeInsight.completion.CompletionType;
+import org.elixir_lang.psi.ElixirFile;
+
+import static com.intellij.patterns.PlatformPatterns.psiElement;
+import static com.intellij.patterns.StandardPatterns.instanceOf;
+
+public class CallDefinitionClause extends CompletionContributor {
+    public CallDefinitionClause() {
+        extend(
+                CompletionType.BASIC,
+                psiElement().inFile(instanceOf(ElixirFile.class)).afterLeaf("."),
+                new org.elixir_lang.codeInsight.completion.provider.CallDefinitionClause()
+        );
+    }
+}

--- a/src/org/elixir_lang/codeInsight/completion/insert_handler/CallDefinitionClause.java
+++ b/src/org/elixir_lang/codeInsight/completion/insert_handler/CallDefinitionClause.java
@@ -1,0 +1,36 @@
+package org.elixir_lang.codeInsight.completion.insert_handler;
+
+import com.intellij.codeInsight.completion.InsertHandler;
+import com.intellij.codeInsight.completion.InsertionContext;
+import com.intellij.codeInsight.lookup.LookupElement;
+import com.intellij.openapi.util.TextRange;
+import org.jetbrains.annotations.NotNull;
+
+public class CallDefinitionClause implements InsertHandler<LookupElement> {
+    /*
+     * CONSTANTS
+     */
+
+    public static final InsertHandler<LookupElement> INSTANCE =
+            new org.elixir_lang.codeInsight.completion.insert_handler.CallDefinitionClause();
+
+    /*
+     * Public Instance Methods
+     */
+
+    @Override
+    public void handleInsert(@NotNull InsertionContext context,
+                             @NotNull LookupElement item) {
+        int tailOffset = context.getTailOffset();
+        String currentTail = context.getDocument().getText(
+                new TextRange(tailOffset, tailOffset + 1)
+        );
+        char firstChar = currentTail.charAt(0);
+
+        if (firstChar != ' ' && firstChar != '(' && firstChar != '[') {
+            context.getDocument().insertString(tailOffset, "()");
+            // + 1 to put between the `(`  and `)`
+            context.getEditor().getCaretModel().moveToOffset(tailOffset + 1);
+        }
+    }
+}

--- a/src/org/elixir_lang/codeInsight/completion/provider/CallDefinitionClause.java
+++ b/src/org/elixir_lang/codeInsight/completion/provider/CallDefinitionClause.java
@@ -1,0 +1,208 @@
+package org.elixir_lang.codeInsight.completion.provider;
+
+import com.intellij.codeInsight.completion.CompletionParameters;
+import com.intellij.codeInsight.completion.CompletionProvider;
+import com.intellij.codeInsight.completion.CompletionResultSet;
+import com.intellij.codeInsight.lookup.LookupElement;
+import com.intellij.openapi.util.Pair;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiPolyVariantReference;
+import com.intellij.psi.PsiReference;
+import com.intellij.psi.ResolveResult;
+import com.intellij.util.ProcessingContext;
+import org.apache.commons.lang.math.IntRange;
+import org.elixir_lang.psi.ElixirAccessExpression;
+import org.elixir_lang.psi.ElixirDotInfixOperator;
+import org.elixir_lang.psi.QualifiableAlias;
+import org.elixir_lang.psi.call.Call;
+import org.elixir_lang.psi.stub.type.call.Stub;
+import org.elixir_lang.reference.Module;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.elixir_lang.psi.impl.ElixirPsiImplUtil.macroChildCalls;
+import static org.elixir_lang.psi.operation.Normalized.operatorIndex;
+import static org.elixir_lang.psi.operation.infix.Normalized.leftOperand;
+import static org.elixir_lang.structure_view.element.CallDefinitionClause.nameArityRange;
+
+public class CallDefinitionClause extends CompletionProvider<CompletionParameters> {
+    /*
+     * Private Instance Methods
+     */
+
+    @NotNull
+    private static Iterable<LookupElement> callDefinitionClauseLookupElements(@NotNull Call scope) {
+        Call[] childCalls = macroChildCalls(scope);
+        List<LookupElement> lookupElementList = null;
+
+        if (childCalls != null && childCalls.length > 0) {
+            for (Call childCall : childCalls) {
+                if (org.elixir_lang.structure_view.element.CallDefinitionClause.is(childCall)) {
+                    Pair<String, IntRange> nameArityRange = nameArityRange(childCall);
+
+                    if (nameArityRange != null) {
+                        String name = nameArityRange.first;
+
+                        if (name != null) {
+                            if (lookupElementList == null) {
+                                lookupElementList = new ArrayList<LookupElement>();
+                            }
+
+                            lookupElementList.add(
+                                    org.elixir_lang.codeInsight.lookup.element.CallDefinitionClause.createWithSmartPointer(
+                                            nameArityRange.first,
+                                            childCall
+                                    )
+                            );
+                        }
+                    }
+                }
+            }
+        }
+
+        if (lookupElementList == null) {
+            lookupElementList = Collections.emptyList();
+        }
+
+        return lookupElementList;
+    }
+
+    @NotNull
+    private static Iterable<LookupElement> callDefinitionClauseLookupElements(@NotNull PsiElement scope) {
+        Iterable<LookupElement> lookupElementIterable;
+
+        if (scope instanceof Call) {
+            lookupElementIterable = callDefinitionClauseLookupElements((Call) scope);
+        } else {
+            lookupElementIterable = Collections.emptyList();
+        }
+
+        return lookupElementIterable;
+    }
+
+    @NotNull
+    private static PsiElement resolveFully(@NotNull PsiElement element, @Nullable PsiReference startingReference) {
+        PsiElement fullyResolved;
+        PsiElement currentResolved = element;
+        PsiReference reference = startingReference;
+
+        do {
+            if (reference == null) {
+                reference = currentResolved.getReference();
+            }
+
+            if (reference != null) {
+                if (reference instanceof PsiPolyVariantReference) {
+                    PsiPolyVariantReference polyVariantReference = (PsiPolyVariantReference) reference;
+                    ResolveResult[] resolveResults = polyVariantReference.multiResolve(false);
+                    int resolveResultCount = resolveResults.length;
+
+                    if (resolveResultCount == 0) {
+                        fullyResolved = currentResolved;
+
+                        break;
+                    } else if (resolveResultCount == 1) {
+                        ResolveResult resolveResult = resolveResults[0];
+
+                        PsiElement nextResolved = resolveResult.getElement();
+
+                        if (nextResolved == null || nextResolved.isEquivalentTo(currentResolved)) {
+                            fullyResolved = currentResolved;
+                            break;
+                        } else {
+                            currentResolved = nextResolved;
+                        }
+                    } else {
+                        PsiElement nextResolved = null;
+
+                        for (ResolveResult resolveResult : resolveResults) {
+                            PsiElement resolveResultElement = resolveResult.getElement();
+
+                            if (resolveResultElement != null &&
+                                    resolveResultElement instanceof Call &&
+                                    Stub.isModular((Call) resolveResultElement)) {
+                                nextResolved = resolveResultElement;
+
+                                break;
+                            }
+                        }
+
+                        if (nextResolved == null || nextResolved.isEquivalentTo(currentResolved)) {
+                            fullyResolved = currentResolved;
+                            break;
+                        } else {
+                            currentResolved = nextResolved;
+                        }
+                    }
+                } else {
+                    PsiElement nextResolved = reference.resolve();
+
+                    if (nextResolved == null || nextResolved.isEquivalentTo(currentResolved)) {
+                        fullyResolved = currentResolved;
+                        break;
+                    } else {
+                        currentResolved = nextResolved;
+                    }
+                }
+            } else {
+                fullyResolved = currentResolved;
+
+                break;
+            }
+
+            reference = null;
+        } while (true);
+
+        return fullyResolved;
+    }
+
+    /*
+     * Protected Instance Methods
+     */
+
+    @Override
+    protected void addCompletions(@NotNull CompletionParameters parameters,
+                                  ProcessingContext context,
+                                  @NotNull CompletionResultSet resultSet) {
+        PsiElement originalPosition = parameters.getOriginalPosition();
+        PsiElement originalParent = null;
+
+        if (originalPosition != null) {
+            originalParent = originalPosition.getParent();
+
+            if (originalParent instanceof ElixirDotInfixOperator) {
+                PsiElement grandParent = originalParent.getParent();
+                PsiElement[] grandParentChildren = grandParent.getChildren();
+                int operatorIndex = operatorIndex(grandParentChildren);
+                PsiElement leftOperand = leftOperand(grandParentChildren, operatorIndex);
+                PsiElement qualifier = leftOperand;
+
+                if (qualifier instanceof ElixirAccessExpression) {
+                    PsiElement[] accessExpressionChildren = leftOperand.getChildren();
+
+                    if (accessExpressionChildren.length > 0) {
+                        qualifier = accessExpressionChildren[0];
+                    }
+                }
+
+                if (qualifier instanceof QualifiableAlias) {
+                                        /* need to construct reference directly as qualified aliases don't return a
+                                           reference except for the outermost */
+                    PsiPolyVariantReference reference = new Module(
+                            (QualifiableAlias) qualifier
+                    );
+                    PsiElement fullyResolved = resolveFully(qualifier, reference);
+
+                    resultSet.withPrefixMatcher("").addAllElements(
+                            callDefinitionClauseLookupElements(fullyResolved)
+                    );
+                }
+
+            }
+        }
+    }
+}

--- a/src/org/elixir_lang/codeInsight/lookup/element/CallDefinitionClause.java
+++ b/src/org/elixir_lang/codeInsight/lookup/element/CallDefinitionClause.java
@@ -1,0 +1,22 @@
+package org.elixir_lang.codeInsight.lookup.element;
+
+import com.intellij.codeInsight.lookup.LookupElement;
+import com.intellij.codeInsight.lookup.LookupElementBuilder;
+import com.intellij.psi.PsiElement;
+import org.jetbrains.annotations.NotNull;
+
+public class CallDefinitionClause {
+    @NotNull
+    public static LookupElement createWithSmartPointer(@NotNull String name, @NotNull PsiElement element) {
+        return LookupElementBuilder.createWithSmartPointer(
+                name,
+                element
+        ).withInsertHandler(
+                org.elixir_lang.codeInsight.completion.insert_handler.CallDefinitionClause.INSTANCE
+        ).withRenderer(
+                new org.elixir_lang.codeInsight.lookup.element_renderer.CallDefinitionClause(
+                        name
+                )
+        );
+    }
+}

--- a/src/org/elixir_lang/codeInsight/lookup/element_renderer/CallDefinitionClause.java
+++ b/src/org/elixir_lang/codeInsight/lookup/element_renderer/CallDefinitionClause.java
@@ -1,0 +1,77 @@
+package org.elixir_lang.codeInsight.lookup.element_renderer;
+
+import com.intellij.codeInsight.lookup.LookupElement;
+import com.intellij.codeInsight.lookup.LookupElementPresentation;
+import com.intellij.navigation.ItemPresentation;
+import com.intellij.openapi.util.TextRange;
+import com.intellij.psi.PsiElement;
+import com.intellij.ui.JBColor;
+import org.elixir_lang.ElixirSyntaxHighlighter;
+import org.elixir_lang.annonator.Parameter;
+import org.elixir_lang.icons.ElixirIcons;
+import org.elixir_lang.psi.call.Call;
+import org.elixir_lang.psi.operation.InMatch;
+import org.elixir_lang.psi.operation.Match;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.*;
+import java.awt.*;
+
+import static org.elixir_lang.reference.Callable.*;
+import static org.elixir_lang.structure_view.element.CallDefinitionClause.head;
+
+public class CallDefinitionClause extends com.intellij.codeInsight.lookup.LookupElementRenderer<LookupElement> {
+    /*
+     * Fields
+     */
+
+    @NotNull
+    private final String name;
+
+    /*
+     * Constructors
+     */
+
+    public CallDefinitionClause(@NotNull String name) {
+        this.name = name;
+    }
+
+    /*
+     * Public Instance Methods
+     */
+
+    @Override
+    public void renderElement(LookupElement element, LookupElementPresentation presentation) {
+        presentation.setItemText(name);
+        presentation.setItemTextBold(true);
+
+        PsiElement psiElement = element.getPsiElement();
+
+        assert psiElement != null;
+
+        if (psiElement instanceof Call) {
+            Call call = (Call) psiElement;
+
+            if (org.elixir_lang.structure_view.element.CallDefinitionClause.is(call)) {
+                org.elixir_lang.structure_view.element.CallDefinitionClause structureView =
+                        new org.elixir_lang.structure_view.element.CallDefinitionClause(call);
+                ItemPresentation structureViewPresentation = structureView.getPresentation();
+
+                presentation.setIcon(structureViewPresentation.getIcon(true));
+                String presentableText = structureViewPresentation.getPresentableText();
+
+                if (presentableText != null) {
+                    presentation.appendTailText(presentableText.substring(name.length()), true);
+                }
+
+                String locationString = structureViewPresentation.getLocationString();
+
+                if (locationString != null) {
+                    presentation.appendTailText(" (" + locationString + ")", false);
+                }
+            }
+        }
+    }
+}

--- a/src/org/elixir_lang/codeInsight/lookup/element_renderer/Variable.java
+++ b/src/org/elixir_lang/codeInsight/lookup/element_renderer/Variable.java
@@ -1,0 +1,138 @@
+package org.elixir_lang.codeInsight.lookup.element_renderer;
+
+import com.intellij.codeInsight.lookup.LookupElement;
+import com.intellij.codeInsight.lookup.LookupElementPresentation;
+import com.intellij.openapi.util.TextRange;
+import com.intellij.psi.PsiElement;
+import com.intellij.ui.JBColor;
+import org.elixir_lang.ElixirSyntaxHighlighter;
+import org.elixir_lang.annonator.Parameter;
+import org.elixir_lang.icons.ElixirIcons;
+import org.elixir_lang.psi.operation.InMatch;
+import org.elixir_lang.psi.operation.Match;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.*;
+import java.awt.*;
+
+import static org.elixir_lang.reference.Callable.isIgnored;
+import static org.elixir_lang.reference.Callable.isParameterWithDefault;
+import static org.elixir_lang.reference.Callable.isVariable;
+
+public class Variable extends com.intellij.codeInsight.lookup.LookupElementRenderer<LookupElement> {
+    /*
+     * Fields
+     */
+
+    @NotNull
+    private final String name;
+
+    /*
+     * Constructors
+     */
+
+    public Variable(@NotNull String name) {
+        this.name = name;
+    }
+
+    /*
+     * Public Instance Methods
+     */
+
+    @Override
+    public void renderElement(LookupElement element, LookupElementPresentation presentation) {
+        presentation.setItemText(name);
+        presentation.setItemTextBold(true);
+
+        PsiElement psiElement = element.getPsiElement();
+
+        assert psiElement != null;
+
+        presentation.setIcon(icon(psiElement));
+        presentation.setItemTextForeground(color(psiElement));
+
+        TextRange psiElementTextRange = psiElement.getTextRange();
+        PsiElement enclosingMatch = enclosingMatch(psiElement);
+        TextRange enclosingMatchTextRange = enclosingMatch.getTextRange();
+        String enclosingMatchText = enclosingMatch.getText();
+
+        int enclosingMatchTextRangeStartOffset = enclosingMatchTextRange.getStartOffset();
+        int itemStartOffset = psiElementTextRange.getStartOffset() - enclosingMatchTextRangeStartOffset;
+        String prefix = enclosingMatchText.substring(0, itemStartOffset);
+        presentation.appendTailText(prefix, true);
+
+        int itemEndOffset = psiElementTextRange.getEndOffset() - enclosingMatchTextRangeStartOffset;
+        String item = enclosingMatchText.substring(itemStartOffset, itemEndOffset);
+        presentation.appendTailText(item, false);
+
+        String suffix = enclosingMatchText.substring(
+                itemEndOffset,
+                enclosingMatchTextRange.getEndOffset() - enclosingMatchTextRangeStartOffset
+        );
+        presentation.appendTailText(suffix, true);
+    }
+
+    /*
+     * Private Instance Methods
+     */
+
+
+    @Contract(pure = true)
+    @NotNull
+    private Color color(@NotNull final PsiElement element) {
+        Color color = JBColor.foreground();
+
+        if (isIgnored(element)) {
+            color = ElixirSyntaxHighlighter.IGNORED_VARIABLE.getDefaultAttributes().getForegroundColor();
+        } else {
+            Parameter parameter = new Parameter(element);
+            Parameter.Type parameterType = Parameter.putParameterized(parameter).type;
+
+            if (parameterType != null) {
+                if (parameterType == Parameter.Type.VARIABLE) {
+                    color = ElixirSyntaxHighlighter.PARAMETER.getDefaultAttributes().getForegroundColor();
+                }
+            } else if (isParameterWithDefault(element)) {
+                color = ElixirSyntaxHighlighter.PARAMETER.getDefaultAttributes().getForegroundColor();
+            } else if (isVariable(element)) {
+                color = ElixirSyntaxHighlighter.VARIABLE.getDefaultAttributes().getForegroundColor();
+            }
+        }
+
+        return color;
+    }
+
+    @Contract(pure = true)
+    @NotNull
+    private PsiElement enclosingMatch(@NotNull final PsiElement ancestor) {
+        PsiElement enclosingMatch = ancestor;
+        PsiElement parent = ancestor.getParent();
+
+        if (parent instanceof InMatch || parent instanceof Match) {
+            enclosingMatch = parent;
+        } else {
+            assert ancestor != null;
+        }
+
+        return enclosingMatch;
+    }
+
+    @Contract(pure = true)
+    @Nullable
+    private Icon icon(@NotNull PsiElement element) {
+        Icon icon = null;
+
+        Parameter parameter = new Parameter(element);
+        Parameter.Type parameterType = Parameter.putParameterized(parameter).type;
+
+        if (parameterType != null) {
+            icon = ElixirIcons.PARAMETER;
+        } else {
+            icon = ElixirIcons.VARIABLE;
+        }
+
+        return icon;
+    }
+}

--- a/src/org/elixir_lang/icons/ElixirIcons.java
+++ b/src/org/elixir_lang/icons/ElixirIcons.java
@@ -93,6 +93,7 @@ public interface ElixirIcons {
     Icon MODULE = PlatformIcons.PACKAGE_ICON;
     Icon OVERRIDABLE = AllIcons.General.OverridenMethod;
     Icon OVERRIDE = AllIcons.General.OverridingMethod;
+    Icon PARAMETER = AllIcons.Nodes.Parameter;
     Icon PROTOCOL = RowIconFactory.create(PlatformIcons.ANONYMOUS_CLASS_ICON, AllIcons.General.OverridenMethod);
     Icon STRUCTURE = AllIcons.Toolwindows.ToolWindowStructure;
     // same icon as intellij-erlang to match their look and feel
@@ -103,6 +104,8 @@ public interface ElixirIcons {
 
     // it is the unknown that is only a question mark
     Icon UNKNOWN = AllIcons.RunConfigurations.Unknown;
+
+    Icon VARIABLE = AllIcons.Nodes.Variable;
 
     Icon ELIXIR_APPLICATION = IconLoader.getIcon("/icons/elixir-Application-16.png");
     Icon ELIXIR_SUPERVISOR = IconLoader.getIcon("/icons/elixir-Supervisor-16.png");

--- a/src/org/elixir_lang/navigation/item_presentation/CallDefinitionHead.java
+++ b/src/org/elixir_lang/navigation/item_presentation/CallDefinitionHead.java
@@ -87,6 +87,9 @@ public class CallDefinitionHead implements ItemPresentation {
     @NotNull
     @Override
     public String getPresentableText() {
-        return psiElement.getText();
+        return psiElement.getText()
+                .replaceAll("\\s+", " ")
+                .replaceAll("([\\[(]) ?", "$1")
+                .replaceAll(" ?(\\]|\\))", "$1");
     }
 }

--- a/src/org/elixir_lang/psi/ElementDescriptionProvider.java
+++ b/src/org/elixir_lang/psi/ElementDescriptionProvider.java
@@ -67,7 +67,8 @@ public class ElementDescriptionProvider implements com.intellij.psi.ElementDescr
     private String getElementDescription(@NotNull ElixirIdentifier identifier, @NotNull ElementDescriptionLocation location) {
         String elementDescription = null;
 
-        Parameter.Type type = Parameter.type(identifier);
+        Parameter parameter = new Parameter(identifier);
+        Parameter.Type type = Parameter.putParameterized(parameter).type;
 
         if (type == Parameter.Type.FUNCTION_NAME) {
             if (location == UsageViewShortNameLocation.INSTANCE) {

--- a/src/org/elixir_lang/psi/ElementDescriptionProvider.java
+++ b/src/org/elixir_lang/psi/ElementDescriptionProvider.java
@@ -6,6 +6,7 @@ import com.intellij.psi.PsiElement;
 import com.intellij.usageView.UsageViewLongNameLocation;
 import com.intellij.usageView.UsageViewShortNameLocation;
 import com.intellij.usageView.UsageViewTypeLocation;
+import org.elixir_lang.annonator.Parameter;
 import org.elixir_lang.psi.call.Call;
 import org.elixir_lang.reference.Callable;
 import org.elixir_lang.structure_view.element.*;
@@ -47,11 +48,12 @@ public class ElementDescriptionProvider implements com.intellij.psi.ElementDescr
 
         if (element instanceof Call) {
             elementDescription = getElementDescription((Call) element, location);
+        } else if (element instanceof ElixirIdentifier) {
+            elementDescription = getElementDescription((ElixirIdentifier) element, location);
         } else if (element instanceof ElixirKeywordKey) {
             elementDescription = getElementDescription((ElixirKeywordKey) element, location);
         } else if (element instanceof MaybeModuleName) {
             elementDescription = getElementDescription((MaybeModuleName) element, location);
-
         }
 
         return elementDescription;
@@ -60,6 +62,29 @@ public class ElementDescriptionProvider implements com.intellij.psi.ElementDescr
     /*
      * Private Instance Methods
      */
+
+    @Nullable
+    private String getElementDescription(@NotNull ElixirIdentifier identifier, @NotNull ElementDescriptionLocation location) {
+        String elementDescription = null;
+
+        Parameter.Type type = Parameter.type(identifier);
+
+        if (type == Parameter.Type.FUNCTION_NAME) {
+            if (location == UsageViewShortNameLocation.INSTANCE) {
+                elementDescription = identifier.getText();
+            } else if (location == UsageViewTypeLocation.INSTANCE) {
+                elementDescription = "function";
+            }
+        } else if (type == Parameter.Type.MACRO_NAME) {
+            if (location == UsageViewShortNameLocation.INSTANCE) {
+                elementDescription = identifier.getText();
+            } else if (location == UsageViewTypeLocation.INSTANCE) {
+                elementDescription = "macro";
+            }
+        }
+
+        return elementDescription;
+    }
 
     @Nullable
     private String getElementDescription(@NotNull ElixirKeywordKey keywordKey,

--- a/src/org/elixir_lang/psi/impl/ElixirPsiImplUtil.java
+++ b/src/org/elixir_lang/psi/impl/ElixirPsiImplUtil.java
@@ -25,7 +25,9 @@ import org.apache.commons.lang.NotImplementedException;
 import org.apache.commons.lang.math.IntRange;
 import org.elixir_lang.ElixirLanguage;
 import org.elixir_lang.Macro;
+import org.elixir_lang.annonator.Parameter;
 import org.elixir_lang.psi.*;
+import org.elixir_lang.psi.Quote;
 import org.elixir_lang.psi.call.Call;
 import org.elixir_lang.psi.call.StubBased;
 import org.elixir_lang.psi.call.arguments.star.NoParentheses;
@@ -35,15 +37,13 @@ import org.elixir_lang.psi.call.arguments.star.Parentheses;
 import org.elixir_lang.psi.call.name.Function;
 import org.elixir_lang.psi.operation.*;
 import org.elixir_lang.psi.operation.Normalized;
+import org.elixir_lang.psi.operation.Type;
 import org.elixir_lang.psi.operation.infix.*;
 import org.elixir_lang.psi.qualification.Qualified;
 import org.elixir_lang.psi.qualification.Unqualified;
 import org.elixir_lang.psi.stub.call.Stub;
 import org.elixir_lang.reference.Callable;
-import org.elixir_lang.structure_view.element.CallDefinitionClause;
-import org.elixir_lang.structure_view.element.CallDefinitionSpecification;
-import org.elixir_lang.structure_view.element.Callback;
-import org.elixir_lang.structure_view.element.Delegation;
+import org.elixir_lang.structure_view.element.*;
 import org.elixir_lang.structure_view.element.modular.Implementation;
 import org.elixir_lang.structure_view.element.modular.Module;
 import org.elixir_lang.structure_view.element.modular.Protocol;
@@ -2772,6 +2772,26 @@ public class ElixirPsiImplUtil {
                 return call.getIcon(0);
             }
         };
+    }
+
+    @Contract(pure = true)
+    @Nullable
+    public static ItemPresentation getPresentation(@NotNull final ElixirIdentifier identifier) {
+        Parameter parameter = new Parameter(identifier);
+        Parameter parameterizedParameter = Parameter.putParameterized(parameter);
+        ItemPresentation itemPresentation = null;
+
+        if ((parameterizedParameter.type == Parameter.Type.FUNCTION_NAME ||
+                parameterizedParameter.type == Parameter.Type.MACRO_NAME) &&
+                parameterizedParameter.parameterized != null) {
+            final NavigatablePsiElement parameterized = parameterizedParameter.parameterized;
+
+            if (parameterized instanceof Call) {
+                itemPresentation = new CallDefinitionClause((Call) parameterized).getPresentation();
+            }
+        }
+
+        return itemPresentation;
     }
 
     @Nullable

--- a/src/org/elixir_lang/psi/scope/CallDefinitionClause.java
+++ b/src/org/elixir_lang/psi/scope/CallDefinitionClause.java
@@ -1,0 +1,90 @@
+package org.elixir_lang.psi.scope;
+
+import com.intellij.openapi.util.Key;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.ResolveState;
+import com.intellij.psi.scope.PsiScopeProcessor;
+import org.elixir_lang.psi.call.Call;
+import org.elixir_lang.structure_view.element.modular.Module;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import static org.elixir_lang.psi.impl.ElixirPsiImplUtil.macroChildCalls;
+
+public abstract class CallDefinitionClause implements PsiScopeProcessor {
+    /*
+     * Public Instance Methods
+     */
+
+    /**
+     * @param element candidate element.
+     * @param state   current state of resolver.
+     * @return false to stop processing.
+     */
+    @Override
+    public boolean execute(@NotNull PsiElement element, @NotNull ResolveState state) {
+        boolean keepProcessing = true;
+
+        if (element instanceof Call) {
+            keepProcessing = execute((Call) element, state);
+        }
+
+        return keepProcessing;
+    }
+
+    @Nullable
+    @Override
+    public <T> T getHint(@NotNull Key<T> hintKey) {
+        return null;
+    }
+
+    @Override
+    public void handleEvent(@NotNull Event event, @Nullable Object associated) {
+    }
+
+    /*
+     * Protected Instance Methods
+     */
+
+    /**
+     * Called on every {@link Call} where {@link org.elixir_lang.structure_view.element.CallDefinitionClause#is} is
+     * {@code true} when checking tree with {@link #execute(Call, ResolveState)}
+     *
+     * @return {@code true} to keep searching up tree; {@code false} to stop searching.
+     */
+    protected abstract boolean executeOnCallDefinitionClause(Call element, ResolveState state);
+
+    /**
+     * Whether to continue searching after each Module's children have been searched.
+     * @return {@code true} to keep searching up the PSI tree; {@code false} to stop searching.
+     */
+    protected abstract boolean keepProcessing();
+
+    /*
+     * Private Instance Methods
+     */
+
+    private boolean execute(@NotNull Call element, @NotNull ResolveState state) {
+        boolean keepProcessing = true;
+
+        if (org.elixir_lang.structure_view.element.CallDefinitionClause.is(element)) {
+            keepProcessing = executeOnCallDefinitionClause(element, state);
+        } else if (Module.is(element)) {
+            Call[] childCalls = macroChildCalls(element);
+
+            if (childCalls != null) {
+                for (Call childCall : childCalls) {
+                    if(!execute(childCall, state)) {
+                        break;
+                    }
+                }
+            }
+
+            // Only check MultiResolve.keepProcessing at the end of a Module to all multiple arities
+            keepProcessing = keepProcessing();
+        }
+
+        return keepProcessing;
+    }
+
+}

--- a/src/org/elixir_lang/psi/scope/Variable.java
+++ b/src/org/elixir_lang/psi/scope/Variable.java
@@ -210,8 +210,8 @@ public abstract class Variable implements PsiScopeProcessor {
     private boolean execute(@NotNull final Call match, @NotNull ResolveState state) {
         boolean keepProcessing = true;
 
-        if (CallDefinitionClause.is(match)) {
-            PsiElement head = CallDefinitionClause.head(match);
+        if (org.elixir_lang.structure_view.element.CallDefinitionClause.is(match)) {
+            PsiElement head = org.elixir_lang.structure_view.element.CallDefinitionClause.head(match);
 
             if (head != null) {
                 PsiElement stripped = CallDefinitionHead.strip(head);

--- a/src/org/elixir_lang/psi/scope/call_definition_clause/MultiResolve.java
+++ b/src/org/elixir_lang/psi/scope/call_definition_clause/MultiResolve.java
@@ -1,0 +1,170 @@
+package org.elixir_lang.psi.scope.call_definition_clause;
+
+import com.intellij.openapi.util.Key;
+import com.intellij.openapi.util.Pair;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiElementResolveResult;
+import com.intellij.psi.ResolveResult;
+import com.intellij.psi.ResolveState;
+import com.intellij.psi.scope.PsiScopeProcessor;
+import com.intellij.psi.util.PsiTreeUtil;
+import org.apache.commons.lang.math.IntRange;
+import org.elixir_lang.psi.call.Call;
+import org.elixir_lang.psi.call.Named;
+import org.elixir_lang.structure_view.element.CallDefinitionClause;
+import org.elixir_lang.structure_view.element.modular.Module;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+
+import static org.elixir_lang.psi.impl.ElixirPsiImplUtil.ENTRANCE;
+import static org.elixir_lang.psi.impl.ElixirPsiImplUtil.macroChildCalls;
+import static org.elixir_lang.structure_view.element.CallDefinitionClause.nameArityRange;
+
+public class MultiResolve implements PsiScopeProcessor {
+    /*
+     * Public Static Methods
+     */
+
+    @Nullable
+    public static List<ResolveResult> resolveResultList(@NotNull String name,
+                                                        int resolvedFinalArity,
+                                                        boolean incompleteCode,
+                                                        @NotNull PsiElement entrance) {
+        return resolveResultList(name, resolvedFinalArity, incompleteCode, entrance, ResolveState.initial());
+    }
+
+    @Nullable
+    public static List<ResolveResult> resolveResultList(@NotNull String name,
+                                                        int resolvedFinalArity,
+                                                        boolean incompleteCode,
+                                                        @NotNull PsiElement entrance,
+                                                        @NotNull ResolveState resolveState) {
+        MultiResolve multiResolve = new MultiResolve(name, resolvedFinalArity, incompleteCode);
+        PsiTreeUtil.treeWalkUp(
+                multiResolve,
+                entrance,
+                entrance.getContainingFile(),
+                resolveState.put(ENTRANCE, entrance)
+        );
+        return multiResolve.getResolveResultList();
+    }
+
+    /*
+     * Fields
+     */
+
+    private final boolean incompleteCode;
+    @NotNull
+    private final String name;
+    private final int resolvedFinalArity;
+    @Nullable
+    private List<ResolveResult> resolveResultList = null;
+
+    /*
+     * Constructors
+     */
+
+    public MultiResolve(@NotNull String name, int resolvedFinalArity, boolean incompleteCode) {
+        this.incompleteCode = incompleteCode;
+        this.name = name;
+        this.resolvedFinalArity = resolvedFinalArity;
+    }
+
+    /*
+     * Public Instance Methods
+     */
+
+    /**
+     * @param element candidate element.
+     * @param state   current state of resolver.
+     * @return false to stop processing.
+     */
+    @Override
+    public boolean execute(@NotNull PsiElement element, @NotNull ResolveState state) {
+        boolean keepProcessing = true;
+
+        if (element instanceof Call) {
+            keepProcessing = execute((Call) element, state);
+        }
+
+        return keepProcessing;
+    }
+
+    @Nullable
+    @Override
+    public <T> T getHint(@NotNull Key<T> hintKey) {
+        return null;
+    }
+
+    @Nullable
+    public List<ResolveResult> getResolveResultList() {
+        return resolveResultList;
+    }
+
+    @Override
+    public void handleEvent(@NotNull Event event, @Nullable Object associated) {
+
+    }
+
+    /*
+     * Private Instance Methods
+     */
+
+    /*
+     * Private Instance Methods
+     */
+
+    private void addToResolveResultList(@NotNull Call call, boolean validResult) {
+        if (call instanceof  Named) {
+            Named named = (Named) call;
+            PsiElement nameIdentifier = named.getNameIdentifier();
+
+            if (nameIdentifier != null) {
+                resolveResultList = org.elixir_lang.psi.scope.MultiResolve.addToResolveResultList(
+                        resolveResultList, new PsiElementResolveResult(nameIdentifier, validResult)
+                );
+            }
+        }
+    }
+
+    private boolean execute(@NotNull Call element, @NotNull ResolveState state) {
+        boolean keepProcessing = true;
+
+        if (CallDefinitionClause.is(element)) {
+            Pair<String, IntRange> nameArityRange = nameArityRange(element);
+
+            if (nameArityRange != null) {
+                String name = nameArityRange.first;
+
+                if (name.equals(this.name)) {
+                    IntRange arityRange = nameArityRange.second;
+
+                    if (arityRange.containsInteger(resolvedFinalArity)) {
+
+                        addToResolveResultList(element, true);
+                    } else if (incompleteCode) {
+                        addToResolveResultList(element, false);
+                    }
+                } else if (incompleteCode && name.startsWith(this.name)) {
+                    addToResolveResultList(element, false);
+                }
+            }
+        } else if (Module.is(element)) {
+            Call[] childCalls = macroChildCalls(element);
+
+            if (childCalls != null) {
+                for (Call childCall : childCalls) {
+                    keepProcessing = execute(childCall, state);
+
+                    if (!keepProcessing) {
+                        break;
+                    }
+                }
+            }
+        }
+
+        return keepProcessing;
+    }
+}

--- a/src/org/elixir_lang/psi/scope/call_definition_clause/MultiResolve.java
+++ b/src/org/elixir_lang/psi/scope/call_definition_clause/MultiResolve.java
@@ -66,7 +66,7 @@ public class MultiResolve implements PsiScopeProcessor {
      * Constructors
      */
 
-    public MultiResolve(@NotNull String name, int resolvedFinalArity, boolean incompleteCode) {
+    private MultiResolve(@NotNull String name, int resolvedFinalArity, boolean incompleteCode) {
         this.incompleteCode = incompleteCode;
         this.name = name;
         this.resolvedFinalArity = resolvedFinalArity;
@@ -129,9 +129,7 @@ public class MultiResolve implements PsiScopeProcessor {
         }
     }
 
-    private boolean execute(@NotNull Call element, @NotNull ResolveState state) {
-        boolean keepProcessing = true;
-
+    private boolean execute(@NotNull Call element, @NotNull @SuppressWarnings("unused") ResolveState state) {
         if (CallDefinitionClause.is(element)) {
             Pair<String, IntRange> nameArityRange = nameArityRange(element);
 
@@ -156,15 +154,13 @@ public class MultiResolve implements PsiScopeProcessor {
 
             if (childCalls != null) {
                 for (Call childCall : childCalls) {
-                    keepProcessing = execute(childCall, state);
-
-                    if (!keepProcessing) {
+                    if(!execute(childCall, state)) {
                         break;
                     }
                 }
             }
         }
 
-        return keepProcessing;
+        return org.elixir_lang.psi.scope.MultiResolve.keepProcessing(incompleteCode, resolveResultList);
     }
 }

--- a/src/org/elixir_lang/psi/scope/call_definition_clause/Variants.java
+++ b/src/org/elixir_lang/psi/scope/call_definition_clause/Variants.java
@@ -96,11 +96,15 @@ public class Variants extends CallDefinitionClause {
                         lookupElementByPsiElement = new THashMap<PsiElement, LookupElement>();
                     }
 
+                    String name = nameIdentifier.getText();
+
                     lookupElementByPsiElement.put(
                             nameIdentifier,
                             LookupElementBuilder.createWithSmartPointer(
-                                    nameIdentifier.getText(),
+                                    name,
                                     nameIdentifier
+                            ).withRenderer(
+                                    new org.elixir_lang.codeInsight.lookup.element_renderer.CallDefinitionClause(name)
                             )
                     );
                 }
@@ -127,7 +131,14 @@ public class Variants extends CallDefinitionClause {
 
             for (NamedElement indexedNameNamedElement : indexedNameNamedElementCollection) {
                 lookupElementList.add(
-                        LookupElementBuilder.createWithSmartPointer(indexedName, indexedNameNamedElement)
+                        LookupElementBuilder.createWithSmartPointer(
+                                indexedName,
+                                indexedNameNamedElement
+                        ).withRenderer(
+                                new org.elixir_lang.codeInsight.lookup.element_renderer.CallDefinitionClause(
+                                        indexedName
+                                )
+                        )
                 );
             }
         }

--- a/src/org/elixir_lang/psi/scope/call_definition_clause/Variants.java
+++ b/src/org/elixir_lang/psi/scope/call_definition_clause/Variants.java
@@ -1,0 +1,139 @@
+package org.elixir_lang.psi.scope.call_definition_clause;
+
+import com.intellij.codeInsight.lookup.LookupElement;
+import com.intellij.codeInsight.lookup.LookupElementBuilder;
+import com.intellij.openapi.project.Project;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.ResolveState;
+import com.intellij.psi.search.GlobalSearchScope;
+import com.intellij.psi.stubs.StubIndex;
+import com.intellij.psi.util.PsiTreeUtil;
+import gnu.trove.THashMap;
+import org.elixir_lang.psi.NamedElement;
+import org.elixir_lang.psi.call.Call;
+import org.elixir_lang.psi.call.Named;
+import org.elixir_lang.psi.scope.CallDefinitionClause;
+import org.elixir_lang.psi.stub.index.AllName;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import static org.elixir_lang.psi.impl.ElixirPsiImplUtil.ENTRANCE;
+
+public class Variants extends CallDefinitionClause {
+    /*
+     * Static Methods
+     */
+
+    @Nullable
+    public static List<LookupElement> lookupElementList(@NotNull PsiElement entrance) {
+        Variants variants = new Variants();
+        PsiTreeUtil.treeWalkUp(
+                variants,
+                entrance,
+                entrance.getContainingFile(),
+                ResolveState.initial().put(ENTRANCE, entrance)
+        );
+        List<LookupElement> lookupElementList = new ArrayList<LookupElement>();
+        lookupElementList.addAll(variants.getLookupElementCollection());
+        variants.addProjectNameElementsTo(lookupElementList, entrance);
+
+        return lookupElementList;
+    }
+
+    /*
+     * Fields
+     */
+
+    private Map<PsiElement, LookupElement> lookupElementByPsiElement = null;
+
+    /*
+     * Protected Instance Methods
+     */
+
+    /**
+     * Called on every {@link Call} where {@link org.elixir_lang.structure_view.element.CallDefinitionClause#is} is
+     * {@code true} when checking tree with {@link #execute(Call, ResolveState)}
+     *
+     * @param element
+     * @param state
+     * @return {@code true} to keep searching up tree; {@code false} to stop searching.
+     */
+    @Override
+    protected boolean executeOnCallDefinitionClause(Call element, ResolveState state) {
+        addToLookupElementByPsiElement(element);
+
+        return true;
+    }
+
+    /**
+     * Whether to continue searching after each Module's children have been searched.
+     *
+     * @return {@code true} to keep searching up the PSI tree; {@code false} to stop searching.
+     */
+    @Override
+    protected boolean keepProcessing() {
+        return false;
+    }
+
+    /*
+     * Private Instance Methods
+     */
+
+    private void addToLookupElementByPsiElement(@NotNull Call call) {
+        if (call instanceof Named) {
+            Named named = (Named) call;
+
+            PsiElement nameIdentifier = named.getNameIdentifier();
+
+            if (nameIdentifier != null) {
+                if (lookupElementByPsiElement == null || !lookupElementByPsiElement.containsKey(nameIdentifier)) {
+                    if (lookupElementByPsiElement == null) {
+                        lookupElementByPsiElement = new THashMap<PsiElement, LookupElement>();
+                    }
+
+                    lookupElementByPsiElement.put(
+                            nameIdentifier,
+                            LookupElementBuilder.createWithSmartPointer(
+                                    nameIdentifier.getText(),
+                                    nameIdentifier
+                            )
+                    );
+                }
+            }
+        }
+    }
+
+    private void addProjectNameElementsTo(@NotNull List<LookupElement> lookupElementList,
+                                          @NotNull PsiElement entrance) {
+        Project project = entrance.getProject();
+        /* getAllKeys is not the actual keys in the actual project.  They need to be checked.
+           See https://intellij-support.jetbrains.com/hc/en-us/community/posts/207930789-StubIndex-persisting-between-test-runs-leading-to-incorrect-completions */
+        Collection<String> indexedNameCollection = StubIndex.getInstance().getAllKeys(AllName.KEY, project);
+        GlobalSearchScope scope = GlobalSearchScope.allScope(project);
+
+        for (String indexedName : indexedNameCollection) {
+            Collection<NamedElement> indexedNameNamedElementCollection = StubIndex.getElements(
+                    AllName.KEY,
+                    indexedName,
+                    project,
+                    scope,
+                    NamedElement.class
+            );
+
+            for (NamedElement indexedNameNamedElement : indexedNameNamedElementCollection) {
+                lookupElementList.add(
+                        LookupElementBuilder.createWithSmartPointer(indexedName, indexedNameNamedElement)
+                );
+            }
+        }
+    }
+
+    private Collection<LookupElement> getLookupElementCollection() {
+        return lookupElementByPsiElement.values();
+    }
+}

--- a/src/org/elixir_lang/psi/scope/call_definition_clause/Variants.java
+++ b/src/org/elixir_lang/psi/scope/call_definition_clause/Variants.java
@@ -1,14 +1,19 @@
 package org.elixir_lang.psi.scope.call_definition_clause;
 
+import com.intellij.codeInsight.completion.InsertHandler;
+import com.intellij.codeInsight.completion.InsertionContext;
 import com.intellij.codeInsight.lookup.LookupElement;
 import com.intellij.codeInsight.lookup.LookupElementBuilder;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.Pair;
+import com.intellij.openapi.util.TextRange;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.ResolveState;
 import com.intellij.psi.search.GlobalSearchScope;
 import com.intellij.psi.stubs.StubIndex;
 import com.intellij.psi.util.PsiTreeUtil;
 import gnu.trove.THashMap;
+import org.apache.commons.lang.math.IntRange;
 import org.elixir_lang.psi.NamedElement;
 import org.elixir_lang.psi.call.Call;
 import org.elixir_lang.psi.call.Named;
@@ -23,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.elixir_lang.psi.impl.ElixirPsiImplUtil.ENTRANCE;
+import static org.elixir_lang.structure_view.element.CallDefinitionClause.nameArityRange;
 
 public class Variants extends CallDefinitionClause {
     /*
@@ -134,6 +140,24 @@ public class Variants extends CallDefinitionClause {
                         LookupElementBuilder.createWithSmartPointer(
                                 indexedName,
                                 indexedNameNamedElement
+                        ).withInsertHandler(
+                                new InsertHandler<LookupElement>() {
+                                    @Override
+                                    public void handleInsert(@NotNull InsertionContext context,
+                                                             @NotNull LookupElement item) {
+                                        int tailOffset = context.getTailOffset();
+                                        String currentTail = context.getDocument().getText(
+                                                new TextRange(tailOffset, tailOffset + 1)
+                                        );
+                                        char firstChar = currentTail.charAt(0);
+
+                                        if (firstChar != ' ' && firstChar != '(' && firstChar != '[') {
+                                            context.getDocument().insertString(tailOffset, "()");
+                                            // + 1 to put between the `(`  and `)`
+                                            context.getEditor().getCaretModel().moveToOffset(tailOffset + 1);
+                                        }
+                                    }
+                                }
                         ).withRenderer(
                                 new org.elixir_lang.codeInsight.lookup.element_renderer.CallDefinitionClause(
                                         indexedName

--- a/src/org/elixir_lang/psi/scope/call_definition_clause/Variants.java
+++ b/src/org/elixir_lang/psi/scope/call_definition_clause/Variants.java
@@ -1,19 +1,14 @@
 package org.elixir_lang.psi.scope.call_definition_clause;
 
-import com.intellij.codeInsight.completion.InsertHandler;
-import com.intellij.codeInsight.completion.InsertionContext;
 import com.intellij.codeInsight.lookup.LookupElement;
 import com.intellij.codeInsight.lookup.LookupElementBuilder;
 import com.intellij.openapi.project.Project;
-import com.intellij.openapi.util.Pair;
-import com.intellij.openapi.util.TextRange;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.ResolveState;
 import com.intellij.psi.search.GlobalSearchScope;
 import com.intellij.psi.stubs.StubIndex;
 import com.intellij.psi.util.PsiTreeUtil;
 import gnu.trove.THashMap;
-import org.apache.commons.lang.math.IntRange;
 import org.elixir_lang.psi.NamedElement;
 import org.elixir_lang.psi.call.Call;
 import org.elixir_lang.psi.call.Named;
@@ -28,7 +23,6 @@ import java.util.List;
 import java.util.Map;
 
 import static org.elixir_lang.psi.impl.ElixirPsiImplUtil.ENTRANCE;
-import static org.elixir_lang.structure_view.element.CallDefinitionClause.nameArityRange;
 
 public class Variants extends CallDefinitionClause {
     /*
@@ -137,31 +131,9 @@ public class Variants extends CallDefinitionClause {
 
             for (NamedElement indexedNameNamedElement : indexedNameNamedElementCollection) {
                 lookupElementList.add(
-                        LookupElementBuilder.createWithSmartPointer(
+                        org.elixir_lang.codeInsight.lookup.element.CallDefinitionClause.createWithSmartPointer(
                                 indexedName,
                                 indexedNameNamedElement
-                        ).withInsertHandler(
-                                new InsertHandler<LookupElement>() {
-                                    @Override
-                                    public void handleInsert(@NotNull InsertionContext context,
-                                                             @NotNull LookupElement item) {
-                                        int tailOffset = context.getTailOffset();
-                                        String currentTail = context.getDocument().getText(
-                                                new TextRange(tailOffset, tailOffset + 1)
-                                        );
-                                        char firstChar = currentTail.charAt(0);
-
-                                        if (firstChar != ' ' && firstChar != '(' && firstChar != '[') {
-                                            context.getDocument().insertString(tailOffset, "()");
-                                            // + 1 to put between the `(`  and `)`
-                                            context.getEditor().getCaretModel().moveToOffset(tailOffset + 1);
-                                        }
-                                    }
-                                }
-                        ).withRenderer(
-                                new org.elixir_lang.codeInsight.lookup.element_renderer.CallDefinitionClause(
-                                        indexedName
-                                )
                         )
                 );
             }

--- a/src/org/elixir_lang/psi/scope/variable/Variants.java
+++ b/src/org/elixir_lang/psi/scope/variable/Variants.java
@@ -103,7 +103,7 @@ public class Variants extends Variable {
                         LookupElementBuilder.createWithSmartPointer(
                                 name,
                                 declaration
-                        )
+                        ).withRenderer(new org.elixir_lang.codeInsight.lookup.element_renderer.Variable(finalName))
                 );
             }
         }

--- a/src/org/elixir_lang/psi/scope/variable/Variants.java
+++ b/src/org/elixir_lang/psi/scope/variable/Variants.java
@@ -4,14 +4,15 @@ import com.intellij.codeInsight.lookup.LookupElement;
 import com.intellij.codeInsight.lookup.LookupElementBuilder;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiNamedElement;
+import com.intellij.psi.PsiReference;
 import com.intellij.psi.ResolveState;
 import com.intellij.psi.util.PsiTreeUtil;
+import gnu.trove.THashMap;
 import org.elixir_lang.psi.scope.Variable;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.*;
 
 import static org.elixir_lang.psi.impl.ElixirPsiImplUtil.ENTRANCE;
 
@@ -30,14 +31,24 @@ public class Variants extends Variable {
                 ResolveState.initial().put(ENTRANCE, entrance)
         );
 
-        return variants.getLookupElementList();
+        Collection<LookupElement> lookupElementCollection = variants.getLookupElementCollection();
+        List<LookupElement> lookupElementList;
+
+        if (lookupElementCollection != null) {
+            lookupElementList = new ArrayList<LookupElement>(lookupElementCollection);
+        } else {
+            lookupElementList = Collections.emptyList();
+        }
+
+        return lookupElementList;
     }
 
     /*
      * Fields
      */
 
-    private List<LookupElement> lookupElementList = null;
+    @Nullable
+    private Map<PsiElement, LookupElement> lookupElementByElement = null;
 
     /*
      *
@@ -57,19 +68,44 @@ public class Variants extends Variable {
      */
     @Override
     protected boolean executeOnVariable(@NotNull PsiNamedElement match, @NotNull ResolveState state) {
-        String name = match.getName();
+        PsiReference reference = match.getReference();
+        String name = null;
+        PsiElement declaration = match;
+
+        if (reference != null) {
+            PsiElement resolved = reference.resolve();
+
+            if (resolved != null) {
+                declaration = resolved;
+
+                if (resolved instanceof PsiNamedElement) {
+                    PsiNamedElement namedResolved = (PsiNamedElement) resolved;
+
+                    name = namedResolved.getName();
+                }
+            }
+        }
+
+        if (name == null) {
+            name = match.getName();
+        }
 
         if (name != null) {
-            if (lookupElementList == null) {
-                lookupElementList = new ArrayList<LookupElement>();
+            if (lookupElementByElement == null) {
+                lookupElementByElement = new THashMap<PsiElement, LookupElement>();
             }
 
-            lookupElementList.add(
-                    LookupElementBuilder.createWithSmartPointer(
-                            name,
-                            match
-                    )
-            );
+            if (!lookupElementByElement.containsKey(declaration)) {
+                final String finalName = name;
+
+                lookupElementByElement.put(
+                        declaration,
+                        LookupElementBuilder.createWithSmartPointer(
+                                name,
+                                declaration
+                        )
+                );
+            }
         }
 
         return true;
@@ -79,7 +115,15 @@ public class Variants extends Variable {
      * Private Instance Methods
      */
 
-    private List<LookupElement> getLookupElementList() {
-        return lookupElementList;
+    @Nullable
+    private Collection<LookupElement> getLookupElementCollection() {
+        Collection<LookupElement> lookupElementCollection = null;
+
+        if (lookupElementByElement != null) {
+            lookupElementCollection = lookupElementByElement.values();
+        }
+
+        return lookupElementCollection;
     }
+
 }

--- a/src/org/elixir_lang/reference/Callable.java
+++ b/src/org/elixir_lang/reference/Callable.java
@@ -195,7 +195,8 @@ public class Callable extends PsiReferenceBase<Call> implements PsiPolyVariantRe
 
     @Contract(pure = true)
     public static boolean isParameter(@NotNull PsiElement ancestor) {
-        return Parameter.type(ancestor) != null;
+        Parameter parameter = new Parameter(ancestor);
+        return Parameter.putParameterized(parameter).type != null;
     }
 
     public static boolean isParameterWithDefault(@NotNull PsiElement element) {

--- a/src/org/elixir_lang/reference/Callable.java
+++ b/src/org/elixir_lang/reference/Callable.java
@@ -329,42 +329,6 @@ public class Callable extends PsiReferenceBase<Call> implements PsiPolyVariantRe
      * Private Static Methods
      */
 
-    /**
-     * Adds {@code namedElement} to {@code lookupElementList} in a {@link LookupElement} using
-     * {@link com.intellij.codeInsight.lookup.LookupElementBuilder#createWithSmartPointer(String, PsiElement)} if
-     * {@code lookupElementList} exists; otherwise, create new {@code List<LookupElement>}, and then add
-     * {@code namedElement}.
-     *
-     * @param lookupElementList The current accumulated {@link LookupElement}s for the {@link PsiElement}s that match
-     *                          the type of {@link #myElement}.  So, if it is an {@link UnqualifiedNoArgumentsCall},
-     *                          then this is a list of potential variables.
-     * @param namedElement an element that matches the criteria for {@link #getVariants()}
-     * @return the modified {@code lookupElementList} if it was not {@code null}; otherwise, a new
-     *   {@code List<LookupElement>}
-     */
-    @NotNull
-    private static List<LookupElement> add(@Nullable List<LookupElement> lookupElementList,
-                                           @NotNull PsiNamedElement namedElement) {
-        if (lookupElementList == null) {
-            lookupElementList = new ArrayList<LookupElement>();
-        }
-
-        String lookupString = namedElement.getName();
-
-        if (lookupString == null) {
-            lookupString = namedElement.getText();
-        }
-
-        lookupElementList.add(
-                LookupElementBuilder.createWithSmartPointer(
-                        lookupString,
-                        namedElement
-                )
-        );
-
-        return lookupElementList;
-    }
-
     private static void error(@NotNull String message, @NotNull PsiElement element) {
         Logger.error(Callable.class, message + " (when element class is " + element.getClass().getName() + ")", element);
     }
@@ -573,21 +537,6 @@ public class Callable extends PsiReferenceBase<Call> implements PsiPolyVariantRe
         }
 
         return useScope;
-    }
-
-    private static List<LookupElement> variablesInElement(@NotNull PsiElement element,
-                                                          @Nullable List<LookupElement> lookupElementList) {
-        if (element instanceof UnqualifiedNoArgumentsCall) {
-            lookupElementList = add(lookupElementList, (UnqualifiedNoArgumentsCall) element);
-        } else {
-            if (!(element instanceof ElixirStabBody ||
-                    element instanceof ElixirEndOfExpression ||
-                    element instanceof PsiWhiteSpace)) {
-                error("Don't know how to find variables", element);
-            }
-        }
-
-        return lookupElementList;
     }
 
     /*

--- a/src/org/elixir_lang/reference/Callable.java
+++ b/src/org/elixir_lang/reference/Callable.java
@@ -3,7 +3,6 @@ package org.elixir_lang.reference;
 import com.google.common.collect.Sets;
 import com.intellij.codeInsight.lookup.LookupElement;
 import com.intellij.codeInsight.lookup.LookupElementBuilder;
-import com.intellij.openapi.util.Condition;
 import com.intellij.openapi.util.TextRange;
 import com.intellij.psi.*;
 import com.intellij.psi.search.LocalSearchScope;
@@ -12,17 +11,15 @@ import com.intellij.usageView.UsageViewLongNameLocation;
 import com.intellij.usageView.UsageViewShortNameLocation;
 import com.intellij.usageView.UsageViewTypeLocation;
 import com.intellij.util.IncorrectOperationException;
-import com.intellij.util.containers.ContainerUtil;
+import org.elixir_lang.annonator.Parameter;
 import org.elixir_lang.errorreport.Logger;
 import org.elixir_lang.psi.*;
 import org.elixir_lang.psi.call.Call;
+import org.elixir_lang.psi.call.Named;
 import org.elixir_lang.psi.call.name.*;
 import org.elixir_lang.psi.call.name.Module;
 import org.elixir_lang.psi.operation.*;
-import org.elixir_lang.psi.scope.variable.MultiResolve;
 import org.elixir_lang.psi.scope.variable.Variants;
-import org.elixir_lang.structure_view.element.CallDefinitionClause;
-import org.elixir_lang.structure_view.element.Delegation;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -60,12 +57,6 @@ public class Callable extends PsiReferenceBase<Call> implements PsiPolyVariantRe
      * Private CONSTANTS
      */
 
-    private static final Condition<ResolveResult> HAS_VALID_RESULT_CONDITION = new Condition<ResolveResult>() {
-        @Override
-        public boolean value(ResolveResult resolveResult) {
-            return resolveResult.isValidResult();
-        }
-    };
     private static final Set<String> BIT_STRING_ENDIANNESS = Sets.newHashSet(
             "big",
             "little",
@@ -152,7 +143,8 @@ public class Callable extends PsiReferenceBase<Call> implements PsiPolyVariantRe
         return elementDescription;
     }
 
-    public static String ignoredElementDescription(Call call, ElementDescriptionLocation location) {
+    public static String ignoredElementDescription(@SuppressWarnings("unused") Call call,
+                                                   ElementDescriptionLocation location) {
         String elementDescription = null;
 
         if (location == UsageViewTypeLocation.INSTANCE) {
@@ -163,6 +155,7 @@ public class Callable extends PsiReferenceBase<Call> implements PsiPolyVariantRe
     }
 
     @Contract(pure = true)
+    @SuppressWarnings("unchecked")
     public static boolean isBitStreamSegmentOption(@NotNull PsiElement element) {
         boolean isBitStreamSegmentOption = false;
 
@@ -181,16 +174,6 @@ public class Callable extends PsiReferenceBase<Call> implements PsiPolyVariantRe
         }
 
         return isBitStreamSegmentOption;
-    }
-
-    /**
-     * Checks if call is a ignored, a parameter, a parameter with default or a variable, in that order.
-     * @param call that may be a variablic
-     * @return if {@link #isIgnored(Call)}, {@link #isParameter(Call)}, {@link #isParameterWithDefault(Call)} or
-     *   {@link #isVariable(Call)} is true
-     */
-    public static boolean isVariablic(@NotNull Call call) {
-        return isIgnored(call) || isParameter(call) || isParameterWithDefault(call) || isVariable(call);
     }
 
     @Contract(pure = true)
@@ -212,62 +195,7 @@ public class Callable extends PsiReferenceBase<Call> implements PsiPolyVariantRe
 
     @Contract(pure = true)
     public static boolean isParameter(@NotNull PsiElement ancestor) {
-        PsiElement parent = ancestor.getParent();
-        boolean isParameter = false;
-
-        if (parent instanceof Call) {
-            isParameter = isParameter((Call) parent);
-        } else if (parent instanceof AtNonNumericOperation ||
-                parent instanceof ElixirAccessExpression ||
-                parent instanceof ElixirAssociations ||
-                parent instanceof ElixirAssociationsBase ||
-                parent instanceof ElixirBitString ||
-                parent instanceof ElixirBracketArguments ||
-                parent instanceof ElixirContainerAssociationOperation ||
-                parent instanceof ElixirKeywordPair ||
-                parent instanceof ElixirKeywords ||
-                parent instanceof ElixirList ||
-                parent instanceof ElixirMapArguments ||
-                parent instanceof ElixirMapConstructionArguments ||
-                parent instanceof ElixirMapOperation ||
-                parent instanceof ElixirMatchedParenthesesArguments ||
-                parent instanceof ElixirNoParenthesesArguments ||
-                parent instanceof ElixirNoParenthesesKeywordPair ||
-                parent instanceof ElixirNoParenthesesKeywords ||
-                /* ElixirNoParenthesesManyStrictNoParenthesesExpression indicates a syntax error where no parentheses
-                   calls are nested, so it's invalid, but try to still resolve parameters to have highlighting */
-                parent instanceof ElixirNoParenthesesManyStrictNoParenthesesExpression ||
-                parent instanceof ElixirNoParenthesesOneArgument ||
-                /* handles `(conn, %{})` in `def (conn, %{})`, which can occur in def templates.
-                   See https://github.com/KronicDeth/intellij-elixir/issues/367#issuecomment-244214975 */
-                parent instanceof ElixirNoParenthesesStrict ||
-                parent instanceof ElixirParenthesesArguments ||
-                parent instanceof ElixirParentheticalStab ||
-                parent instanceof ElixirStab ||
-                parent instanceof ElixirStabNoParenthesesSignature ||
-                parent instanceof ElixirStabBody ||
-                parent instanceof ElixirStabOperation ||
-                parent instanceof ElixirStabParenthesesSignature ||
-                parent instanceof ElixirStructOperation ||
-                parent instanceof ElixirTuple) {
-            isParameter = isParameter(parent);
-        } else if (parent instanceof ElixirAnonymousFunction || parent instanceof InMatch) {
-            isParameter = true;
-        } else {
-            if (!(parent instanceof BracketOperation ||
-                    parent instanceof ElixirBlockItem ||
-                    parent instanceof ElixirDoBlock ||
-                    parent instanceof ElixirInterpolation ||
-                    parent instanceof ElixirMapUpdateArguments ||
-                    parent instanceof ElixirQuoteStringBody ||
-                    parent instanceof PsiFile ||
-                    parent instanceof QualifiedAlias ||
-                    parent instanceof QualifiedMultipleAliases)) {
-                error("Don't know how to check if parameter", parent);
-            }
-        }
-
-        return isParameter;
+        return Parameter.type(ancestor) != null;
     }
 
     public static boolean isParameterWithDefault(@NotNull PsiElement element) {
@@ -282,8 +210,8 @@ public class Callable extends PsiReferenceBase<Call> implements PsiPolyVariantRe
             if (operatorText.equals(DEFAULT_OPERATOR)) {
                 PsiElement defaulted = parentOperation.leftOperand();
 
-                if (defaulted.isEquivalentTo(element)) {
-                    isParameterWithDefault = isParameter((Call) parentOperation);
+                if (defaulted != null && defaulted.isEquivalentTo(element)) {
+                    isParameterWithDefault = isParameter(parentOperation);
                 }
             }
         }
@@ -369,7 +297,8 @@ public class Callable extends PsiReferenceBase<Call> implements PsiPolyVariantRe
         return elementDescription;
     }
 
-    public static String parameterWithDefaultElementDescription(Call call, ElementDescriptionLocation location) {
+    public static String parameterWithDefaultElementDescription(@SuppressWarnings("unused") Call call,
+                                                                ElementDescriptionLocation location) {
         String elementDescription = null;
 
         if (location == UsageViewTypeLocation.INSTANCE) {
@@ -398,46 +327,6 @@ public class Callable extends PsiReferenceBase<Call> implements PsiPolyVariantRe
     /*
      * Private Static Methods
      */
-
-    @Nullable
-    private static List<ResolveResult> add(@Nullable List<ResolveResult> resolveResultList,
-                                           @NotNull String name,
-                                           boolean incompleteCode,
-                                           @NotNull PsiNamedElement match) {
-        String matchName = match.getName();
-
-        if (matchName != null) {
-            if (matchName.equals(name)) {
-                resolveResultList = add(resolveResultList, new PsiElementResolveResult(match, true));
-            } else if (incompleteCode && matchName.startsWith(name)) {
-                resolveResultList = add(resolveResultList, new PsiElementResolveResult(match, false));
-            }
-        }
-
-        return resolveResultList;
-    }
-
-    /**
-     * Adds {@code resolveResult} to {@code resolveResultList} if it exists; otherwise, create new
-     * {@code List<ResolveList>}, add {@code resolveResult} to it.  Return the modified or new
-     * {@code List<ResolveResult>}.
-     *
-     * @param resolveResultList The current accumulated {@link ResolveResult}s, or {@code null} if no results have been
-     *                          found yet.
-     * @param resolveResult     The element to add to {@code resolveResultList}
-     * @return {@code resolveResult} if it is not {@code null}; otherwise, a new {@code List<ResolveResult>}.
-     */
-    @NotNull
-    private static List<ResolveResult> add(@Nullable List<ResolveResult> resolveResultList,
-                                           @NotNull ResolveResult resolveResult) {
-        if (resolveResultList == null) {
-            resolveResultList = new ArrayList<ResolveResult>();
-        }
-
-        resolveResultList.add(resolveResult);
-
-        return resolveResultList;
-    }
 
     /**
      * Adds {@code namedElement} to {@code lookupElementList} in a {@link LookupElement} using
@@ -480,26 +369,6 @@ public class Callable extends PsiReferenceBase<Call> implements PsiPolyVariantRe
     }
 
     /**
-     * Whether the {@code resolveResultList} has any {@link ResolveResult} where {@link ResolveResult#isValidResult()}
-     * is {@code true}.
-     *
-     * @param resolveResultList
-     * @return {@code false} if {@code resolveResultList} is {@code null}; otherwise, {@code true} if the
-     * {@code resolveResultList} has any {@link ResolveResult} where {@link ResolveResult#isValidResult()} is
-     * {@code true}.
-     */
-    @Contract(pure = true)
-    private static boolean hasValidResult(@Nullable List<ResolveResult> resolveResultList) {
-        boolean hasValidResult = false;
-
-        if (resolveResultList != null) {
-            hasValidResult = ContainerUtil.exists(resolveResultList, HAS_VALID_RESULT_CONDITION);
-        }
-
-        return hasValidResult;
-    }
-
-    /**
      * Searches downward from {@code ancestor}, only returning true if {@code element} is a type, unit, size or
      * modifier.
      *
@@ -537,19 +406,6 @@ public class Callable extends PsiReferenceBase<Call> implements PsiPolyVariantRe
         }
 
         return is;
-    }
-
-    private static boolean isParameter(@NotNull Call call) {
-        boolean isParameter;
-
-        if (CallDefinitionClause.is(call) || Delegation.is(call) || call.hasDoBlockOrKeyword()) {
-            isParameter = true;
-        } else {
-            // use generic handling, so that parent is checked
-            isParameter = isParameter((PsiElement) call);
-        }
-
-        return isParameter;
     }
 
     @Contract(pure = true)
@@ -624,6 +480,7 @@ public class Callable extends PsiReferenceBase<Call> implements PsiPolyVariantRe
         PsiElement parent = match.getParent();
 
         if (parent instanceof ElixirStabBody) {
+            @SuppressWarnings("unchecked")
             PsiElement ancestor = PsiTreeUtil.getContextOfType(
                     parent,
                     ElixirAnonymousFunction.class,
@@ -716,22 +573,12 @@ public class Callable extends PsiReferenceBase<Call> implements PsiPolyVariantRe
         return lookupElementList;
     }
 
-    @Nullable
-    private static List<LookupElement> variablesInPreviousSiblings(@NotNull PsiElement lastSibling,
-                                                                   @Nullable List<LookupElement> lookupElementList) {
-        for (PsiElement sibling = lastSibling; sibling != null; sibling = sibling.getPrevSibling()) {
-            lookupElementList = variablesInElement(sibling, lookupElementList);
-        }
-
-        return lookupElementList;
-    }
-
     /*
      * Constructors
      */
 
     public Callable(@NotNull Call call) {
-        super(call, TextRange.create(0, call.getTextLength()));
+        super(call);
     }
 
     @Override
@@ -786,19 +633,35 @@ public class Callable extends PsiReferenceBase<Call> implements PsiPolyVariantRe
     @Override
     public ResolveResult[] multiResolve(boolean incompleteCode) {
         List<ResolveResult> resolveResultList = null;
+        String name = myElement.getName();
 
-        /* to differentiate from UnqualifiedParenthesesCalls with no arguments in the parentheses that would have a
-           final arity of 0 too */
-        if (myElement instanceof UnqualifiedNoArgumentsCall) {
-            // ensure that a pipe isn't making a no argument call really a 1-arity call
+        if (name != null) {
             int resolvedFinalArity = myElement.resolvedFinalArity();
+            List<ResolveResult> variableResolveList = null;
 
             if (resolvedFinalArity == 0) {
-                String name = myElement.getName();
+                variableResolveList = org.elixir_lang.psi.scope.variable.MultiResolve.resolveResultList(
+                        name,
+                        incompleteCode,
+                        myElement
+                );
+            }
 
-                if (name != null) {
-                    resolveResultList = MultiResolve.resolveResultList(name, incompleteCode, myElement);
-                }
+            List<ResolveResult> callDefinitionClauseResolveResultList =
+                    org.elixir_lang.psi.scope.call_definition_clause.MultiResolve.resolveResultList(
+                            name,
+                            resolvedFinalArity,
+                            incompleteCode,
+                            myElement
+                    );
+
+            if (variableResolveList != null && callDefinitionClauseResolveResultList != null) {
+                resolveResultList = new ArrayList<ResolveResult>(variableResolveList);
+                resolveResultList.addAll(callDefinitionClauseResolveResultList);
+            } else if (variableResolveList != null) {
+                resolveResultList = variableResolveList;
+            } else if (callDefinitionClauseResolveResultList != null) {
+                resolveResultList = callDefinitionClauseResolveResultList;
             }
         }
 
@@ -823,5 +686,38 @@ public class Callable extends PsiReferenceBase<Call> implements PsiPolyVariantRe
     public PsiElement resolve() {
         ResolveResult[] resolveResults = multiResolve(false);
         return resolveResults.length == 1 ? resolveResults[0].getElement() : null;
+    }
+
+    /*
+     * Protected Instance Methods
+     */
+
+    @Override
+    protected TextRange calculateDefaultRangeInElement() {
+        TextRange defaultRangeInElement = null;
+        TextRange myElementRangeInDocument = myElement.getTextRange();
+        int myElementStartOffset = myElementRangeInDocument.getStartOffset();
+
+        if (myElement instanceof Named) {
+            Named named = (Named) myElement;
+            PsiElement nameIdentifier = named.getNameIdentifier();
+
+            if (nameIdentifier != null) {
+                TextRange nameIdentifierRangeInDocument = nameIdentifier.getTextRange();
+                defaultRangeInElement = new TextRange(
+                        nameIdentifierRangeInDocument.getStartOffset() - myElementStartOffset,
+                        nameIdentifierRangeInDocument.getEndOffset() - myElementStartOffset
+                );
+            }
+        }
+
+        if (defaultRangeInElement == null) {
+            defaultRangeInElement = new TextRange(
+                    0,
+                    myElementRangeInDocument.getEndOffset() - myElementStartOffset
+            );
+        }
+
+        return defaultRangeInElement;
     }
 }

--- a/testData/org/elixir_lang/codeInsight/completion/contributor/call_definition_clause/mixed_declaration.ex
+++ b/testData/org/elixir_lang/codeInsight/completion/contributor/call_definition_clause/mixed_declaration.ex
@@ -1,0 +1,22 @@
+defmodule Prefix.MixedDeclaration do
+  # Macros
+
+  defmacro public_macro, do: :a
+
+  ## Private Macros
+
+  defmacrop private_macro, do: :b
+
+  # Functions
+
+  def public_function, do: :c
+
+  ## Private Functions
+
+  def private_function, do: :d
+
+  # Modules
+
+  defmodule Nested do
+  end
+end

--- a/testData/org/elixir_lang/codeInsight/completion/contributor/call_definition_clause/mixed_usage.ex
+++ b/testData/org/elixir_lang/codeInsight/completion/contributor/call_definition_clause/mixed_usage.ex
@@ -1,0 +1,5 @@
+defmodule Prefix.MixedUsage do
+  alias Prefix.MixedDeclaration
+
+  MixedDeclaration.<caret>
+end

--- a/testData/org/elixir_lang/codeInsight/completion/contributor/call_definition_clause/private_function_declaration.ex
+++ b/testData/org/elixir_lang/codeInsight/completion/contributor/call_definition_clause/private_function_declaration.ex
@@ -1,0 +1,4 @@
+defmodule Prefix.PrivateFunctionDeclaration do
+  defp private_function1(), do: :a
+  defp private_function2(), do: :b
+end

--- a/testData/org/elixir_lang/codeInsight/completion/contributor/call_definition_clause/private_function_usage.ex
+++ b/testData/org/elixir_lang/codeInsight/completion/contributor/call_definition_clause/private_function_usage.ex
@@ -1,0 +1,5 @@
+defmodule Prefix.PrivateFunctionUsage do
+  alias Prefix.PrivateFunctionDeclaration
+
+  PrivateFunctionDeclaration.<caret>
+end

--- a/testData/org/elixir_lang/codeInsight/completion/contributor/call_definition_clause/private_macro_declaration.ex
+++ b/testData/org/elixir_lang/codeInsight/completion/contributor/call_definition_clause/private_macro_declaration.ex
@@ -1,0 +1,4 @@
+defmodule Prefix.PrivateMacroDeclaration do
+  defmacrop private_macro1(), do: :a
+  defmacrop private_macro2(), do: :b
+end

--- a/testData/org/elixir_lang/codeInsight/completion/contributor/call_definition_clause/private_macro_usage.ex
+++ b/testData/org/elixir_lang/codeInsight/completion/contributor/call_definition_clause/private_macro_usage.ex
@@ -1,0 +1,5 @@
+defmodule Prefix.PrivateMacroUsage do
+  alias Prefix.PrivateMacroDeclaration
+
+  PrivateMacroDeclaration.<caret>
+end

--- a/testData/org/elixir_lang/codeInsight/completion/contributor/call_definition_clause/public_function_declaration.ex
+++ b/testData/org/elixir_lang/codeInsight/completion/contributor/call_definition_clause/public_function_declaration.ex
@@ -1,0 +1,4 @@
+defmodule Prefix.PublicFunctionDeclaration do
+  def public_function1(), do: :a
+  def public_function2(), do: :b
+end

--- a/testData/org/elixir_lang/codeInsight/completion/contributor/call_definition_clause/public_function_usage.ex
+++ b/testData/org/elixir_lang/codeInsight/completion/contributor/call_definition_clause/public_function_usage.ex
@@ -1,0 +1,5 @@
+defmodule Prefix.PublicFunctionUsage do
+  alias Prefix.PublicFunctionDeclaration
+
+  PublicFunctionDeclaration.<caret>
+end

--- a/testData/org/elixir_lang/codeInsight/completion/contributor/call_definition_clause/public_macro_declaration.ex
+++ b/testData/org/elixir_lang/codeInsight/completion/contributor/call_definition_clause/public_macro_declaration.ex
@@ -1,0 +1,4 @@
+defmodule Prefix.PublicMacroDeclaration do
+  defmacro public_macro1(), do: :a
+  defmacro public_macro2(), do: :b
+end

--- a/testData/org/elixir_lang/codeInsight/completion/contributor/call_definition_clause/public_macro_usage.ex
+++ b/testData/org/elixir_lang/codeInsight/completion/contributor/call_definition_clause/public_macro_usage.ex
@@ -1,0 +1,5 @@
+defmodule Prefix.PublicMacroUsage do
+  alias Prefix.PublicMacroDeclaration
+
+  PublicMacroDeclaration.<caret>
+end

--- a/testData/org/elixir_lang/reference/callable/intramodule/ambiguous_back.ex
+++ b/testData/org/elixir_lang/reference/callable/intramodule/ambiguous_back.ex
@@ -1,0 +1,11 @@
+defmodule A do
+  def usage do
+    referenced<caret>
+
+    a = 1
+  end
+
+  def referenced do
+
+  end
+end

--- a/testData/org/elixir_lang/reference/callable/intramodule/ambiguous_forward.ex
+++ b/testData/org/elixir_lang/reference/callable/intramodule/ambiguous_forward.ex
@@ -1,0 +1,11 @@
+defmodule A do
+  def referenced do
+
+  end
+
+  def usage do
+    referenced<caret>
+
+    a = 1
+  end
+end

--- a/testData/org/elixir_lang/reference/callable/intramodule/ambiguous_recursive.ex
+++ b/testData/org/elixir_lang/reference/callable/intramodule/ambiguous_recursive.ex
@@ -1,0 +1,7 @@
+defmodule A do
+  def referenced do
+    referenced<caret>
+
+    a = 1
+  end
+end

--- a/testData/org/elixir_lang/reference/callable/intramodule/function_name_multiple_same_arity.ex
+++ b/testData/org/elixir_lang/reference/callable/intramodule/function_name_multiple_same_arity.ex
@@ -1,0 +1,13 @@
+defmodule A do
+  def referenced() do
+    referenced(true)
+
+    a = 1
+  end
+
+  def referenced<caret>(true) do
+  end
+
+  def referenced(false) do
+  end
+end

--- a/testData/org/elixir_lang/reference/callable/intramodule/parentheses_multiple_correct_arity.ex
+++ b/testData/org/elixir_lang/reference/callable/intramodule/parentheses_multiple_correct_arity.ex
@@ -1,0 +1,13 @@
+defmodule A do
+  def referenced() do
+    referenced<caret>(true)
+
+    a = 1
+  end
+
+  def referenced(true) do
+  end
+
+  def referenced(false) do
+  end
+end

--- a/testData/org/elixir_lang/reference/callable/intramodule/parentheses_recursive.ex
+++ b/testData/org/elixir_lang/reference/callable/intramodule/parentheses_recursive.ex
@@ -1,0 +1,7 @@
+defmodule A do
+  def referenced do
+    referenced<caret>()
+
+    a = 1
+  end
+end

--- a/testData/org/elixir_lang/reference/callable/intramodule/parentheses_single_correct_arity.ex
+++ b/testData/org/elixir_lang/reference/callable/intramodule/parentheses_single_correct_arity.ex
@@ -1,0 +1,10 @@
+defmodule A do
+  def referenced() do
+    referenced<caret>(1)
+
+    a = 1
+  end
+
+  def referenced(_) do
+  end
+end

--- a/testData/org/elixir_lang/reference/module/as/nested/completion.ex
+++ b/testData/org/elixir_lang/reference/module/as/nested/completion.ex
@@ -1,4 +1,4 @@
-defmodule Prefix.Usage do
+defmodule Prefix.Completion do
   alias Prefix.Suffix, as: As
 
   As.<caret>

--- a/testData/org/elixir_lang/reference/module/as/nested/reference.ex
+++ b/testData/org/elixir_lang/reference/module/as/nested/reference.ex
@@ -1,4 +1,4 @@
-defmodule Prefix.Usage do
+defmodule Prefix.Reference do
   alias Prefix.Suffix, as: As
 
   As.Nested<caret>

--- a/tests/org/elixir_lang/codeInsight/completion/contributor/CallDefinitionClauseTest.java
+++ b/tests/org/elixir_lang/codeInsight/completion/contributor/CallDefinitionClauseTest.java
@@ -1,0 +1,84 @@
+package org.elixir_lang.codeInsight.completion.contributor;
+
+import com.intellij.codeInsight.completion.CompletionType;
+import com.intellij.testFramework.fixtures.LightPlatformCodeInsightFixtureTestCase;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+
+public class CallDefinitionClauseTest extends LightPlatformCodeInsightFixtureTestCase {
+    /*
+     * Tests
+     */
+
+    public void testPrivateFunction() {
+        myFixture.configureByFiles("private_function_usage.ex", "private_function_declaration.ex");
+        myFixture.complete(CompletionType.BASIC, 1);
+        List<String> strings = myFixture.getLookupElementStrings();
+        assertNotNull("Completion lookup not shown", strings);
+        assertCompletion("private_function1", strings);
+        assertCompletion("private_function2", strings);
+        assertEquals("Wrong number of completions", 2, strings.size());
+    }
+
+    public void testPublicFunction() {
+        myFixture.configureByFiles("public_function_usage.ex", "public_function_declaration.ex");
+        myFixture.complete(CompletionType.BASIC, 1);
+        List<String> strings = myFixture.getLookupElementStrings();
+        assertNotNull("Completion lookup not shown", strings);
+        assertCompletion("public_function1", strings);
+        assertCompletion("public_function2", strings);
+        assertEquals("Wrong number of completions", 2, strings.size());
+    }
+
+    public void testPrivateMacroFunction() {
+        myFixture.configureByFiles("private_macro_usage.ex", "private_macro_declaration.ex");
+        myFixture.complete(CompletionType.BASIC, 1);
+        List<String> strings = myFixture.getLookupElementStrings();
+        assertNotNull("Completion lookup not shown", strings);
+        assertCompletion("private_macro1", strings);
+        assertCompletion("private_macro2", strings);
+        assertEquals("Wrong number of completions", 2, strings.size());
+    }
+
+    public void testPublicMacroFunction() {
+        myFixture.configureByFiles("public_macro_usage.ex", "public_macro_declaration.ex");
+        myFixture.complete(CompletionType.BASIC, 1);
+        List<String> strings = myFixture.getLookupElementStrings();
+        assertNotNull("Completion lookup not shown", strings);
+        assertCompletion("public_macro1", strings);
+        assertCompletion("public_macro2", strings);
+        assertEquals("Wrong number of completions", 2, strings.size());
+    }
+
+    public void testMixesWithNestedModules() {
+        myFixture.configureByFiles("mixed_usage.ex", "mixed_declaration.ex");
+        myFixture.complete(CompletionType.BASIC, 1);
+        List<String> strings = myFixture.getLookupElementStrings();
+        assertNotNull("Completion lookup not shown", strings);
+        assertCompletion("public_macro", strings);
+        assertCompletion("private_macro", strings);
+        assertCompletion("public_function", strings);
+        assertCompletion("private_function", strings);
+        assertCompletion("MixedDeclaration.Nested", strings);
+        assertCompletion("Prefix.MixedDeclaration.Nested", strings);
+        assertEquals("Wrong number of completions", 6, strings.size());
+    }
+
+    /*
+     * Protected Instance Methods
+     */
+
+    @Override
+    protected String getTestDataPath() {
+        return "testData/org/elixir_lang/codeInsight/completion/contributor/call_definition_clause";
+    }
+
+    /*
+     * Private Instance Methods
+     */
+
+    void assertCompletion(@NotNull String expectedCompletion, @NotNull List<String> actualCompletions) {
+        assertTrue("Did not complete with \"" + expectedCompletion + "\"", actualCompletions.contains(expectedCompletion));
+    }
+}

--- a/tests/org/elixir_lang/reference/callable/IntramoduleTest.java
+++ b/tests/org/elixir_lang/reference/callable/IntramoduleTest.java
@@ -1,0 +1,69 @@
+package org.elixir_lang.reference.callable;
+
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiReference;
+import com.intellij.testFramework.fixtures.LightCodeInsightFixtureTestCase;
+import org.elixir_lang.psi.ElixirIdentifier;
+
+public class IntramoduleTest extends LightCodeInsightFixtureTestCase {
+    /*
+     * Tests
+     */
+
+    public void testAmbiguousBackReference() {
+        myFixture.configureByFiles("ambiguous_back.ex");
+        PsiElement ambiguous = myFixture
+                .getFile()
+                .findElementAt(myFixture.getCaretOffset())
+                .getParent()
+                .getPrevSibling();
+
+        assertInstanceOf(ambiguous.getFirstChild(), ElixirIdentifier.class);
+
+        PsiReference reference = ambiguous.getReference();
+
+        assertNotNull("`referenced` has no reference", reference);
+
+        PsiElement resolved = reference.resolve();
+
+        assertNotNull("`referenced` not resolved", resolved);
+        assertEquals(
+                "ambiguous reference does not resolve to previous function declaration",
+                "def referenced do\n\n  end",
+                resolved.getParent().getParent().getParent().getText()
+        );
+    }
+
+    public void testAmbiguousForwardReference() {
+        myFixture.configureByFiles("ambiguous_forward.ex");
+        PsiElement ambiguous = myFixture
+                .getFile()
+                .findElementAt(myFixture.getCaretOffset())
+                .getParent()
+                .getPrevSibling();
+
+        assertInstanceOf(ambiguous.getFirstChild(), ElixirIdentifier.class);
+
+        PsiReference reference = ambiguous.getReference();
+
+        assertNotNull("`referenced` has no reference", reference);
+
+        PsiElement resolved = reference.resolve();
+
+        assertNotNull("`referenced` not resolved", resolved);
+        assertEquals(
+                "ambiguous reference does not resolve to forward function declaration",
+                "def referenced do\n\n  end",
+                resolved.getParent().getParent().getParent().getText()
+        );
+    }
+
+    /*
+     * Protected Instance Methods
+     */
+
+    @Override
+    protected String getTestDataPath() {
+        return "testData/org/elixir_lang/reference/callable/intramodule";
+    }
+}

--- a/tests/org/elixir_lang/reference/callable/IntramoduleTest.java
+++ b/tests/org/elixir_lang/reference/callable/IntramoduleTest.java
@@ -1,9 +1,7 @@
 package org.elixir_lang.reference.callable;
 
-import com.intellij.psi.PsiElement;
-import com.intellij.psi.PsiPolyVariantReference;
-import com.intellij.psi.PsiReference;
-import com.intellij.psi.ResolveResult;
+import com.intellij.navigation.ItemPresentation;
+import com.intellij.psi.*;
 import com.intellij.testFramework.fixtures.LightCodeInsightFixtureTestCase;
 import org.elixir_lang.psi.ElixirIdentifier;
 
@@ -133,20 +131,44 @@ public class IntramoduleTest extends LightCodeInsightFixtureTestCase {
         assertEquals("Did not resolve to both clauses", 2, resolveResults.length);
 
         ResolveResult firstResolveResult = resolveResults[0];
+        PsiElement firstResolved = firstResolveResult.getElement();
 
         assertEquals(
                 "first ResolveResult is not the true clause",
                 "def referenced(true) do\n  end",
-                firstResolveResult.getElement().getParent().getParent().getParent().getText()
+                firstResolved.getParent().getParent().getParent().getText()
         );
 
+        assertInstanceOf(firstResolved, NavigatablePsiElement.class);
+
+        NavigatablePsiElement navigatableFirstResolved = (NavigatablePsiElement) firstResolved;
+
+        ItemPresentation firstPresentation = navigatableFirstResolved.getPresentation();
+
+        assertNotNull("first ResolveResult element has no presentation", firstPresentation);
+
+        assertEquals("A", firstPresentation.getLocationString());
+        assertEquals("referenced(true)", firstPresentation.getPresentableText());
+
         ResolveResult secondResolveResult = resolveResults[1];
+        PsiElement secondResolved = secondResolveResult.getElement();
 
         assertEquals(
                 "second ResolveResult is not the false clause",
                 "def referenced(false) do\n  end",
-                secondResolveResult.getElement().getParent().getParent().getParent().getText()
+                secondResolved.getParent().getParent().getParent().getText()
         );
+
+        assertInstanceOf(secondResolved, NavigatablePsiElement.class);
+
+        NavigatablePsiElement navigatableSecondResolved = (NavigatablePsiElement) secondResolved;
+
+        ItemPresentation secondPresentation = navigatableSecondResolved.getPresentation();
+
+        assertNotNull("second ResolveResult element has no presentation", secondPresentation);
+
+        assertEquals("A", secondPresentation.getLocationString());
+        assertEquals("referenced(false)", secondPresentation.getPresentableText());
     }
 
     public void testParenthesesSingleCorrectArityReference() {

--- a/tests/org/elixir_lang/reference/callable/IntramoduleTest.java
+++ b/tests/org/elixir_lang/reference/callable/IntramoduleTest.java
@@ -107,6 +107,31 @@ public class IntramoduleTest extends LightCodeInsightFixtureTestCase {
         );
     }
 
+    public void testParenthesesSingleCorrectArityReference() {
+        myFixture.configureByFiles("parentheses_single_correct_arity.ex");
+        PsiElement parenthesesCall = myFixture
+                .getFile()
+                .findElementAt(myFixture.getCaretOffset())
+                .getParent()
+                .getParent()
+                .getParent();
+
+        assertInstanceOf(parenthesesCall.getFirstChild(), ElixirIdentifier.class);
+
+        PsiReference reference = parenthesesCall.getReference();
+
+        assertNotNull("`referenced` has no reference", reference);
+
+        PsiElement resolved = reference.resolve();
+
+        assertNotNull("`referenced` not resolved", resolved);
+        assertEquals(
+                "parentheses 1-arity reference does not resolve to single 1-arity function declaration",
+                "def referenced(_) do\n  end",
+                resolved.getParent().getParent().getParent().getText()
+        );
+    }
+
     /*
      * Protected Instance Methods
      */

--- a/tests/org/elixir_lang/reference/callable/IntramoduleTest.java
+++ b/tests/org/elixir_lang/reference/callable/IntramoduleTest.java
@@ -58,6 +58,30 @@ public class IntramoduleTest extends LightCodeInsightFixtureTestCase {
         );
     }
 
+    public void testAmbiguousRecursiveReference() {
+        myFixture.configureByFiles("ambiguous_recursive.ex");
+        PsiElement ambiguous = myFixture
+                .getFile()
+                .findElementAt(myFixture.getCaretOffset())
+                .getParent()
+                .getPrevSibling();
+
+        assertInstanceOf(ambiguous.getFirstChild(), ElixirIdentifier.class);
+
+        PsiReference reference = ambiguous.getReference();
+
+        assertNotNull("`referenced` has no reference", reference);
+
+        PsiElement resolved = reference.resolve();
+
+        assertNotNull("`referenced` not resolved", resolved);
+        assertEquals(
+                "ambiguous reference does not resolve to recursive function declaration",
+                "def referenced do\n    referenced\n\n    a = 1\n  end",
+                resolved.getParent().getParent().getParent().getText()
+        );
+    }
+
     /*
      * Protected Instance Methods
      */

--- a/tests/org/elixir_lang/reference/callable/IntramoduleTest.java
+++ b/tests/org/elixir_lang/reference/callable/IntramoduleTest.java
@@ -82,6 +82,31 @@ public class IntramoduleTest extends LightCodeInsightFixtureTestCase {
         );
     }
 
+    public void testParenthesesRecursiveReference() {
+        myFixture.configureByFiles("parentheses_recursive.ex");
+        PsiElement parenthesesCall = myFixture
+                .getFile()
+                .findElementAt(myFixture.getCaretOffset())
+                .getParent()
+                .getParent()
+                .getParent();
+
+        assertInstanceOf(parenthesesCall.getFirstChild(), ElixirIdentifier.class);
+
+        PsiReference reference = parenthesesCall.getReference();
+
+        assertNotNull("`referenced` has no reference", reference);
+
+        PsiElement resolved = reference.resolve();
+
+        assertNotNull("`referenced` not resolved", resolved);
+        assertEquals(
+                "ambiguous reference does not resolve to recursive function declaration",
+                "def referenced do\n    referenced()\n\n    a = 1\n  end",
+                resolved.getParent().getParent().getParent().getText()
+        );
+    }
+
     /*
      * Protected Instance Methods
      */

--- a/tests/org/elixir_lang/reference/module/as/NestedTest.java
+++ b/tests/org/elixir_lang/reference/module/as/NestedTest.java
@@ -1,16 +1,14 @@
 package org.elixir_lang.reference.module.as;
 
 import com.intellij.codeInsight.completion.CompletionType;
-import com.intellij.openapi.vfs.newvfs.impl.VfsRootAccess;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiPolyVariantReference;
 import com.intellij.psi.ResolveResult;
-import com.intellij.psi.stubs.StubIndex;
+import com.intellij.psi.impl.source.tree.LeafPsiElement;
 import com.intellij.testFramework.fixtures.LightPlatformCodeInsightFixtureTestCase;
 import org.elixir_lang.psi.ElixirAlias;
 import org.elixir_lang.psi.QualifiedAlias;
 
-import java.util.Arrays;
 import java.util.List;
 
 public class NestedTest extends LightPlatformCodeInsightFixtureTestCase {
@@ -22,15 +20,13 @@ public class NestedTest extends LightPlatformCodeInsightFixtureTestCase {
         myFixture.configureByFiles("completion.ex", "suffix.ex", "nested.ex");
         myFixture.complete(CompletionType.BASIC, 1);
         List<String> strings = myFixture.getLookupElementStrings();
-        assertTrue(
-                strings.containsAll(
-                        Arrays.asList(
-                                // nested aliased name
-                                "As.Nested"
-                        )
-                )
-        );
-        assertEquals(1, strings.size());
+        assertNull("Completion lookup shown", strings);
+        PsiElement autoInsertedLeafElement = myFixture.getFile().findElementAt(myFixture.getCaretOffset() - 1);
+        assertNotNull(autoInsertedLeafElement);
+        assertInstanceOf(autoInsertedLeafElement, LeafPsiElement.class);
+        PsiElement autoInsertedCompositeElement = autoInsertedLeafElement.getParent();
+        assertInstanceOf(autoInsertedCompositeElement, ElixirAlias.class);
+        assertEquals(autoInsertedCompositeElement.getText(), "Nested");
     }
 
     public void testReference() {


### PR DESCRIPTION
# Changelog
## Enhancements
* Go To Declaration for functions and macros (only those defined in parseable-Elixir source.  References to Erlang functions or only those available in `.beam` file, such as the standard library will not resolve.)
* Completion for functions and macros (only those defined in parseable-Elixir source.  Erlang functions and Elixir function only in compiled `.beam` file, such as the standard library will not complete.)
  * Completion uses the same presentation as Structure View, so the you can tell whether the name is a function/macro, whether it is public/private, and the Module where it is defined.
  * Completed functions/macro insert `()` after the name in preparation for Elixir 1.4 where it is an error to have bare function calls.  It also makes it more obvious that you inserted a function and not a variable.
  * Completion works for all functions when a bare identifier is used.  For a qualified identifier, only functions/macros under than Module are shown. 
