### PR TITLE
Use shipped GeneratedParserUtilBase.DUMMY_BLOCK

### DIFF
--- a/src/org/elixir_lang/psi/scope/Variable.java
+++ b/src/org/elixir_lang/psi/scope/Variable.java
@@ -20,7 +20,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 
-import static com.intellij.lang.parser.GeneratedParserUtilBase.DUMMY_BLOCK;
+import static org.elixir_lang.grammar.parser.GeneratedParserUtilBase.DUMMY_BLOCK;
 import static org.elixir_lang.psi.call.name.Function.*;
 import static org.elixir_lang.psi.impl.ElixirPsiImplUtil.*;
 import static org.elixir_lang.psi.operation.Normalized.operatorIndex;


### PR DESCRIPTION
Fixes #460

# Changelog
## Bug Fixes
* Use shipped `GeneratedParserUtilBase.DUMMY_BLOCK` because the `DUMMY_BLOCK` *MUST* match the `GeneratedParserUtilBase` to detect dummy blocks inserted for error handling.