### PR TITLE
Add Mix ExUnit run configuration

### DIFF
--- a/jps-shared/src/org/elixir_lang/jps/mix/MixSettingsState.java
+++ b/jps-shared/src/org/elixir_lang/jps/mix/MixSettingsState.java
@@ -10,13 +10,16 @@ public class MixSettingsState {
   @Tag("mixPath")
   @NotNull
   public String myMixPath;
+  public boolean supportsFormatterOption;
 
   public MixSettingsState(){
     myMixPath = "";
+    supportsFormatterOption = false;
   }
 
   public MixSettingsState(MixSettingsState state){
     myMixPath = state.myMixPath;
+    supportsFormatterOption = state.supportsFormatterOption;
   }
 
   @Override

--- a/jps-shared/src/org/elixir_lang/jps/mix/MixSettingsState.java
+++ b/jps-shared/src/org/elixir_lang/jps/mix/MixSettingsState.java
@@ -17,7 +17,7 @@ public class MixSettingsState {
     supportsFormatterOption = false;
   }
 
-  public MixSettingsState(MixSettingsState state){
+  MixSettingsState(MixSettingsState state){
     myMixPath = state.myMixPath;
     supportsFormatterOption = state.supportsFormatterOption;
   }

--- a/res/exunit/team_city_ex_unit_formatter.ex
+++ b/res/exunit/team_city_ex_unit_formatter.ex
@@ -1,0 +1,100 @@
+# https://github.com/lixhq/teamcity-exunit-formatter
+defmodule TeamCityExUnitFormatter do
+  @moduledoc false
+
+  use GenEvent
+
+  def formatter(_color, msg), do: msg
+
+  def init(opts) do
+    config = %{
+      seed: opts[:seed],
+      trace: opts[:trace],
+      width: 80,
+      tests_counter: 0,
+      failures_counter: 0,
+      skipped_counter: 0,
+      invalids_counter: 0
+    }
+    {:ok, config}
+  end
+
+  def handle_event({:case_started, %ExUnit.TestCase{name: name}}, config) do
+    IO.puts format :test_suite_started, name: name
+    {:ok, config}
+  end
+
+  def handle_event({:case_finished, %ExUnit.TestCase{name: name}}, config) do
+    IO.puts format :test_suite_finished, name: name
+    {:ok, config}
+  end
+
+  def handle_event({:test_started, %ExUnit.Test{name: name, case: the_case, tags: tags}}, config) do
+    IO.puts format :test_started, name: "#{the_case}.#{name}", locationHint: "file://#{tags[:file]}:#{tags[:line]}"
+    {:ok, config}
+  end
+
+  def handle_event({:test_finished, %ExUnit.Test{name: name, case: the_case, time: time, state: {:failed, {_, reason, _} = failed}} = test}, config) do
+    formatted = ExUnit.Formatter.format_test_failure(test, failed, config.failures_counter + 1, config.width, &formatter/2)
+    IO.puts format :test_failed, name: "#{the_case}.#{name}", message: inspect(reason), details: formatted
+    IO.puts format :test_finished, name: "#{the_case}.#{name}", duration: div(time, 1000)
+    {:ok, %{config | tests_counter: config.tests_counter + 1,
+                     failures_counter: config.failures_counter + 1}}
+  end
+
+  def handle_event({:test_finished, %ExUnit.Test{name: name, case: the_case, time: time, state: {:failed, failed}} = test}, config) when is_list(failed) do
+    formatted = ExUnit.Formatter.format_test_failure(test, failed, config.failures_counter + 1, config.width, &formatter/2)
+    message = Enum.map_join(failed, "", fn {_kind, reason, _stack} -> inspect(reason) end)
+    IO.puts format :test_failed, name: "#{the_case}.#{name}", message: message, details: formatted
+    IO.puts format :test_finished, name: "#{the_case}.#{name}", duration: div(time, 1000)
+    {:ok, %{config | tests_counter: config.tests_counter + 1,
+                     failures_counter: config.failures_counter + 1}}
+  end
+
+  def handle_event({:test_finished, %ExUnit.Test{name: name, case: the_case, state: {:skip, _}}}, config) do
+    IO.puts format :test_ignored, name: "#{the_case}.#{name}"
+    IO.puts format :test_finished, name: "#{the_case}.#{name}"
+    {:ok, %{config | tests_counter: config.tests_counter + 1,
+                     skipped_counter: config.skipped_counter + 1}}
+  end
+
+  def handle_event({:test_finished, %ExUnit.Test{name: name, case: the_case, time: time}}, config) do
+    IO.puts format :test_finished, name: "#{the_case}.#{name}", duration: div(time, 1000)
+    {:ok, config}
+  end
+
+  def handle_event(_, config) do
+    {:ok, config}
+  end
+
+  defp format(type, attributes) do
+    attrs = attributes
+            |> Enum.map(&format_attribute/1)
+            |> Enum.join(" ")
+    messageName = camelize Atom.to_string(type)
+    "##teamcity[#{messageName} #{attrs}]"
+  end
+
+  defp format_attribute({k, v}) do
+    "#{Atom.to_string k}='#{escape_output v}'"
+  end
+
+  defp camelize(s) do
+    [head | tail] = String.split s, "_"
+    "#{head}#{Enum.map tail, &String.capitalize/1}"
+  end
+
+   #Must escape certain characters, see: https://confluence.jetbrains.com/display/TCD9/Build+Script+Interaction+with+TeamCity
+  defp escape_output(s) when not is_binary(s) do escape_output("#{s}") end
+  defp escape_output(s) do
+    s
+      |> String.replace("|", "||")
+      |> String.replace("'", "|'")
+      |> String.replace("\n", "|n")
+      |> String.replace("\r", "|r")
+      #|> String.replace(~r/u([0-9a-f]{4})/i, "|0x\\1")
+      #|> String.replace(~r/\x{([0-9a-f]{4})}/ui, "|0x\\1")
+      |> String.replace("[", "|[")
+      |> String.replace("]", "|]")
+  end
+end

--- a/res/exunit/test_with_formatter.ex
+++ b/res/exunit/test_with_formatter.ex
@@ -1,0 +1,364 @@
+# The --formatter option was added to mix test after 1.3.4, so for earlier versions we have to include this task
+defmodule Mix.Tasks.TestWithFormatter do
+  defmodule Cover do
+    @moduledoc false
+
+    def start(compile_path, opts) do
+      Mix.shell.info "Cover compiling modules ..."
+      _ = :cover.start
+
+      case :cover.compile_beam_directory(compile_path |> to_charlist) do
+        results when is_list(results) ->
+          :ok
+        {:error, _} ->
+          Mix.raise "Failed to cover compile directory: " <> compile_path
+      end
+
+      output = opts[:output]
+
+      fn() ->
+        Mix.shell.info "\nGenerating cover results ..."
+        File.mkdir_p!(output)
+        Enum.each :cover.modules, fn(mod) ->
+          {:ok, _} = :cover.analyse_to_file(mod, '#{output}/#{mod}.html', [:html])
+        end
+      end
+    end
+  end
+
+  use Mix.Task
+
+  alias Mix.Compilers.Test, as: CT
+
+  @shortdoc "Runs a project's tests"
+  @recursive true
+  @preferred_cli_env :test
+
+  @moduledoc """
+  Runs the tests for a project.
+
+  This task starts the current application, loads up
+  `test/test_helper.exs` and then requires all files matching the
+  `test/**/_test.exs` pattern in parallel.
+
+  A list of files can be given after the task name in order to select
+  the files to compile:
+
+      mix test test/some/particular/file_test.exs
+
+  ## Command line options
+
+    * `--trace`      - run tests with detailed reporting; automatically sets `--max-cases` to 1
+    * `--max-cases`  - set the maximum number of cases running async
+    * `--cover`      - the directory to include coverage results
+    * `--raise`      - raise if the test suit failed
+    * `--force`      - forces compilation regardless of modification times
+    * `--no-compile` - do not compile, even if files require compilation
+    * `--no-start`   - do not start applications after compilation
+    * `--no-color`   - disable color in the output
+    * `--color`      - enable color in the output
+    * `--include`    - include tests that match the filter
+    * `--exclude`    - exclude tests that match the filter
+    * `--only`       - run only tests that match the filter
+    * `--seed`       - seeds the random number generator used to randomize tests order;
+      `--seed 0` disables randomization
+    * `--timeout`    - set the timeout for the tests
+    * `--no-deps-check` - do not check dependencies
+    * `--no-archives-check` - do not check archives
+    * `--no-elixir-version-check` - do not check the Elixir version from mix.exs
+    * `--stale` - run only tests which reference modules that changed since the
+      last `test --stale`. You can read more about this option in the "Stale" section below.
+    * `--listen-on-stdin` - run tests, and then listen on stdin. Receiving a newline will
+      result in the tests being run again. Very useful when combined with `--stale` and
+      external commands which produce output on stdout upon file system modification.
+    * `--formatter`  - formatter module
+
+  ## Filters
+
+  ExUnit provides tags and filtering functionality that allows developers
+  to select which tests to run. The most common functionality is to exclude
+  some particular tests from running by default in your test helper file:
+
+      # Exclude all external tests from running
+      ExUnit.configure exclude: [external: true]
+
+  Then, whenever desired, those tests could be included in the run via the
+  `--include` flag:
+
+      mix test --include external:true
+
+  The example above will run all tests that have the external flag set to
+  `true`. It is also possible to include all examples that have a given tag,
+  regardless of its value:
+
+      mix test --include external
+
+  Note that all tests are included by default, so unless they are excluded
+  first (either in the test helper or via the `--exclude` option), the
+  `--include` flag has no effect.
+
+  For this reason, Mix also provides an `--only` option that excludes all
+  tests and includes only the given ones:
+
+      mix test --only external
+
+  Which is equivalent to:
+
+      mix test --include external --exclude test
+
+  In case a single file is being tested, it is possible pass a specific
+  line number:
+
+      mix test test/some/particular/file_test.exs:12
+
+  Which is equivalent to:
+
+      mix test --only line:12 test/some/particular/file_test.exs
+
+  Note that line filter takes the closest test on or before the given line number.
+  In the case a single file contains more than one test module (test case),
+  line filter applies to every test case before the given line number, thus more
+  than one test might be taken for the run.
+
+  ## Configuration
+
+    * `:test_paths` - list of paths containing test files, defaults to
+      `["test"]`. It is expected all test paths to contain a `test_helper.exs`
+      file.
+
+    * `:test_pattern` - a pattern to load test files, defaults to `*_test.exs`.
+
+    * `:warn_test_pattern` - a pattern to match potentially missed test files
+      and display a warning, defaults to `*_test.ex`.
+
+    * `:test_coverage` - a set of options to be passed down to the coverage
+      mechanism.
+
+  ## Coverage
+
+  The `:test_coverage` configuration accepts the following options:
+
+    * `:output` - the output for cover results, defaults to `"cover"`
+    * `:tool`   - the coverage tool
+
+  By default, a very simple wrapper around OTP's `cover` is used as a tool,
+  but it can be overridden as follows:
+
+      test_coverage: [tool: CoverModule]
+
+  `CoverModule` can be any module that exports `start/2`, receiving the
+  compilation path and the `test_coverage` options as arguments.
+  It must return either `nil` or an anonymous function of zero arity that will
+  be run after the test suite is done.
+
+  ## "Stale"
+
+  The `--stale` command line option attempts to run only those test files which
+  reference modules that have changed since the last time you ran this task with
+  `--stale`.
+
+  The first time this task is run with `--stale`, all tests are run and a manifest
+  is generated. On subsequent runs, a test file is marked "stale" if any modules it
+  references (and any modules those modules reference, recursively) were modified
+  since the last run with `--stale`. A test file is also marked "stale" if it has
+  been changed since the last run with `--stale`.
+  """
+
+  @switches [force: :boolean, color: :boolean, cover: :boolean,
+             trace: :boolean, max_cases: :integer, include: :keep,
+             exclude: :keep, seed: :integer, only: :keep, compile: :boolean,
+             start: :boolean, timeout: :integer, raise: :boolean,
+             deps_check: :boolean, archives_check: :boolean, elixir_version_check: :boolean,
+             stale: :boolean, listen_on_stdin: :boolean, formatter: :keep]
+
+  @cover [output: "cover", tool: Cover]
+
+  @spec run(OptionParser.argv) :: :ok
+  def run(args) do
+    {opts, files} = OptionParser.parse!(args, strict: @switches)
+
+    if opts[:listen_on_stdin] do
+      System.at_exit fn _ ->
+        IO.gets(:stdio, "")
+        Mix.shell.info "Restarting..."
+        :init.restart()
+        :timer.sleep(:infinity)
+      end
+    end
+
+    unless System.get_env("MIX_ENV") || Mix.env == :test do
+      Mix.raise "\"mix test\" is running on environment \"#{Mix.env}\". If you are " <>
+                                "running tests along another task, please set MIX_ENV explicitly"
+    end
+
+    Mix.Task.run "loadpaths", args
+
+    if Keyword.get(opts, :compile, true) do
+      Mix.Project.compile(args)
+    end
+
+    project = Mix.Project.config
+
+    # Start cover after we load deps but before we start the app.
+    cover =
+      if opts[:cover] do
+        compile_path = Mix.Project.compile_path(project)
+        cover = Keyword.merge(@cover, project[:test_coverage] || [])
+        cover[:tool].start(compile_path, cover)
+      end
+
+    # Start the app and configure exunit with command line options
+    # before requiring test_helper.exs so that the configuration is
+    # available in test_helper.exs. Then configure exunit again so
+    # that command line options override test_helper.exs
+    Mix.shell.print_app
+    Mix.Task.run "app.start", args
+
+    # Ensure ExUnit is loaded.
+    case Application.load(:ex_unit) do
+      :ok -> :ok
+      {:error, {:already_loaded, :ex_unit}} -> :ok
+    end
+
+    # Configure ExUnit with command line options before requiring
+    # test helpers so that the configuration is available in helpers.
+    # Then configure ExUnit again so command line options override
+    ex_unit_opts = ex_unit_opts(opts)
+    ExUnit.configure(ex_unit_opts)
+
+    test_paths = project[:test_paths] || ["test"]
+    Enum.each(test_paths, &require_test_helper(&1))
+    ExUnit.configure(merge_helper_opts(ex_unit_opts))
+
+    # Finally parse, require and load the files
+    test_files = parse_files(files, test_paths)
+    test_pattern = project[:test_pattern] || "*_test.exs"
+    warn_test_pattern = project[:warn_test_pattern] || "*_test.ex"
+
+    matched_test_files = Mix.Utils.extract_files(test_files, test_pattern)
+    matched_warn_test_files =
+      Mix.Utils.extract_files(test_files, warn_test_pattern) -- matched_test_files
+
+    display_warn_test_pattern(matched_warn_test_files, test_pattern)
+
+    case CT.require_and_run(files, matched_test_files, test_paths, opts) do
+      {:ok, %{failures: failures}} ->
+        cover && cover.()
+
+        cond do
+          failures > 0 and opts[:raise] ->
+            Mix.raise "mix test failed"
+          failures > 0 ->
+            System.at_exit fn _ -> exit({:shutdown, 1}) end
+          true ->
+            :ok
+        end
+
+      :noop ->
+        :ok
+    end
+  end
+
+  defp display_warn_test_pattern(files, pattern) do
+    for file <- files do
+      Mix.shell.info "warning: #{file} does not match #{inspect pattern} and won't be loaded"
+    end
+  end
+
+  @doc false
+  def ex_unit_opts(opts) do
+    opts =
+      opts
+      |> filter_opts(:include)
+      |> filter_opts(:exclude)
+      |> filter_only_opts()
+      |> formatter_opts()
+
+    default_opts(opts) ++
+      Keyword.take(opts, [:trace, :max_cases, :include, :exclude, :seed, :timeout, :formatters])
+  end
+
+  defp merge_helper_opts(opts) do
+    opts
+    |> merge_opts(:exclude)
+  end
+
+  defp default_opts(opts) do
+    # Set autorun to false because Mix
+    # automatically runs the test suite for us.
+    case Keyword.fetch(opts, :color) do
+      {:ok, enabled?} -> [autorun: false, colors: [enabled: enabled?]]
+      :error -> [autorun: false]
+    end
+  end
+
+  defp parse_files([], test_paths) do
+    test_paths
+  end
+
+  defp parse_files([single_file], _test_paths) do
+    # Check if the single file path matches test/path/to_test.exs:123, if it does
+    # apply "--only line:123" and trim the trailing :123 part.
+    {single_file, opts} = ExUnit.Filters.parse_path(single_file)
+    ExUnit.configure(opts)
+    [single_file]
+  end
+
+  defp parse_files(files, _test_paths) do
+    files
+  end
+
+  defp parse_filters(opts, key) do
+    if Keyword.has_key?(opts, key) do
+      ExUnit.Filters.parse(Keyword.get_values(opts, key))
+    end
+  end
+
+  defp filter_opts(opts, key) do
+    if filters = parse_filters(opts, key) do
+      Keyword.put(opts, key, filters)
+    else
+      opts
+    end
+  end
+
+  def formatter_opts(opts) do
+    if Keyword.has_key?(opts, :formatter) do
+      formatters =
+        opts
+        |> Keyword.get_values(:formatter)
+        |> Enum.map(&(Module.concat(String.split(&1, "."))))
+
+      Keyword.put(opts, :formatters, formatters)
+    else
+      opts
+    end
+  end
+
+  defp merge_opts(opts, key) do
+    value = List.wrap Application.get_env(:ex_unit, key, [])
+    Keyword.update(opts, key, value, &Enum.uniq(&1 ++ value))
+  end
+
+  defp filter_only_opts(opts) do
+    if filters = parse_filters(opts, :only) do
+      opts
+      |> Keyword.put_new(:include, [])
+      |> Keyword.put_new(:exclude, [])
+      |> Keyword.update!(:include, &(filters ++ &1))
+      |> Keyword.update!(:exclude, &[:test | &1])
+    else
+      opts
+    end
+  end
+
+  defp require_test_helper(dir) do
+    file = Path.join(dir, "test_helper.exs")
+
+    if File.exists?(file) do
+      Code.require_file file
+    else
+      Mix.raise "Cannot run tests because test helper file #{inspect file} does not exist"
+    end
+  end
+end

--- a/src/META-INF/plugin.xml
+++ b/src/META-INF/plugin.xml
@@ -1951,6 +1951,9 @@
     <projectService serviceImplementation="org.elixir_lang.mix.settings.MixSettings" />
     <programRunner implementation="org.elixir_lang.mix.runner.MixRunner" />
     <configurationType implementation="org.elixir_lang.mix.runner.MixRunConfigurationType" />
+    <programRunner implementation="org.elixir_lang.mix.runner.exunit.MixExUnitRunner" />
+    <configurationType implementation="org.elixir_lang.mix.runner.exunit.MixExUnitRunConfigurationType" />
+    <runConfigurationProducer implementation="org.elixir_lang.mix.runner.exunit.MixExUnitRunConfigurationProducer" />
 
     <colorSettingsPage implementation="org.elixir_lang.ElixirColorSettingsPage"/>
     <fileTypeFactory implementation="org.elixir_lang.ElixirFileTypeFactory"/>

--- a/src/org/elixir_lang/exunit/ElixirModules.java
+++ b/src/org/elixir_lang/exunit/ElixirModules.java
@@ -9,8 +9,8 @@ import java.io.*;
 import java.net.URL;
 
 public class ElixirModules {
-  public static final String FORMATTER_FILE_NAME = "team_city_ex_unit_formatter.ex";
-  public static final String MIX_TASK_FILE_NAME = "test_with_formatter.ex";
+  private static final String FORMATTER_FILE_NAME = "team_city_ex_unit_formatter.ex";
+  private static final String MIX_TASK_FILE_NAME = "test_with_formatter.ex";
 
   private ElixirModules() {
   }

--- a/src/org/elixir_lang/exunit/ElixirModules.java
+++ b/src/org/elixir_lang/exunit/ElixirModules.java
@@ -9,11 +9,11 @@ import java.io.*;
 import java.net.URL;
 
 public class ElixirModules {
-  private ElixirModules() {
-  }
-
   public static final String FORMATTER_FILE_NAME = "team_city_ex_unit_formatter.ex";
   public static final String MIX_TASK_FILE_NAME = "test_with_formatter.ex";
+
+  private ElixirModules() {
+  }
 
   private static File putFile(@NotNull String fileName, @NotNull File directory) throws IOException {
     URL moduleUrl = ResourceUtil.getResource(ElixirModules.class, "/exunit", fileName);
@@ -21,12 +21,15 @@ public class ElixirModules {
       throw new IOException("Failed to locate Elixir module " + fileName);
     }
 
-    try (BufferedInputStream inputStream = new BufferedInputStream(URLUtil.openStream(moduleUrl))) {
-      File file = new File(directory, fileName);
-      try (BufferedOutputStream outputStream = new BufferedOutputStream(new FileOutputStream(file))) {
-        FileUtil.copy(inputStream, outputStream);
-        return file;
-      }
+    BufferedInputStream inputStream = new BufferedInputStream(URLUtil.openStream(moduleUrl));
+    File file = new File(directory, fileName);
+    BufferedOutputStream outputStream = new BufferedOutputStream(new FileOutputStream(file));
+    try {
+      FileUtil.copy(inputStream, outputStream);
+      return file;
+    } finally {
+      inputStream.close();
+      outputStream.close();
     }
   }
 

--- a/src/org/elixir_lang/exunit/ElixirModules.java
+++ b/src/org/elixir_lang/exunit/ElixirModules.java
@@ -1,0 +1,40 @@
+package org.elixir_lang.exunit;
+
+import com.intellij.openapi.util.io.FileUtil;
+import com.intellij.util.ResourceUtil;
+import com.intellij.util.io.URLUtil;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.*;
+import java.net.URL;
+
+public class ElixirModules {
+  private ElixirModules() {
+  }
+
+  public static final String FORMATTER_FILE_NAME = "team_city_ex_unit_formatter.ex";
+  public static final String MIX_TASK_FILE_NAME = "test_with_formatter.ex";
+
+  private static File putFile(@NotNull String fileName, @NotNull File directory) throws IOException {
+    URL moduleUrl = ResourceUtil.getResource(ElixirModules.class, "/exunit", fileName);
+    if (moduleUrl == null) {
+      throw new IOException("Failed to locate Elixir module " + fileName);
+    }
+
+    try (BufferedInputStream inputStream = new BufferedInputStream(URLUtil.openStream(moduleUrl))) {
+      File file = new File(directory, fileName);
+      try (BufferedOutputStream outputStream = new BufferedOutputStream(new FileOutputStream(file))) {
+        FileUtil.copy(inputStream, outputStream);
+        return file;
+      }
+    }
+  }
+
+  public static File putFormatterTo(@NotNull File directory) throws IOException {
+    return putFile(FORMATTER_FILE_NAME, directory);
+  }
+
+  public static File putMixTaskTo(@NotNull File directory) throws IOException {
+    return putFile(MIX_TASK_FILE_NAME, directory);
+  }
+}

--- a/src/org/elixir_lang/mix/importWizard/MixProjectImportBuilder.java
+++ b/src/org/elixir_lang/mix/importWizard/MixProjectImportBuilder.java
@@ -241,7 +241,7 @@ public class MixProjectImportBuilder extends ProjectImportBuilder<ImportedOtpApp
             indicator.checkCanceled();
             if(file.isDirectory()){
               indicator.setText2(file.getPath());
-              if(isBuildOrConfigOrTestsDirectory(projectRoot.getPath(), file.getPath())) return false;
+              if(isBuildOrConfigOrDepsOrTestsDirectory(projectRoot.getPath(), file.getPath())) return false;
             }
 
             ContainerUtil.addAllNotNull(importedOtpApps, createImportedOtpApp(file));
@@ -281,9 +281,10 @@ public class MixProjectImportBuilder extends ProjectImportBuilder<ImportedOtpApp
   /**
    * private methos
    * */
-  private static boolean isBuildOrConfigOrTestsDirectory(String projectRootPath, String path){
+  private static boolean isBuildOrConfigOrDepsOrTestsDirectory(String projectRootPath, String path){
     return (projectRootPath + "/_build").equals(path)
         || (projectRootPath + "/config").equals(path)
+        || (projectRootPath + "/deps").equals(path)
         || (projectRootPath + "/tests").equals(path);
   }
 
@@ -332,7 +333,7 @@ public class MixProjectImportBuilder extends ProjectImportBuilder<ImportedOtpApp
       public boolean visitFile(@NotNull VirtualFile file) {
         indicator.checkCanceled();
         if(file.isDirectory()){
-          if(isBuildOrConfigOrTestsDirectory(root.getPath(), file.getPath())) return false;
+          if(isBuildOrConfigOrDepsOrTestsDirectory(root.getPath(), file.getPath())) return false;
           indicator.setText2(file.getPath());
         }else if(file.getName().equalsIgnoreCase("mix.exs")){
           foundMixExs.add(file);

--- a/src/org/elixir_lang/mix/runner/MixRunConfigurationBase.java
+++ b/src/org/elixir_lang/mix/runner/MixRunConfigurationBase.java
@@ -32,7 +32,7 @@ import java.util.Map;
 /**
  * https://github.com/ignatov/intellij-erlang/blob/master/src/org/intellij/erlang/rebar/runner/RebarRunConfigurationBase.java
  */
-abstract class MixRunConfigurationBase extends ModuleBasedConfiguration<ElixirModuleBasedConfiguration>
+public abstract class MixRunConfigurationBase extends ModuleBasedConfiguration<ElixirModuleBasedConfiguration>
         implements CommonProgramRunConfigurationParameters,
         RunConfigurationWithSuppressedDefaultRunAction,
         RunConfigurationWithSuppressedDefaultDebugAction {
@@ -64,7 +64,7 @@ abstract class MixRunConfigurationBase extends ModuleBasedConfiguration<ElixirMo
    * Constructors
    */
 
-  MixRunConfigurationBase(@NotNull String name, @NotNull Project project, @NotNull ConfigurationFactory configurationFactory){
+  protected MixRunConfigurationBase(@NotNull String name, @NotNull Project project, @NotNull ConfigurationFactory configurationFactory){
     super(name, new ElixirModuleBasedConfiguration(project), configurationFactory);
   }
 

--- a/src/org/elixir_lang/mix/runner/MixRunConfigurationEditorForm.java
+++ b/src/org/elixir_lang/mix/runner/MixRunConfigurationEditorForm.java
@@ -18,14 +18,14 @@ import java.awt.event.ActionListener;
  *
  * @link https://github.com/ignatov/intellij-erlang/blob/master/src/org/intellij/erlang/rebar/runner/RebarRunConfigurationEditorForm.java
  */
-final class MixRunConfigurationEditorForm extends SettingsEditor<MixRunConfigurationBase>{
+public final class MixRunConfigurationEditorForm extends SettingsEditor<MixRunConfigurationBase>{
   private JPanel myComponent;
   private JCheckBox myRunInModuleCheckBox;
   private JCheckBox mySkipDependenciesCheckBox;
   private ModulesComboBox myModulesComboBox;
   private CommonProgramParametersPanel commonProgramParametersPanel;
 
-  MixRunConfigurationEditorForm(){
+  public MixRunConfigurationEditorForm(){
     myRunInModuleCheckBox.addActionListener(new ActionListener() {
       @Override
       public void actionPerformed(ActionEvent e) {
@@ -39,21 +39,25 @@ final class MixRunConfigurationEditorForm extends SettingsEditor<MixRunConfigura
 
   @Override
   protected void resetEditorFrom(@NotNull MixRunConfigurationBase configuration) {
-    mySkipDependenciesCheckBox.setSelected(configuration.isSkipDependencies());
-    Module module = null;
-    if(!ElixirSystemUtil.isSmallIde()){
-      myModulesComboBox.fillModules(configuration.getProject(), ElixirModuleType.getInstance());
-      module = configuration.getConfigurationModule().getModule();
-    }
+      reset(configuration);
+  }
 
-    if(module != null){
-      setRunInModuleSelected(true);
-      myModulesComboBox.setSelectedModule(module);
-    }else{
-      setRunInModuleSelected(false);
-    }
+  public void reset(@NotNull MixRunConfigurationBase configuration) {
+      mySkipDependenciesCheckBox.setSelected(configuration.isSkipDependencies());
+      Module module = null;
+      if(!ElixirSystemUtil.isSmallIde()){
+        myModulesComboBox.fillModules(configuration.getProject(), ElixirModuleType.getInstance());
+        module = configuration.getConfigurationModule().getModule();
+      }
 
-    commonProgramParametersPanel.reset(configuration);
+      if(module != null){
+        setRunInModuleSelected(true);
+        myModulesComboBox.setSelectedModule(module);
+      }else{
+        setRunInModuleSelected(false);
+      }
+
+      commonProgramParametersPanel.reset(configuration);
   }
 
   @Override

--- a/src/org/elixir_lang/mix/runner/MixRunningState.java
+++ b/src/org/elixir_lang/mix/runner/MixRunningState.java
@@ -11,40 +11,66 @@ import com.intellij.execution.process.ProcessHandler;
 import com.intellij.execution.runners.ExecutionEnvironment;
 import com.intellij.execution.runners.ProgramRunner;
 import com.intellij.execution.ui.ConsoleView;
+import com.intellij.openapi.project.Project;
 import org.elixir_lang.console.ElixirConsoleUtil;
+import org.elixir_lang.sdk.ElixirSdkType;
 import org.jetbrains.annotations.NotNull;
+
+import static org.elixir_lang.mix.runner.MixRunningStateUtil.*;
 
 /**
  * Created by zyuyou on 15/7/8.
  * https://github.com/ignatov/intellij-erlang/blob/master/src/org/intellij/erlang/rebar/runner/RebarRunningState.java
  */
-final class MixRunningState extends CommandLineState{
-  private final MixRunConfigurationBase myConfiguration;
+final class MixRunningState extends CommandLineState {
+    private final MixRunConfigurationBase myConfiguration;
 
-  protected MixRunningState(@NotNull ExecutionEnvironment environment, MixRunConfigurationBase configuration) {
-    super(environment);
-    myConfiguration = configuration;
-  }
+    MixRunningState(@NotNull ExecutionEnvironment environment, MixRunConfigurationBase configuration) {
+        super(environment);
+        myConfiguration = configuration;
+    }
 
-  @NotNull
-  @Override
-  public ExecutionResult execute(@NotNull Executor executor, @NotNull ProgramRunner runner) throws ExecutionException {
-    TextConsoleBuilder consoleBuilder = new TextConsoleBuilderImpl(myConfiguration.getProject()){
-      @Override
-      public ConsoleView getConsole() {
-        ConsoleView consoleView = super.getConsole();
-        ElixirConsoleUtil.attachFilters(myConfiguration.getProject(), consoleView);
-        return consoleView;
-      }
-    };
-    setConsoleBuilder(consoleBuilder);
-    return super.execute(executor, runner);
-  }
+    @NotNull
+    private static GeneralCommandLine commandLine(@NotNull MixRunConfigurationBase configuration) throws ExecutionException {
+        GeneralCommandLine commandLine = getBaseMixCommandLine(configuration);
 
-  @NotNull
-  @Override
-  protected ProcessHandler startProcess() throws ExecutionException {
-    GeneralCommandLine commandLine = MixRunningStateUtil.getMixCommandLine(myConfiguration);
-    return MixRunningStateUtil.runMix(myConfiguration.getProject(), commandLine);
-  }
+        Project project = configuration.getProject();
+        String mixPath = mixPath(project);
+
+        if (mixPath.endsWith(".bat")) {
+            commandLine.setExePath(mixPath);
+        } else {
+            String sdkPath = ElixirSdkType.getSdkPath(project);
+            String elixirPath = elixirPath(sdkPath);
+
+            commandLine.setExePath(elixirPath);
+            commandLine.addParameter(mixPath);
+        }
+
+        commandLine = addProgramParameters(commandLine, configuration);
+
+        return addNewSkipDependencies(commandLine, configuration);
+    }
+
+    @NotNull
+    @Override
+    public ExecutionResult execute(@NotNull Executor executor, @NotNull ProgramRunner runner) throws ExecutionException {
+        TextConsoleBuilder consoleBuilder = new TextConsoleBuilderImpl(myConfiguration.getProject()) {
+            @Override
+            public ConsoleView getConsole() {
+                ConsoleView consoleView = super.getConsole();
+                ElixirConsoleUtil.attachFilters(myConfiguration.getProject(), consoleView);
+                return consoleView;
+            }
+        };
+        setConsoleBuilder(consoleBuilder);
+        return super.execute(executor, runner);
+    }
+
+    @NotNull
+    @Override
+    protected ProcessHandler startProcess() throws ExecutionException {
+        GeneralCommandLine commandLine = commandLine(myConfiguration);
+        return MixRunningStateUtil.runMix(myConfiguration.getProject(), commandLine);
+    }
 }

--- a/src/org/elixir_lang/mix/runner/MixRunningState.java
+++ b/src/org/elixir_lang/mix/runner/MixRunningState.java
@@ -71,6 +71,6 @@ final class MixRunningState extends CommandLineState {
     @Override
     protected ProcessHandler startProcess() throws ExecutionException {
         GeneralCommandLine commandLine = commandLine(myConfiguration);
-        return MixRunningStateUtil.runMix(myConfiguration.getProject(), commandLine);
+        return runMix(myConfiguration.getProject(), commandLine);
     }
 }

--- a/src/org/elixir_lang/mix/runner/MixRunningStateUtil.java
+++ b/src/org/elixir_lang/mix/runner/MixRunningStateUtil.java
@@ -27,9 +27,6 @@ public class MixRunningStateUtil {
 
   static final String SKIP_DEPENDENCIES_PARAMETER = "--no-deps-check";
 
-  public MixRunningStateUtil() {
-  }
-
   @NotNull
   public static GeneralCommandLine withEnvironment(@NotNull GeneralCommandLine commandLine,
                                                    @NotNull MixRunConfigurationBase configuration) {

--- a/src/org/elixir_lang/mix/runner/MixRunningStateUtil.java
+++ b/src/org/elixir_lang/mix/runner/MixRunningStateUtil.java
@@ -25,22 +25,22 @@ import static org.apache.commons.lang.StringUtils.isBlank;
  */
 public class MixRunningStateUtil {
 
-  static final String SKIP_DEPENDENCIES_PARAMETER = "--no-deps-check";
+  private static final String SKIP_DEPENDENCIES_PARAMETER = "--no-deps-check";
 
   @NotNull
-  public static GeneralCommandLine withEnvironment(@NotNull GeneralCommandLine commandLine,
-                                                   @NotNull MixRunConfigurationBase configuration) {
+  private static GeneralCommandLine withEnvironment(@NotNull GeneralCommandLine commandLine,
+                                                    @NotNull MixRunConfigurationBase configuration) {
     return commandLine.withEnvironment(configuration.getEnvs());
   }
 
   @NotNull
-  public static GeneralCommandLine withWorkDirectory(@NotNull GeneralCommandLine commandLine,
-                                                     @NotNull MixRunConfigurationBase configuration) {
+  private static GeneralCommandLine withWorkDirectory(@NotNull GeneralCommandLine commandLine,
+                                                      @NotNull MixRunConfigurationBase configuration) {
     return commandLine.withWorkDirectory(getWorkingDirectory(configuration));
   }
 
   @NotNull
-  public static String mixPath(@NotNull Project project) {
+  static String mixPath(@NotNull Project project) {
     MixSettings mixSettings = MixSettings.getInstance(project);
     return mixSettings.getMixPath();
   }
@@ -111,7 +111,7 @@ public class MixRunningStateUtil {
   }
 
   @NotNull
-  public static String getWorkingDirectory(@NotNull MixRunConfigurationBase configuration){
+  private static String getWorkingDirectory(@NotNull MixRunConfigurationBase configuration){
     String workingDirectory = configuration.getWorkingDirectory();
 
     if (isBlank(workingDirectory)) {

--- a/src/org/elixir_lang/mix/runner/MixRunningStateUtil.java
+++ b/src/org/elixir_lang/mix/runner/MixRunningStateUtil.java
@@ -92,7 +92,7 @@ public class MixRunningStateUtil {
       return new OSProcessHandler(commandLine.createProcess(), commandLine.getCommandLineString());
     }catch (ExecutionException e){
       String message = e.getMessage();
-      boolean isEmpty = message.equals("Executable is not specified");
+      boolean isEmpty = "Executable is not specified".equals(message);
       boolean notCorrect = message.startsWith("Cannot run program");
       if(isEmpty || notCorrect){
         Notifications.Bus.notify(

--- a/src/org/elixir_lang/mix/runner/exunit/MixExUnitRunConfiguration.java
+++ b/src/org/elixir_lang/mix/runner/exunit/MixExUnitRunConfiguration.java
@@ -9,23 +9,9 @@ import com.intellij.openapi.options.SettingsEditor;
 import com.intellij.openapi.project.Project;
 import org.elixir_lang.mix.runner.MixRunConfigurationBase;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 final class MixExUnitRunConfiguration extends MixRunConfigurationBase {
-
-  @NotNull
-  private String mixTestArgs = "";
-
-  @NotNull
-  String getMixTestArgs() {
-    return mixTestArgs;
-  }
-
-  void setMixTestArgs(@NotNull String mixTestArgs) {
-    this.mixTestArgs = mixTestArgs;
-  }
-
-  MixExUnitRunConfiguration(@NotNull String name, @NotNull Project project){
+  public MixExUnitRunConfiguration(@NotNull String name, @NotNull Project project){
     super(name, project, MixExUnitRunConfigurationFactory.getInstance());
   }
 
@@ -35,9 +21,10 @@ final class MixExUnitRunConfiguration extends MixRunConfigurationBase {
     return new MixExUnitRunConfigurationEditorForm();
   }
 
-  @Nullable
+  @NotNull
   @Override
-  public RunProfileState getState(@NotNull Executor executor, @NotNull ExecutionEnvironment environment) throws ExecutionException {
+  public RunProfileState getState(@NotNull Executor executor,
+                                  @NotNull ExecutionEnvironment environment) throws ExecutionException {
     return new MixExUnitRunningState(environment, this);
   }
 }

--- a/src/org/elixir_lang/mix/runner/exunit/MixExUnitRunConfiguration.java
+++ b/src/org/elixir_lang/mix/runner/exunit/MixExUnitRunConfiguration.java
@@ -11,20 +11,21 @@ import org.elixir_lang.mix.runner.MixRunConfigurationBase;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-public final class MixExUnitRunConfiguration extends MixRunConfigurationBase {
+final class MixExUnitRunConfiguration extends MixRunConfigurationBase {
 
   @NotNull
   private String mixTestArgs = "";
 
-  public String getMixTestArgs() {
+  @NotNull
+  String getMixTestArgs() {
     return mixTestArgs;
   }
 
-  public void setMixTestArgs(@NotNull String mixTestArgs) {
+  void setMixTestArgs(@NotNull String mixTestArgs) {
     this.mixTestArgs = mixTestArgs;
   }
 
-  public MixExUnitRunConfiguration(@NotNull String name, @NotNull Project project){
+  MixExUnitRunConfiguration(@NotNull String name, @NotNull Project project){
     super(name, project, MixExUnitRunConfigurationFactory.getInstance());
   }
 

--- a/src/org/elixir_lang/mix/runner/exunit/MixExUnitRunConfiguration.java
+++ b/src/org/elixir_lang/mix/runner/exunit/MixExUnitRunConfiguration.java
@@ -1,0 +1,42 @@
+package org.elixir_lang.mix.runner.exunit;
+
+import com.intellij.execution.ExecutionException;
+import com.intellij.execution.Executor;
+import com.intellij.execution.configurations.RunConfiguration;
+import com.intellij.execution.configurations.RunProfileState;
+import com.intellij.execution.runners.ExecutionEnvironment;
+import com.intellij.openapi.options.SettingsEditor;
+import com.intellij.openapi.project.Project;
+import org.elixir_lang.mix.runner.MixRunConfigurationBase;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public final class MixExUnitRunConfiguration extends MixRunConfigurationBase {
+
+  @NotNull
+  private String mixTestArgs = "";
+
+  public String getMixTestArgs() {
+    return mixTestArgs;
+  }
+
+  public void setMixTestArgs(@NotNull String mixTestArgs) {
+    this.mixTestArgs = mixTestArgs;
+  }
+
+  public MixExUnitRunConfiguration(@NotNull String name, @NotNull Project project){
+    super(name, project, MixExUnitRunConfigurationFactory.getInstance());
+  }
+
+  @NotNull
+  @Override
+  public SettingsEditor<? extends RunConfiguration> getConfigurationEditor() {
+    return new MixExUnitRunConfigurationEditorForm();
+  }
+
+  @Nullable
+  @Override
+  public RunProfileState getState(@NotNull Executor executor, @NotNull ExecutionEnvironment environment) throws ExecutionException {
+    return new MixExUnitRunningState(environment, this);
+  }
+}

--- a/src/org/elixir_lang/mix/runner/exunit/MixExUnitRunConfigurationEditorForm.form
+++ b/src/org/elixir_lang/mix/runner/exunit/MixExUnitRunConfigurationEditorForm.form
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="org.elixir_lang.mix.runner.exunit.MixExUnitRunConfigurationEditorForm">
+  <grid id="27dc6" binding="myComponent" layout-manager="GridLayoutManager" row-count="2" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+    <margin top="0" left="0" bottom="0" right="0"/>
+    <constraints>
+      <xy x="20" y="20" width="500" height="400"/>
+    </constraints>
+    <properties/>
+    <border type="none"/>
+    <children>
+      <grid id="77064" layout-manager="GridLayoutManager" row-count="1" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+        <margin top="0" left="0" bottom="0" right="0"/>
+        <constraints>
+          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties/>
+        <border type="none"/>
+        <children>
+          <component id="7c645" class="javax.swing.JLabel">
+            <constraints>
+              <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text value="'mix test' args:"/>
+            </properties>
+          </component>
+          <component id="96b7c" class="javax.swing.JTextField" binding="mixTestArgs">
+            <constraints>
+              <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+                <preferred-size width="150" height="-1"/>
+              </grid>
+            </constraints>
+            <properties/>
+          </component>
+        </children>
+      </grid>
+      <vspacer id="9ff80">
+        <constraints>
+          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+        </constraints>
+      </vspacer>
+    </children>
+  </grid>
+</form>

--- a/src/org/elixir_lang/mix/runner/exunit/MixExUnitRunConfigurationEditorForm.form
+++ b/src/org/elixir_lang/mix/runner/exunit/MixExUnitRunConfigurationEditorForm.form
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="org.elixir_lang.mix.runner.exunit.MixExUnitRunConfigurationEditorForm">
-  <grid id="27dc6" binding="myComponent" layout-manager="GridLayoutManager" row-count="2" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="27dc6" binding="myComponent" layout-manager="GridLayoutManager" row-count="1" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
       <xy x="20" y="20" width="500" height="400"/>
@@ -8,37 +8,11 @@
     <properties/>
     <border type="none"/>
     <children>
-      <grid id="77064" layout-manager="GridLayoutManager" row-count="1" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
-        <margin top="0" left="0" bottom="0" right="0"/>
+      <nested-form id="4d01c" form-file="org/elixir_lang/mix/runner/MixRunConfigurationEditorForm.form" binding="mixRunConfigurationEditorForm">
         <constraints>
           <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
         </constraints>
-        <properties/>
-        <border type="none"/>
-        <children>
-          <component id="7c645" class="javax.swing.JLabel">
-            <constraints>
-              <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-            </constraints>
-            <properties>
-              <text value="'mix test' args:"/>
-            </properties>
-          </component>
-          <component id="96b7c" class="javax.swing.JTextField" binding="mixTestArgs">
-            <constraints>
-              <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
-                <preferred-size width="150" height="-1"/>
-              </grid>
-            </constraints>
-            <properties/>
-          </component>
-        </children>
-      </grid>
-      <vspacer id="9ff80">
-        <constraints>
-          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
-        </constraints>
-      </vspacer>
+      </nested-form>
     </children>
   </grid>
 </form>

--- a/src/org/elixir_lang/mix/runner/exunit/MixExUnitRunConfigurationEditorForm.java
+++ b/src/org/elixir_lang/mix/runner/exunit/MixExUnitRunConfigurationEditorForm.java
@@ -10,9 +10,6 @@ public final class MixExUnitRunConfigurationEditorForm extends SettingsEditor<Mi
   private JPanel myComponent;
   private JTextField mixTestArgs;
 
-  public MixExUnitRunConfigurationEditorForm(){
-  }
-
   @Override
   protected void resetEditorFrom(@NotNull MixExUnitRunConfiguration configuration) {
     mixTestArgs.setText(configuration.getMixTestArgs());
@@ -32,9 +29,5 @@ public final class MixExUnitRunConfigurationEditorForm extends SettingsEditor<Mi
   @Override
   protected void disposeEditor() {
     myComponent.setVisible(false);
-  }
-
-  private void createUIComponents() {
-    // TODO: place custom component creation code here
   }
 }

--- a/src/org/elixir_lang/mix/runner/exunit/MixExUnitRunConfigurationEditorForm.java
+++ b/src/org/elixir_lang/mix/runner/exunit/MixExUnitRunConfigurationEditorForm.java
@@ -2,22 +2,23 @@ package org.elixir_lang.mix.runner.exunit;
 
 import com.intellij.openapi.options.ConfigurationException;
 import com.intellij.openapi.options.SettingsEditor;
+import org.elixir_lang.mix.runner.MixRunConfigurationEditorForm;
 import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
 
 public final class MixExUnitRunConfigurationEditorForm extends SettingsEditor<MixExUnitRunConfiguration>{
   private JPanel myComponent;
-  private JTextField mixTestArgs;
+  private MixRunConfigurationEditorForm mixRunConfigurationEditorForm;
 
   @Override
   protected void resetEditorFrom(@NotNull MixExUnitRunConfiguration configuration) {
-    mixTestArgs.setText(configuration.getMixTestArgs());
+    mixRunConfigurationEditorForm.reset(configuration);
   }
 
   @Override
-  protected void applyEditorTo(@NotNull MixExUnitRunConfiguration mixRunConfiguration) throws ConfigurationException {
-    mixRunConfiguration.setMixTestArgs(mixTestArgs.getText());
+  protected void applyEditorTo(@NotNull MixExUnitRunConfiguration configuration) throws ConfigurationException {
+    mixRunConfigurationEditorForm.applyTo(configuration);
   }
 
   @NotNull

--- a/src/org/elixir_lang/mix/runner/exunit/MixExUnitRunConfigurationEditorForm.java
+++ b/src/org/elixir_lang/mix/runner/exunit/MixExUnitRunConfigurationEditorForm.java
@@ -1,0 +1,40 @@
+package org.elixir_lang.mix.runner.exunit;
+
+import com.intellij.openapi.options.ConfigurationException;
+import com.intellij.openapi.options.SettingsEditor;
+import org.jetbrains.annotations.NotNull;
+
+import javax.swing.*;
+
+public final class MixExUnitRunConfigurationEditorForm extends SettingsEditor<MixExUnitRunConfiguration>{
+  private JPanel myComponent;
+  private JTextField mixTestArgs;
+
+  public MixExUnitRunConfigurationEditorForm(){
+  }
+
+  @Override
+  protected void resetEditorFrom(@NotNull MixExUnitRunConfiguration configuration) {
+    mixTestArgs.setText(configuration.getMixTestArgs());
+  }
+
+  @Override
+  protected void applyEditorTo(@NotNull MixExUnitRunConfiguration mixRunConfiguration) throws ConfigurationException {
+    mixRunConfiguration.setMixTestArgs(mixTestArgs.getText());
+  }
+
+  @NotNull
+  @Override
+  protected JComponent createEditor() {
+    return myComponent;
+  }
+
+  @Override
+  protected void disposeEditor() {
+    myComponent.setVisible(false);
+  }
+
+  private void createUIComponents() {
+    // TODO: place custom component creation code here
+  }
+}

--- a/src/org/elixir_lang/mix/runner/exunit/MixExUnitRunConfigurationFactory.java
+++ b/src/org/elixir_lang/mix/runner/exunit/MixExUnitRunConfigurationFactory.java
@@ -1,0 +1,34 @@
+package org.elixir_lang.mix.runner.exunit;
+
+import com.intellij.compiler.options.CompileStepBeforeRun;
+import com.intellij.execution.BeforeRunTask;
+import com.intellij.execution.configurations.ConfigurationFactory;
+import com.intellij.execution.configurations.RunConfiguration;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.Key;
+import org.jetbrains.annotations.NotNull;
+
+public final class MixExUnitRunConfigurationFactory extends ConfigurationFactory{
+  private static final MixExUnitRunConfigurationFactory INSTANCE = new MixExUnitRunConfigurationFactory();
+
+  private MixExUnitRunConfigurationFactory() {
+    super(MixExUnitRunConfigurationType.getInstance());
+  }
+
+  @Override
+  public void configureBeforeRunTaskDefaults(Key<? extends BeforeRunTask> providerID, BeforeRunTask task) {
+    if(providerID == CompileStepBeforeRun.ID){
+      task.setEnabled(false);
+    }
+  }
+
+  @Override
+  public RunConfiguration createTemplateConfiguration(Project project) {
+    return new MixExUnitRunConfiguration(MixExUnitRunConfigurationType.TYPE_NAME, project);
+  }
+
+  @NotNull
+  public static MixExUnitRunConfigurationFactory getInstance(){
+    return INSTANCE;
+  }
+}

--- a/src/org/elixir_lang/mix/runner/exunit/MixExUnitRunConfigurationProducer.java
+++ b/src/org/elixir_lang/mix/runner/exunit/MixExUnitRunConfigurationProducer.java
@@ -28,7 +28,7 @@ public class MixExUnitRunConfigurationProducer extends RunConfigurationProducer<
     if (psiElement instanceof PsiDirectory) {
       PsiDirectory dir = (PsiDirectory) psiElement;
       configuration.setName(configurationName(dir));
-      configuration.setMixTestArgs(dir.getVirtualFile().getPath());
+      configuration.setProgramParameters(dir.getVirtualFile().getPath());
       return true;
     } else {
       PsiFile containingFile = psiElement.getContainingFile();
@@ -36,7 +36,7 @@ public class MixExUnitRunConfigurationProducer extends RunConfigurationProducer<
 
       int lineNumber = lineNumber(psiElement);
       configuration.setName(configurationName(containingFile, lineNumber));
-      configuration.setMixTestArgs(mixTestArgs(containingFile, lineNumber));
+      configuration.setProgramParameters(programParameters(containingFile, lineNumber));
 
       return true;
     }
@@ -57,7 +57,7 @@ public class MixExUnitRunConfigurationProducer extends RunConfigurationProducer<
 
     int lineNumber = lineNumber(psiElement);
     return StringUtil.equals(configuration.getName(), configurationName(containingFile, lineNumber)) &&
-        StringUtil.equals(configuration.getMixTestArgs(), mixTestArgs(containingFile, lineNumber));
+        StringUtil.equals(configuration.getProgramParameters(), programParameters(containingFile, lineNumber));
   }
 
   private int lineNumber(@NotNull PsiElement psiElement) {
@@ -95,7 +95,7 @@ public class MixExUnitRunConfigurationProducer extends RunConfigurationProducer<
     }
   }
 
-  private String mixTestArgs(PsiFileSystemItem file, int lineNumber) {
+  private String programParameters(PsiFileSystemItem file, int lineNumber) {
     String path = file.getVirtualFile().getPath();
     if (lineNumber == -1) {
       return path;

--- a/src/org/elixir_lang/mix/runner/exunit/MixExUnitRunConfigurationProducer.java
+++ b/src/org/elixir_lang/mix/runner/exunit/MixExUnitRunConfigurationProducer.java
@@ -1,0 +1,100 @@
+package org.elixir_lang.mix.runner.exunit;
+
+import com.intellij.execution.actions.ConfigurationContext;
+import com.intellij.execution.actions.RunConfigurationProducer;
+import com.intellij.openapi.editor.Document;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.Ref;
+import com.intellij.openapi.util.text.StringUtil;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.*;
+import org.elixir_lang.psi.ElixirFile;
+import org.jetbrains.annotations.NotNull;
+
+public class MixExUnitRunConfigurationProducer extends RunConfigurationProducer<MixExUnitRunConfiguration> {
+  public MixExUnitRunConfigurationProducer() {
+    super(MixExUnitRunConfigurationType.getInstance());
+  }
+
+  @Override
+  protected final boolean setupConfigurationFromContext(MixExUnitRunConfiguration runConfig, ConfigurationContext context, Ref<PsiElement> ref) {
+    PsiElement location = ref.get();
+    return location != null && location.isValid() &&
+      setupConfigurationFromContextImpl(runConfig, context, location);
+  }
+
+  protected boolean setupConfigurationFromContextImpl(@NotNull MixExUnitRunConfiguration configuration,
+                                                      @NotNull ConfigurationContext context,
+                                                      @NotNull PsiElement psiElement) {
+    if (psiElement instanceof PsiDirectory) {
+      PsiDirectory dir = (PsiDirectory) psiElement;
+      configuration.setName(configurationName(dir));
+      configuration.setMixTestArgs(dir.getVirtualFile().getPath());
+      return true;
+    } else {
+      PsiFile containingFile = psiElement.getContainingFile();
+      if (!(containingFile instanceof ElixirFile || containingFile instanceof PsiDirectory)) return false;
+
+      int lineNumber = lineNumber(psiElement);
+      configuration.setName(configurationName(containingFile, lineNumber));
+      configuration.setMixTestArgs(mixTestArgs(containingFile, lineNumber));
+
+      return true;
+    }
+  }
+
+  @Override
+  public final boolean isConfigurationFromContext(MixExUnitRunConfiguration runConfig, ConfigurationContext context) {
+    PsiElement location = context.getPsiLocation();
+    return location != null && location.isValid() &&
+      isConfigurationFromContextImpl(runConfig, context, location);
+  }
+
+  public boolean isConfigurationFromContextImpl(@NotNull MixExUnitRunConfiguration configuration,
+                                                @NotNull ConfigurationContext context,
+                                                @NotNull PsiElement psiElement) {
+    PsiFile containingFile = psiElement.getContainingFile();
+    VirtualFile vFile = containingFile != null ? containingFile.getVirtualFile() : null;
+    if (vFile == null) return false;
+
+    int lineNumber = lineNumber(psiElement);
+    return StringUtil.equals(configuration.getName(), configurationName(containingFile, lineNumber)) &&
+        StringUtil.equals(configuration.getMixTestArgs(), mixTestArgs(containingFile, lineNumber));
+  }
+
+  private int lineNumber(@NotNull PsiElement psiElement) {
+    PsiFile containingFile = psiElement.getContainingFile();
+    Project project = containingFile.getProject();
+    PsiDocumentManager psiDocumentManager = PsiDocumentManager.getInstance(project);
+    Document document = psiDocumentManager.getDocument(containingFile);
+    int textOffset = psiElement.getTextOffset();
+    int lineNumber = document.getLineNumber(textOffset);
+    if (lineNumber == 0) {
+      return -1;
+    } else {
+      return lineNumber + 1;
+    }
+  }
+
+  private String configurationName(PsiFileSystemItem file) {
+    return "Mix ExUnit " + file.getName();
+  }
+
+  private String configurationName(PsiFileSystemItem file, int lineNumber) {
+    if (lineNumber == -1) {
+      return configurationName(file);
+    } else {
+      return configurationName(file) + ":" + lineNumber;
+    }
+  }
+
+  private String mixTestArgs(PsiFileSystemItem file, int lineNumber) {
+    String path = file.getVirtualFile().getPath();
+    if (lineNumber == -1) {
+      return path;
+    } else {
+      return path + ":" + lineNumber;
+    }
+  }
+
+}

--- a/src/org/elixir_lang/mix/runner/exunit/MixExUnitRunConfigurationProducer.java
+++ b/src/org/elixir_lang/mix/runner/exunit/MixExUnitRunConfigurationProducer.java
@@ -20,12 +20,11 @@ public class MixExUnitRunConfigurationProducer extends RunConfigurationProducer<
   protected final boolean setupConfigurationFromContext(MixExUnitRunConfiguration runConfig, ConfigurationContext context, Ref<PsiElement> ref) {
     PsiElement location = ref.get();
     return location != null && location.isValid() &&
-      setupConfigurationFromContextImpl(runConfig, context, location);
+      setupConfigurationFromContextImpl(runConfig, location);
   }
 
-  protected boolean setupConfigurationFromContextImpl(@NotNull MixExUnitRunConfiguration configuration,
-                                                      @NotNull ConfigurationContext context,
-                                                      @NotNull PsiElement psiElement) {
+  private boolean setupConfigurationFromContextImpl(@NotNull MixExUnitRunConfiguration configuration,
+                                                    @NotNull PsiElement psiElement) {
     if (psiElement instanceof PsiDirectory) {
       PsiDirectory dir = (PsiDirectory) psiElement;
       configuration.setName(configurationName(dir));
@@ -47,12 +46,11 @@ public class MixExUnitRunConfigurationProducer extends RunConfigurationProducer<
   public final boolean isConfigurationFromContext(MixExUnitRunConfiguration runConfig, ConfigurationContext context) {
     PsiElement location = context.getPsiLocation();
     return location != null && location.isValid() &&
-      isConfigurationFromContextImpl(runConfig, context, location);
+      isConfigurationFromContextImpl(runConfig, location);
   }
 
-  public boolean isConfigurationFromContextImpl(@NotNull MixExUnitRunConfiguration configuration,
-                                                @NotNull ConfigurationContext context,
-                                                @NotNull PsiElement psiElement) {
+  private boolean isConfigurationFromContextImpl(@NotNull MixExUnitRunConfiguration configuration,
+                                                 @NotNull PsiElement psiElement) {
     PsiFile containingFile = psiElement.getContainingFile();
     VirtualFile vFile = containingFile != null ? containingFile.getVirtualFile() : null;
     if (vFile == null) return false;
@@ -67,13 +65,22 @@ public class MixExUnitRunConfigurationProducer extends RunConfigurationProducer<
     Project project = containingFile.getProject();
     PsiDocumentManager psiDocumentManager = PsiDocumentManager.getInstance(project);
     Document document = psiDocumentManager.getDocument(containingFile);
-    int textOffset = psiElement.getTextOffset();
-    int lineNumber = document.getLineNumber(textOffset);
-    if (lineNumber == 0) {
-      return -1;
-    } else {
-      return lineNumber + 1;
+    int documentLineNumber = 0;
+
+    if (document != null) {
+      int textOffset = psiElement.getTextOffset();
+      documentLineNumber = document.getLineNumber(textOffset);
     }
+
+    int lineNumber;
+
+    if (documentLineNumber == 0) {
+      lineNumber = -1;
+    } else {
+      lineNumber = documentLineNumber + 1;
+    }
+
+    return lineNumber;
   }
 
   private String configurationName(PsiFileSystemItem file) {

--- a/src/org/elixir_lang/mix/runner/exunit/MixExUnitRunConfigurationType.java
+++ b/src/org/elixir_lang/mix/runner/exunit/MixExUnitRunConfigurationType.java
@@ -1,0 +1,27 @@
+package org.elixir_lang.mix.runner.exunit;
+
+import com.intellij.execution.configurations.ConfigurationFactory;
+import com.intellij.execution.configurations.ConfigurationTypeBase;
+import com.intellij.openapi.extensions.Extensions;
+import org.elixir_lang.icons.ElixirIcons;
+import org.jetbrains.annotations.NotNull;
+
+public final class MixExUnitRunConfigurationType extends ConfigurationTypeBase {
+  public static final String TYPE_ID = "MixExUnitRunConfigurationType";
+  public static final String TYPE_NAME = "Elixir Mix ExUnit";
+
+
+  protected MixExUnitRunConfigurationType() {
+    super(TYPE_ID, TYPE_NAME, "Runs Mix test", ElixirIcons.MIX_EX_UNIT);
+  }
+
+  public static MixExUnitRunConfigurationType getInstance(){
+    return Extensions.findExtension(CONFIGURATION_TYPE_EP, MixExUnitRunConfigurationType.class);
+  }
+
+  @NotNull
+  @Override
+  public ConfigurationFactory[] getConfigurationFactories() {
+    return new ConfigurationFactory[]{MixExUnitRunConfigurationFactory.getInstance()};
+  }
+}

--- a/src/org/elixir_lang/mix/runner/exunit/MixExUnitRunner.java
+++ b/src/org/elixir_lang/mix/runner/exunit/MixExUnitRunner.java
@@ -1,0 +1,21 @@
+package org.elixir_lang.mix.runner.exunit;
+
+import com.intellij.execution.configurations.RunProfile;
+import com.intellij.execution.executors.DefaultRunExecutor;
+import com.intellij.execution.runners.DefaultProgramRunner;
+import org.jetbrains.annotations.NotNull;
+
+public final class MixExUnitRunner extends DefaultProgramRunner{
+  public static final String MIX_RUNNER_ID = "MixExUnitRunner";
+
+  @NotNull
+  @Override
+  public String getRunnerId() {
+    return MIX_RUNNER_ID;
+  }
+
+  @Override
+  public boolean canRun(@NotNull String executorId, @NotNull RunProfile profile) {
+    return DefaultRunExecutor.EXECUTOR_ID.equals(executorId) && profile instanceof MixExUnitRunConfiguration;
+  }
+}

--- a/src/org/elixir_lang/mix/runner/exunit/MixExUnitRunner.java
+++ b/src/org/elixir_lang/mix/runner/exunit/MixExUnitRunner.java
@@ -6,7 +6,7 @@ import com.intellij.execution.runners.DefaultProgramRunner;
 import org.jetbrains.annotations.NotNull;
 
 public final class MixExUnitRunner extends DefaultProgramRunner{
-  public static final String MIX_RUNNER_ID = "MixExUnitRunner";
+  private static final String MIX_RUNNER_ID = "MixExUnitRunner";
 
   @NotNull
   @Override

--- a/src/org/elixir_lang/mix/runner/exunit/MixExUnitRunningState.java
+++ b/src/org/elixir_lang/mix/runner/exunit/MixExUnitRunningState.java
@@ -1,0 +1,108 @@
+package org.elixir_lang.mix.runner.exunit;
+
+import com.intellij.execution.DefaultExecutionResult;
+import com.intellij.execution.ExecutionException;
+import com.intellij.execution.ExecutionResult;
+import com.intellij.execution.Executor;
+import com.intellij.execution.configurations.CommandLineState;
+import com.intellij.execution.configurations.GeneralCommandLine;
+import com.intellij.execution.process.ProcessHandler;
+import com.intellij.execution.runners.ExecutionEnvironment;
+import com.intellij.execution.runners.ProgramRunner;
+import com.intellij.execution.testframework.TestConsoleProperties;
+import com.intellij.execution.testframework.sm.SMTestRunnerConnectionUtil;
+import com.intellij.execution.testframework.sm.runner.SMTRunnerConsoleProperties;
+import com.intellij.execution.ui.ConsoleView;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.io.FileUtil;
+import com.intellij.openapi.util.text.StringUtil;
+import com.intellij.util.containers.ContainerUtil;
+import org.elixir_lang.console.ElixirConsoleUtil;
+import org.elixir_lang.exunit.ElixirModules;
+import org.elixir_lang.jps.model.JpsElixirSdkType;
+import org.elixir_lang.mix.runner.MixRunningStateUtil;
+import org.elixir_lang.mix.settings.MixSettings;
+import org.elixir_lang.sdk.ElixirSdkType;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+
+import static org.elixir_lang.mix.runner.MixRunningStateUtil.getWorkingDirectory;
+
+final class MixExUnitRunningState extends CommandLineState{
+  private final MixExUnitRunConfiguration myConfiguration;
+
+  protected MixExUnitRunningState(@NotNull ExecutionEnvironment environment, MixExUnitRunConfiguration configuration) {
+    super(environment);
+    myConfiguration = configuration;
+  }
+
+  @NotNull
+  @Override
+  public ExecutionResult execute(@NotNull Executor executor, @NotNull ProgramRunner runner) throws ExecutionException {
+    ProcessHandler processHandler = startProcess();
+
+    TestConsoleProperties properties = new SMTRunnerConsoleProperties(myConfiguration, "ExUnit", executor);
+    ConsoleView console = SMTestRunnerConnectionUtil.createAndAttachConsole("ExUnit", processHandler, properties);
+    ElixirConsoleUtil.attachFilters(myConfiguration.getProject(), console);
+    return new DefaultExecutionResult(console, processHandler, createActions(console, processHandler));
+  }
+
+  @NotNull
+  @Override
+  protected ProcessHandler startProcess() throws ExecutionException {
+    GeneralCommandLine commandLine = getMixExunitCommandLine(myConfiguration);
+    return MixRunningStateUtil.runMix(myConfiguration.getProject(), commandLine);
+  }
+
+  private static File createElixirModulesDirectory() throws IOException {
+    return FileUtil.createTempDirectory("intellij_elixir_modules", null);
+  }
+
+  @NotNull
+  public static GeneralCommandLine getMixExunitCommandLine(@NotNull MixExUnitRunConfiguration configuration) throws ExecutionException {
+    Project project = configuration.getProject();
+    MixSettings mixSettings = MixSettings.getInstance(project);
+
+    // Copy Elixir modules to temp dir
+    String elixirModulesFilePath;
+    try {
+      File elixirModulesDir = createElixirModulesDirectory();
+      ElixirModules.putFormatterTo(elixirModulesDir);
+
+      // Support for the --formatter option was recently added to Mix. Older versions of Elixir will need to use the
+      // custom task we've included in order to support this option
+      if (!mixSettings.getSupportsFormatterOption()) {
+        ElixirModules.putMixTaskTo(elixirModulesDir);
+      }
+
+      elixirModulesFilePath = new File(elixirModulesDir.getCanonicalPath(), "*.ex").toString();
+    } catch(IOException e) {
+      throw new ExecutionException(e);
+    }
+
+    String sdkPath = ElixirSdkType.getSdkPath(project);
+
+    String elixirPath = sdkPath != null ? JpsElixirSdkType.getScriptInterpreterExecutable(sdkPath).getAbsolutePath() :
+        JpsElixirSdkType.getExecutableFileName(JpsElixirSdkType.SCRIPT_INTERPRETER);
+
+    GeneralCommandLine commandLine = new GeneralCommandLine();
+
+    commandLine.withWorkDirectory(getWorkingDirectory(configuration));
+
+    // Because we pass additional options to `elixir`, we can't use `mix.bat`. We assume there's a `mix` script in the
+    // same directory if the user specified the .bat file in the "Elixir External Tools" config
+    String mixPath = StringUtil.trimEnd(mixSettings.getMixPath(), ".bat");
+
+    String task = mixSettings.getSupportsFormatterOption() ? "test" : "test_with_formatter";
+
+    commandLine.setExePath(elixirPath);
+    commandLine.addParameters("-r", elixirModulesFilePath, mixPath, task, "--formatter", "TeamCityExUnitFormatter");
+
+    List<String> split = ContainerUtil.list(configuration.getMixTestArgs().split("\\s+"));
+    if (!(split.size() == 1 && split.get(0).equals(""))) commandLine.addParameters(split);
+    return commandLine;
+  }
+}

--- a/src/org/elixir_lang/mix/runner/exunit/MixExUnitRunningState.java
+++ b/src/org/elixir_lang/mix/runner/exunit/MixExUnitRunningState.java
@@ -67,22 +67,7 @@ final class MixExUnitRunningState extends CommandLineState{
     MixSettings mixSettings = MixSettings.getInstance(project);
 
     // Copy Elixir modules to temp dir
-    String elixirModulesFilePath;
-    try {
-      File elixirModulesDir = createElixirModulesDirectory();
-      ElixirModules.putFormatterTo(elixirModulesDir);
-
-      // Support for the --formatter option was recently added to Mix. Older versions of Elixir will need to use the
-      // custom task we've included in order to support this option
-      if (!mixSettings.getSupportsFormatterOption()) {
-        ElixirModules.putMixTaskTo(elixirModulesDir);
-      }
-
-      elixirModulesFilePath = new File(elixirModulesDir.getCanonicalPath(), "*.ex").toString();
-    } catch(IOException e) {
-      throw new ExecutionException(e);
-    }
-
+    String elixirModulesFilePath = populateElixirModulesDirectory(!mixSettings.getSupportsFormatterOption());
     String sdkPath = ElixirSdkType.getSdkPath(project);
 
     String elixirPath = sdkPath != null ? JpsElixirSdkType.getScriptInterpreterExecutable(sdkPath).getAbsolutePath() :
@@ -105,4 +90,23 @@ final class MixExUnitRunningState extends CommandLineState{
     if (!(split.size() == 1 && split.get(0).equals(""))) commandLine.addParameters(split);
     return commandLine;
   }
+
+  @NotNull
+  private static String populateElixirModulesDirectory(boolean useCustomMixTask) throws ExecutionException {
+    try {
+      File elixirModulesDir = createElixirModulesDirectory();
+      ElixirModules.putFormatterTo(elixirModulesDir);
+
+      // Support for the --formatter option was recently added to Mix. Older versions of Elixir will need to use the
+      // custom task we've included in order to support this option
+      if (useCustomMixTask) {
+        ElixirModules.putMixTaskTo(elixirModulesDir);
+      }
+
+      return new File(elixirModulesDir.getCanonicalPath(), "*.ex").toString();
+    } catch(IOException e) {
+      throw new ExecutionException(e);
+    }
+  }
+
 }

--- a/src/org/elixir_lang/mix/runner/exunit/MixExUnitRunningState.java
+++ b/src/org/elixir_lang/mix/runner/exunit/MixExUnitRunningState.java
@@ -36,7 +36,7 @@ import static org.elixir_lang.mix.runner.MixRunningStateUtil.getWorkingDirectory
 final class MixExUnitRunningState extends CommandLineState{
   private final MixExUnitRunConfiguration myConfiguration;
 
-  protected MixExUnitRunningState(@NotNull ExecutionEnvironment environment, MixExUnitRunConfiguration configuration) {
+  MixExUnitRunningState(@NotNull ExecutionEnvironment environment, MixExUnitRunConfiguration configuration) {
     super(environment);
     myConfiguration = configuration;
   }
@@ -55,7 +55,7 @@ final class MixExUnitRunningState extends CommandLineState{
   @NotNull
   @Override
   protected ProcessHandler startProcess() throws ExecutionException {
-    GeneralCommandLine commandLine = getMixExunitCommandLine(myConfiguration);
+    GeneralCommandLine commandLine = getMixExUnitCommandLine(myConfiguration);
     return MixRunningStateUtil.runMix(myConfiguration.getProject(), commandLine);
   }
 
@@ -102,7 +102,7 @@ final class MixExUnitRunningState extends CommandLineState{
   }
 
   @NotNull
-  public static GeneralCommandLine getMixExunitCommandLine(@NotNull MixExUnitRunConfiguration configuration) throws ExecutionException {
+  private static GeneralCommandLine getMixExUnitCommandLine(@NotNull MixExUnitRunConfiguration configuration) throws ExecutionException {
     Project project = configuration.getProject();
     MixSettings mixSettings = MixSettings.getInstance(project);
 

--- a/src/org/elixir_lang/mix/settings/MixConfigurationForm.form
+++ b/src/org/elixir_lang/mix/settings/MixConfigurationForm.form
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="org.elixir_lang.mix.settings.MixConfigurationForm">
-  <grid id="27dc6" binding="myPanel" layout-manager="GridLayoutManager" row-count="5" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="27dc6" binding="myPanel" layout-manager="GridLayoutManager" row-count="5" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
       <xy x="20" y="20" width="500" height="400"/>
@@ -10,7 +10,7 @@
     <children>
       <component id="ee33e" class="com.intellij.ui.TitledSeparator">
         <constraints>
-          <grid row="0" column="0" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="0" column="0" row-span="1" col-span="3" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text value="Mix"/>
@@ -26,7 +26,7 @@
       </component>
       <component id="494ef" class="com.intellij.openapi.ui.TextFieldWithBrowseButton" binding="myMixPathSelector">
         <constraints>
-          <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="1" column="1" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text value=""/>
@@ -42,7 +42,7 @@
       </component>
       <component id="be2d2" class="javax.swing.JTextField" binding="myMixVersionText">
         <constraints>
-          <grid row="2" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+          <grid row="2" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
             <preferred-size width="150" height="-1"/>
           </grid>
         </constraints>
@@ -52,20 +52,20 @@
           <text value="N/A"/>
         </properties>
       </component>
-      <grid id="9dd4e" binding="myLinkContainer" custom-create="true" layout-manager="GridLayoutManager" row-count="1" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
-        <margin top="0" left="0" bottom="0" right="0"/>
-        <constraints>
-          <grid row="3" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
-        </constraints>
-        <properties/>
-        <border type="none"/>
-        <children/>
-      </grid>
       <vspacer id="dbd7">
         <constraints>
-          <grid row="4" column="1" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+          <grid row="4" column="1" row-span="1" col-span="2" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
         </constraints>
       </vspacer>
+      <component id="43ab0" class="javax.swing.JCheckBox" binding="supportsFormatterOptionCheckBox">
+        <constraints>
+          <grid row="3" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <enabled value="false"/>
+          <text value="Test supports '--formatter'"/>
+        </properties>
+      </component>
     </children>
   </grid>
 </form>

--- a/src/org/elixir_lang/mix/settings/MixConfigurationForm.java
+++ b/src/org/elixir_lang/mix/settings/MixConfigurationForm.java
@@ -18,6 +18,7 @@ import com.intellij.util.containers.ContainerUtil;
 import com.intellij.util.download.DownloadableFileDescription;
 import com.intellij.util.download.DownloadableFileService;
 import com.intellij.util.download.FileDownloader;
+import org.elixir_lang.sdk.ElixirSdkRelease;
 import org.elixir_lang.sdk.ElixirSystemUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -140,7 +141,8 @@ public class MixConfigurationForm {
 
           // Support for the --formatter option may be added in a 1.3.x release, but I'm being conservative for now
           // and assuming it won't be released until 1.4
-          supportsFormatterOptionCheckBox.setSelected(compareVersions(versionString, "1.4") >= 0);
+          ElixirSdkRelease elixirSdkRelease = ElixirSdkRelease.fromString(versionString);
+          supportsFormatterOptionCheckBox.setSelected(elixirSdkRelease.compareTo(ElixirSdkRelease.V_1_4) >= 0);
           valid = true;
 
           break;
@@ -187,23 +189,5 @@ public class MixConfigurationForm {
     });
 
     myLinkContainer.add(link, BorderLayout.NORTH);
-  }
-
-  private static int compareVersions(String version1, String version2){
-
-    String[] levels1 = version1.split("\\.");
-    String[] levels2 = version2.split("\\.");
-
-    int length = Math.max(levels1.length, levels2.length);
-    for (int i = 0; i < length; i++){
-      Integer v1 = i < levels1.length ? Integer.parseInt(levels1[i]) : 0;
-      Integer v2 = i < levels2.length ? Integer.parseInt(levels2[i]) : 0;
-      int compare = v1.compareTo(v2);
-      if (compare != 0){
-        return compare;
-      }
-    }
-
-    return 0;
   }
 }

--- a/src/org/elixir_lang/mix/settings/MixConfigurationForm.java
+++ b/src/org/elixir_lang/mix/settings/MixConfigurationForm.java
@@ -65,6 +65,7 @@ public class MixConfigurationForm {
   private JTextField myMixVersionText;
   private JPanel myLinkContainer;
   private TextFieldWithBrowseButton myMixPathSelector;
+  private JCheckBox supportsFormatterOptionCheckBox;
 
   private boolean myMixPathValid;
 
@@ -91,6 +92,8 @@ public class MixConfigurationForm {
   public String getPath(){
     return myMixPathSelector.getText();
   }
+
+  public boolean getSupportsFormatterOption() { return supportsFormatterOptionCheckBox.isSelected(); }
 
   public boolean isPathValid(){
     return myMixPathValid;
@@ -133,6 +136,11 @@ public class MixConfigurationForm {
 
         if (transformedStdout != null) {
           myMixVersionText.setText(transformedStdout);
+          String versionString = transformedStdout.replaceAll("^[^0-9]*", "");
+
+          // Support for the --formatter option may be added in a 1.3.x release, but I'm being conservative for now
+          // and assuming it won't be released until 1.4
+          supportsFormatterOptionCheckBox.setSelected(compareVersions(versionString, "1.4") >= 0);
           valid = true;
 
           break;
@@ -179,5 +187,23 @@ public class MixConfigurationForm {
     });
 
     myLinkContainer.add(link, BorderLayout.NORTH);
+  }
+
+  private static int compareVersions(String version1, String version2){
+
+    String[] levels1 = version1.split("\\.");
+    String[] levels2 = version2.split("\\.");
+
+    int length = Math.max(levels1.length, levels2.length);
+    for (int i = 0; i < length; i++){
+      Integer v1 = i < levels1.length ? Integer.parseInt(levels1[i]) : 0;
+      Integer v2 = i < levels2.length ? Integer.parseInt(levels2[i]) : 0;
+      int compare = v1.compareTo(v2);
+      if (compare != 0){
+        return compare;
+      }
+    }
+
+    return 0;
   }
 }

--- a/src/org/elixir_lang/mix/settings/MixConfigurationForm.java
+++ b/src/org/elixir_lang/mix/settings/MixConfigurationForm.java
@@ -142,7 +142,11 @@ public class MixConfigurationForm {
           // Support for the --formatter option may be added in a 1.3.x release, but I'm being conservative for now
           // and assuming it won't be released until 1.4
           ElixirSdkRelease elixirSdkRelease = ElixirSdkRelease.fromString(versionString);
-          supportsFormatterOptionCheckBox.setSelected(elixirSdkRelease.compareTo(ElixirSdkRelease.V_1_4) >= 0);
+
+          if (elixirSdkRelease != null) {
+            supportsFormatterOptionCheckBox.setSelected(elixirSdkRelease.compareTo(ElixirSdkRelease.V_1_4) >= 0);
+          }
+
           valid = true;
 
           break;

--- a/src/org/elixir_lang/mix/settings/MixSettings.java
+++ b/src/org/elixir_lang/mix/settings/MixSettings.java
@@ -49,6 +49,14 @@ public class MixSettings implements PersistentStateComponent<MixSettingsState>{
     myMixSettingsState.myMixPath = mixPath;
   }
 
+  public void setSupportsFormatterOption(boolean supportsFormatterOption) {
+    myMixSettingsState.supportsFormatterOption = supportsFormatterOption;
+  }
+
+  public boolean getSupportsFormatterOption() {
+    return myMixSettingsState.supportsFormatterOption;
+  }
+
   @Override
   public String toString() {
     return "MixSettings(state='" + myMixSettingsState.toString() + "')";

--- a/src/org/elixir_lang/sdk/ElixirSdkRelease.java
+++ b/src/org/elixir_lang/sdk/ElixirSdkRelease.java
@@ -48,9 +48,9 @@ public final class ElixirSdkRelease implements Comparable<ElixirSdkRelease> {
 
     if (mine == null && others == null) {
       comparison = 0;
-    } else if (mine == null && others != null) {
+    } else if (mine == null) {
       comparison = -1;
-    } else if (mine != null && others == null) {
+    } else if (others == null) {
       comparison = 1;
     } else {
       try {
@@ -86,10 +86,10 @@ public final class ElixirSdkRelease implements Comparable<ElixirSdkRelease> {
 
     if (mine == null && others == null) {
       comparison = 0;
-    } else if (mine == null && others != null) {
+    } else if (mine == null) {
       // https://github.com/elixir-lang/elixir/blob/27c350da06ee4df5a4710507abe443ffba5b07dd/lib/elixir/lib/version.ex#L203
       comparison = 1;
-    } else if (mine != null && others == null) {
+    } else if (others == null) {
       // https://github.com/elixir-lang/elixir/blob/27c350da06ee4df5a4710507abe443ffba5b07dd/lib/elixir/lib/version.ex#L204
       comparison = -1;
     } else {

--- a/src/org/elixir_lang/sdk/ElixirSdkRelease.java
+++ b/src/org/elixir_lang/sdk/ElixirSdkRelease.java
@@ -14,6 +14,8 @@ public final class ElixirSdkRelease implements Comparable<ElixirSdkRelease> {
 
   public static final ElixirSdkRelease V_1_0_4 = new ElixirSdkRelease("1", "0", "4", null, null);
   public static final ElixirSdkRelease V_1_2 = new ElixirSdkRelease("1", "2", null, null, null);
+  public static final ElixirSdkRelease V_1_4 = new ElixirSdkRelease("1", "4", null, null, null);
+
 
   private static final Pattern VERSION_PATTERN = Pattern.compile(
           // @version_regex from Version in elixir itself

--- a/src/org/elixir_lang/settings/ElixirExternalToolsConfigurable.java
+++ b/src/org/elixir_lang/settings/ElixirExternalToolsConfigurable.java
@@ -99,6 +99,7 @@ public class ElixirExternalToolsConfigurable implements SearchableConfigurable, 
   @Override
   public void apply() throws ConfigurationException {
     myMixSettings.setMixPath(myMixConfigurationForm.getPath());
+    myMixSettings.setSupportsFormatterOption(myMixConfigurationForm.getSupportsFormatterOption());
 
     if(ElixirSystemUtil.isSmallIde()){
       ElixirSdkForSmallIdes.setUpOrUpdateSdk(myProject, mySdkPathSelector.getText());

--- a/src/org/elixir_lang/settings/ElixirExternalToolsConfigurable.java
+++ b/src/org/elixir_lang/settings/ElixirExternalToolsConfigurable.java
@@ -41,8 +41,8 @@ public class ElixirExternalToolsConfigurable implements SearchableConfigurable, 
     myProject = project;
     myMixSettings = MixSettings.getInstance(project);
     mySdkPathSelector.addBrowseFolderListener("Select Elixir SDK path", "", null,
-        FileChooserDescriptorFactory.createSingleFolderDescriptor().withTitle("Elixir SDK root"));
-    
+        FileChooserDescriptorFactory.createSingleFolderDescriptor().withTitle("Elixir SDK Root"));
+
     if(StringUtil.isEmpty(myMixSettings.getMixPath())){
       VirtualFile baseDir = project.getBaseDir();
       if(baseDir != null){


### PR DESCRIPTION
This adds ExUnit test integration using the `mix test` command. It supports creating a run configuration manually or from a PSI element, meaning you can use the usual shortcut to run the test at the cursor's position, or run individual test files or directories. You can even right click on a particular test result to re-run just that test.

The latest elixir release (1.3.4) does not support specifying a custom test formatter on the CLI, but I submitted a change to enable that and it's been merged into master, so it should be released at some point. Until it is, I've bundled a custom mix task `TestWithFormatter`. Based on the Mix version in the "External Tools" settings, we guess whether this custom task is necessary or not.

I think the branch currently works, but it could use improvements in a few areas:
- Needs tests
- The RunConfigurationProducer will accept any Elixir file or directory. I'm not sure how best to limit it to test files and directories.
- Needs documentation

I think this is a really useful addition to the IDE, but I could potentially use some help (or at least feedback) to get it cleaned up a bit before merge. Feedback much appreciated.

# TODO
- [x] Manual testing (assigned to @KronicDeth)
  - [x] Directory
  - [x] File
  - [x] Line
- [x] `RunConfigurationProducer` to test files and directories.  (unassigned)
- [ ] Documentation
  - [ ] README updates (postpone until release: adding them early leads to users opening bugs that functional doesn't work because they think master's README matches the released version)
- [x] `"mix test" args` should use path relative to project base dir OR the `apps/<name>` directory for umbrella apps.
- [x] Working directory support of Umbrella apps (Added in general in #523) (Added in 4c0e4f31d666c81980dfb436a995ef9da1b50a06)