### PR TITLE
Skip over ElixirNoParenthesesStrict for isVariable

### DIFF
--- a/src/org/elixir_lang/reference/Callable.java
+++ b/src/org/elixir_lang/reference/Callable.java
@@ -259,9 +259,11 @@ public class Callable extends PsiReferenceBase<Call> implements PsiPolyVariantRe
                 ancestor instanceof ElixirNoParenthesesArguments ||
                 ancestor instanceof ElixirNoParenthesesKeywordPair ||
                 ancestor instanceof ElixirNoParenthesesKeywords ||
-                /* ElixirNoParenthesesManyStrictNoParenthesesExpression indicates a syntax error, but it can also occur
-                   during typing, so try searching above the syntax error to resolve whether a variable */
+                /* ElixirNoParenthesesManyStrictNoParenthesesExpression and ElixirNoParenthesesStrict
+                   indicates a syntax error, but it can also occur during typing, so try searching above the syntax
+                   error to resolve whether a variable */
                 ancestor instanceof ElixirNoParenthesesManyStrictNoParenthesesExpression ||
+                ancestor instanceof ElixirNoParenthesesStrict ||
                 ancestor instanceof ElixirParenthesesArguments ||
                 ancestor instanceof ElixirParentheticalStab ||
                 ancestor instanceof ElixirStab ||

--- a/testData/org/elixir_lang/reference/callable/issue_456/is_variable.ex
+++ b/testData/org/elixir_lang/reference/callable/issue_456/is_variable.ex
@@ -1,0 +1,1 @@
+from (f in FanTag, order_by<caret>)

--- a/tests/org/elixir_lang/reference/callable/Issue456Test.java
+++ b/tests/org/elixir_lang/reference/callable/Issue456Test.java
@@ -1,0 +1,33 @@
+package org.elixir_lang.reference.callable;
+
+import com.intellij.psi.PsiElement;
+import com.intellij.testFramework.fixtures.LightCodeInsightFixtureTestCase;
+import org.elixir_lang.psi.call.Call;
+
+import static org.elixir_lang.reference.Callable.isVariable;
+
+public class Issue456Test extends LightCodeInsightFixtureTestCase {
+    /*
+     * Tests
+     */
+
+    public void testIsVariable() {
+        myFixture.configureByFiles("is_variable.ex");
+        PsiElement callable = myFixture
+                .getFile()
+                .findElementAt(myFixture.getCaretOffset())
+                .getPrevSibling();
+
+        assertInstanceOf(callable, Call.class);
+        assertFalse("order_by is incorrectly marked as a variable", isVariable(callable));
+    }
+
+    /*
+     * Protected Instance Methods
+     */
+
+    @Override
+    protected String getTestDataPath() {
+        return "testData/org/elixir_lang/reference/callable/issue_456";
+    }
+}


### PR DESCRIPTION
Fixes #456

# Changelog
## Enhancements
* Regression test for #456

## Bug Fixes
* Skip over `ElixirNoParenthesesStrict` for `isVariable`