### PR TITLE
stripGuard handles errors in left operand for when

### DIFF
--- a/testData/org/elixir_lang/structure_view/element/call_definition_head/issue_468.ex
+++ b/testData/org/elixir_lang/structure_view/element/call_definition_head/issue_468.ex
@@ -1,0 +1,11 @@
+def create(state = %__MODULE__{ecto_schema_module: ecto_schema_module, view: view}, params) when when is_ is_map(params)  do
+  with :ok <- can(state, :create, ecto_schema_module),
+       {:ok, document} <- document(params, :create),
+       insertable_params = insertable_params(state, document),
+       {:ok, changeset} <- changeset(state, insertable_params),
+       :ok <- can(state, :create, changeset),
+       {:ok, created} <- create_changeset(state, changeset) do
+    authorized = authorized(state, created)
+    {:ok, view.show(authorized, params)}
+  end
+end

--- a/testData/org/elixir_lang/structure_view/element/call_definition_head/no_when.ex
+++ b/testData/org/elixir_lang/structure_view/element/call_definition_head/no_when.ex
@@ -1,0 +1,11 @@
+def create(state = %__MODULE__{ecto_schema_module: ecto_schema_module, view: view}, params) do
+  with :ok <- can(state, :create, ecto_schema_module),
+       {:ok, document} <- document(params, :create),
+       insertable_params = insertable_params(state, document),
+       {:ok, changeset} <- changeset(state, insertable_params),
+       :ok <- can(state, :create, changeset),
+       {:ok, created} <- create_changeset(state, changeset) do
+    authorized = authorized(state, created)
+    {:ok, view.show(authorized, params)}
+  end
+end

--- a/testData/org/elixir_lang/structure_view/element/call_definition_head/single_when.ex
+++ b/testData/org/elixir_lang/structure_view/element/call_definition_head/single_when.ex
@@ -1,0 +1,11 @@
+def create(state = %__MODULE__{ecto_schema_module: ecto_schema_module, view: view}, params) when is_map(params) do
+  with :ok <- can(state, :create, ecto_schema_module),
+       {:ok, document} <- document(params, :create),
+       insertable_params = insertable_params(state, document),
+       {:ok, changeset} <- changeset(state, insertable_params),
+       :ok <- can(state, :create, changeset),
+       {:ok, created} <- create_changeset(state, changeset) do
+    authorized = authorized(state, created)
+    {:ok, view.show(authorized, params)}
+  end
+end

--- a/tests/org/elixir_lang/structure_view/element/CallDefinitionHeadTest.java
+++ b/tests/org/elixir_lang/structure_view/element/CallDefinitionHeadTest.java
@@ -1,0 +1,62 @@
+package org.elixir_lang.structure_view.element;
+
+import com.intellij.psi.PsiElement;
+import com.intellij.testFramework.fixtures.LightPlatformCodeInsightFixtureTestCase;
+import org.elixir_lang.psi.call.Call;
+
+public class CallDefinitionHeadTest extends LightPlatformCodeInsightFixtureTestCase {
+    /*
+     * Tests
+     */
+
+    public void testIssue468() {
+        myFixture.configureByFile("issue_468.ex");
+        assertIssue468CallDefinitionHeadClauseHead();
+    }
+
+    public void testSingleWhen() {
+        myFixture.configureByFile("single_when.ex");
+        assertIssue468CallDefinitionHeadClauseHead();
+    }
+
+    public void testNoWhen() {
+        myFixture.configureByFile("no_when.ex");
+        assertIssue468CallDefinitionHeadClauseHead();
+    }
+
+    /*
+     * Protected Instance Methods
+     */
+
+    @Override
+    protected String getTestDataPath() {
+        return "testData/org/elixir_lang/structure_view/element/call_definition_head";
+    }
+
+    /*
+     * Private Instance Methods
+     */
+
+    private void assertIssue468CallDefinitionHeadClauseHead() {
+        PsiElement element = myFixture
+                .getFile()
+                .findElementAt(myFixture.getCaretOffset())
+                .getParent()
+                .getParent();
+
+        assertNotNull(element);
+        assertInstanceOf(element, Call.class);
+
+        Call call = (Call) element;
+
+        assertTrue("Call at caret is not a call definition clause", CallDefinitionClause.is(call));
+        PsiElement head = CallDefinitionClause.head(call);
+
+        assertNotNull("Call definition has a null head", head);
+
+        assertEquals(
+                "create(state = %__MODULE__{ecto_schema_module: ecto_schema_module, view: view}, params)",
+                CallDefinitionHead.stripGuard(head).getText()
+        );
+    }
+}


### PR DESCRIPTION
Fixes #468

# Changelog
## Enhancements
* Regression test ofr #468

## Bug Fixes
* When#leftOperand will return null (because it's normalized) if there are left-hand error elements, but when stripping guards we want best-effort to match human expectations, so don't use normalized null, but use left, non-error element if it is unique.