### PR TITLE
Check if name is longer than presentable text of CallDefinitionClause

### DIFF
--- a/src/org/elixir_lang/code_insight/lookup/element_renderer/CallDefinitionClause.java
+++ b/src/org/elixir_lang/code_insight/lookup/element_renderer/CallDefinitionClause.java
@@ -4,6 +4,7 @@ import com.intellij.codeInsight.lookup.LookupElement;
 import com.intellij.codeInsight.lookup.LookupElementPresentation;
 import com.intellij.navigation.ItemPresentation;
 import com.intellij.psi.PsiElement;
+import org.elixir_lang.errorreport.Logger;
 import org.elixir_lang.psi.call.Call;
 import org.jetbrains.annotations.NotNull;
 
@@ -48,7 +49,18 @@ public class CallDefinitionClause extends com.intellij.codeInsight.lookup.Lookup
                 String presentableText = structureViewPresentation.getPresentableText();
 
                 if (presentableText != null) {
-                    presentation.appendTailText(presentableText.substring(name.length()), true);
+                    int nameLength = name.length();
+                    int presentableTextLength = presentableText.length();
+
+                    if (nameLength <= presentableTextLength) {
+                        presentation.appendTailText(presentableText.substring(nameLength), true);
+                    } else {
+                        Logger.error(
+                                CallDefinitionClause.class,
+                                "name (`" + name + "`) is longer than the presentable test (`" + presentableText + "`)",
+                                psiElement
+                        );
+                    }
                 }
 
                 String locationString = structureViewPresentation.getLocationString();

--- a/testData/org/elixir_lang/code_insight/lookup/element_renderer/call_definition_clause/issue_457.ex
+++ b/testData/org/elixir_lang/code_insight/lookup/element_renderer/call_definition_clause/issue_457.ex
@@ -1,0 +1,4 @@
+defmodule Issue457 do
+  <caret>def foo do
+  end
+end

--- a/tests/org/elixir_lang/code_insight/lookup/element_renderer/CallDefinitionClauseTest.java
+++ b/tests/org/elixir_lang/code_insight/lookup/element_renderer/CallDefinitionClauseTest.java
@@ -1,0 +1,82 @@
+package org.elixir_lang.code_insight.lookup.element_renderer;
+
+import com.intellij.codeInsight.lookup.LookupElement;
+import com.intellij.codeInsight.lookup.LookupElementPresentation;
+import com.intellij.psi.PsiElement;
+import com.intellij.testFramework.fixtures.LightPlatformCodeInsightFixtureTestCase;
+import org.elixir_lang.psi.call.Call;
+import org.jetbrains.annotations.NotNull;
+
+public class CallDefinitionClauseTest extends LightPlatformCodeInsightFixtureTestCase {
+    /*
+     * Tests
+     */
+
+    public void testIssue457ShorterName() {
+        String name = "fo";
+        LookupElement lookupElement = lookupElement(name);
+        LookupElementPresentation lookupElementPresentation = new LookupElementPresentation();
+
+        lookupElement.renderElement(lookupElementPresentation);
+
+        assertEquals(name, lookupElementPresentation.getItemText());
+    }
+
+    public void testIssue457EqualName() {
+        String name = "foo";
+        LookupElement lookupElement = lookupElement(name);
+        LookupElementPresentation lookupElementPresentation = new LookupElementPresentation();
+
+        lookupElement.renderElement(lookupElementPresentation);
+
+        assertEquals(name, lookupElementPresentation.getItemText());
+    }
+
+    public void testIssue457LongerName() {
+        LookupElement lookupElement = lookupElement("fooo");
+        LookupElementPresentation lookupElementPresentation = new LookupElementPresentation();
+        boolean assertionErrorThrown = false;
+
+        try {
+            lookupElement.renderElement(lookupElementPresentation);
+        } catch (AssertionError e) {
+            assertionErrorThrown = true;
+        }
+
+        assertTrue(assertionErrorThrown);
+    }
+
+    /*
+     * Protected Instance Methods
+     */
+
+    @Override
+    protected String getTestDataPath() {
+        return "testData/org/elixir_lang/code_insight/lookup/element_renderer/call_definition_clause";
+    }
+
+    /*
+     * Private Instance Methods
+     */
+
+    private LookupElement lookupElement(@NotNull String name) {
+        myFixture.configureByFile("issue_457.ex");
+
+        PsiElement elementAtCaret = myFixture.getFile().findElementAt(myFixture.getCaretOffset());
+
+        assertNotNull(elementAtCaret);
+
+        PsiElement maybeDefElement = elementAtCaret.getParent().getParent();
+
+        assertInstanceOf(maybeDefElement, Call.class);
+
+        Call maybeDefCall = (Call) maybeDefElement;
+
+        assertTrue(org.elixir_lang.structure_view.element.CallDefinitionClause.is(maybeDefCall));
+
+        return org.elixir_lang.code_insight.lookup.element.CallDefinitionClause.createWithSmartPointer(
+                name,
+                maybeDefElement
+        );
+    }
+}


### PR DESCRIPTION
Fix #457

# Changelog
## Bug Fixes
* Still not obvious why `name` for a `CallDefinitionClause` lookup renderer can be longer than `presentableText`, so still log an error, but with `Logger.error`, so we get `name`, `presentableText`, and the original `element`.