### PR TITLE
Highlight types in QualifiedNoParenthesesCall

### DIFF
--- a/src/org/elixir_lang/annonator/ModuleAttribute.java
+++ b/src/org/elixir_lang/annonator/ModuleAttribute.java
@@ -412,6 +412,10 @@ public class ModuleAttribute implements Annotator, DumbAware {
         }
     }
 
+    private void highlightTypeError(@NotNull PsiElement element, @NotNull AnnotationHolder annotationHolder, @NotNull String message) {
+        annotationHolder.createErrorAnnotation(element, message);
+    }
+
     private void highlightTypesAndTypeTypeParameterDeclarations(ElixirUnmatchedUnqualifiedNoArgumentsCall psiElement,
                                                                 Set<String> typeParameterNameSet,
                                                                 AnnotationHolder annotationHolder,
@@ -940,6 +944,8 @@ public class ModuleAttribute implements Annotator, DumbAware {
                     annotationHolder,
                     typeTextAttributesKey
             );
+        } else if (psiElement instanceof InterpolatedString) {
+            highlightTypeError(psiElement, annotationHolder, "Strings aren't allowed in types");
         } else if (psiElement instanceof When) {
             /* NOTE: MUST be before `Infix` as `When` is a subinterface of
               `Infix` */

--- a/src/org/elixir_lang/annonator/ModuleAttribute.java
+++ b/src/org/elixir_lang/annonator/ModuleAttribute.java
@@ -977,6 +977,13 @@ public class ModuleAttribute implements Annotator, DumbAware {
                     annotationHolder,
                     typeTextAttributesKey
             );
+        } else if (psiElement instanceof QualifiedNoParenthesesCall) {
+            highlightTypesAndTypeParameterUsages(
+                    (QualifiedNoParenthesesCall) psiElement,
+                    typeParameterNameSet,
+                    annotationHolder,
+                    typeTextAttributesKey
+            );
         } else if (psiElement instanceof UnqualifiedNoParenthesesCall) {
             highlightTypesAndTypeParameterUsages(
                     (UnqualifiedNoParenthesesCall) psiElement,
@@ -1044,6 +1051,31 @@ public class ModuleAttribute implements Annotator, DumbAware {
         );
         highlightTypesAndTypeParameterUsages(
                 qualifiedNoArgumentsCall.getRelativeIdentifier(),
+                typeParameterNameSet,
+                annotationHolder,
+                textAttributesKey
+        );
+    }
+
+    private void highlightTypesAndTypeParameterUsages(
+            QualifiedNoParenthesesCall qualifiedNoParenthesesCall,
+            Set<String> typeParameterNameSet,
+            AnnotationHolder annotationHolder,
+            TextAttributesKey textAttributesKey) {
+        highlightTypesAndTypeParameterUsages(
+                qualifiedNoParenthesesCall.getFirstChild(),
+                typeParameterNameSet,
+                annotationHolder,
+                textAttributesKey
+        );
+        highlightTypesAndTypeParameterUsages(
+                qualifiedNoParenthesesCall.getRelativeIdentifier(),
+                typeParameterNameSet,
+                annotationHolder,
+                textAttributesKey
+        );
+        highlightTypesAndTypeParameterUsages(
+                qualifiedNoParenthesesCall.primaryArguments(),
                 typeParameterNameSet,
                 annotationHolder,
                 textAttributesKey

--- a/testData/org/elixir_lang/annotator/module_attribute/issue_469.ex
+++ b/testData/org/elixir_lang/annotator/module_attribute/issue_469.ex
@@ -1,0 +1,98 @@
+defmodule Interpreter.Resources do
+  @moduledoc """
+  A module that exposes Ecto schema structs
+  """
+
+  # Types
+
+  @typedoc """
+  ID that uniquely identifies the `struct`
+  """
+  @type id :: term
+
+  @type params :: map
+
+  @typedoc """
+    * `:associations` - associations to load in the `struct`
+  """
+  @type query_options :: %{optional(:associations) => atom | [atom]}
+
+  @type sandbox_access_token :: %{required(:owner) => term}
+
+  # Callbacks
+
+  @doc """
+  Allows access to sandbox for testing
+  """
+  @callback allow_sandbox_access(sandbox_access_token) :: :ok | {:already, :owner | :allowed} | :not_found
+
+  @doc """
+  Changeset for creating a struct from the `params`
+  """
+  @callback changeset(params) :: Ecto.Changeset.
+
+  @doc <error descr="Strings aren't allowed in types">"""
+  Deletes a single `struct`
+
+  # Returns
+
+    * `{:ok, struct}` - the delete succeeded and the returned struct is the state before delete
+    * `{:error, Ecto.Changeset.t}` - errors while deleting the `struct`.  `Ecto.Changeset.t` `errors` contains errors.
+  """</error>
+  @callback delete(struct) :: {:ok, struct} | {:error, Ecto.Changeset.t}
+
+  @doc """
+  Gets a single `struct`
+
+  # Returns
+
+    * `nil` - if the `id` was not found
+    * `struct` - if the `id` was found
+
+  """
+  @callback get(id, query_options) :: nil | struct
+
+  @doc """
+  Inserts `changeset` into a single new `struct`
+
+  # Returns
+    * `{:ok, struct}` - `changeset` was inserted into `struct`
+    * `{:error, Ecto.Changeset.t}` - insert failed.  `Ecto.Changeset.t` `errors` contain errors.
+  """
+  @callback insert(Ecto.Changeset.t, query_options) :: {:ok, struct} | {:error, Ecto.Changeset.t}
+
+  @doc """
+  Inserts `params` into a single new `struct`
+
+  # Returns
+
+    * `{:ok, struct}` - params were inserted into `struct`
+    * `{:error, Ecto.Changeset.t}` - insert failed.  `Ecto.Changeset.t` `errors` contain errors.
+
+  """
+  @callback insert(params, query_options) :: {:ok, struct} | {:error, Ecto.Changeset.t}
+
+  @doc """
+  Gets a list of `struct`s.
+  """
+  @callback list(query_options) :: [struct]
+
+  @doc """
+  # Returns
+
+    * `true` - if `allow_sandbox_access/1` should be called before any of the query methods are called
+    * `false` - otherwise
+  """
+  @callback sandboxed?() :: boolean
+
+  @doc """
+  Updates `struct`
+
+  # Returns
+
+    * `{:ok, struct}` - the update succeeded and the returned `struct` contains the updates
+    * `{error, Ecto.Changeset.t}` - errors while updating `struct` with `params`.  `Ecto.Changeset.t` `errors` contains
+      errors.
+  """
+  @callback update(struct, params, query_options) :: {:ok, struct} | {:error, Ecto.Changeset.t}
+end

--- a/tests/org/elixir_lang/annotator/ModuleAttributeTest.java
+++ b/tests/org/elixir_lang/annotator/ModuleAttributeTest.java
@@ -24,6 +24,11 @@ public class ModuleAttributeTest extends LightCodeInsightFixtureTestCase {
         myFixture.checkHighlighting(false, false, true);
     }
 
+    public void testIssue469() {
+        myFixture.configureByFile("issue_469.ex");
+        myFixture.checkHighlighting(false, false, true);
+    }
+
     /*
      * Protected Instance Methods
      */


### PR DESCRIPTION
Fixes #469

# Changelog
## Enhancements
* Regression test for #469
* Highlight Strings and String Heredocs as errors in types.

## Bug Fixes
* Highlight types in `QualifiedNoParenthesesCall`
