### PR TITLE
Don't add current call definition clause being written to completion 

### DIFF
--- a/src/org/elixir_lang/annonator/Parameter.java
+++ b/src/org/elixir_lang/annonator/Parameter.java
@@ -19,6 +19,10 @@ public class Parameter {
         FUNCTION_NAME,
         MACRO_NAME,
         VARIABLE;
+
+        public static boolean isCallDefinitionClauseName(Type type) {
+            return type == FUNCTION_NAME || type == MACRO_NAME;
+        }
     }
 
     /*
@@ -221,8 +225,18 @@ public class Parameter {
      */
 
     /**
+     * Whether the {@link #type} is call definition clause name
+     *
+     * @return {@code true} if {@link #type} is {@link Type#FUNCTION_NAME} or {@link Type#MACRO_NAME}.
+     */
+    @Contract(pure = true)
+    public boolean isCallDefinitionClauseName() {
+        return Type.isCallDefinitionClauseName(type);
+    }
+
+    /**
      * Whether {@link #entrance} represents a parameter to a {@link #parameterized} element
-     * @return {@true true} if {@link #parameterized} is not {@code null}
+     * @return {@code true} if {@link #parameterized} is not {@code null}
      */
     @Contract(pure = true)
     boolean isValid() {

--- a/src/org/elixir_lang/code_insight/highlighting/brace_matcher/NonTrivial.java
+++ b/src/org/elixir_lang/code_insight/highlighting/brace_matcher/NonTrivial.java
@@ -21,10 +21,13 @@ public class NonTrivial extends PairedBraceMatcherAdapter {
 
     if (pair == Paired.DO_END || pair == Paired.FN_END) {
       iterator.advance();
-      IElementType tokenType = iterator.getTokenType();
 
-      if (tokenType == ElixirTypes.KEYWORD_PAIR_COLON) {
-        pair = null;
+      if (!iterator.atEnd()) {
+        IElementType tokenType = iterator.getTokenType();
+
+        if (tokenType == ElixirTypes.KEYWORD_PAIR_COLON) {
+          pair = null;
+        }
       }
 
       iterator.retreat();

--- a/testData/org/elixir_lang/psi/scope/call_definition_clause/variants/self_completion.ex
+++ b/testData/org/elixir_lang/psi/scope/call_definition_clause/variants/self_completion.ex
@@ -1,0 +1,7 @@
+defmodule SelfCompletion do
+  def an_already_defined_function, do: :ok
+
+  def the_function_currently_being_defined<caret>
+
+  def an_already_defined_function, do: :ok
+end

--- a/tests/org/elixir_lang/psi/scope/call_definition_clause/VariantsTest.java
+++ b/tests/org/elixir_lang/psi/scope/call_definition_clause/VariantsTest.java
@@ -1,7 +1,11 @@
 package org.elixir_lang.psi.scope.call_definition_clause;
 
 import com.intellij.codeInsight.completion.CompletionType;
+import com.intellij.codeInsight.lookup.LookupElement;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiReference;
 import com.intellij.testFramework.fixtures.LightPlatformCodeInsightFixtureTestCase;
+import org.elixir_lang.psi.call.Call;
 
 import java.util.List;
 
@@ -16,6 +20,32 @@ public class VariantsTest extends LightPlatformCodeInsightFixtureTestCase {
         List<String> strings = myFixture.getLookupElementStrings();
         assertNotNull("Completion not shown", strings);
         assertEquals("Wrong number of completions", 0, strings.size());
+    }
+
+    public void testIssue462() {
+        myFixture.configureByFiles("self_completion.ex");
+        PsiElement head = myFixture
+                .getFile()
+                .findElementAt(myFixture.getCaretOffset() - 1)
+                .getParent()
+                .getParent();
+        assertInstanceOf(head, Call.class);
+        PsiReference reference = head.getReference();
+        assertNotNull("Call definition head does not have a reference", reference);
+        Object[] variants = reference.getVariants();
+        int count = 0;
+
+        for (Object variant : variants) {
+            if (variant instanceof LookupElement) {
+                LookupElement lookupElement = (LookupElement) variant;
+
+                if (lookupElement.getLookupString().equals("the_function_currently_being_defined")) {
+                      count += 1;
+                }
+            }
+        }
+
+        assertEquals("There is at least one entry for the function currently being defined in variants", 0, count);
     }
 
     /*


### PR DESCRIPTION
Fixes #462

# Changelog
## Bug Fixes
* Check if `iterator.atEnd()` before calling `iterator.getTokenType()` to avoid `IndexOutOfBounds` exception.
* Don't add current call definition clause being written to completion 