### PR TITLE
Set ENTRANCE to matchAncestor instead of previous expression

### DIFF
--- a/src/org/elixir_lang/psi/scope/variable/MultiResolve.java
+++ b/src/org/elixir_lang/psi/scope/variable/MultiResolve.java
@@ -109,7 +109,8 @@ public class MultiResolve extends Variable {
 
         do {
             expression = expression.getParent();
-        } while (expression instanceof ElixirDoBlock ||
+        } while (expression instanceof Arguments ||
+                expression instanceof ElixirDoBlock ||
                 expression instanceof ElixirStab ||
                 expression instanceof ElixirStabBody);
 

--- a/src/org/elixir_lang/psi/scope/variable/MultiResolve.java
+++ b/src/org/elixir_lang/psi/scope/variable/MultiResolve.java
@@ -208,7 +208,10 @@ public class MultiResolve extends Variable {
                                             name,
                                             incompleteCode,
                                             expression,
-                                            ResolveState.initial().put(LAST_BINDING_KEY, element)
+                                            ResolveState
+                                                    .initial()
+                                                    .put(ENTRANCE, matchAncestor)
+                                                    .put(LAST_BINDING_KEY, element)
                                     );
 
                                     if (preboundResolveResultList != null && preboundResolveResultList.size() > 0) {

--- a/src/org/elixir_lang/psi/scope/variable/MultiResolve.java
+++ b/src/org/elixir_lang/psi/scope/variable/MultiResolve.java
@@ -81,12 +81,19 @@ public class MultiResolve extends Variable {
                                                         @NotNull PsiElement entrance,
                                                         @NotNull ResolveState resolveState) {
         MultiResolve multiResolve = new MultiResolve(name, incompleteCode);
+        ResolveState treeWalkUpResolveState = resolveState;
+
+        if (treeWalkUpResolveState.get(ENTRANCE) == null) {
+            treeWalkUpResolveState = treeWalkUpResolveState.put(ENTRANCE, entrance);
+        }
+
         PsiTreeUtil.treeWalkUp(
                 multiResolve,
                 entrance,
                 entrance.getContainingFile(),
-                resolveState.put(ENTRANCE, entrance)
+                treeWalkUpResolveState
         );
+
         return multiResolve.getResolveResultList();
     }
 

--- a/testData/org/elixir_lang/issue_470/in_match_in_match.ex
+++ b/testData/org/elixir_lang/issue_470/in_match_in_match.ex
@@ -1,0 +1,3 @@
+with k <- g(p, "k"),
+     l <- g(p, "l") do
+end

--- a/testData/org/elixir_lang/issue_470/in_match_match.ex
+++ b/testData/org/elixir_lang/issue_470/in_match_match.ex
@@ -1,0 +1,3 @@
+with k <- g(p, "k"),
+     l = g(p, "l") do
+end

--- a/testData/org/elixir_lang/issue_470/in_match_match_match.ex
+++ b/testData/org/elixir_lang/issue_470/in_match_match_match.ex
@@ -1,0 +1,4 @@
+with k <- g(p, "k"),
+     l = g(p, "l"),
+     m = g(p, "m") do
+end

--- a/testData/org/elixir_lang/issue_470/match_in_match.ex
+++ b/testData/org/elixir_lang/issue_470/match_in_match.ex
@@ -1,0 +1,3 @@
+with k = g(p, "k"),
+     l <- g(p, "l") do
+end

--- a/testData/org/elixir_lang/issue_470/match_in_match_match.ex
+++ b/testData/org/elixir_lang/issue_470/match_in_match_match.ex
@@ -1,0 +1,4 @@
+with k = g(p, "k"),
+     l <- g(p, "l"),
+     m = g(p, "m") do
+end

--- a/testData/org/elixir_lang/issue_470/match_match.ex
+++ b/testData/org/elixir_lang/issue_470/match_match.ex
@@ -1,0 +1,3 @@
+with k = g(p, "k"),
+     l = g(p, "l") do
+end

--- a/tests/org/elixir_lang/Issue470.java
+++ b/tests/org/elixir_lang/Issue470.java
@@ -1,0 +1,48 @@
+package org.elixir_lang;
+
+import com.intellij.testFramework.fixtures.LightCodeInsightFixtureTestCase;
+
+public class Issue470 extends LightCodeInsightFixtureTestCase {
+    /*
+     * Tests
+     */
+
+    public void testInMatchInMatch() {
+        myFixture.configureByFile("in_match_in_match.ex");
+        myFixture.checkHighlighting(false, false, true);
+    }
+
+    public void testInMatchMatch() {
+        myFixture.configureByFile("in_match_match.ex");
+        myFixture.checkHighlighting(false, false, true);
+    }
+
+    public void testInMatchMatchMatch() {
+        myFixture.configureByFile("in_match_match_match.ex");
+        myFixture.checkHighlighting(false, false, true);
+    }
+
+    public void testMatchInMatch() {
+        myFixture.configureByFile("match_in_match.ex");
+        myFixture.checkHighlighting(false, false, true);
+    }
+
+    public void testMatchInMatchMatch() {
+        myFixture.configureByFile("match_in_match_match.ex");
+        myFixture.checkHighlighting(false, false, true);
+    }
+
+    public void testMatchMatch() {
+        myFixture.configureByFile("match_match.ex");
+        myFixture.checkHighlighting(false, false, true);
+    }
+
+    /*
+     * Protected Instance Methods
+     */
+
+    @Override
+    protected String getTestDataPath() {
+        return "testData/org/elixir_lang/issue_470";
+    }
+}


### PR DESCRIPTION
Fixes #470

# Changelog
## Enhancements
* Failing regression test for #470

## Bug Fixes
* Skip `Arguments` elements in `previousParentExpresion` to eliminate an unnecessary level of processing declarations since calls will enter their arguments.
* Only put new `ENTRANCE` in `ResolveState` in `variable.MultiResolve.resolveResultList`, so that caller can override the default value.
* Set `ENTRANCE` to `matchAncestor` instead of previous expression to eliminate the looping that occurred when a variable was unbound (or a function) because the check for `with` (and `for`) was expecting the `ENTRANCE` to be the previous child expression instead of the `with`
clause as a whole (or the `Arguments` element as had been the case before
6fcc19b).