### PR TITLE
Use Normalized operator for Prefix primaryArguments

### DIFF
--- a/src/org/elixir_lang/psi/impl/ElixirPsiImplUtil.java
+++ b/src/org/elixir_lang/psi/impl/ElixirPsiImplUtil.java
@@ -1423,12 +1423,8 @@ public class ElixirPsiImplUtil {
     @Contract(pure = true)
     @NotNull
     public static PsiElement[] primaryArguments(@NotNull final Prefix prefix) {
-        PsiElement[] children = prefix.getChildren();
-
-        assert children.length == 2;
-
         return new PsiElement[]{
-                children[1]
+            prefix.operand()
         };
     }
 

--- a/testData/org/elixir_lang/psi/operation/prefix/zero_operands.ex
+++ b/testData/org/elixir_lang/psi/operation/prefix/zero_operands.ex
@@ -1,0 +1,3 @@
+defmodule Prefix do
+  <caret>!<<a
+end

--- a/tests/org/elixir_lang/psi/operation/PrefixTest.java
+++ b/tests/org/elixir_lang/psi/operation/PrefixTest.java
@@ -1,0 +1,44 @@
+package org.elixir_lang.psi.operation;
+
+import com.intellij.psi.PsiElement;
+import com.intellij.testFramework.fixtures.LightPlatformCodeInsightFixtureTestCase;
+import org.elixir_lang.psi.Operator;
+import org.elixir_lang.psi.call.Call;
+
+public class PrefixTest extends LightPlatformCodeInsightFixtureTestCase {
+    /*
+     * Tests
+     */
+
+    public void testPrimaryArgumentsWithZeroOperands() {
+        myFixture.configureByFile("zero_operands.ex");
+        PsiElement elementAt = myFixture.getFile().findElementAt(myFixture.getCaretOffset());
+
+        assertNotNull(elementAt);
+
+        PsiElement parent = elementAt.getParent();
+
+        assertInstanceOf(parent, Operator.class);
+
+        PsiElement grandParent = parent.getParent();
+
+        assertInstanceOf(grandParent, Prefix.class);
+        assertInstanceOf(grandParent, Call.class);
+
+        Call grandParentPrefixCall = (Call) grandParent;
+        PsiElement[] primaryArguments = grandParentPrefixCall.primaryArguments();
+
+        assertNotNull(primaryArguments);
+        assertEquals(1, primaryArguments.length);
+        assertNull(primaryArguments[0]);
+    }
+
+    /*
+     * Protected Instance Methods
+     */
+
+    @Override
+    protected String getTestDataPath() {
+        return "testData/org/elixir_lang/psi/operation/prefix";
+    }
+}


### PR DESCRIPTION
Fixes #446

# Changelog
## Enhancements
* Regression test for #446

## Bug Fixes
* Don't do a naked `assert` that there are 2 children because this can fail during error recovery on the operand, instead use the `prefix.Normalized.operand()` through `prefix.operand()`.
  
  **WARNING: This changes the `@NotNull` array so that its sole element changes from
`@NotNull` to `@Nullable`.  It may trigger new bugs.**