### PR TITLE
Fix #453

### DIFF
--- a/src/org/elixir_lang/psi/scope/call_definition_clause/Variants.java
+++ b/src/org/elixir_lang/psi/scope/call_definition_clause/Variants.java
@@ -17,10 +17,7 @@ import org.elixir_lang.psi.stub.index.AllName;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import static org.elixir_lang.psi.impl.ElixirPsiImplUtil.ENTRANCE;
 
@@ -49,6 +46,7 @@ public class Variants extends CallDefinitionClause {
      * Fields
      */
 
+    @Nullable
     private Map<PsiElement, LookupElement> lookupElementByPsiElement = null;
 
     /*
@@ -140,7 +138,16 @@ public class Variants extends CallDefinitionClause {
         }
     }
 
+    @NotNull
     private Collection<LookupElement> getLookupElementCollection() {
-        return lookupElementByPsiElement.values();
+        Collection<LookupElement> lookupElementCollection;
+
+        if (lookupElementByPsiElement != null) {
+            lookupElementCollection = lookupElementByPsiElement.values();
+        } else {
+            lookupElementCollection = Collections.emptySet();
+        }
+
+        return lookupElementCollection;
     }
 }

--- a/testData/org/elixir_lang/psi/scope/call_definition_clause/variants/defmodule.ex
+++ b/testData/org/elixir_lang/psi/scope/call_definition_clause/variants/defmodule.ex
@@ -1,0 +1,1 @@
+de<caret>

--- a/tests/org/elixir_lang/psi/scope/call_definition_clause/VariantsTest.java
+++ b/tests/org/elixir_lang/psi/scope/call_definition_clause/VariantsTest.java
@@ -1,0 +1,30 @@
+package org.elixir_lang.psi.scope.call_definition_clause;
+
+import com.intellij.codeInsight.completion.CompletionType;
+import com.intellij.testFramework.fixtures.LightPlatformCodeInsightFixtureTestCase;
+
+import java.util.List;
+
+public class VariantsTest extends LightPlatformCodeInsightFixtureTestCase {
+    /*
+     * Tests
+     */
+
+    public void testIssue453() {
+        myFixture.configureByFiles("defmodule.ex");
+        myFixture.complete(CompletionType.BASIC);
+        List<String> strings = myFixture.getLookupElementStrings();
+        assertNotNull("Completion not shown", strings);
+        assertEquals("Wrong number of completions", 0, strings.size());
+    }
+
+    /*
+     * Protected Instance Methods
+     */
+
+    @Override
+    protected String getTestDataPath() {
+        return "testData/org/elixir_lang/psi/scope/call_definition_clause/variants";
+    }
+
+}


### PR DESCRIPTION
Fixes #453

# Changelog
## Enhancements
* Regression Test for #453.
## Bug Fixes
* Return `emptySet` when `lookupElementByPsiElement` is `null`.