### PR TITLE
Resolve functions qualified by Aliases

### DIFF
--- a/gen/org/elixir_lang/parser/ElixirParser.java
+++ b/gen/org/elixir_lang/parser/ElixirParser.java
@@ -9,7 +9,7 @@ import com.intellij.lang.PsiParser;
 import com.intellij.psi.tree.IElementType;
 import com.intellij.psi.tree.TokenSet;
 
-import static com.intellij.lang.parser.GeneratedParserUtilBase.*;
+import static org.elixir_lang.grammar.parser.GeneratedParserUtilBase.*;
 import static org.elixir_lang.psi.ElixirTypes.*;
 
 @SuppressWarnings({"SimplifiableIfStatement", "UnusedAssignment"})

--- a/gen/org/elixir_lang/parser/ElixirParser.java
+++ b/gen/org/elixir_lang/parser/ElixirParser.java
@@ -9,7 +9,7 @@ import com.intellij.lang.PsiParser;
 import com.intellij.psi.tree.IElementType;
 import com.intellij.psi.tree.TokenSet;
 
-import static org.elixir_lang.grammar.parser.GeneratedParserUtilBase.*;
+import static com.intellij.lang.parser.GeneratedParserUtilBase.*;
 import static org.elixir_lang.psi.ElixirTypes.*;
 
 @SuppressWarnings({"SimplifiableIfStatement", "UnusedAssignment"})

--- a/gen/org/elixir_lang/psi/ElixirAtNumericOperation.java
+++ b/gen/org/elixir_lang/psi/ElixirAtNumericOperation.java
@@ -51,13 +51,13 @@ public interface ElixirAtNumericOperation extends Named, Prefix {
 
   boolean hasDoBlockOrKeyword();
 
-  boolean isCalling(String resolvedModuleName, String resolvedFunctionName);
+  boolean isCalling(String resolvedModuleName, String functionName);
 
-  boolean isCalling(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity);
+  boolean isCalling(String resolvedModuleName, String functionName, int resolvedFinalArity);
 
-  boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName);
+  boolean isCallingMacro(String resolvedModuleName, String functionName);
 
-  boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity);
+  boolean isCallingMacro(String resolvedModuleName, String functionName, int resolvedFinalArity);
 
   @Nullable
   String moduleName();
@@ -88,9 +88,6 @@ public interface ElixirAtNumericOperation extends Named, Prefix {
 
   @NotNull
   IntRange resolvedFinalArityRange();
-
-  @NotNull
-  String resolvedFunctionName();
 
   @NotNull
   String resolvedModuleName();

--- a/gen/org/elixir_lang/psi/ElixirCaptureNumericOperation.java
+++ b/gen/org/elixir_lang/psi/ElixirCaptureNumericOperation.java
@@ -51,13 +51,13 @@ public interface ElixirCaptureNumericOperation extends Named, Prefix {
 
   boolean hasDoBlockOrKeyword();
 
-  boolean isCalling(String resolvedModuleName, String resolvedFunctionName);
+  boolean isCalling(String resolvedModuleName, String functionName);
 
-  boolean isCalling(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity);
+  boolean isCalling(String resolvedModuleName, String functionName, int resolvedFinalArity);
 
-  boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName);
+  boolean isCallingMacro(String resolvedModuleName, String functionName);
 
-  boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity);
+  boolean isCallingMacro(String resolvedModuleName, String functionName, int resolvedFinalArity);
 
   @Nullable
   String moduleName();
@@ -88,9 +88,6 @@ public interface ElixirCaptureNumericOperation extends Named, Prefix {
 
   @NotNull
   IntRange resolvedFinalArityRange();
-
-  @NotNull
-  String resolvedFunctionName();
 
   @NotNull
   String resolvedModuleName();

--- a/gen/org/elixir_lang/psi/ElixirMatchedAdditionOperation.java
+++ b/gen/org/elixir_lang/psi/ElixirMatchedAdditionOperation.java
@@ -37,13 +37,13 @@ public interface ElixirMatchedAdditionOperation extends ElixirMatchedExpression,
 
   boolean hasDoBlockOrKeyword();
 
-  boolean isCalling(String resolvedModuleName, String resolvedFunctionName);
+  boolean isCalling(String resolvedModuleName, String functionName);
 
-  boolean isCalling(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity);
+  boolean isCalling(String resolvedModuleName, String functionName, int resolvedFinalArity);
 
-  boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName);
+  boolean isCallingMacro(String resolvedModuleName, String functionName);
 
-  boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity);
+  boolean isCallingMacro(String resolvedModuleName, String functionName, int resolvedFinalArity);
 
   @Nullable
   Quotable leftOperand();
@@ -70,9 +70,6 @@ public interface ElixirMatchedAdditionOperation extends ElixirMatchedExpression,
 
   @NotNull
   IntRange resolvedFinalArityRange();
-
-  @NotNull
-  String resolvedFunctionName();
 
   @NotNull
   String resolvedModuleName();

--- a/gen/org/elixir_lang/psi/ElixirMatchedAndOperation.java
+++ b/gen/org/elixir_lang/psi/ElixirMatchedAndOperation.java
@@ -37,13 +37,13 @@ public interface ElixirMatchedAndOperation extends ElixirMatchedExpression, Name
 
   boolean hasDoBlockOrKeyword();
 
-  boolean isCalling(String resolvedModuleName, String resolvedFunctionName);
+  boolean isCalling(String resolvedModuleName, String functionName);
 
-  boolean isCalling(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity);
+  boolean isCalling(String resolvedModuleName, String functionName, int resolvedFinalArity);
 
-  boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName);
+  boolean isCallingMacro(String resolvedModuleName, String functionName);
 
-  boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity);
+  boolean isCallingMacro(String resolvedModuleName, String functionName, int resolvedFinalArity);
 
   @Nullable
   Quotable leftOperand();
@@ -70,9 +70,6 @@ public interface ElixirMatchedAndOperation extends ElixirMatchedExpression, Name
 
   @NotNull
   IntRange resolvedFinalArityRange();
-
-  @NotNull
-  String resolvedFunctionName();
 
   @NotNull
   String resolvedModuleName();

--- a/gen/org/elixir_lang/psi/ElixirMatchedArrowOperation.java
+++ b/gen/org/elixir_lang/psi/ElixirMatchedArrowOperation.java
@@ -37,13 +37,13 @@ public interface ElixirMatchedArrowOperation extends ElixirMatchedExpression, Na
 
   boolean hasDoBlockOrKeyword();
 
-  boolean isCalling(String resolvedModuleName, String resolvedFunctionName);
+  boolean isCalling(String resolvedModuleName, String functionName);
 
-  boolean isCalling(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity);
+  boolean isCalling(String resolvedModuleName, String functionName, int resolvedFinalArity);
 
-  boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName);
+  boolean isCallingMacro(String resolvedModuleName, String functionName);
 
-  boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity);
+  boolean isCallingMacro(String resolvedModuleName, String functionName, int resolvedFinalArity);
 
   @Nullable
   Quotable leftOperand();
@@ -70,9 +70,6 @@ public interface ElixirMatchedArrowOperation extends ElixirMatchedExpression, Na
 
   @NotNull
   IntRange resolvedFinalArityRange();
-
-  @NotNull
-  String resolvedFunctionName();
 
   @NotNull
   String resolvedModuleName();

--- a/gen/org/elixir_lang/psi/ElixirMatchedAtUnqualifiedNoParenthesesCall.java
+++ b/gen/org/elixir_lang/psi/ElixirMatchedAtUnqualifiedNoParenthesesCall.java
@@ -51,13 +51,13 @@ public interface ElixirMatchedAtUnqualifiedNoParenthesesCall extends ElixirMatch
   @NotNull
   SearchScope getUseScope();
 
-  boolean isCalling(String resolvedModuleName, String resolvedFunctionName);
+  boolean isCalling(String resolvedModuleName, String functionName);
 
-  boolean isCalling(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity);
+  boolean isCalling(String resolvedModuleName, String functionName, int resolvedFinalArity);
 
-  boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName);
+  boolean isCallingMacro(String resolvedModuleName, String functionName);
 
-  boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity);
+  boolean isCallingMacro(String resolvedModuleName, String functionName, int resolvedFinalArity);
 
   @Nullable
   String moduleName();
@@ -78,9 +78,6 @@ public interface ElixirMatchedAtUnqualifiedNoParenthesesCall extends ElixirMatch
 
   @NotNull
   IntRange resolvedFinalArityRange();
-
-  @Nullable
-  String resolvedFunctionName();
 
   @Nullable
   String resolvedModuleName();

--- a/gen/org/elixir_lang/psi/ElixirMatchedCaptureNonNumericOperation.java
+++ b/gen/org/elixir_lang/psi/ElixirMatchedCaptureNonNumericOperation.java
@@ -33,13 +33,13 @@ public interface ElixirMatchedCaptureNonNumericOperation extends ElixirMatchedEx
 
   boolean hasDoBlockOrKeyword();
 
-  boolean isCalling(String resolvedModuleName, String resolvedFunctionName);
+  boolean isCalling(String resolvedModuleName, String functionName);
 
-  boolean isCalling(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity);
+  boolean isCalling(String resolvedModuleName, String functionName, int resolvedFinalArity);
 
-  boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName);
+  boolean isCallingMacro(String resolvedModuleName, String functionName);
 
-  boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity);
+  boolean isCallingMacro(String resolvedModuleName, String functionName, int resolvedFinalArity);
 
   @Nullable
   String moduleName();
@@ -70,9 +70,6 @@ public interface ElixirMatchedCaptureNonNumericOperation extends ElixirMatchedEx
 
   @NotNull
   IntRange resolvedFinalArityRange();
-
-  @NotNull
-  String resolvedFunctionName();
 
   @NotNull
   String resolvedModuleName();

--- a/gen/org/elixir_lang/psi/ElixirMatchedComparisonOperation.java
+++ b/gen/org/elixir_lang/psi/ElixirMatchedComparisonOperation.java
@@ -37,13 +37,13 @@ public interface ElixirMatchedComparisonOperation extends ElixirMatchedExpressio
 
   boolean hasDoBlockOrKeyword();
 
-  boolean isCalling(String resolvedModuleName, String resolvedFunctionName);
+  boolean isCalling(String resolvedModuleName, String functionName);
 
-  boolean isCalling(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity);
+  boolean isCalling(String resolvedModuleName, String functionName, int resolvedFinalArity);
 
-  boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName);
+  boolean isCallingMacro(String resolvedModuleName, String functionName);
 
-  boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity);
+  boolean isCallingMacro(String resolvedModuleName, String functionName, int resolvedFinalArity);
 
   @Nullable
   Quotable leftOperand();
@@ -70,9 +70,6 @@ public interface ElixirMatchedComparisonOperation extends ElixirMatchedExpressio
 
   @NotNull
   IntRange resolvedFinalArityRange();
-
-  @NotNull
-  String resolvedFunctionName();
 
   @NotNull
   String resolvedModuleName();

--- a/gen/org/elixir_lang/psi/ElixirMatchedDotCall.java
+++ b/gen/org/elixir_lang/psi/ElixirMatchedDotCall.java
@@ -51,13 +51,13 @@ public interface ElixirMatchedDotCall extends ElixirMatchedExpression, DotCall<M
   @Nullable
   PsiReference getReference();
 
-  boolean isCalling(String resolvedModuleName, String resolvedFunctionName);
+  boolean isCalling(String resolvedModuleName, String functionName);
 
-  boolean isCalling(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity);
+  boolean isCalling(String resolvedModuleName, String functionName, int resolvedFinalArity);
 
-  boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName);
+  boolean isCallingMacro(String resolvedModuleName, String functionName);
 
-  boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity);
+  boolean isCallingMacro(String resolvedModuleName, String functionName, int resolvedFinalArity);
 
   @Nullable
   String moduleName();
@@ -78,9 +78,6 @@ public interface ElixirMatchedDotCall extends ElixirMatchedExpression, DotCall<M
 
   @NotNull
   IntRange resolvedFinalArityRange();
-
-  @Nullable
-  String resolvedFunctionName();
 
   @Nullable
   String resolvedModuleName();

--- a/gen/org/elixir_lang/psi/ElixirMatchedInMatchOperation.java
+++ b/gen/org/elixir_lang/psi/ElixirMatchedInMatchOperation.java
@@ -37,13 +37,13 @@ public interface ElixirMatchedInMatchOperation extends ElixirMatchedExpression, 
 
   boolean hasDoBlockOrKeyword();
 
-  boolean isCalling(String resolvedModuleName, String resolvedFunctionName);
+  boolean isCalling(String resolvedModuleName, String functionName);
 
-  boolean isCalling(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity);
+  boolean isCalling(String resolvedModuleName, String functionName, int resolvedFinalArity);
 
-  boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName);
+  boolean isCallingMacro(String resolvedModuleName, String functionName);
 
-  boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity);
+  boolean isCallingMacro(String resolvedModuleName, String functionName, int resolvedFinalArity);
 
   @Nullable
   Quotable leftOperand();
@@ -70,9 +70,6 @@ public interface ElixirMatchedInMatchOperation extends ElixirMatchedExpression, 
 
   @NotNull
   IntRange resolvedFinalArityRange();
-
-  @NotNull
-  String resolvedFunctionName();
 
   @NotNull
   String resolvedModuleName();

--- a/gen/org/elixir_lang/psi/ElixirMatchedInOperation.java
+++ b/gen/org/elixir_lang/psi/ElixirMatchedInOperation.java
@@ -32,13 +32,13 @@ public interface ElixirMatchedInOperation extends ElixirMatchedExpression, Call,
 
   boolean hasDoBlockOrKeyword();
 
-  boolean isCalling(String resolvedModuleName, String resolvedFunctionName);
+  boolean isCalling(String resolvedModuleName, String functionName);
 
-  boolean isCalling(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity);
+  boolean isCalling(String resolvedModuleName, String functionName, int resolvedFinalArity);
 
-  boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName);
+  boolean isCallingMacro(String resolvedModuleName, String functionName);
 
-  boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity);
+  boolean isCallingMacro(String resolvedModuleName, String functionName, int resolvedFinalArity);
 
   @Nullable
   Quotable leftOperand();
@@ -65,9 +65,6 @@ public interface ElixirMatchedInOperation extends ElixirMatchedExpression, Call,
 
   @NotNull
   IntRange resolvedFinalArityRange();
-
-  @NotNull
-  String resolvedFunctionName();
 
   @NotNull
   String resolvedModuleName();

--- a/gen/org/elixir_lang/psi/ElixirMatchedMatchOperation.java
+++ b/gen/org/elixir_lang/psi/ElixirMatchedMatchOperation.java
@@ -37,13 +37,13 @@ public interface ElixirMatchedMatchOperation extends ElixirMatchedExpression, Na
 
   boolean hasDoBlockOrKeyword();
 
-  boolean isCalling(String resolvedModuleName, String resolvedFunctionName);
+  boolean isCalling(String resolvedModuleName, String functionName);
 
-  boolean isCalling(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity);
+  boolean isCalling(String resolvedModuleName, String functionName, int resolvedFinalArity);
 
-  boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName);
+  boolean isCallingMacro(String resolvedModuleName, String functionName);
 
-  boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity);
+  boolean isCallingMacro(String resolvedModuleName, String functionName, int resolvedFinalArity);
 
   @Nullable
   Quotable leftOperand();
@@ -70,9 +70,6 @@ public interface ElixirMatchedMatchOperation extends ElixirMatchedExpression, Na
 
   @NotNull
   IntRange resolvedFinalArityRange();
-
-  @NotNull
-  String resolvedFunctionName();
 
   @NotNull
   String resolvedModuleName();

--- a/gen/org/elixir_lang/psi/ElixirMatchedMultiplicationOperation.java
+++ b/gen/org/elixir_lang/psi/ElixirMatchedMultiplicationOperation.java
@@ -37,13 +37,13 @@ public interface ElixirMatchedMultiplicationOperation extends ElixirMatchedExpre
 
   boolean hasDoBlockOrKeyword();
 
-  boolean isCalling(String resolvedModuleName, String resolvedFunctionName);
+  boolean isCalling(String resolvedModuleName, String functionName);
 
-  boolean isCalling(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity);
+  boolean isCalling(String resolvedModuleName, String functionName, int resolvedFinalArity);
 
-  boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName);
+  boolean isCallingMacro(String resolvedModuleName, String functionName);
 
-  boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity);
+  boolean isCallingMacro(String resolvedModuleName, String functionName, int resolvedFinalArity);
 
   @Nullable
   Quotable leftOperand();
@@ -70,9 +70,6 @@ public interface ElixirMatchedMultiplicationOperation extends ElixirMatchedExpre
 
   @NotNull
   IntRange resolvedFinalArityRange();
-
-  @NotNull
-  String resolvedFunctionName();
 
   @NotNull
   String resolvedModuleName();

--- a/gen/org/elixir_lang/psi/ElixirMatchedOrOperation.java
+++ b/gen/org/elixir_lang/psi/ElixirMatchedOrOperation.java
@@ -37,13 +37,13 @@ public interface ElixirMatchedOrOperation extends ElixirMatchedExpression, Named
 
   boolean hasDoBlockOrKeyword();
 
-  boolean isCalling(String resolvedModuleName, String resolvedFunctionName);
+  boolean isCalling(String resolvedModuleName, String functionName);
 
-  boolean isCalling(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity);
+  boolean isCalling(String resolvedModuleName, String functionName, int resolvedFinalArity);
 
-  boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName);
+  boolean isCallingMacro(String resolvedModuleName, String functionName);
 
-  boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity);
+  boolean isCallingMacro(String resolvedModuleName, String functionName, int resolvedFinalArity);
 
   @Nullable
   Quotable leftOperand();
@@ -70,9 +70,6 @@ public interface ElixirMatchedOrOperation extends ElixirMatchedExpression, Named
 
   @NotNull
   IntRange resolvedFinalArityRange();
-
-  @NotNull
-  String resolvedFunctionName();
 
   @NotNull
   String resolvedModuleName();

--- a/gen/org/elixir_lang/psi/ElixirMatchedPipeOperation.java
+++ b/gen/org/elixir_lang/psi/ElixirMatchedPipeOperation.java
@@ -37,13 +37,13 @@ public interface ElixirMatchedPipeOperation extends ElixirMatchedExpression, Nam
 
   boolean hasDoBlockOrKeyword();
 
-  boolean isCalling(String resolvedModuleName, String resolvedFunctionName);
+  boolean isCalling(String resolvedModuleName, String functionName);
 
-  boolean isCalling(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity);
+  boolean isCalling(String resolvedModuleName, String functionName, int resolvedFinalArity);
 
-  boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName);
+  boolean isCallingMacro(String resolvedModuleName, String functionName);
 
-  boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity);
+  boolean isCallingMacro(String resolvedModuleName, String functionName, int resolvedFinalArity);
 
   @Nullable
   Quotable leftOperand();
@@ -70,9 +70,6 @@ public interface ElixirMatchedPipeOperation extends ElixirMatchedExpression, Nam
 
   @NotNull
   IntRange resolvedFinalArityRange();
-
-  @NotNull
-  String resolvedFunctionName();
 
   @NotNull
   String resolvedModuleName();

--- a/gen/org/elixir_lang/psi/ElixirMatchedQualifiedBracketOperation.java
+++ b/gen/org/elixir_lang/psi/ElixirMatchedQualifiedBracketOperation.java
@@ -2,6 +2,7 @@
 package org.elixir_lang.psi;
 
 import com.ericsson.otp.erlang.OtpErlangObject;
+import com.intellij.psi.PsiElement;
 import org.jetbrains.annotations.NotNull;
 
 public interface ElixirMatchedQualifiedBracketOperation extends ElixirMatchedExpression, QualifiedBracketOperation {
@@ -17,6 +18,9 @@ public interface ElixirMatchedQualifiedBracketOperation extends ElixirMatchedExp
 
   @NotNull
   ElixirRelativeIdentifier getRelativeIdentifier();
+
+  @NotNull
+  PsiElement qualifier();
 
   @NotNull
   OtpErlangObject quote();

--- a/gen/org/elixir_lang/psi/ElixirMatchedQualifiedNoArgumentsCall.java
+++ b/gen/org/elixir_lang/psi/ElixirMatchedQualifiedNoArgumentsCall.java
@@ -69,6 +69,9 @@ public interface ElixirMatchedQualifiedNoArgumentsCall extends ElixirMatchedExpr
   boolean processDeclarations(PsiScopeProcessor processor, ResolveState state, PsiElement lastParent, PsiElement place);
 
   @NotNull
+  PsiElement qualifier();
+
+  @NotNull
   OtpErlangObject quote();
 
   @NotNull

--- a/gen/org/elixir_lang/psi/ElixirMatchedQualifiedNoArgumentsCall.java
+++ b/gen/org/elixir_lang/psi/ElixirMatchedQualifiedNoArgumentsCall.java
@@ -49,13 +49,13 @@ public interface ElixirMatchedQualifiedNoArgumentsCall extends ElixirMatchedExpr
   @Nullable
   PsiReference getReference();
 
-  boolean isCalling(String resolvedModuleName, String resolvedFunctionName);
+  boolean isCalling(String resolvedModuleName, String functionName);
 
-  boolean isCalling(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity);
+  boolean isCalling(String resolvedModuleName, String functionName, int resolvedFinalArity);
 
-  boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName);
+  boolean isCallingMacro(String resolvedModuleName, String functionName);
 
-  boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity);
+  boolean isCallingMacro(String resolvedModuleName, String functionName, int resolvedFinalArity);
 
   @NotNull
   String moduleName();
@@ -76,9 +76,6 @@ public interface ElixirMatchedQualifiedNoArgumentsCall extends ElixirMatchedExpr
 
   @NotNull
   IntRange resolvedFinalArityRange();
-
-  @NotNull
-  String resolvedFunctionName();
 
   @NotNull
   String resolvedModuleName();

--- a/gen/org/elixir_lang/psi/ElixirMatchedQualifiedNoParenthesesCall.java
+++ b/gen/org/elixir_lang/psi/ElixirMatchedQualifiedNoParenthesesCall.java
@@ -72,6 +72,9 @@ public interface ElixirMatchedQualifiedNoParenthesesCall extends ElixirMatchedEx
   boolean processDeclarations(PsiScopeProcessor processor, ResolveState state, PsiElement lastParent, PsiElement place);
 
   @NotNull
+  PsiElement qualifier();
+
+  @NotNull
   OtpErlangObject quote();
 
   @NotNull

--- a/gen/org/elixir_lang/psi/ElixirMatchedQualifiedNoParenthesesCall.java
+++ b/gen/org/elixir_lang/psi/ElixirMatchedQualifiedNoParenthesesCall.java
@@ -52,13 +52,13 @@ public interface ElixirMatchedQualifiedNoParenthesesCall extends ElixirMatchedEx
   @Nullable
   PsiReference getReference();
 
-  boolean isCalling(String resolvedModuleName, String resolvedFunctionName);
+  boolean isCalling(String resolvedModuleName, String functionName);
 
-  boolean isCalling(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity);
+  boolean isCalling(String resolvedModuleName, String functionName, int resolvedFinalArity);
 
-  boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName);
+  boolean isCallingMacro(String resolvedModuleName, String functionName);
 
-  boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity);
+  boolean isCallingMacro(String resolvedModuleName, String functionName, int resolvedFinalArity);
 
   @NotNull
   String moduleName();
@@ -79,9 +79,6 @@ public interface ElixirMatchedQualifiedNoParenthesesCall extends ElixirMatchedEx
 
   @NotNull
   IntRange resolvedFinalArityRange();
-
-  @NotNull
-  String resolvedFunctionName();
 
   @NotNull
   String resolvedModuleName();

--- a/gen/org/elixir_lang/psi/ElixirMatchedQualifiedParenthesesCall.java
+++ b/gen/org/elixir_lang/psi/ElixirMatchedQualifiedParenthesesCall.java
@@ -72,6 +72,9 @@ public interface ElixirMatchedQualifiedParenthesesCall extends ElixirMatchedExpr
   boolean processDeclarations(PsiScopeProcessor processor, ResolveState state, PsiElement lastParent, PsiElement place);
 
   @NotNull
+  PsiElement qualifier();
+
+  @NotNull
   OtpErlangObject quote();
 
   @NotNull

--- a/gen/org/elixir_lang/psi/ElixirMatchedQualifiedParenthesesCall.java
+++ b/gen/org/elixir_lang/psi/ElixirMatchedQualifiedParenthesesCall.java
@@ -52,13 +52,13 @@ public interface ElixirMatchedQualifiedParenthesesCall extends ElixirMatchedExpr
   @Nullable
   PsiReference getReference();
 
-  boolean isCalling(String resolvedModuleName, String resolvedFunctionName);
+  boolean isCalling(String resolvedModuleName, String functionName);
 
-  boolean isCalling(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity);
+  boolean isCalling(String resolvedModuleName, String functionName, int resolvedFinalArity);
 
-  boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName);
+  boolean isCallingMacro(String resolvedModuleName, String functionName);
 
-  boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity);
+  boolean isCallingMacro(String resolvedModuleName, String functionName, int resolvedFinalArity);
 
   @NotNull
   String moduleName();
@@ -79,9 +79,6 @@ public interface ElixirMatchedQualifiedParenthesesCall extends ElixirMatchedExpr
 
   @NotNull
   IntRange resolvedFinalArityRange();
-
-  @NotNull
-  String resolvedFunctionName();
 
   @NotNull
   String resolvedModuleName();

--- a/gen/org/elixir_lang/psi/ElixirMatchedRelationalOperation.java
+++ b/gen/org/elixir_lang/psi/ElixirMatchedRelationalOperation.java
@@ -37,13 +37,13 @@ public interface ElixirMatchedRelationalOperation extends ElixirMatchedExpressio
 
   boolean hasDoBlockOrKeyword();
 
-  boolean isCalling(String resolvedModuleName, String resolvedFunctionName);
+  boolean isCalling(String resolvedModuleName, String functionName);
 
-  boolean isCalling(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity);
+  boolean isCalling(String resolvedModuleName, String functionName, int resolvedFinalArity);
 
-  boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName);
+  boolean isCallingMacro(String resolvedModuleName, String functionName);
 
-  boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity);
+  boolean isCallingMacro(String resolvedModuleName, String functionName, int resolvedFinalArity);
 
   @Nullable
   Quotable leftOperand();
@@ -70,9 +70,6 @@ public interface ElixirMatchedRelationalOperation extends ElixirMatchedExpressio
 
   @NotNull
   IntRange resolvedFinalArityRange();
-
-  @NotNull
-  String resolvedFunctionName();
 
   @NotNull
   String resolvedModuleName();

--- a/gen/org/elixir_lang/psi/ElixirMatchedTwoOperation.java
+++ b/gen/org/elixir_lang/psi/ElixirMatchedTwoOperation.java
@@ -37,13 +37,13 @@ public interface ElixirMatchedTwoOperation extends ElixirMatchedExpression, Name
 
   boolean hasDoBlockOrKeyword();
 
-  boolean isCalling(String resolvedModuleName, String resolvedFunctionName);
+  boolean isCalling(String resolvedModuleName, String functionName);
 
-  boolean isCalling(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity);
+  boolean isCalling(String resolvedModuleName, String functionName, int resolvedFinalArity);
 
-  boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName);
+  boolean isCallingMacro(String resolvedModuleName, String functionName);
 
-  boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity);
+  boolean isCallingMacro(String resolvedModuleName, String functionName, int resolvedFinalArity);
 
   @Nullable
   Quotable leftOperand();
@@ -70,9 +70,6 @@ public interface ElixirMatchedTwoOperation extends ElixirMatchedExpression, Name
 
   @NotNull
   IntRange resolvedFinalArityRange();
-
-  @NotNull
-  String resolvedFunctionName();
 
   @NotNull
   String resolvedModuleName();

--- a/gen/org/elixir_lang/psi/ElixirMatchedTypeOperation.java
+++ b/gen/org/elixir_lang/psi/ElixirMatchedTypeOperation.java
@@ -37,13 +37,13 @@ public interface ElixirMatchedTypeOperation extends ElixirMatchedExpression, Nam
 
   boolean hasDoBlockOrKeyword();
 
-  boolean isCalling(String resolvedModuleName, String resolvedFunctionName);
+  boolean isCalling(String resolvedModuleName, String functionName);
 
-  boolean isCalling(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity);
+  boolean isCalling(String resolvedModuleName, String functionName, int resolvedFinalArity);
 
-  boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName);
+  boolean isCallingMacro(String resolvedModuleName, String functionName);
 
-  boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity);
+  boolean isCallingMacro(String resolvedModuleName, String functionName, int resolvedFinalArity);
 
   @Nullable
   Quotable leftOperand();
@@ -70,9 +70,6 @@ public interface ElixirMatchedTypeOperation extends ElixirMatchedExpression, Nam
 
   @NotNull
   IntRange resolvedFinalArityRange();
-
-  @NotNull
-  String resolvedFunctionName();
 
   @NotNull
   String resolvedModuleName();

--- a/gen/org/elixir_lang/psi/ElixirMatchedUnaryNonNumericOperation.java
+++ b/gen/org/elixir_lang/psi/ElixirMatchedUnaryNonNumericOperation.java
@@ -31,13 +31,13 @@ public interface ElixirMatchedUnaryNonNumericOperation extends ElixirMatchedExpr
 
   boolean hasDoBlockOrKeyword();
 
-  boolean isCalling(String resolvedModuleName, String resolvedFunctionName);
+  boolean isCalling(String resolvedModuleName, String functionName);
 
-  boolean isCalling(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity);
+  boolean isCalling(String resolvedModuleName, String functionName, int resolvedFinalArity);
 
-  boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName);
+  boolean isCallingMacro(String resolvedModuleName, String functionName);
 
-  boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity);
+  boolean isCallingMacro(String resolvedModuleName, String functionName, int resolvedFinalArity);
 
   @Nullable
   String moduleName();
@@ -68,9 +68,6 @@ public interface ElixirMatchedUnaryNonNumericOperation extends ElixirMatchedExpr
 
   @NotNull
   IntRange resolvedFinalArityRange();
-
-  @NotNull
-  String resolvedFunctionName();
 
   @NotNull
   String resolvedModuleName();

--- a/gen/org/elixir_lang/psi/ElixirMatchedUnqualifiedNoArgumentsCall.java
+++ b/gen/org/elixir_lang/psi/ElixirMatchedUnqualifiedNoArgumentsCall.java
@@ -48,13 +48,13 @@ public interface ElixirMatchedUnqualifiedNoArgumentsCall extends ElixirMatchedEx
   @NotNull
   SearchScope getUseScope();
 
-  boolean isCalling(String resolvedModuleName, String resolvedFunctionName);
+  boolean isCalling(String resolvedModuleName, String functionName);
 
-  boolean isCalling(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity);
+  boolean isCalling(String resolvedModuleName, String functionName, int resolvedFinalArity);
 
-  boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName);
+  boolean isCallingMacro(String resolvedModuleName, String functionName);
 
-  boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity);
+  boolean isCallingMacro(String resolvedModuleName, String functionName, int resolvedFinalArity);
 
   @Nullable
   String moduleName();
@@ -75,9 +75,6 @@ public interface ElixirMatchedUnqualifiedNoArgumentsCall extends ElixirMatchedEx
 
   @NotNull
   IntRange resolvedFinalArityRange();
-
-  @NotNull
-  String resolvedFunctionName();
 
   @NotNull
   String resolvedModuleName();

--- a/gen/org/elixir_lang/psi/ElixirMatchedUnqualifiedNoParenthesesCall.java
+++ b/gen/org/elixir_lang/psi/ElixirMatchedUnqualifiedNoParenthesesCall.java
@@ -47,13 +47,13 @@ public interface ElixirMatchedUnqualifiedNoParenthesesCall extends ElixirMatched
   @Nullable
   PsiReference getReference();
 
-  boolean isCalling(String resolvedModuleName, String resolvedFunctionName);
+  boolean isCalling(String resolvedModuleName, String functionName);
 
-  boolean isCalling(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity);
+  boolean isCalling(String resolvedModuleName, String functionName, int resolvedFinalArity);
 
-  boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName);
+  boolean isCallingMacro(String resolvedModuleName, String functionName);
 
-  boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity);
+  boolean isCallingMacro(String resolvedModuleName, String functionName, int resolvedFinalArity);
 
   @Nullable
   String moduleName();
@@ -74,9 +74,6 @@ public interface ElixirMatchedUnqualifiedNoParenthesesCall extends ElixirMatched
 
   @NotNull
   IntRange resolvedFinalArityRange();
-
-  @NotNull
-  String resolvedFunctionName();
 
   @NotNull
   String resolvedModuleName();

--- a/gen/org/elixir_lang/psi/ElixirMatchedUnqualifiedParenthesesCall.java
+++ b/gen/org/elixir_lang/psi/ElixirMatchedUnqualifiedParenthesesCall.java
@@ -47,13 +47,13 @@ public interface ElixirMatchedUnqualifiedParenthesesCall extends ElixirMatchedEx
   @Nullable
   PsiReference getReference();
 
-  boolean isCalling(String resolvedModuleName, String resolvedFunctionName);
+  boolean isCalling(String resolvedModuleName, String functionName);
 
-  boolean isCalling(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity);
+  boolean isCalling(String resolvedModuleName, String functionName, int resolvedFinalArity);
 
-  boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName);
+  boolean isCallingMacro(String resolvedModuleName, String functionName);
 
-  boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity);
+  boolean isCallingMacro(String resolvedModuleName, String functionName, int resolvedFinalArity);
 
   @Nullable
   String moduleName();
@@ -74,9 +74,6 @@ public interface ElixirMatchedUnqualifiedParenthesesCall extends ElixirMatchedEx
 
   @NotNull
   IntRange resolvedFinalArityRange();
-
-  @NotNull
-  String resolvedFunctionName();
 
   @NotNull
   String resolvedModuleName();

--- a/gen/org/elixir_lang/psi/ElixirMatchedWhenOperation.java
+++ b/gen/org/elixir_lang/psi/ElixirMatchedWhenOperation.java
@@ -37,13 +37,13 @@ public interface ElixirMatchedWhenOperation extends ElixirMatchedExpression, Nam
 
   boolean hasDoBlockOrKeyword();
 
-  boolean isCalling(String resolvedModuleName, String resolvedFunctionName);
+  boolean isCalling(String resolvedModuleName, String functionName);
 
-  boolean isCalling(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity);
+  boolean isCalling(String resolvedModuleName, String functionName, int resolvedFinalArity);
 
-  boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName);
+  boolean isCallingMacro(String resolvedModuleName, String functionName);
 
-  boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity);
+  boolean isCallingMacro(String resolvedModuleName, String functionName, int resolvedFinalArity);
 
   @Nullable
   Quotable leftOperand();
@@ -70,9 +70,6 @@ public interface ElixirMatchedWhenOperation extends ElixirMatchedExpression, Nam
 
   @NotNull
   IntRange resolvedFinalArityRange();
-
-  @NotNull
-  String resolvedFunctionName();
 
   @NotNull
   String resolvedModuleName();

--- a/gen/org/elixir_lang/psi/ElixirUnaryNumericOperation.java
+++ b/gen/org/elixir_lang/psi/ElixirUnaryNumericOperation.java
@@ -51,13 +51,13 @@ public interface ElixirUnaryNumericOperation extends Named, Prefix {
 
   boolean hasDoBlockOrKeyword();
 
-  boolean isCalling(String resolvedModuleName, String resolvedFunctionName);
+  boolean isCalling(String resolvedModuleName, String functionName);
 
-  boolean isCalling(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity);
+  boolean isCalling(String resolvedModuleName, String functionName, int resolvedFinalArity);
 
-  boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName);
+  boolean isCallingMacro(String resolvedModuleName, String functionName);
 
-  boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity);
+  boolean isCallingMacro(String resolvedModuleName, String functionName, int resolvedFinalArity);
 
   @Nullable
   String moduleName();
@@ -88,9 +88,6 @@ public interface ElixirUnaryNumericOperation extends Named, Prefix {
 
   @NotNull
   IntRange resolvedFinalArityRange();
-
-  @NotNull
-  String resolvedFunctionName();
 
   @NotNull
   String resolvedModuleName();

--- a/gen/org/elixir_lang/psi/ElixirUnmatchedAdditionOperation.java
+++ b/gen/org/elixir_lang/psi/ElixirUnmatchedAdditionOperation.java
@@ -37,13 +37,13 @@ public interface ElixirUnmatchedAdditionOperation extends ElixirUnmatchedExpress
 
   boolean hasDoBlockOrKeyword();
 
-  boolean isCalling(String resolvedModuleName, String resolvedFunctionName);
+  boolean isCalling(String resolvedModuleName, String functionName);
 
-  boolean isCalling(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity);
+  boolean isCalling(String resolvedModuleName, String functionName, int resolvedFinalArity);
 
-  boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName);
+  boolean isCallingMacro(String resolvedModuleName, String functionName);
 
-  boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity);
+  boolean isCallingMacro(String resolvedModuleName, String functionName, int resolvedFinalArity);
 
   @Nullable
   Quotable leftOperand();
@@ -70,9 +70,6 @@ public interface ElixirUnmatchedAdditionOperation extends ElixirUnmatchedExpress
 
   @NotNull
   IntRange resolvedFinalArityRange();
-
-  @NotNull
-  String resolvedFunctionName();
 
   @NotNull
   String resolvedModuleName();

--- a/gen/org/elixir_lang/psi/ElixirUnmatchedAndOperation.java
+++ b/gen/org/elixir_lang/psi/ElixirUnmatchedAndOperation.java
@@ -37,13 +37,13 @@ public interface ElixirUnmatchedAndOperation extends ElixirUnmatchedExpression, 
 
   boolean hasDoBlockOrKeyword();
 
-  boolean isCalling(String resolvedModuleName, String resolvedFunctionName);
+  boolean isCalling(String resolvedModuleName, String functionName);
 
-  boolean isCalling(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity);
+  boolean isCalling(String resolvedModuleName, String functionName, int resolvedFinalArity);
 
-  boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName);
+  boolean isCallingMacro(String resolvedModuleName, String functionName);
 
-  boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity);
+  boolean isCallingMacro(String resolvedModuleName, String functionName, int resolvedFinalArity);
 
   @Nullable
   Quotable leftOperand();
@@ -70,9 +70,6 @@ public interface ElixirUnmatchedAndOperation extends ElixirUnmatchedExpression, 
 
   @NotNull
   IntRange resolvedFinalArityRange();
-
-  @NotNull
-  String resolvedFunctionName();
 
   @NotNull
   String resolvedModuleName();

--- a/gen/org/elixir_lang/psi/ElixirUnmatchedArrowOperation.java
+++ b/gen/org/elixir_lang/psi/ElixirUnmatchedArrowOperation.java
@@ -37,13 +37,13 @@ public interface ElixirUnmatchedArrowOperation extends ElixirUnmatchedExpression
 
   boolean hasDoBlockOrKeyword();
 
-  boolean isCalling(String resolvedModuleName, String resolvedFunctionName);
+  boolean isCalling(String resolvedModuleName, String functionName);
 
-  boolean isCalling(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity);
+  boolean isCalling(String resolvedModuleName, String functionName, int resolvedFinalArity);
 
-  boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName);
+  boolean isCallingMacro(String resolvedModuleName, String functionName);
 
-  boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity);
+  boolean isCallingMacro(String resolvedModuleName, String functionName, int resolvedFinalArity);
 
   @Nullable
   Quotable leftOperand();
@@ -70,9 +70,6 @@ public interface ElixirUnmatchedArrowOperation extends ElixirUnmatchedExpression
 
   @NotNull
   IntRange resolvedFinalArityRange();
-
-  @NotNull
-  String resolvedFunctionName();
 
   @NotNull
   String resolvedModuleName();

--- a/gen/org/elixir_lang/psi/ElixirUnmatchedAtUnqualifiedNoParenthesesCall.java
+++ b/gen/org/elixir_lang/psi/ElixirUnmatchedAtUnqualifiedNoParenthesesCall.java
@@ -51,13 +51,13 @@ public interface ElixirUnmatchedAtUnqualifiedNoParenthesesCall extends ElixirUnm
   @NotNull
   SearchScope getUseScope();
 
-  boolean isCalling(String resolvedModuleName, String resolvedFunctionName);
+  boolean isCalling(String resolvedModuleName, String functionName);
 
-  boolean isCalling(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity);
+  boolean isCalling(String resolvedModuleName, String functionName, int resolvedFinalArity);
 
-  boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName);
+  boolean isCallingMacro(String resolvedModuleName, String functionName);
 
-  boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity);
+  boolean isCallingMacro(String resolvedModuleName, String functionName, int resolvedFinalArity);
 
   @Nullable
   String moduleName();
@@ -78,9 +78,6 @@ public interface ElixirUnmatchedAtUnqualifiedNoParenthesesCall extends ElixirUnm
 
   @NotNull
   IntRange resolvedFinalArityRange();
-
-  @Nullable
-  String resolvedFunctionName();
 
   @Nullable
   String resolvedModuleName();

--- a/gen/org/elixir_lang/psi/ElixirUnmatchedCaptureNonNumericOperation.java
+++ b/gen/org/elixir_lang/psi/ElixirUnmatchedCaptureNonNumericOperation.java
@@ -33,13 +33,13 @@ public interface ElixirUnmatchedCaptureNonNumericOperation extends ElixirUnmatch
 
   boolean hasDoBlockOrKeyword();
 
-  boolean isCalling(String resolvedModuleName, String resolvedFunctionName);
+  boolean isCalling(String resolvedModuleName, String functionName);
 
-  boolean isCalling(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity);
+  boolean isCalling(String resolvedModuleName, String functionName, int resolvedFinalArity);
 
-  boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName);
+  boolean isCallingMacro(String resolvedModuleName, String functionName);
 
-  boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity);
+  boolean isCallingMacro(String resolvedModuleName, String functionName, int resolvedFinalArity);
 
   @Nullable
   String moduleName();
@@ -70,9 +70,6 @@ public interface ElixirUnmatchedCaptureNonNumericOperation extends ElixirUnmatch
 
   @NotNull
   IntRange resolvedFinalArityRange();
-
-  @NotNull
-  String resolvedFunctionName();
 
   @NotNull
   String resolvedModuleName();

--- a/gen/org/elixir_lang/psi/ElixirUnmatchedComparisonOperation.java
+++ b/gen/org/elixir_lang/psi/ElixirUnmatchedComparisonOperation.java
@@ -37,13 +37,13 @@ public interface ElixirUnmatchedComparisonOperation extends ElixirUnmatchedExpre
 
   boolean hasDoBlockOrKeyword();
 
-  boolean isCalling(String resolvedModuleName, String resolvedFunctionName);
+  boolean isCalling(String resolvedModuleName, String functionName);
 
-  boolean isCalling(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity);
+  boolean isCalling(String resolvedModuleName, String functionName, int resolvedFinalArity);
 
-  boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName);
+  boolean isCallingMacro(String resolvedModuleName, String functionName);
 
-  boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity);
+  boolean isCallingMacro(String resolvedModuleName, String functionName, int resolvedFinalArity);
 
   @Nullable
   Quotable leftOperand();
@@ -70,9 +70,6 @@ public interface ElixirUnmatchedComparisonOperation extends ElixirUnmatchedExpre
 
   @NotNull
   IntRange resolvedFinalArityRange();
-
-  @NotNull
-  String resolvedFunctionName();
 
   @NotNull
   String resolvedModuleName();

--- a/gen/org/elixir_lang/psi/ElixirUnmatchedDotCall.java
+++ b/gen/org/elixir_lang/psi/ElixirUnmatchedDotCall.java
@@ -51,13 +51,13 @@ public interface ElixirUnmatchedDotCall extends ElixirUnmatchedExpression, DotCa
   @Nullable
   PsiReference getReference();
 
-  boolean isCalling(String resolvedModuleName, String resolvedFunctionName);
+  boolean isCalling(String resolvedModuleName, String functionName);
 
-  boolean isCalling(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity);
+  boolean isCalling(String resolvedModuleName, String functionName, int resolvedFinalArity);
 
-  boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName);
+  boolean isCallingMacro(String resolvedModuleName, String functionName);
 
-  boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity);
+  boolean isCallingMacro(String resolvedModuleName, String functionName, int resolvedFinalArity);
 
   @Nullable
   String moduleName();
@@ -78,9 +78,6 @@ public interface ElixirUnmatchedDotCall extends ElixirUnmatchedExpression, DotCa
 
   @NotNull
   IntRange resolvedFinalArityRange();
-
-  @Nullable
-  String resolvedFunctionName();
 
   @Nullable
   String resolvedModuleName();

--- a/gen/org/elixir_lang/psi/ElixirUnmatchedInMatchOperation.java
+++ b/gen/org/elixir_lang/psi/ElixirUnmatchedInMatchOperation.java
@@ -37,13 +37,13 @@ public interface ElixirUnmatchedInMatchOperation extends ElixirUnmatchedExpressi
 
   boolean hasDoBlockOrKeyword();
 
-  boolean isCalling(String resolvedModuleName, String resolvedFunctionName);
+  boolean isCalling(String resolvedModuleName, String functionName);
 
-  boolean isCalling(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity);
+  boolean isCalling(String resolvedModuleName, String functionName, int resolvedFinalArity);
 
-  boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName);
+  boolean isCallingMacro(String resolvedModuleName, String functionName);
 
-  boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity);
+  boolean isCallingMacro(String resolvedModuleName, String functionName, int resolvedFinalArity);
 
   @Nullable
   Quotable leftOperand();
@@ -70,9 +70,6 @@ public interface ElixirUnmatchedInMatchOperation extends ElixirUnmatchedExpressi
 
   @NotNull
   IntRange resolvedFinalArityRange();
-
-  @NotNull
-  String resolvedFunctionName();
 
   @NotNull
   String resolvedModuleName();

--- a/gen/org/elixir_lang/psi/ElixirUnmatchedInOperation.java
+++ b/gen/org/elixir_lang/psi/ElixirUnmatchedInOperation.java
@@ -32,13 +32,13 @@ public interface ElixirUnmatchedInOperation extends ElixirUnmatchedExpression, C
 
   boolean hasDoBlockOrKeyword();
 
-  boolean isCalling(String resolvedModuleName, String resolvedFunctionName);
+  boolean isCalling(String resolvedModuleName, String functionName);
 
-  boolean isCalling(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity);
+  boolean isCalling(String resolvedModuleName, String functionName, int resolvedFinalArity);
 
-  boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName);
+  boolean isCallingMacro(String resolvedModuleName, String functionName);
 
-  boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity);
+  boolean isCallingMacro(String resolvedModuleName, String functionName, int resolvedFinalArity);
 
   @Nullable
   Quotable leftOperand();
@@ -65,9 +65,6 @@ public interface ElixirUnmatchedInOperation extends ElixirUnmatchedExpression, C
 
   @NotNull
   IntRange resolvedFinalArityRange();
-
-  @NotNull
-  String resolvedFunctionName();
 
   @NotNull
   String resolvedModuleName();

--- a/gen/org/elixir_lang/psi/ElixirUnmatchedMatchOperation.java
+++ b/gen/org/elixir_lang/psi/ElixirUnmatchedMatchOperation.java
@@ -37,13 +37,13 @@ public interface ElixirUnmatchedMatchOperation extends ElixirUnmatchedExpression
 
   boolean hasDoBlockOrKeyword();
 
-  boolean isCalling(String resolvedModuleName, String resolvedFunctionName);
+  boolean isCalling(String resolvedModuleName, String functionName);
 
-  boolean isCalling(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity);
+  boolean isCalling(String resolvedModuleName, String functionName, int resolvedFinalArity);
 
-  boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName);
+  boolean isCallingMacro(String resolvedModuleName, String functionName);
 
-  boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity);
+  boolean isCallingMacro(String resolvedModuleName, String functionName, int resolvedFinalArity);
 
   @Nullable
   Quotable leftOperand();
@@ -70,9 +70,6 @@ public interface ElixirUnmatchedMatchOperation extends ElixirUnmatchedExpression
 
   @NotNull
   IntRange resolvedFinalArityRange();
-
-  @NotNull
-  String resolvedFunctionName();
 
   @NotNull
   String resolvedModuleName();

--- a/gen/org/elixir_lang/psi/ElixirUnmatchedMultiplicationOperation.java
+++ b/gen/org/elixir_lang/psi/ElixirUnmatchedMultiplicationOperation.java
@@ -37,13 +37,13 @@ public interface ElixirUnmatchedMultiplicationOperation extends ElixirUnmatchedE
 
   boolean hasDoBlockOrKeyword();
 
-  boolean isCalling(String resolvedModuleName, String resolvedFunctionName);
+  boolean isCalling(String resolvedModuleName, String functionName);
 
-  boolean isCalling(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity);
+  boolean isCalling(String resolvedModuleName, String functionName, int resolvedFinalArity);
 
-  boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName);
+  boolean isCallingMacro(String resolvedModuleName, String functionName);
 
-  boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity);
+  boolean isCallingMacro(String resolvedModuleName, String functionName, int resolvedFinalArity);
 
   @Nullable
   Quotable leftOperand();
@@ -70,9 +70,6 @@ public interface ElixirUnmatchedMultiplicationOperation extends ElixirUnmatchedE
 
   @NotNull
   IntRange resolvedFinalArityRange();
-
-  @NotNull
-  String resolvedFunctionName();
 
   @NotNull
   String resolvedModuleName();

--- a/gen/org/elixir_lang/psi/ElixirUnmatchedOrOperation.java
+++ b/gen/org/elixir_lang/psi/ElixirUnmatchedOrOperation.java
@@ -37,13 +37,13 @@ public interface ElixirUnmatchedOrOperation extends ElixirUnmatchedExpression, N
 
   boolean hasDoBlockOrKeyword();
 
-  boolean isCalling(String resolvedModuleName, String resolvedFunctionName);
+  boolean isCalling(String resolvedModuleName, String functionName);
 
-  boolean isCalling(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity);
+  boolean isCalling(String resolvedModuleName, String functionName, int resolvedFinalArity);
 
-  boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName);
+  boolean isCallingMacro(String resolvedModuleName, String functionName);
 
-  boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity);
+  boolean isCallingMacro(String resolvedModuleName, String functionName, int resolvedFinalArity);
 
   @Nullable
   Quotable leftOperand();
@@ -70,9 +70,6 @@ public interface ElixirUnmatchedOrOperation extends ElixirUnmatchedExpression, N
 
   @NotNull
   IntRange resolvedFinalArityRange();
-
-  @NotNull
-  String resolvedFunctionName();
 
   @NotNull
   String resolvedModuleName();

--- a/gen/org/elixir_lang/psi/ElixirUnmatchedPipeOperation.java
+++ b/gen/org/elixir_lang/psi/ElixirUnmatchedPipeOperation.java
@@ -37,13 +37,13 @@ public interface ElixirUnmatchedPipeOperation extends ElixirUnmatchedExpression,
 
   boolean hasDoBlockOrKeyword();
 
-  boolean isCalling(String resolvedModuleName, String resolvedFunctionName);
+  boolean isCalling(String resolvedModuleName, String functionName);
 
-  boolean isCalling(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity);
+  boolean isCalling(String resolvedModuleName, String functionName, int resolvedFinalArity);
 
-  boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName);
+  boolean isCallingMacro(String resolvedModuleName, String functionName);
 
-  boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity);
+  boolean isCallingMacro(String resolvedModuleName, String functionName, int resolvedFinalArity);
 
   @Nullable
   Quotable leftOperand();
@@ -70,9 +70,6 @@ public interface ElixirUnmatchedPipeOperation extends ElixirUnmatchedExpression,
 
   @NotNull
   IntRange resolvedFinalArityRange();
-
-  @NotNull
-  String resolvedFunctionName();
 
   @NotNull
   String resolvedModuleName();

--- a/gen/org/elixir_lang/psi/ElixirUnmatchedQualifiedBracketOperation.java
+++ b/gen/org/elixir_lang/psi/ElixirUnmatchedQualifiedBracketOperation.java
@@ -2,6 +2,7 @@
 package org.elixir_lang.psi;
 
 import com.ericsson.otp.erlang.OtpErlangObject;
+import com.intellij.psi.PsiElement;
 import org.jetbrains.annotations.NotNull;
 
 public interface ElixirUnmatchedQualifiedBracketOperation extends ElixirUnmatchedExpression, QualifiedBracketOperation {
@@ -17,6 +18,9 @@ public interface ElixirUnmatchedQualifiedBracketOperation extends ElixirUnmatche
 
   @NotNull
   ElixirUnmatchedExpression getUnmatchedExpression();
+
+  @NotNull
+  PsiElement qualifier();
 
   @NotNull
   OtpErlangObject quote();

--- a/gen/org/elixir_lang/psi/ElixirUnmatchedQualifiedNoArgumentsCall.java
+++ b/gen/org/elixir_lang/psi/ElixirUnmatchedQualifiedNoArgumentsCall.java
@@ -69,6 +69,9 @@ public interface ElixirUnmatchedQualifiedNoArgumentsCall extends ElixirUnmatched
   boolean processDeclarations(PsiScopeProcessor processor, ResolveState state, PsiElement lastParent, PsiElement place);
 
   @NotNull
+  PsiElement qualifier();
+
+  @NotNull
   OtpErlangObject quote();
 
   @NotNull

--- a/gen/org/elixir_lang/psi/ElixirUnmatchedQualifiedNoArgumentsCall.java
+++ b/gen/org/elixir_lang/psi/ElixirUnmatchedQualifiedNoArgumentsCall.java
@@ -49,13 +49,13 @@ public interface ElixirUnmatchedQualifiedNoArgumentsCall extends ElixirUnmatched
   @Nullable
   PsiReference getReference();
 
-  boolean isCalling(String resolvedModuleName, String resolvedFunctionName);
+  boolean isCalling(String resolvedModuleName, String functionName);
 
-  boolean isCalling(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity);
+  boolean isCalling(String resolvedModuleName, String functionName, int resolvedFinalArity);
 
-  boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName);
+  boolean isCallingMacro(String resolvedModuleName, String functionName);
 
-  boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity);
+  boolean isCallingMacro(String resolvedModuleName, String functionName, int resolvedFinalArity);
 
   @NotNull
   String moduleName();
@@ -76,9 +76,6 @@ public interface ElixirUnmatchedQualifiedNoArgumentsCall extends ElixirUnmatched
 
   @NotNull
   IntRange resolvedFinalArityRange();
-
-  @NotNull
-  String resolvedFunctionName();
 
   @NotNull
   String resolvedModuleName();

--- a/gen/org/elixir_lang/psi/ElixirUnmatchedQualifiedNoParenthesesCall.java
+++ b/gen/org/elixir_lang/psi/ElixirUnmatchedQualifiedNoParenthesesCall.java
@@ -72,6 +72,9 @@ public interface ElixirUnmatchedQualifiedNoParenthesesCall extends ElixirUnmatch
   boolean processDeclarations(PsiScopeProcessor processor, ResolveState state, PsiElement lastParent, PsiElement place);
 
   @NotNull
+  PsiElement qualifier();
+
+  @NotNull
   OtpErlangObject quote();
 
   @NotNull

--- a/gen/org/elixir_lang/psi/ElixirUnmatchedQualifiedNoParenthesesCall.java
+++ b/gen/org/elixir_lang/psi/ElixirUnmatchedQualifiedNoParenthesesCall.java
@@ -52,13 +52,13 @@ public interface ElixirUnmatchedQualifiedNoParenthesesCall extends ElixirUnmatch
   @Nullable
   PsiReference getReference();
 
-  boolean isCalling(String resolvedModuleName, String resolvedFunctionName);
+  boolean isCalling(String resolvedModuleName, String functionName);
 
-  boolean isCalling(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity);
+  boolean isCalling(String resolvedModuleName, String functionName, int resolvedFinalArity);
 
-  boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName);
+  boolean isCallingMacro(String resolvedModuleName, String functionName);
 
-  boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity);
+  boolean isCallingMacro(String resolvedModuleName, String functionName, int resolvedFinalArity);
 
   @NotNull
   String moduleName();
@@ -79,9 +79,6 @@ public interface ElixirUnmatchedQualifiedNoParenthesesCall extends ElixirUnmatch
 
   @NotNull
   IntRange resolvedFinalArityRange();
-
-  @NotNull
-  String resolvedFunctionName();
 
   @NotNull
   String resolvedModuleName();

--- a/gen/org/elixir_lang/psi/ElixirUnmatchedQualifiedParenthesesCall.java
+++ b/gen/org/elixir_lang/psi/ElixirUnmatchedQualifiedParenthesesCall.java
@@ -72,6 +72,9 @@ public interface ElixirUnmatchedQualifiedParenthesesCall extends ElixirUnmatched
   boolean processDeclarations(PsiScopeProcessor processor, ResolveState state, PsiElement lastParent, PsiElement place);
 
   @NotNull
+  PsiElement qualifier();
+
+  @NotNull
   OtpErlangObject quote();
 
   @NotNull

--- a/gen/org/elixir_lang/psi/ElixirUnmatchedQualifiedParenthesesCall.java
+++ b/gen/org/elixir_lang/psi/ElixirUnmatchedQualifiedParenthesesCall.java
@@ -52,13 +52,13 @@ public interface ElixirUnmatchedQualifiedParenthesesCall extends ElixirUnmatched
   @Nullable
   PsiReference getReference();
 
-  boolean isCalling(String resolvedModuleName, String resolvedFunctionName);
+  boolean isCalling(String resolvedModuleName, String functionName);
 
-  boolean isCalling(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity);
+  boolean isCalling(String resolvedModuleName, String functionName, int resolvedFinalArity);
 
-  boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName);
+  boolean isCallingMacro(String resolvedModuleName, String functionName);
 
-  boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity);
+  boolean isCallingMacro(String resolvedModuleName, String functionName, int resolvedFinalArity);
 
   @NotNull
   String moduleName();
@@ -79,9 +79,6 @@ public interface ElixirUnmatchedQualifiedParenthesesCall extends ElixirUnmatched
 
   @NotNull
   IntRange resolvedFinalArityRange();
-
-  @NotNull
-  String resolvedFunctionName();
 
   @NotNull
   String resolvedModuleName();

--- a/gen/org/elixir_lang/psi/ElixirUnmatchedRelationalOperation.java
+++ b/gen/org/elixir_lang/psi/ElixirUnmatchedRelationalOperation.java
@@ -37,13 +37,13 @@ public interface ElixirUnmatchedRelationalOperation extends ElixirUnmatchedExpre
 
   boolean hasDoBlockOrKeyword();
 
-  boolean isCalling(String resolvedModuleName, String resolvedFunctionName);
+  boolean isCalling(String resolvedModuleName, String functionName);
 
-  boolean isCalling(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity);
+  boolean isCalling(String resolvedModuleName, String functionName, int resolvedFinalArity);
 
-  boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName);
+  boolean isCallingMacro(String resolvedModuleName, String functionName);
 
-  boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity);
+  boolean isCallingMacro(String resolvedModuleName, String functionName, int resolvedFinalArity);
 
   @Nullable
   Quotable leftOperand();
@@ -70,9 +70,6 @@ public interface ElixirUnmatchedRelationalOperation extends ElixirUnmatchedExpre
 
   @NotNull
   IntRange resolvedFinalArityRange();
-
-  @NotNull
-  String resolvedFunctionName();
 
   @NotNull
   String resolvedModuleName();

--- a/gen/org/elixir_lang/psi/ElixirUnmatchedTwoOperation.java
+++ b/gen/org/elixir_lang/psi/ElixirUnmatchedTwoOperation.java
@@ -37,13 +37,13 @@ public interface ElixirUnmatchedTwoOperation extends ElixirUnmatchedExpression, 
 
   boolean hasDoBlockOrKeyword();
 
-  boolean isCalling(String resolvedModuleName, String resolvedFunctionName);
+  boolean isCalling(String resolvedModuleName, String functionName);
 
-  boolean isCalling(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity);
+  boolean isCalling(String resolvedModuleName, String functionName, int resolvedFinalArity);
 
-  boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName);
+  boolean isCallingMacro(String resolvedModuleName, String functionName);
 
-  boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity);
+  boolean isCallingMacro(String resolvedModuleName, String functionName, int resolvedFinalArity);
 
   @Nullable
   Quotable leftOperand();
@@ -70,9 +70,6 @@ public interface ElixirUnmatchedTwoOperation extends ElixirUnmatchedExpression, 
 
   @NotNull
   IntRange resolvedFinalArityRange();
-
-  @NotNull
-  String resolvedFunctionName();
 
   @NotNull
   String resolvedModuleName();

--- a/gen/org/elixir_lang/psi/ElixirUnmatchedTypeOperation.java
+++ b/gen/org/elixir_lang/psi/ElixirUnmatchedTypeOperation.java
@@ -37,13 +37,13 @@ public interface ElixirUnmatchedTypeOperation extends ElixirUnmatchedExpression,
 
   boolean hasDoBlockOrKeyword();
 
-  boolean isCalling(String resolvedModuleName, String resolvedFunctionName);
+  boolean isCalling(String resolvedModuleName, String functionName);
 
-  boolean isCalling(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity);
+  boolean isCalling(String resolvedModuleName, String functionName, int resolvedFinalArity);
 
-  boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName);
+  boolean isCallingMacro(String resolvedModuleName, String functionName);
 
-  boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity);
+  boolean isCallingMacro(String resolvedModuleName, String functionName, int resolvedFinalArity);
 
   @Nullable
   Quotable leftOperand();
@@ -70,9 +70,6 @@ public interface ElixirUnmatchedTypeOperation extends ElixirUnmatchedExpression,
 
   @NotNull
   IntRange resolvedFinalArityRange();
-
-  @NotNull
-  String resolvedFunctionName();
 
   @NotNull
   String resolvedModuleName();

--- a/gen/org/elixir_lang/psi/ElixirUnmatchedUnaryNonNumericOperation.java
+++ b/gen/org/elixir_lang/psi/ElixirUnmatchedUnaryNonNumericOperation.java
@@ -31,13 +31,13 @@ public interface ElixirUnmatchedUnaryNonNumericOperation extends ElixirUnmatched
 
   boolean hasDoBlockOrKeyword();
 
-  boolean isCalling(String resolvedModuleName, String resolvedFunctionName);
+  boolean isCalling(String resolvedModuleName, String functionName);
 
-  boolean isCalling(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity);
+  boolean isCalling(String resolvedModuleName, String functionName, int resolvedFinalArity);
 
-  boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName);
+  boolean isCallingMacro(String resolvedModuleName, String functionName);
 
-  boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity);
+  boolean isCallingMacro(String resolvedModuleName, String functionName, int resolvedFinalArity);
 
   @Nullable
   String moduleName();
@@ -68,9 +68,6 @@ public interface ElixirUnmatchedUnaryNonNumericOperation extends ElixirUnmatched
 
   @NotNull
   IntRange resolvedFinalArityRange();
-
-  @NotNull
-  String resolvedFunctionName();
 
   @NotNull
   String resolvedModuleName();

--- a/gen/org/elixir_lang/psi/ElixirUnmatchedUnqualifiedNoArgumentsCall.java
+++ b/gen/org/elixir_lang/psi/ElixirUnmatchedUnqualifiedNoArgumentsCall.java
@@ -48,13 +48,13 @@ public interface ElixirUnmatchedUnqualifiedNoArgumentsCall extends ElixirUnmatch
   @NotNull
   SearchScope getUseScope();
 
-  boolean isCalling(String resolvedModuleName, String resolvedFunctionName);
+  boolean isCalling(String resolvedModuleName, String functionName);
 
-  boolean isCalling(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity);
+  boolean isCalling(String resolvedModuleName, String functionName, int resolvedFinalArity);
 
-  boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName);
+  boolean isCallingMacro(String resolvedModuleName, String functionName);
 
-  boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity);
+  boolean isCallingMacro(String resolvedModuleName, String functionName, int resolvedFinalArity);
 
   @Nullable
   String moduleName();
@@ -75,9 +75,6 @@ public interface ElixirUnmatchedUnqualifiedNoArgumentsCall extends ElixirUnmatch
 
   @NotNull
   IntRange resolvedFinalArityRange();
-
-  @NotNull
-  String resolvedFunctionName();
 
   @NotNull
   String resolvedModuleName();

--- a/gen/org/elixir_lang/psi/ElixirUnmatchedUnqualifiedNoParenthesesCall.java
+++ b/gen/org/elixir_lang/psi/ElixirUnmatchedUnqualifiedNoParenthesesCall.java
@@ -47,13 +47,13 @@ public interface ElixirUnmatchedUnqualifiedNoParenthesesCall extends ElixirUnmat
   @Nullable
   PsiReference getReference();
 
-  boolean isCalling(String resolvedModuleName, String resolvedFunctionName);
+  boolean isCalling(String resolvedModuleName, String functionName);
 
-  boolean isCalling(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity);
+  boolean isCalling(String resolvedModuleName, String functionName, int resolvedFinalArity);
 
-  boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName);
+  boolean isCallingMacro(String resolvedModuleName, String functionName);
 
-  boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity);
+  boolean isCallingMacro(String resolvedModuleName, String functionName, int resolvedFinalArity);
 
   @Nullable
   String moduleName();
@@ -74,9 +74,6 @@ public interface ElixirUnmatchedUnqualifiedNoParenthesesCall extends ElixirUnmat
 
   @NotNull
   IntRange resolvedFinalArityRange();
-
-  @NotNull
-  String resolvedFunctionName();
 
   @NotNull
   String resolvedModuleName();

--- a/gen/org/elixir_lang/psi/ElixirUnmatchedUnqualifiedParenthesesCall.java
+++ b/gen/org/elixir_lang/psi/ElixirUnmatchedUnqualifiedParenthesesCall.java
@@ -47,13 +47,13 @@ public interface ElixirUnmatchedUnqualifiedParenthesesCall extends ElixirUnmatch
   @Nullable
   PsiReference getReference();
 
-  boolean isCalling(String resolvedModuleName, String resolvedFunctionName);
+  boolean isCalling(String resolvedModuleName, String functionName);
 
-  boolean isCalling(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity);
+  boolean isCalling(String resolvedModuleName, String functionName, int resolvedFinalArity);
 
-  boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName);
+  boolean isCallingMacro(String resolvedModuleName, String functionName);
 
-  boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity);
+  boolean isCallingMacro(String resolvedModuleName, String functionName, int resolvedFinalArity);
 
   @Nullable
   String moduleName();
@@ -74,9 +74,6 @@ public interface ElixirUnmatchedUnqualifiedParenthesesCall extends ElixirUnmatch
 
   @NotNull
   IntRange resolvedFinalArityRange();
-
-  @NotNull
-  String resolvedFunctionName();
 
   @NotNull
   String resolvedModuleName();

--- a/gen/org/elixir_lang/psi/ElixirUnmatchedWhenOperation.java
+++ b/gen/org/elixir_lang/psi/ElixirUnmatchedWhenOperation.java
@@ -37,13 +37,13 @@ public interface ElixirUnmatchedWhenOperation extends ElixirUnmatchedExpression,
 
   boolean hasDoBlockOrKeyword();
 
-  boolean isCalling(String resolvedModuleName, String resolvedFunctionName);
+  boolean isCalling(String resolvedModuleName, String functionName);
 
-  boolean isCalling(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity);
+  boolean isCalling(String resolvedModuleName, String functionName, int resolvedFinalArity);
 
-  boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName);
+  boolean isCallingMacro(String resolvedModuleName, String functionName);
 
-  boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity);
+  boolean isCallingMacro(String resolvedModuleName, String functionName, int resolvedFinalArity);
 
   @Nullable
   Quotable leftOperand();
@@ -70,9 +70,6 @@ public interface ElixirUnmatchedWhenOperation extends ElixirUnmatchedExpression,
 
   @NotNull
   IntRange resolvedFinalArityRange();
-
-  @NotNull
-  String resolvedFunctionName();
 
   @NotNull
   String resolvedModuleName();

--- a/gen/org/elixir_lang/psi/ElixirUnqualifiedNoParenthesesManyArgumentsCall.java
+++ b/gen/org/elixir_lang/psi/ElixirUnqualifiedNoParenthesesManyArgumentsCall.java
@@ -63,13 +63,13 @@ public interface ElixirUnqualifiedNoParenthesesManyArgumentsCall extends PsiElem
   @Nullable
   PsiReference getReference();
 
-  boolean isCalling(String resolvedModuleName, String resolvedFunctionName);
+  boolean isCalling(String resolvedModuleName, String functionName);
 
-  boolean isCalling(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity);
+  boolean isCalling(String resolvedModuleName, String functionName, int resolvedFinalArity);
 
-  boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName);
+  boolean isCallingMacro(String resolvedModuleName, String functionName);
 
-  boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity);
+  boolean isCallingMacro(String resolvedModuleName, String functionName, int resolvedFinalArity);
 
   @Nullable
   String moduleName();
@@ -90,9 +90,6 @@ public interface ElixirUnqualifiedNoParenthesesManyArgumentsCall extends PsiElem
 
   @NotNull
   IntRange resolvedFinalArityRange();
-
-  @NotNull
-  String resolvedFunctionName();
 
   @NotNull
   String resolvedModuleName();

--- a/gen/org/elixir_lang/psi/impl/ElixirAtNumericOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirAtNumericOperationImpl.java
@@ -103,20 +103,20 @@ public class ElixirAtNumericOperationImpl extends ASTWrapperPsiElement implement
     return ElixirPsiImplUtil.hasDoBlockOrKeyword(this);
   }
 
-  public boolean isCalling(String resolvedModuleName, String resolvedFunctionName) {
-    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, resolvedFunctionName);
+  public boolean isCalling(String resolvedModuleName, String functionName) {
+    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, functionName);
   }
 
-  public boolean isCalling(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity) {
-    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, resolvedFunctionName, resolvedFinalArity);
+  public boolean isCalling(String resolvedModuleName, String functionName, int resolvedFinalArity) {
+    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, functionName, resolvedFinalArity);
   }
 
-  public boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName) {
-    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, resolvedFunctionName);
+  public boolean isCallingMacro(String resolvedModuleName, String functionName) {
+    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, functionName);
   }
 
-  public boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity) {
-    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, resolvedFunctionName, resolvedFinalArity);
+  public boolean isCallingMacro(String resolvedModuleName, String functionName, int resolvedFinalArity) {
+    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, functionName, resolvedFinalArity);
   }
 
   @Nullable
@@ -167,11 +167,6 @@ public class ElixirAtNumericOperationImpl extends ASTWrapperPsiElement implement
   @NotNull
   public IntRange resolvedFinalArityRange() {
     return ElixirPsiImplUtil.resolvedFinalArityRange(this);
-  }
-
-  @NotNull
-  public String resolvedFunctionName() {
-    return ElixirPsiImplUtil.resolvedFunctionName(this);
   }
 
   @NotNull

--- a/gen/org/elixir_lang/psi/impl/ElixirCaptureNumericOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirCaptureNumericOperationImpl.java
@@ -103,20 +103,20 @@ public class ElixirCaptureNumericOperationImpl extends ASTWrapperPsiElement impl
     return ElixirPsiImplUtil.hasDoBlockOrKeyword(this);
   }
 
-  public boolean isCalling(String resolvedModuleName, String resolvedFunctionName) {
-    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, resolvedFunctionName);
+  public boolean isCalling(String resolvedModuleName, String functionName) {
+    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, functionName);
   }
 
-  public boolean isCalling(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity) {
-    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, resolvedFunctionName, resolvedFinalArity);
+  public boolean isCalling(String resolvedModuleName, String functionName, int resolvedFinalArity) {
+    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, functionName, resolvedFinalArity);
   }
 
-  public boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName) {
-    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, resolvedFunctionName);
+  public boolean isCallingMacro(String resolvedModuleName, String functionName) {
+    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, functionName);
   }
 
-  public boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity) {
-    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, resolvedFunctionName, resolvedFinalArity);
+  public boolean isCallingMacro(String resolvedModuleName, String functionName, int resolvedFinalArity) {
+    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, functionName, resolvedFinalArity);
   }
 
   @Nullable
@@ -167,11 +167,6 @@ public class ElixirCaptureNumericOperationImpl extends ASTWrapperPsiElement impl
   @NotNull
   public IntRange resolvedFinalArityRange() {
     return ElixirPsiImplUtil.resolvedFinalArityRange(this);
-  }
-
-  @NotNull
-  public String resolvedFunctionName() {
-    return ElixirPsiImplUtil.resolvedFunctionName(this);
   }
 
   @NotNull

--- a/gen/org/elixir_lang/psi/impl/ElixirMatchedAdditionOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMatchedAdditionOperationImpl.java
@@ -70,20 +70,20 @@ public class ElixirMatchedAdditionOperationImpl extends ElixirMatchedExpressionI
     return ElixirPsiImplUtil.hasDoBlockOrKeyword(this);
   }
 
-  public boolean isCalling(String resolvedModuleName, String resolvedFunctionName) {
-    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, resolvedFunctionName);
+  public boolean isCalling(String resolvedModuleName, String functionName) {
+    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, functionName);
   }
 
-  public boolean isCalling(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity) {
-    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, resolvedFunctionName, resolvedFinalArity);
+  public boolean isCalling(String resolvedModuleName, String functionName, int resolvedFinalArity) {
+    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, functionName, resolvedFinalArity);
   }
 
-  public boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName) {
-    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, resolvedFunctionName);
+  public boolean isCallingMacro(String resolvedModuleName, String functionName) {
+    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, functionName);
   }
 
-  public boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity) {
-    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, resolvedFunctionName, resolvedFinalArity);
+  public boolean isCallingMacro(String resolvedModuleName, String functionName, int resolvedFinalArity) {
+    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, functionName, resolvedFinalArity);
   }
 
   @Nullable
@@ -128,11 +128,6 @@ public class ElixirMatchedAdditionOperationImpl extends ElixirMatchedExpressionI
   @NotNull
   public IntRange resolvedFinalArityRange() {
     return ElixirPsiImplUtil.resolvedFinalArityRange(this);
-  }
-
-  @NotNull
-  public String resolvedFunctionName() {
-    return ElixirPsiImplUtil.resolvedFunctionName(this);
   }
 
   @NotNull

--- a/gen/org/elixir_lang/psi/impl/ElixirMatchedAndOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMatchedAndOperationImpl.java
@@ -71,20 +71,20 @@ public class ElixirMatchedAndOperationImpl extends ElixirMatchedExpressionImpl i
     return ElixirPsiImplUtil.hasDoBlockOrKeyword(this);
   }
 
-  public boolean isCalling(String resolvedModuleName, String resolvedFunctionName) {
-    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, resolvedFunctionName);
+  public boolean isCalling(String resolvedModuleName, String functionName) {
+    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, functionName);
   }
 
-  public boolean isCalling(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity) {
-    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, resolvedFunctionName, resolvedFinalArity);
+  public boolean isCalling(String resolvedModuleName, String functionName, int resolvedFinalArity) {
+    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, functionName, resolvedFinalArity);
   }
 
-  public boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName) {
-    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, resolvedFunctionName);
+  public boolean isCallingMacro(String resolvedModuleName, String functionName) {
+    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, functionName);
   }
 
-  public boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity) {
-    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, resolvedFunctionName, resolvedFinalArity);
+  public boolean isCallingMacro(String resolvedModuleName, String functionName, int resolvedFinalArity) {
+    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, functionName, resolvedFinalArity);
   }
 
   @Nullable
@@ -129,11 +129,6 @@ public class ElixirMatchedAndOperationImpl extends ElixirMatchedExpressionImpl i
   @NotNull
   public IntRange resolvedFinalArityRange() {
     return ElixirPsiImplUtil.resolvedFinalArityRange(this);
-  }
-
-  @NotNull
-  public String resolvedFunctionName() {
-    return ElixirPsiImplUtil.resolvedFunctionName(this);
   }
 
   @NotNull

--- a/gen/org/elixir_lang/psi/impl/ElixirMatchedArrowOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMatchedArrowOperationImpl.java
@@ -70,20 +70,20 @@ public class ElixirMatchedArrowOperationImpl extends ElixirMatchedExpressionImpl
     return ElixirPsiImplUtil.hasDoBlockOrKeyword(this);
   }
 
-  public boolean isCalling(String resolvedModuleName, String resolvedFunctionName) {
-    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, resolvedFunctionName);
+  public boolean isCalling(String resolvedModuleName, String functionName) {
+    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, functionName);
   }
 
-  public boolean isCalling(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity) {
-    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, resolvedFunctionName, resolvedFinalArity);
+  public boolean isCalling(String resolvedModuleName, String functionName, int resolvedFinalArity) {
+    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, functionName, resolvedFinalArity);
   }
 
-  public boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName) {
-    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, resolvedFunctionName);
+  public boolean isCallingMacro(String resolvedModuleName, String functionName) {
+    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, functionName);
   }
 
-  public boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity) {
-    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, resolvedFunctionName, resolvedFinalArity);
+  public boolean isCallingMacro(String resolvedModuleName, String functionName, int resolvedFinalArity) {
+    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, functionName, resolvedFinalArity);
   }
 
   @Nullable
@@ -128,11 +128,6 @@ public class ElixirMatchedArrowOperationImpl extends ElixirMatchedExpressionImpl
   @NotNull
   public IntRange resolvedFinalArityRange() {
     return ElixirPsiImplUtil.resolvedFinalArityRange(this);
-  }
-
-  @NotNull
-  public String resolvedFunctionName() {
-    return ElixirPsiImplUtil.resolvedFunctionName(this);
   }
 
   @NotNull

--- a/gen/org/elixir_lang/psi/impl/ElixirMatchedAtUnqualifiedNoParenthesesCallImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMatchedAtUnqualifiedNoParenthesesCallImpl.java
@@ -98,20 +98,20 @@ public class ElixirMatchedAtUnqualifiedNoParenthesesCallImpl extends NamedStubbe
     return ElixirPsiImplUtil.getUseScope(this);
   }
 
-  public boolean isCalling(String resolvedModuleName, String resolvedFunctionName) {
-    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, resolvedFunctionName);
+  public boolean isCalling(String resolvedModuleName, String functionName) {
+    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, functionName);
   }
 
-  public boolean isCalling(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity) {
-    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, resolvedFunctionName, resolvedFinalArity);
+  public boolean isCalling(String resolvedModuleName, String functionName, int resolvedFinalArity) {
+    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, functionName, resolvedFinalArity);
   }
 
-  public boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName) {
-    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, resolvedFunctionName);
+  public boolean isCallingMacro(String resolvedModuleName, String functionName) {
+    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, functionName);
   }
 
-  public boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity) {
-    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, resolvedFunctionName, resolvedFinalArity);
+  public boolean isCallingMacro(String resolvedModuleName, String functionName, int resolvedFinalArity) {
+    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, functionName, resolvedFinalArity);
   }
 
   @Nullable
@@ -146,11 +146,6 @@ public class ElixirMatchedAtUnqualifiedNoParenthesesCallImpl extends NamedStubbe
   @NotNull
   public IntRange resolvedFinalArityRange() {
     return ElixirPsiImplUtil.resolvedFinalArityRange(this);
-  }
-
-  @Nullable
-  public String resolvedFunctionName() {
-    return ElixirPsiImplUtil.resolvedFunctionName(this);
   }
 
   @Nullable

--- a/gen/org/elixir_lang/psi/impl/ElixirMatchedCaptureNonNumericOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMatchedCaptureNonNumericOperationImpl.java
@@ -66,20 +66,20 @@ public class ElixirMatchedCaptureNonNumericOperationImpl extends ElixirMatchedEx
     return ElixirPsiImplUtil.hasDoBlockOrKeyword(this);
   }
 
-  public boolean isCalling(String resolvedModuleName, String resolvedFunctionName) {
-    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, resolvedFunctionName);
+  public boolean isCalling(String resolvedModuleName, String functionName) {
+    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, functionName);
   }
 
-  public boolean isCalling(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity) {
-    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, resolvedFunctionName, resolvedFinalArity);
+  public boolean isCalling(String resolvedModuleName, String functionName, int resolvedFinalArity) {
+    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, functionName, resolvedFinalArity);
   }
 
-  public boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName) {
-    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, resolvedFunctionName);
+  public boolean isCallingMacro(String resolvedModuleName, String functionName) {
+    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, functionName);
   }
 
-  public boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity) {
-    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, resolvedFunctionName, resolvedFinalArity);
+  public boolean isCallingMacro(String resolvedModuleName, String functionName, int resolvedFinalArity) {
+    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, functionName, resolvedFinalArity);
   }
 
   @Nullable
@@ -130,11 +130,6 @@ public class ElixirMatchedCaptureNonNumericOperationImpl extends ElixirMatchedEx
   @NotNull
   public IntRange resolvedFinalArityRange() {
     return ElixirPsiImplUtil.resolvedFinalArityRange(this);
-  }
-
-  @NotNull
-  public String resolvedFunctionName() {
-    return ElixirPsiImplUtil.resolvedFunctionName(this);
   }
 
   @NotNull

--- a/gen/org/elixir_lang/psi/impl/ElixirMatchedComparisonOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMatchedComparisonOperationImpl.java
@@ -70,20 +70,20 @@ public class ElixirMatchedComparisonOperationImpl extends ElixirMatchedExpressio
     return ElixirPsiImplUtil.hasDoBlockOrKeyword(this);
   }
 
-  public boolean isCalling(String resolvedModuleName, String resolvedFunctionName) {
-    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, resolvedFunctionName);
+  public boolean isCalling(String resolvedModuleName, String functionName) {
+    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, functionName);
   }
 
-  public boolean isCalling(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity) {
-    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, resolvedFunctionName, resolvedFinalArity);
+  public boolean isCalling(String resolvedModuleName, String functionName, int resolvedFinalArity) {
+    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, functionName, resolvedFinalArity);
   }
 
-  public boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName) {
-    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, resolvedFunctionName);
+  public boolean isCallingMacro(String resolvedModuleName, String functionName) {
+    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, functionName);
   }
 
-  public boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity) {
-    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, resolvedFunctionName, resolvedFinalArity);
+  public boolean isCallingMacro(String resolvedModuleName, String functionName, int resolvedFinalArity) {
+    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, functionName, resolvedFinalArity);
   }
 
   @Nullable
@@ -128,11 +128,6 @@ public class ElixirMatchedComparisonOperationImpl extends ElixirMatchedExpressio
   @NotNull
   public IntRange resolvedFinalArityRange() {
     return ElixirPsiImplUtil.resolvedFinalArityRange(this);
-  }
-
-  @NotNull
-  public String resolvedFunctionName() {
-    return ElixirPsiImplUtil.resolvedFunctionName(this);
   }
 
   @NotNull

--- a/gen/org/elixir_lang/psi/impl/ElixirMatchedDotCallImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMatchedDotCallImpl.java
@@ -99,20 +99,20 @@ public class ElixirMatchedDotCallImpl extends NamedStubbedPsiElementBase<Matched
     return ElixirPsiImplUtil.getReference(this);
   }
 
-  public boolean isCalling(String resolvedModuleName, String resolvedFunctionName) {
-    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, resolvedFunctionName);
+  public boolean isCalling(String resolvedModuleName, String functionName) {
+    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, functionName);
   }
 
-  public boolean isCalling(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity) {
-    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, resolvedFunctionName, resolvedFinalArity);
+  public boolean isCalling(String resolvedModuleName, String functionName, int resolvedFinalArity) {
+    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, functionName, resolvedFinalArity);
   }
 
-  public boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName) {
-    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, resolvedFunctionName);
+  public boolean isCallingMacro(String resolvedModuleName, String functionName) {
+    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, functionName);
   }
 
-  public boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity) {
-    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, resolvedFunctionName, resolvedFinalArity);
+  public boolean isCallingMacro(String resolvedModuleName, String functionName, int resolvedFinalArity) {
+    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, functionName, resolvedFinalArity);
   }
 
   @Nullable
@@ -147,11 +147,6 @@ public class ElixirMatchedDotCallImpl extends NamedStubbedPsiElementBase<Matched
   @NotNull
   public IntRange resolvedFinalArityRange() {
     return ElixirPsiImplUtil.resolvedFinalArityRange(this);
-  }
-
-  @Nullable
-  public String resolvedFunctionName() {
-    return ElixirPsiImplUtil.resolvedFunctionName(this);
   }
 
   @Nullable

--- a/gen/org/elixir_lang/psi/impl/ElixirMatchedInMatchOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMatchedInMatchOperationImpl.java
@@ -70,20 +70,20 @@ public class ElixirMatchedInMatchOperationImpl extends ElixirMatchedExpressionIm
     return ElixirPsiImplUtil.hasDoBlockOrKeyword(this);
   }
 
-  public boolean isCalling(String resolvedModuleName, String resolvedFunctionName) {
-    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, resolvedFunctionName);
+  public boolean isCalling(String resolvedModuleName, String functionName) {
+    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, functionName);
   }
 
-  public boolean isCalling(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity) {
-    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, resolvedFunctionName, resolvedFinalArity);
+  public boolean isCalling(String resolvedModuleName, String functionName, int resolvedFinalArity) {
+    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, functionName, resolvedFinalArity);
   }
 
-  public boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName) {
-    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, resolvedFunctionName);
+  public boolean isCallingMacro(String resolvedModuleName, String functionName) {
+    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, functionName);
   }
 
-  public boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity) {
-    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, resolvedFunctionName, resolvedFinalArity);
+  public boolean isCallingMacro(String resolvedModuleName, String functionName, int resolvedFinalArity) {
+    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, functionName, resolvedFinalArity);
   }
 
   @Nullable
@@ -128,11 +128,6 @@ public class ElixirMatchedInMatchOperationImpl extends ElixirMatchedExpressionIm
   @NotNull
   public IntRange resolvedFinalArityRange() {
     return ElixirPsiImplUtil.resolvedFinalArityRange(this);
-  }
-
-  @NotNull
-  public String resolvedFunctionName() {
-    return ElixirPsiImplUtil.resolvedFunctionName(this);
   }
 
   @NotNull

--- a/gen/org/elixir_lang/psi/impl/ElixirMatchedInOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMatchedInOperationImpl.java
@@ -61,20 +61,20 @@ public class ElixirMatchedInOperationImpl extends ElixirMatchedExpressionImpl im
     return ElixirPsiImplUtil.hasDoBlockOrKeyword(this);
   }
 
-  public boolean isCalling(String resolvedModuleName, String resolvedFunctionName) {
-    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, resolvedFunctionName);
+  public boolean isCalling(String resolvedModuleName, String functionName) {
+    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, functionName);
   }
 
-  public boolean isCalling(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity) {
-    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, resolvedFunctionName, resolvedFinalArity);
+  public boolean isCalling(String resolvedModuleName, String functionName, int resolvedFinalArity) {
+    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, functionName, resolvedFinalArity);
   }
 
-  public boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName) {
-    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, resolvedFunctionName);
+  public boolean isCallingMacro(String resolvedModuleName, String functionName) {
+    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, functionName);
   }
 
-  public boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity) {
-    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, resolvedFunctionName, resolvedFinalArity);
+  public boolean isCallingMacro(String resolvedModuleName, String functionName, int resolvedFinalArity) {
+    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, functionName, resolvedFinalArity);
   }
 
   @Nullable
@@ -119,11 +119,6 @@ public class ElixirMatchedInOperationImpl extends ElixirMatchedExpressionImpl im
   @NotNull
   public IntRange resolvedFinalArityRange() {
     return ElixirPsiImplUtil.resolvedFinalArityRange(this);
-  }
-
-  @NotNull
-  public String resolvedFunctionName() {
-    return ElixirPsiImplUtil.resolvedFunctionName(this);
   }
 
   @NotNull

--- a/gen/org/elixir_lang/psi/impl/ElixirMatchedMatchOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMatchedMatchOperationImpl.java
@@ -71,20 +71,20 @@ public class ElixirMatchedMatchOperationImpl extends ElixirMatchedExpressionImpl
     return ElixirPsiImplUtil.hasDoBlockOrKeyword(this);
   }
 
-  public boolean isCalling(String resolvedModuleName, String resolvedFunctionName) {
-    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, resolvedFunctionName);
+  public boolean isCalling(String resolvedModuleName, String functionName) {
+    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, functionName);
   }
 
-  public boolean isCalling(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity) {
-    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, resolvedFunctionName, resolvedFinalArity);
+  public boolean isCalling(String resolvedModuleName, String functionName, int resolvedFinalArity) {
+    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, functionName, resolvedFinalArity);
   }
 
-  public boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName) {
-    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, resolvedFunctionName);
+  public boolean isCallingMacro(String resolvedModuleName, String functionName) {
+    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, functionName);
   }
 
-  public boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity) {
-    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, resolvedFunctionName, resolvedFinalArity);
+  public boolean isCallingMacro(String resolvedModuleName, String functionName, int resolvedFinalArity) {
+    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, functionName, resolvedFinalArity);
   }
 
   @Nullable
@@ -129,11 +129,6 @@ public class ElixirMatchedMatchOperationImpl extends ElixirMatchedExpressionImpl
   @NotNull
   public IntRange resolvedFinalArityRange() {
     return ElixirPsiImplUtil.resolvedFinalArityRange(this);
-  }
-
-  @NotNull
-  public String resolvedFunctionName() {
-    return ElixirPsiImplUtil.resolvedFunctionName(this);
   }
 
   @NotNull

--- a/gen/org/elixir_lang/psi/impl/ElixirMatchedMultiplicationOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMatchedMultiplicationOperationImpl.java
@@ -70,20 +70,20 @@ public class ElixirMatchedMultiplicationOperationImpl extends ElixirMatchedExpre
     return ElixirPsiImplUtil.hasDoBlockOrKeyword(this);
   }
 
-  public boolean isCalling(String resolvedModuleName, String resolvedFunctionName) {
-    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, resolvedFunctionName);
+  public boolean isCalling(String resolvedModuleName, String functionName) {
+    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, functionName);
   }
 
-  public boolean isCalling(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity) {
-    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, resolvedFunctionName, resolvedFinalArity);
+  public boolean isCalling(String resolvedModuleName, String functionName, int resolvedFinalArity) {
+    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, functionName, resolvedFinalArity);
   }
 
-  public boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName) {
-    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, resolvedFunctionName);
+  public boolean isCallingMacro(String resolvedModuleName, String functionName) {
+    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, functionName);
   }
 
-  public boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity) {
-    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, resolvedFunctionName, resolvedFinalArity);
+  public boolean isCallingMacro(String resolvedModuleName, String functionName, int resolvedFinalArity) {
+    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, functionName, resolvedFinalArity);
   }
 
   @Nullable
@@ -128,11 +128,6 @@ public class ElixirMatchedMultiplicationOperationImpl extends ElixirMatchedExpre
   @NotNull
   public IntRange resolvedFinalArityRange() {
     return ElixirPsiImplUtil.resolvedFinalArityRange(this);
-  }
-
-  @NotNull
-  public String resolvedFunctionName() {
-    return ElixirPsiImplUtil.resolvedFunctionName(this);
   }
 
   @NotNull

--- a/gen/org/elixir_lang/psi/impl/ElixirMatchedOrOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMatchedOrOperationImpl.java
@@ -70,20 +70,20 @@ public class ElixirMatchedOrOperationImpl extends ElixirMatchedExpressionImpl im
     return ElixirPsiImplUtil.hasDoBlockOrKeyword(this);
   }
 
-  public boolean isCalling(String resolvedModuleName, String resolvedFunctionName) {
-    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, resolvedFunctionName);
+  public boolean isCalling(String resolvedModuleName, String functionName) {
+    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, functionName);
   }
 
-  public boolean isCalling(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity) {
-    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, resolvedFunctionName, resolvedFinalArity);
+  public boolean isCalling(String resolvedModuleName, String functionName, int resolvedFinalArity) {
+    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, functionName, resolvedFinalArity);
   }
 
-  public boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName) {
-    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, resolvedFunctionName);
+  public boolean isCallingMacro(String resolvedModuleName, String functionName) {
+    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, functionName);
   }
 
-  public boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity) {
-    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, resolvedFunctionName, resolvedFinalArity);
+  public boolean isCallingMacro(String resolvedModuleName, String functionName, int resolvedFinalArity) {
+    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, functionName, resolvedFinalArity);
   }
 
   @Nullable
@@ -128,11 +128,6 @@ public class ElixirMatchedOrOperationImpl extends ElixirMatchedExpressionImpl im
   @NotNull
   public IntRange resolvedFinalArityRange() {
     return ElixirPsiImplUtil.resolvedFinalArityRange(this);
-  }
-
-  @NotNull
-  public String resolvedFunctionName() {
-    return ElixirPsiImplUtil.resolvedFunctionName(this);
   }
 
   @NotNull

--- a/gen/org/elixir_lang/psi/impl/ElixirMatchedPipeOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMatchedPipeOperationImpl.java
@@ -70,20 +70,20 @@ public class ElixirMatchedPipeOperationImpl extends ElixirMatchedExpressionImpl 
     return ElixirPsiImplUtil.hasDoBlockOrKeyword(this);
   }
 
-  public boolean isCalling(String resolvedModuleName, String resolvedFunctionName) {
-    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, resolvedFunctionName);
+  public boolean isCalling(String resolvedModuleName, String functionName) {
+    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, functionName);
   }
 
-  public boolean isCalling(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity) {
-    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, resolvedFunctionName, resolvedFinalArity);
+  public boolean isCalling(String resolvedModuleName, String functionName, int resolvedFinalArity) {
+    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, functionName, resolvedFinalArity);
   }
 
-  public boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName) {
-    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, resolvedFunctionName);
+  public boolean isCallingMacro(String resolvedModuleName, String functionName) {
+    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, functionName);
   }
 
-  public boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity) {
-    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, resolvedFunctionName, resolvedFinalArity);
+  public boolean isCallingMacro(String resolvedModuleName, String functionName, int resolvedFinalArity) {
+    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, functionName, resolvedFinalArity);
   }
 
   @Nullable
@@ -128,11 +128,6 @@ public class ElixirMatchedPipeOperationImpl extends ElixirMatchedExpressionImpl 
   @NotNull
   public IntRange resolvedFinalArityRange() {
     return ElixirPsiImplUtil.resolvedFinalArityRange(this);
-  }
-
-  @NotNull
-  public String resolvedFunctionName() {
-    return ElixirPsiImplUtil.resolvedFunctionName(this);
   }
 
   @NotNull

--- a/gen/org/elixir_lang/psi/impl/ElixirMatchedQualifiedBracketOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMatchedQualifiedBracketOperationImpl.java
@@ -3,6 +3,7 @@ package org.elixir_lang.psi.impl;
 
 import com.ericsson.otp.erlang.OtpErlangObject;
 import com.intellij.lang.ASTNode;
+import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
 import org.elixir_lang.psi.*;
@@ -45,6 +46,11 @@ public class ElixirMatchedQualifiedBracketOperationImpl extends ElixirMatchedExp
   @NotNull
   public ElixirRelativeIdentifier getRelativeIdentifier() {
     return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirRelativeIdentifier.class));
+  }
+
+  @NotNull
+  public PsiElement qualifier() {
+    return ElixirPsiImplUtil.qualifier(this);
   }
 
   @NotNull

--- a/gen/org/elixir_lang/psi/impl/ElixirMatchedQualifiedNoArgumentsCallImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMatchedQualifiedNoArgumentsCallImpl.java
@@ -133,6 +133,11 @@ public class ElixirMatchedQualifiedNoArgumentsCallImpl extends NamedStubbedPsiEl
   }
 
   @NotNull
+  public PsiElement qualifier() {
+    return ElixirPsiImplUtil.qualifier(this);
+  }
+
+  @NotNull
   public OtpErlangObject quote() {
     return ElixirPsiImplUtil.quote(this);
   }

--- a/gen/org/elixir_lang/psi/impl/ElixirMatchedQualifiedNoArgumentsCallImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMatchedQualifiedNoArgumentsCallImpl.java
@@ -97,20 +97,20 @@ public class ElixirMatchedQualifiedNoArgumentsCallImpl extends NamedStubbedPsiEl
     return ElixirPsiImplUtil.getReference(this);
   }
 
-  public boolean isCalling(String resolvedModuleName, String resolvedFunctionName) {
-    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, resolvedFunctionName);
+  public boolean isCalling(String resolvedModuleName, String functionName) {
+    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, functionName);
   }
 
-  public boolean isCalling(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity) {
-    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, resolvedFunctionName, resolvedFinalArity);
+  public boolean isCalling(String resolvedModuleName, String functionName, int resolvedFinalArity) {
+    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, functionName, resolvedFinalArity);
   }
 
-  public boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName) {
-    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, resolvedFunctionName);
+  public boolean isCallingMacro(String resolvedModuleName, String functionName) {
+    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, functionName);
   }
 
-  public boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity) {
-    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, resolvedFunctionName, resolvedFinalArity);
+  public boolean isCallingMacro(String resolvedModuleName, String functionName, int resolvedFinalArity) {
+    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, functionName, resolvedFinalArity);
   }
 
   @NotNull
@@ -145,11 +145,6 @@ public class ElixirMatchedQualifiedNoArgumentsCallImpl extends NamedStubbedPsiEl
   @NotNull
   public IntRange resolvedFinalArityRange() {
     return ElixirPsiImplUtil.resolvedFinalArityRange(this);
-  }
-
-  @NotNull
-  public String resolvedFunctionName() {
-    return ElixirPsiImplUtil.resolvedFunctionName(this);
   }
 
   @NotNull

--- a/gen/org/elixir_lang/psi/impl/ElixirMatchedQualifiedNoParenthesesCallImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMatchedQualifiedNoParenthesesCallImpl.java
@@ -139,6 +139,11 @@ public class ElixirMatchedQualifiedNoParenthesesCallImpl extends NamedStubbedPsi
   }
 
   @NotNull
+  public PsiElement qualifier() {
+    return ElixirPsiImplUtil.qualifier(this);
+  }
+
+  @NotNull
   public OtpErlangObject quote() {
     return ElixirPsiImplUtil.quote(this);
   }

--- a/gen/org/elixir_lang/psi/impl/ElixirMatchedQualifiedNoParenthesesCallImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMatchedQualifiedNoParenthesesCallImpl.java
@@ -103,20 +103,20 @@ public class ElixirMatchedQualifiedNoParenthesesCallImpl extends NamedStubbedPsi
     return ElixirPsiImplUtil.getReference(this);
   }
 
-  public boolean isCalling(String resolvedModuleName, String resolvedFunctionName) {
-    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, resolvedFunctionName);
+  public boolean isCalling(String resolvedModuleName, String functionName) {
+    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, functionName);
   }
 
-  public boolean isCalling(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity) {
-    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, resolvedFunctionName, resolvedFinalArity);
+  public boolean isCalling(String resolvedModuleName, String functionName, int resolvedFinalArity) {
+    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, functionName, resolvedFinalArity);
   }
 
-  public boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName) {
-    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, resolvedFunctionName);
+  public boolean isCallingMacro(String resolvedModuleName, String functionName) {
+    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, functionName);
   }
 
-  public boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity) {
-    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, resolvedFunctionName, resolvedFinalArity);
+  public boolean isCallingMacro(String resolvedModuleName, String functionName, int resolvedFinalArity) {
+    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, functionName, resolvedFinalArity);
   }
 
   @NotNull
@@ -151,11 +151,6 @@ public class ElixirMatchedQualifiedNoParenthesesCallImpl extends NamedStubbedPsi
   @NotNull
   public IntRange resolvedFinalArityRange() {
     return ElixirPsiImplUtil.resolvedFinalArityRange(this);
-  }
-
-  @NotNull
-  public String resolvedFunctionName() {
-    return ElixirPsiImplUtil.resolvedFunctionName(this);
   }
 
   @NotNull

--- a/gen/org/elixir_lang/psi/impl/ElixirMatchedQualifiedParenthesesCallImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMatchedQualifiedParenthesesCallImpl.java
@@ -139,6 +139,11 @@ public class ElixirMatchedQualifiedParenthesesCallImpl extends NamedStubbedPsiEl
   }
 
   @NotNull
+  public PsiElement qualifier() {
+    return ElixirPsiImplUtil.qualifier(this);
+  }
+
+  @NotNull
   public OtpErlangObject quote() {
     return ElixirPsiImplUtil.quote(this);
   }

--- a/gen/org/elixir_lang/psi/impl/ElixirMatchedQualifiedParenthesesCallImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMatchedQualifiedParenthesesCallImpl.java
@@ -103,20 +103,20 @@ public class ElixirMatchedQualifiedParenthesesCallImpl extends NamedStubbedPsiEl
     return ElixirPsiImplUtil.getReference(this);
   }
 
-  public boolean isCalling(String resolvedModuleName, String resolvedFunctionName) {
-    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, resolvedFunctionName);
+  public boolean isCalling(String resolvedModuleName, String functionName) {
+    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, functionName);
   }
 
-  public boolean isCalling(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity) {
-    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, resolvedFunctionName, resolvedFinalArity);
+  public boolean isCalling(String resolvedModuleName, String functionName, int resolvedFinalArity) {
+    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, functionName, resolvedFinalArity);
   }
 
-  public boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName) {
-    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, resolvedFunctionName);
+  public boolean isCallingMacro(String resolvedModuleName, String functionName) {
+    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, functionName);
   }
 
-  public boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity) {
-    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, resolvedFunctionName, resolvedFinalArity);
+  public boolean isCallingMacro(String resolvedModuleName, String functionName, int resolvedFinalArity) {
+    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, functionName, resolvedFinalArity);
   }
 
   @NotNull
@@ -151,11 +151,6 @@ public class ElixirMatchedQualifiedParenthesesCallImpl extends NamedStubbedPsiEl
   @NotNull
   public IntRange resolvedFinalArityRange() {
     return ElixirPsiImplUtil.resolvedFinalArityRange(this);
-  }
-
-  @NotNull
-  public String resolvedFunctionName() {
-    return ElixirPsiImplUtil.resolvedFunctionName(this);
   }
 
   @NotNull

--- a/gen/org/elixir_lang/psi/impl/ElixirMatchedRelationalOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMatchedRelationalOperationImpl.java
@@ -70,20 +70,20 @@ public class ElixirMatchedRelationalOperationImpl extends ElixirMatchedExpressio
     return ElixirPsiImplUtil.hasDoBlockOrKeyword(this);
   }
 
-  public boolean isCalling(String resolvedModuleName, String resolvedFunctionName) {
-    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, resolvedFunctionName);
+  public boolean isCalling(String resolvedModuleName, String functionName) {
+    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, functionName);
   }
 
-  public boolean isCalling(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity) {
-    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, resolvedFunctionName, resolvedFinalArity);
+  public boolean isCalling(String resolvedModuleName, String functionName, int resolvedFinalArity) {
+    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, functionName, resolvedFinalArity);
   }
 
-  public boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName) {
-    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, resolvedFunctionName);
+  public boolean isCallingMacro(String resolvedModuleName, String functionName) {
+    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, functionName);
   }
 
-  public boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity) {
-    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, resolvedFunctionName, resolvedFinalArity);
+  public boolean isCallingMacro(String resolvedModuleName, String functionName, int resolvedFinalArity) {
+    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, functionName, resolvedFinalArity);
   }
 
   @Nullable
@@ -128,11 +128,6 @@ public class ElixirMatchedRelationalOperationImpl extends ElixirMatchedExpressio
   @NotNull
   public IntRange resolvedFinalArityRange() {
     return ElixirPsiImplUtil.resolvedFinalArityRange(this);
-  }
-
-  @NotNull
-  public String resolvedFunctionName() {
-    return ElixirPsiImplUtil.resolvedFunctionName(this);
   }
 
   @NotNull

--- a/gen/org/elixir_lang/psi/impl/ElixirMatchedTwoOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMatchedTwoOperationImpl.java
@@ -70,20 +70,20 @@ public class ElixirMatchedTwoOperationImpl extends ElixirMatchedExpressionImpl i
     return ElixirPsiImplUtil.hasDoBlockOrKeyword(this);
   }
 
-  public boolean isCalling(String resolvedModuleName, String resolvedFunctionName) {
-    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, resolvedFunctionName);
+  public boolean isCalling(String resolvedModuleName, String functionName) {
+    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, functionName);
   }
 
-  public boolean isCalling(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity) {
-    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, resolvedFunctionName, resolvedFinalArity);
+  public boolean isCalling(String resolvedModuleName, String functionName, int resolvedFinalArity) {
+    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, functionName, resolvedFinalArity);
   }
 
-  public boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName) {
-    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, resolvedFunctionName);
+  public boolean isCallingMacro(String resolvedModuleName, String functionName) {
+    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, functionName);
   }
 
-  public boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity) {
-    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, resolvedFunctionName, resolvedFinalArity);
+  public boolean isCallingMacro(String resolvedModuleName, String functionName, int resolvedFinalArity) {
+    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, functionName, resolvedFinalArity);
   }
 
   @Nullable
@@ -128,11 +128,6 @@ public class ElixirMatchedTwoOperationImpl extends ElixirMatchedExpressionImpl i
   @NotNull
   public IntRange resolvedFinalArityRange() {
     return ElixirPsiImplUtil.resolvedFinalArityRange(this);
-  }
-
-  @NotNull
-  public String resolvedFunctionName() {
-    return ElixirPsiImplUtil.resolvedFunctionName(this);
   }
 
   @NotNull

--- a/gen/org/elixir_lang/psi/impl/ElixirMatchedTypeOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMatchedTypeOperationImpl.java
@@ -70,20 +70,20 @@ public class ElixirMatchedTypeOperationImpl extends ElixirMatchedExpressionImpl 
     return ElixirPsiImplUtil.hasDoBlockOrKeyword(this);
   }
 
-  public boolean isCalling(String resolvedModuleName, String resolvedFunctionName) {
-    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, resolvedFunctionName);
+  public boolean isCalling(String resolvedModuleName, String functionName) {
+    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, functionName);
   }
 
-  public boolean isCalling(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity) {
-    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, resolvedFunctionName, resolvedFinalArity);
+  public boolean isCalling(String resolvedModuleName, String functionName, int resolvedFinalArity) {
+    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, functionName, resolvedFinalArity);
   }
 
-  public boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName) {
-    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, resolvedFunctionName);
+  public boolean isCallingMacro(String resolvedModuleName, String functionName) {
+    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, functionName);
   }
 
-  public boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity) {
-    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, resolvedFunctionName, resolvedFinalArity);
+  public boolean isCallingMacro(String resolvedModuleName, String functionName, int resolvedFinalArity) {
+    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, functionName, resolvedFinalArity);
   }
 
   @Nullable
@@ -128,11 +128,6 @@ public class ElixirMatchedTypeOperationImpl extends ElixirMatchedExpressionImpl 
   @NotNull
   public IntRange resolvedFinalArityRange() {
     return ElixirPsiImplUtil.resolvedFinalArityRange(this);
-  }
-
-  @NotNull
-  public String resolvedFunctionName() {
-    return ElixirPsiImplUtil.resolvedFunctionName(this);
   }
 
   @NotNull

--- a/gen/org/elixir_lang/psi/impl/ElixirMatchedUnaryNonNumericOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMatchedUnaryNonNumericOperationImpl.java
@@ -66,20 +66,20 @@ public class ElixirMatchedUnaryNonNumericOperationImpl extends ElixirMatchedExpr
     return ElixirPsiImplUtil.hasDoBlockOrKeyword(this);
   }
 
-  public boolean isCalling(String resolvedModuleName, String resolvedFunctionName) {
-    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, resolvedFunctionName);
+  public boolean isCalling(String resolvedModuleName, String functionName) {
+    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, functionName);
   }
 
-  public boolean isCalling(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity) {
-    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, resolvedFunctionName, resolvedFinalArity);
+  public boolean isCalling(String resolvedModuleName, String functionName, int resolvedFinalArity) {
+    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, functionName, resolvedFinalArity);
   }
 
-  public boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName) {
-    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, resolvedFunctionName);
+  public boolean isCallingMacro(String resolvedModuleName, String functionName) {
+    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, functionName);
   }
 
-  public boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity) {
-    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, resolvedFunctionName, resolvedFinalArity);
+  public boolean isCallingMacro(String resolvedModuleName, String functionName, int resolvedFinalArity) {
+    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, functionName, resolvedFinalArity);
   }
 
   @Nullable
@@ -130,11 +130,6 @@ public class ElixirMatchedUnaryNonNumericOperationImpl extends ElixirMatchedExpr
   @NotNull
   public IntRange resolvedFinalArityRange() {
     return ElixirPsiImplUtil.resolvedFinalArityRange(this);
-  }
-
-  @NotNull
-  public String resolvedFunctionName() {
-    return ElixirPsiImplUtil.resolvedFunctionName(this);
   }
 
   @NotNull

--- a/gen/org/elixir_lang/psi/impl/ElixirMatchedUnqualifiedNoArgumentsCallImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMatchedUnqualifiedNoArgumentsCallImpl.java
@@ -95,20 +95,20 @@ public class ElixirMatchedUnqualifiedNoArgumentsCallImpl extends NamedStubbedPsi
     return ElixirPsiImplUtil.getUseScope(this);
   }
 
-  public boolean isCalling(String resolvedModuleName, String resolvedFunctionName) {
-    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, resolvedFunctionName);
+  public boolean isCalling(String resolvedModuleName, String functionName) {
+    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, functionName);
   }
 
-  public boolean isCalling(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity) {
-    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, resolvedFunctionName, resolvedFinalArity);
+  public boolean isCalling(String resolvedModuleName, String functionName, int resolvedFinalArity) {
+    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, functionName, resolvedFinalArity);
   }
 
-  public boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName) {
-    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, resolvedFunctionName);
+  public boolean isCallingMacro(String resolvedModuleName, String functionName) {
+    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, functionName);
   }
 
-  public boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity) {
-    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, resolvedFunctionName, resolvedFinalArity);
+  public boolean isCallingMacro(String resolvedModuleName, String functionName, int resolvedFinalArity) {
+    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, functionName, resolvedFinalArity);
   }
 
   @Nullable
@@ -143,11 +143,6 @@ public class ElixirMatchedUnqualifiedNoArgumentsCallImpl extends NamedStubbedPsi
   @NotNull
   public IntRange resolvedFinalArityRange() {
     return ElixirPsiImplUtil.resolvedFinalArityRange(this);
-  }
-
-  @NotNull
-  public String resolvedFunctionName() {
-    return ElixirPsiImplUtil.resolvedFunctionName(this);
   }
 
   @NotNull

--- a/gen/org/elixir_lang/psi/impl/ElixirMatchedUnqualifiedNoParenthesesCallImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMatchedUnqualifiedNoParenthesesCallImpl.java
@@ -92,20 +92,20 @@ public class ElixirMatchedUnqualifiedNoParenthesesCallImpl extends NamedStubbedP
     return ElixirPsiImplUtil.getReference(this);
   }
 
-  public boolean isCalling(String resolvedModuleName, String resolvedFunctionName) {
-    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, resolvedFunctionName);
+  public boolean isCalling(String resolvedModuleName, String functionName) {
+    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, functionName);
   }
 
-  public boolean isCalling(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity) {
-    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, resolvedFunctionName, resolvedFinalArity);
+  public boolean isCalling(String resolvedModuleName, String functionName, int resolvedFinalArity) {
+    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, functionName, resolvedFinalArity);
   }
 
-  public boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName) {
-    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, resolvedFunctionName);
+  public boolean isCallingMacro(String resolvedModuleName, String functionName) {
+    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, functionName);
   }
 
-  public boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity) {
-    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, resolvedFunctionName, resolvedFinalArity);
+  public boolean isCallingMacro(String resolvedModuleName, String functionName, int resolvedFinalArity) {
+    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, functionName, resolvedFinalArity);
   }
 
   @Nullable
@@ -140,11 +140,6 @@ public class ElixirMatchedUnqualifiedNoParenthesesCallImpl extends NamedStubbedP
   @NotNull
   public IntRange resolvedFinalArityRange() {
     return ElixirPsiImplUtil.resolvedFinalArityRange(this);
-  }
-
-  @NotNull
-  public String resolvedFunctionName() {
-    return ElixirPsiImplUtil.resolvedFunctionName(this);
   }
 
   @NotNull

--- a/gen/org/elixir_lang/psi/impl/ElixirMatchedUnqualifiedParenthesesCallImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMatchedUnqualifiedParenthesesCallImpl.java
@@ -92,20 +92,20 @@ public class ElixirMatchedUnqualifiedParenthesesCallImpl extends NamedStubbedPsi
     return ElixirPsiImplUtil.getReference(this);
   }
 
-  public boolean isCalling(String resolvedModuleName, String resolvedFunctionName) {
-    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, resolvedFunctionName);
+  public boolean isCalling(String resolvedModuleName, String functionName) {
+    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, functionName);
   }
 
-  public boolean isCalling(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity) {
-    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, resolvedFunctionName, resolvedFinalArity);
+  public boolean isCalling(String resolvedModuleName, String functionName, int resolvedFinalArity) {
+    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, functionName, resolvedFinalArity);
   }
 
-  public boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName) {
-    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, resolvedFunctionName);
+  public boolean isCallingMacro(String resolvedModuleName, String functionName) {
+    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, functionName);
   }
 
-  public boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity) {
-    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, resolvedFunctionName, resolvedFinalArity);
+  public boolean isCallingMacro(String resolvedModuleName, String functionName, int resolvedFinalArity) {
+    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, functionName, resolvedFinalArity);
   }
 
   @Nullable
@@ -140,11 +140,6 @@ public class ElixirMatchedUnqualifiedParenthesesCallImpl extends NamedStubbedPsi
   @NotNull
   public IntRange resolvedFinalArityRange() {
     return ElixirPsiImplUtil.resolvedFinalArityRange(this);
-  }
-
-  @NotNull
-  public String resolvedFunctionName() {
-    return ElixirPsiImplUtil.resolvedFunctionName(this);
   }
 
   @NotNull

--- a/gen/org/elixir_lang/psi/impl/ElixirMatchedWhenOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMatchedWhenOperationImpl.java
@@ -70,20 +70,20 @@ public class ElixirMatchedWhenOperationImpl extends ElixirMatchedExpressionImpl 
     return ElixirPsiImplUtil.hasDoBlockOrKeyword(this);
   }
 
-  public boolean isCalling(String resolvedModuleName, String resolvedFunctionName) {
-    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, resolvedFunctionName);
+  public boolean isCalling(String resolvedModuleName, String functionName) {
+    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, functionName);
   }
 
-  public boolean isCalling(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity) {
-    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, resolvedFunctionName, resolvedFinalArity);
+  public boolean isCalling(String resolvedModuleName, String functionName, int resolvedFinalArity) {
+    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, functionName, resolvedFinalArity);
   }
 
-  public boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName) {
-    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, resolvedFunctionName);
+  public boolean isCallingMacro(String resolvedModuleName, String functionName) {
+    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, functionName);
   }
 
-  public boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity) {
-    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, resolvedFunctionName, resolvedFinalArity);
+  public boolean isCallingMacro(String resolvedModuleName, String functionName, int resolvedFinalArity) {
+    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, functionName, resolvedFinalArity);
   }
 
   @Nullable
@@ -128,11 +128,6 @@ public class ElixirMatchedWhenOperationImpl extends ElixirMatchedExpressionImpl 
   @NotNull
   public IntRange resolvedFinalArityRange() {
     return ElixirPsiImplUtil.resolvedFinalArityRange(this);
-  }
-
-  @NotNull
-  public String resolvedFunctionName() {
-    return ElixirPsiImplUtil.resolvedFunctionName(this);
   }
 
   @NotNull

--- a/gen/org/elixir_lang/psi/impl/ElixirUnaryNumericOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnaryNumericOperationImpl.java
@@ -103,20 +103,20 @@ public class ElixirUnaryNumericOperationImpl extends ASTWrapperPsiElement implem
     return ElixirPsiImplUtil.hasDoBlockOrKeyword(this);
   }
 
-  public boolean isCalling(String resolvedModuleName, String resolvedFunctionName) {
-    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, resolvedFunctionName);
+  public boolean isCalling(String resolvedModuleName, String functionName) {
+    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, functionName);
   }
 
-  public boolean isCalling(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity) {
-    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, resolvedFunctionName, resolvedFinalArity);
+  public boolean isCalling(String resolvedModuleName, String functionName, int resolvedFinalArity) {
+    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, functionName, resolvedFinalArity);
   }
 
-  public boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName) {
-    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, resolvedFunctionName);
+  public boolean isCallingMacro(String resolvedModuleName, String functionName) {
+    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, functionName);
   }
 
-  public boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity) {
-    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, resolvedFunctionName, resolvedFinalArity);
+  public boolean isCallingMacro(String resolvedModuleName, String functionName, int resolvedFinalArity) {
+    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, functionName, resolvedFinalArity);
   }
 
   @Nullable
@@ -167,11 +167,6 @@ public class ElixirUnaryNumericOperationImpl extends ASTWrapperPsiElement implem
   @NotNull
   public IntRange resolvedFinalArityRange() {
     return ElixirPsiImplUtil.resolvedFinalArityRange(this);
-  }
-
-  @NotNull
-  public String resolvedFunctionName() {
-    return ElixirPsiImplUtil.resolvedFunctionName(this);
   }
 
   @NotNull

--- a/gen/org/elixir_lang/psi/impl/ElixirUnmatchedAdditionOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnmatchedAdditionOperationImpl.java
@@ -70,20 +70,20 @@ public class ElixirUnmatchedAdditionOperationImpl extends ElixirUnmatchedExpress
     return ElixirPsiImplUtil.hasDoBlockOrKeyword(this);
   }
 
-  public boolean isCalling(String resolvedModuleName, String resolvedFunctionName) {
-    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, resolvedFunctionName);
+  public boolean isCalling(String resolvedModuleName, String functionName) {
+    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, functionName);
   }
 
-  public boolean isCalling(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity) {
-    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, resolvedFunctionName, resolvedFinalArity);
+  public boolean isCalling(String resolvedModuleName, String functionName, int resolvedFinalArity) {
+    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, functionName, resolvedFinalArity);
   }
 
-  public boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName) {
-    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, resolvedFunctionName);
+  public boolean isCallingMacro(String resolvedModuleName, String functionName) {
+    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, functionName);
   }
 
-  public boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity) {
-    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, resolvedFunctionName, resolvedFinalArity);
+  public boolean isCallingMacro(String resolvedModuleName, String functionName, int resolvedFinalArity) {
+    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, functionName, resolvedFinalArity);
   }
 
   @Nullable
@@ -128,11 +128,6 @@ public class ElixirUnmatchedAdditionOperationImpl extends ElixirUnmatchedExpress
   @NotNull
   public IntRange resolvedFinalArityRange() {
     return ElixirPsiImplUtil.resolvedFinalArityRange(this);
-  }
-
-  @NotNull
-  public String resolvedFunctionName() {
-    return ElixirPsiImplUtil.resolvedFunctionName(this);
   }
 
   @NotNull

--- a/gen/org/elixir_lang/psi/impl/ElixirUnmatchedAndOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnmatchedAndOperationImpl.java
@@ -71,20 +71,20 @@ public class ElixirUnmatchedAndOperationImpl extends ElixirUnmatchedExpressionIm
     return ElixirPsiImplUtil.hasDoBlockOrKeyword(this);
   }
 
-  public boolean isCalling(String resolvedModuleName, String resolvedFunctionName) {
-    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, resolvedFunctionName);
+  public boolean isCalling(String resolvedModuleName, String functionName) {
+    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, functionName);
   }
 
-  public boolean isCalling(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity) {
-    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, resolvedFunctionName, resolvedFinalArity);
+  public boolean isCalling(String resolvedModuleName, String functionName, int resolvedFinalArity) {
+    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, functionName, resolvedFinalArity);
   }
 
-  public boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName) {
-    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, resolvedFunctionName);
+  public boolean isCallingMacro(String resolvedModuleName, String functionName) {
+    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, functionName);
   }
 
-  public boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity) {
-    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, resolvedFunctionName, resolvedFinalArity);
+  public boolean isCallingMacro(String resolvedModuleName, String functionName, int resolvedFinalArity) {
+    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, functionName, resolvedFinalArity);
   }
 
   @Nullable
@@ -129,11 +129,6 @@ public class ElixirUnmatchedAndOperationImpl extends ElixirUnmatchedExpressionIm
   @NotNull
   public IntRange resolvedFinalArityRange() {
     return ElixirPsiImplUtil.resolvedFinalArityRange(this);
-  }
-
-  @NotNull
-  public String resolvedFunctionName() {
-    return ElixirPsiImplUtil.resolvedFunctionName(this);
   }
 
   @NotNull

--- a/gen/org/elixir_lang/psi/impl/ElixirUnmatchedArrowOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnmatchedArrowOperationImpl.java
@@ -70,20 +70,20 @@ public class ElixirUnmatchedArrowOperationImpl extends ElixirUnmatchedExpression
     return ElixirPsiImplUtil.hasDoBlockOrKeyword(this);
   }
 
-  public boolean isCalling(String resolvedModuleName, String resolvedFunctionName) {
-    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, resolvedFunctionName);
+  public boolean isCalling(String resolvedModuleName, String functionName) {
+    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, functionName);
   }
 
-  public boolean isCalling(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity) {
-    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, resolvedFunctionName, resolvedFinalArity);
+  public boolean isCalling(String resolvedModuleName, String functionName, int resolvedFinalArity) {
+    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, functionName, resolvedFinalArity);
   }
 
-  public boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName) {
-    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, resolvedFunctionName);
+  public boolean isCallingMacro(String resolvedModuleName, String functionName) {
+    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, functionName);
   }
 
-  public boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity) {
-    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, resolvedFunctionName, resolvedFinalArity);
+  public boolean isCallingMacro(String resolvedModuleName, String functionName, int resolvedFinalArity) {
+    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, functionName, resolvedFinalArity);
   }
 
   @Nullable
@@ -128,11 +128,6 @@ public class ElixirUnmatchedArrowOperationImpl extends ElixirUnmatchedExpression
   @NotNull
   public IntRange resolvedFinalArityRange() {
     return ElixirPsiImplUtil.resolvedFinalArityRange(this);
-  }
-
-  @NotNull
-  public String resolvedFunctionName() {
-    return ElixirPsiImplUtil.resolvedFunctionName(this);
   }
 
   @NotNull

--- a/gen/org/elixir_lang/psi/impl/ElixirUnmatchedAtUnqualifiedNoParenthesesCallImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnmatchedAtUnqualifiedNoParenthesesCallImpl.java
@@ -99,20 +99,20 @@ public class ElixirUnmatchedAtUnqualifiedNoParenthesesCallImpl extends NamedStub
     return ElixirPsiImplUtil.getUseScope(this);
   }
 
-  public boolean isCalling(String resolvedModuleName, String resolvedFunctionName) {
-    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, resolvedFunctionName);
+  public boolean isCalling(String resolvedModuleName, String functionName) {
+    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, functionName);
   }
 
-  public boolean isCalling(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity) {
-    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, resolvedFunctionName, resolvedFinalArity);
+  public boolean isCalling(String resolvedModuleName, String functionName, int resolvedFinalArity) {
+    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, functionName, resolvedFinalArity);
   }
 
-  public boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName) {
-    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, resolvedFunctionName);
+  public boolean isCallingMacro(String resolvedModuleName, String functionName) {
+    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, functionName);
   }
 
-  public boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity) {
-    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, resolvedFunctionName, resolvedFinalArity);
+  public boolean isCallingMacro(String resolvedModuleName, String functionName, int resolvedFinalArity) {
+    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, functionName, resolvedFinalArity);
   }
 
   @Nullable
@@ -147,11 +147,6 @@ public class ElixirUnmatchedAtUnqualifiedNoParenthesesCallImpl extends NamedStub
   @NotNull
   public IntRange resolvedFinalArityRange() {
     return ElixirPsiImplUtil.resolvedFinalArityRange(this);
-  }
-
-  @Nullable
-  public String resolvedFunctionName() {
-    return ElixirPsiImplUtil.resolvedFunctionName(this);
   }
 
   @Nullable

--- a/gen/org/elixir_lang/psi/impl/ElixirUnmatchedCaptureNonNumericOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnmatchedCaptureNonNumericOperationImpl.java
@@ -66,20 +66,20 @@ public class ElixirUnmatchedCaptureNonNumericOperationImpl extends ElixirUnmatch
     return ElixirPsiImplUtil.hasDoBlockOrKeyword(this);
   }
 
-  public boolean isCalling(String resolvedModuleName, String resolvedFunctionName) {
-    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, resolvedFunctionName);
+  public boolean isCalling(String resolvedModuleName, String functionName) {
+    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, functionName);
   }
 
-  public boolean isCalling(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity) {
-    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, resolvedFunctionName, resolvedFinalArity);
+  public boolean isCalling(String resolvedModuleName, String functionName, int resolvedFinalArity) {
+    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, functionName, resolvedFinalArity);
   }
 
-  public boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName) {
-    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, resolvedFunctionName);
+  public boolean isCallingMacro(String resolvedModuleName, String functionName) {
+    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, functionName);
   }
 
-  public boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity) {
-    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, resolvedFunctionName, resolvedFinalArity);
+  public boolean isCallingMacro(String resolvedModuleName, String functionName, int resolvedFinalArity) {
+    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, functionName, resolvedFinalArity);
   }
 
   @Nullable
@@ -130,11 +130,6 @@ public class ElixirUnmatchedCaptureNonNumericOperationImpl extends ElixirUnmatch
   @NotNull
   public IntRange resolvedFinalArityRange() {
     return ElixirPsiImplUtil.resolvedFinalArityRange(this);
-  }
-
-  @NotNull
-  public String resolvedFunctionName() {
-    return ElixirPsiImplUtil.resolvedFunctionName(this);
   }
 
   @NotNull

--- a/gen/org/elixir_lang/psi/impl/ElixirUnmatchedComparisonOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnmatchedComparisonOperationImpl.java
@@ -70,20 +70,20 @@ public class ElixirUnmatchedComparisonOperationImpl extends ElixirUnmatchedExpre
     return ElixirPsiImplUtil.hasDoBlockOrKeyword(this);
   }
 
-  public boolean isCalling(String resolvedModuleName, String resolvedFunctionName) {
-    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, resolvedFunctionName);
+  public boolean isCalling(String resolvedModuleName, String functionName) {
+    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, functionName);
   }
 
-  public boolean isCalling(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity) {
-    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, resolvedFunctionName, resolvedFinalArity);
+  public boolean isCalling(String resolvedModuleName, String functionName, int resolvedFinalArity) {
+    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, functionName, resolvedFinalArity);
   }
 
-  public boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName) {
-    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, resolvedFunctionName);
+  public boolean isCallingMacro(String resolvedModuleName, String functionName) {
+    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, functionName);
   }
 
-  public boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity) {
-    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, resolvedFunctionName, resolvedFinalArity);
+  public boolean isCallingMacro(String resolvedModuleName, String functionName, int resolvedFinalArity) {
+    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, functionName, resolvedFinalArity);
   }
 
   @Nullable
@@ -128,11 +128,6 @@ public class ElixirUnmatchedComparisonOperationImpl extends ElixirUnmatchedExpre
   @NotNull
   public IntRange resolvedFinalArityRange() {
     return ElixirPsiImplUtil.resolvedFinalArityRange(this);
-  }
-
-  @NotNull
-  public String resolvedFunctionName() {
-    return ElixirPsiImplUtil.resolvedFunctionName(this);
   }
 
   @NotNull

--- a/gen/org/elixir_lang/psi/impl/ElixirUnmatchedDotCallImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnmatchedDotCallImpl.java
@@ -100,20 +100,20 @@ public class ElixirUnmatchedDotCallImpl extends NamedStubbedPsiElementBase<Unmat
     return ElixirPsiImplUtil.getReference(this);
   }
 
-  public boolean isCalling(String resolvedModuleName, String resolvedFunctionName) {
-    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, resolvedFunctionName);
+  public boolean isCalling(String resolvedModuleName, String functionName) {
+    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, functionName);
   }
 
-  public boolean isCalling(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity) {
-    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, resolvedFunctionName, resolvedFinalArity);
+  public boolean isCalling(String resolvedModuleName, String functionName, int resolvedFinalArity) {
+    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, functionName, resolvedFinalArity);
   }
 
-  public boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName) {
-    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, resolvedFunctionName);
+  public boolean isCallingMacro(String resolvedModuleName, String functionName) {
+    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, functionName);
   }
 
-  public boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity) {
-    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, resolvedFunctionName, resolvedFinalArity);
+  public boolean isCallingMacro(String resolvedModuleName, String functionName, int resolvedFinalArity) {
+    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, functionName, resolvedFinalArity);
   }
 
   @Nullable
@@ -148,11 +148,6 @@ public class ElixirUnmatchedDotCallImpl extends NamedStubbedPsiElementBase<Unmat
   @NotNull
   public IntRange resolvedFinalArityRange() {
     return ElixirPsiImplUtil.resolvedFinalArityRange(this);
-  }
-
-  @Nullable
-  public String resolvedFunctionName() {
-    return ElixirPsiImplUtil.resolvedFunctionName(this);
   }
 
   @Nullable

--- a/gen/org/elixir_lang/psi/impl/ElixirUnmatchedInMatchOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnmatchedInMatchOperationImpl.java
@@ -70,20 +70,20 @@ public class ElixirUnmatchedInMatchOperationImpl extends ElixirUnmatchedExpressi
     return ElixirPsiImplUtil.hasDoBlockOrKeyword(this);
   }
 
-  public boolean isCalling(String resolvedModuleName, String resolvedFunctionName) {
-    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, resolvedFunctionName);
+  public boolean isCalling(String resolvedModuleName, String functionName) {
+    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, functionName);
   }
 
-  public boolean isCalling(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity) {
-    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, resolvedFunctionName, resolvedFinalArity);
+  public boolean isCalling(String resolvedModuleName, String functionName, int resolvedFinalArity) {
+    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, functionName, resolvedFinalArity);
   }
 
-  public boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName) {
-    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, resolvedFunctionName);
+  public boolean isCallingMacro(String resolvedModuleName, String functionName) {
+    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, functionName);
   }
 
-  public boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity) {
-    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, resolvedFunctionName, resolvedFinalArity);
+  public boolean isCallingMacro(String resolvedModuleName, String functionName, int resolvedFinalArity) {
+    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, functionName, resolvedFinalArity);
   }
 
   @Nullable
@@ -128,11 +128,6 @@ public class ElixirUnmatchedInMatchOperationImpl extends ElixirUnmatchedExpressi
   @NotNull
   public IntRange resolvedFinalArityRange() {
     return ElixirPsiImplUtil.resolvedFinalArityRange(this);
-  }
-
-  @NotNull
-  public String resolvedFunctionName() {
-    return ElixirPsiImplUtil.resolvedFunctionName(this);
   }
 
   @NotNull

--- a/gen/org/elixir_lang/psi/impl/ElixirUnmatchedInOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnmatchedInOperationImpl.java
@@ -61,20 +61,20 @@ public class ElixirUnmatchedInOperationImpl extends ElixirUnmatchedExpressionImp
     return ElixirPsiImplUtil.hasDoBlockOrKeyword(this);
   }
 
-  public boolean isCalling(String resolvedModuleName, String resolvedFunctionName) {
-    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, resolvedFunctionName);
+  public boolean isCalling(String resolvedModuleName, String functionName) {
+    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, functionName);
   }
 
-  public boolean isCalling(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity) {
-    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, resolvedFunctionName, resolvedFinalArity);
+  public boolean isCalling(String resolvedModuleName, String functionName, int resolvedFinalArity) {
+    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, functionName, resolvedFinalArity);
   }
 
-  public boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName) {
-    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, resolvedFunctionName);
+  public boolean isCallingMacro(String resolvedModuleName, String functionName) {
+    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, functionName);
   }
 
-  public boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity) {
-    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, resolvedFunctionName, resolvedFinalArity);
+  public boolean isCallingMacro(String resolvedModuleName, String functionName, int resolvedFinalArity) {
+    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, functionName, resolvedFinalArity);
   }
 
   @Nullable
@@ -119,11 +119,6 @@ public class ElixirUnmatchedInOperationImpl extends ElixirUnmatchedExpressionImp
   @NotNull
   public IntRange resolvedFinalArityRange() {
     return ElixirPsiImplUtil.resolvedFinalArityRange(this);
-  }
-
-  @NotNull
-  public String resolvedFunctionName() {
-    return ElixirPsiImplUtil.resolvedFunctionName(this);
   }
 
   @NotNull

--- a/gen/org/elixir_lang/psi/impl/ElixirUnmatchedMatchOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnmatchedMatchOperationImpl.java
@@ -71,20 +71,20 @@ public class ElixirUnmatchedMatchOperationImpl extends ElixirUnmatchedExpression
     return ElixirPsiImplUtil.hasDoBlockOrKeyword(this);
   }
 
-  public boolean isCalling(String resolvedModuleName, String resolvedFunctionName) {
-    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, resolvedFunctionName);
+  public boolean isCalling(String resolvedModuleName, String functionName) {
+    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, functionName);
   }
 
-  public boolean isCalling(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity) {
-    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, resolvedFunctionName, resolvedFinalArity);
+  public boolean isCalling(String resolvedModuleName, String functionName, int resolvedFinalArity) {
+    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, functionName, resolvedFinalArity);
   }
 
-  public boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName) {
-    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, resolvedFunctionName);
+  public boolean isCallingMacro(String resolvedModuleName, String functionName) {
+    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, functionName);
   }
 
-  public boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity) {
-    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, resolvedFunctionName, resolvedFinalArity);
+  public boolean isCallingMacro(String resolvedModuleName, String functionName, int resolvedFinalArity) {
+    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, functionName, resolvedFinalArity);
   }
 
   @Nullable
@@ -129,11 +129,6 @@ public class ElixirUnmatchedMatchOperationImpl extends ElixirUnmatchedExpression
   @NotNull
   public IntRange resolvedFinalArityRange() {
     return ElixirPsiImplUtil.resolvedFinalArityRange(this);
-  }
-
-  @NotNull
-  public String resolvedFunctionName() {
-    return ElixirPsiImplUtil.resolvedFunctionName(this);
   }
 
   @NotNull

--- a/gen/org/elixir_lang/psi/impl/ElixirUnmatchedMultiplicationOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnmatchedMultiplicationOperationImpl.java
@@ -70,20 +70,20 @@ public class ElixirUnmatchedMultiplicationOperationImpl extends ElixirUnmatchedE
     return ElixirPsiImplUtil.hasDoBlockOrKeyword(this);
   }
 
-  public boolean isCalling(String resolvedModuleName, String resolvedFunctionName) {
-    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, resolvedFunctionName);
+  public boolean isCalling(String resolvedModuleName, String functionName) {
+    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, functionName);
   }
 
-  public boolean isCalling(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity) {
-    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, resolvedFunctionName, resolvedFinalArity);
+  public boolean isCalling(String resolvedModuleName, String functionName, int resolvedFinalArity) {
+    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, functionName, resolvedFinalArity);
   }
 
-  public boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName) {
-    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, resolvedFunctionName);
+  public boolean isCallingMacro(String resolvedModuleName, String functionName) {
+    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, functionName);
   }
 
-  public boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity) {
-    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, resolvedFunctionName, resolvedFinalArity);
+  public boolean isCallingMacro(String resolvedModuleName, String functionName, int resolvedFinalArity) {
+    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, functionName, resolvedFinalArity);
   }
 
   @Nullable
@@ -128,11 +128,6 @@ public class ElixirUnmatchedMultiplicationOperationImpl extends ElixirUnmatchedE
   @NotNull
   public IntRange resolvedFinalArityRange() {
     return ElixirPsiImplUtil.resolvedFinalArityRange(this);
-  }
-
-  @NotNull
-  public String resolvedFunctionName() {
-    return ElixirPsiImplUtil.resolvedFunctionName(this);
   }
 
   @NotNull

--- a/gen/org/elixir_lang/psi/impl/ElixirUnmatchedOrOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnmatchedOrOperationImpl.java
@@ -70,20 +70,20 @@ public class ElixirUnmatchedOrOperationImpl extends ElixirUnmatchedExpressionImp
     return ElixirPsiImplUtil.hasDoBlockOrKeyword(this);
   }
 
-  public boolean isCalling(String resolvedModuleName, String resolvedFunctionName) {
-    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, resolvedFunctionName);
+  public boolean isCalling(String resolvedModuleName, String functionName) {
+    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, functionName);
   }
 
-  public boolean isCalling(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity) {
-    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, resolvedFunctionName, resolvedFinalArity);
+  public boolean isCalling(String resolvedModuleName, String functionName, int resolvedFinalArity) {
+    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, functionName, resolvedFinalArity);
   }
 
-  public boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName) {
-    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, resolvedFunctionName);
+  public boolean isCallingMacro(String resolvedModuleName, String functionName) {
+    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, functionName);
   }
 
-  public boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity) {
-    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, resolvedFunctionName, resolvedFinalArity);
+  public boolean isCallingMacro(String resolvedModuleName, String functionName, int resolvedFinalArity) {
+    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, functionName, resolvedFinalArity);
   }
 
   @Nullable
@@ -128,11 +128,6 @@ public class ElixirUnmatchedOrOperationImpl extends ElixirUnmatchedExpressionImp
   @NotNull
   public IntRange resolvedFinalArityRange() {
     return ElixirPsiImplUtil.resolvedFinalArityRange(this);
-  }
-
-  @NotNull
-  public String resolvedFunctionName() {
-    return ElixirPsiImplUtil.resolvedFunctionName(this);
   }
 
   @NotNull

--- a/gen/org/elixir_lang/psi/impl/ElixirUnmatchedPipeOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnmatchedPipeOperationImpl.java
@@ -70,20 +70,20 @@ public class ElixirUnmatchedPipeOperationImpl extends ElixirUnmatchedExpressionI
     return ElixirPsiImplUtil.hasDoBlockOrKeyword(this);
   }
 
-  public boolean isCalling(String resolvedModuleName, String resolvedFunctionName) {
-    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, resolvedFunctionName);
+  public boolean isCalling(String resolvedModuleName, String functionName) {
+    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, functionName);
   }
 
-  public boolean isCalling(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity) {
-    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, resolvedFunctionName, resolvedFinalArity);
+  public boolean isCalling(String resolvedModuleName, String functionName, int resolvedFinalArity) {
+    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, functionName, resolvedFinalArity);
   }
 
-  public boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName) {
-    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, resolvedFunctionName);
+  public boolean isCallingMacro(String resolvedModuleName, String functionName) {
+    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, functionName);
   }
 
-  public boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity) {
-    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, resolvedFunctionName, resolvedFinalArity);
+  public boolean isCallingMacro(String resolvedModuleName, String functionName, int resolvedFinalArity) {
+    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, functionName, resolvedFinalArity);
   }
 
   @Nullable
@@ -128,11 +128,6 @@ public class ElixirUnmatchedPipeOperationImpl extends ElixirUnmatchedExpressionI
   @NotNull
   public IntRange resolvedFinalArityRange() {
     return ElixirPsiImplUtil.resolvedFinalArityRange(this);
-  }
-
-  @NotNull
-  public String resolvedFunctionName() {
-    return ElixirPsiImplUtil.resolvedFunctionName(this);
   }
 
   @NotNull

--- a/gen/org/elixir_lang/psi/impl/ElixirUnmatchedQualifiedBracketOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnmatchedQualifiedBracketOperationImpl.java
@@ -3,6 +3,7 @@ package org.elixir_lang.psi.impl;
 
 import com.ericsson.otp.erlang.OtpErlangObject;
 import com.intellij.lang.ASTNode;
+import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
 import org.elixir_lang.psi.*;
@@ -45,6 +46,11 @@ public class ElixirUnmatchedQualifiedBracketOperationImpl extends ElixirUnmatche
   @NotNull
   public ElixirUnmatchedExpression getUnmatchedExpression() {
     return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirUnmatchedExpression.class));
+  }
+
+  @NotNull
+  public PsiElement qualifier() {
+    return ElixirPsiImplUtil.qualifier(this);
   }
 
   @NotNull

--- a/gen/org/elixir_lang/psi/impl/ElixirUnmatchedQualifiedNoArgumentsCallImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnmatchedQualifiedNoArgumentsCallImpl.java
@@ -134,6 +134,11 @@ public class ElixirUnmatchedQualifiedNoArgumentsCallImpl extends NamedStubbedPsi
   }
 
   @NotNull
+  public PsiElement qualifier() {
+    return ElixirPsiImplUtil.qualifier(this);
+  }
+
+  @NotNull
   public OtpErlangObject quote() {
     return ElixirPsiImplUtil.quote(this);
   }

--- a/gen/org/elixir_lang/psi/impl/ElixirUnmatchedQualifiedNoArgumentsCallImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnmatchedQualifiedNoArgumentsCallImpl.java
@@ -98,20 +98,20 @@ public class ElixirUnmatchedQualifiedNoArgumentsCallImpl extends NamedStubbedPsi
     return ElixirPsiImplUtil.getReference(this);
   }
 
-  public boolean isCalling(String resolvedModuleName, String resolvedFunctionName) {
-    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, resolvedFunctionName);
+  public boolean isCalling(String resolvedModuleName, String functionName) {
+    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, functionName);
   }
 
-  public boolean isCalling(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity) {
-    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, resolvedFunctionName, resolvedFinalArity);
+  public boolean isCalling(String resolvedModuleName, String functionName, int resolvedFinalArity) {
+    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, functionName, resolvedFinalArity);
   }
 
-  public boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName) {
-    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, resolvedFunctionName);
+  public boolean isCallingMacro(String resolvedModuleName, String functionName) {
+    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, functionName);
   }
 
-  public boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity) {
-    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, resolvedFunctionName, resolvedFinalArity);
+  public boolean isCallingMacro(String resolvedModuleName, String functionName, int resolvedFinalArity) {
+    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, functionName, resolvedFinalArity);
   }
 
   @NotNull
@@ -146,11 +146,6 @@ public class ElixirUnmatchedQualifiedNoArgumentsCallImpl extends NamedStubbedPsi
   @NotNull
   public IntRange resolvedFinalArityRange() {
     return ElixirPsiImplUtil.resolvedFinalArityRange(this);
-  }
-
-  @NotNull
-  public String resolvedFunctionName() {
-    return ElixirPsiImplUtil.resolvedFunctionName(this);
   }
 
   @NotNull

--- a/gen/org/elixir_lang/psi/impl/ElixirUnmatchedQualifiedNoParenthesesCallImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnmatchedQualifiedNoParenthesesCallImpl.java
@@ -140,6 +140,11 @@ public class ElixirUnmatchedQualifiedNoParenthesesCallImpl extends NamedStubbedP
   }
 
   @NotNull
+  public PsiElement qualifier() {
+    return ElixirPsiImplUtil.qualifier(this);
+  }
+
+  @NotNull
   public OtpErlangObject quote() {
     return ElixirPsiImplUtil.quote(this);
   }

--- a/gen/org/elixir_lang/psi/impl/ElixirUnmatchedQualifiedNoParenthesesCallImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnmatchedQualifiedNoParenthesesCallImpl.java
@@ -104,20 +104,20 @@ public class ElixirUnmatchedQualifiedNoParenthesesCallImpl extends NamedStubbedP
     return ElixirPsiImplUtil.getReference(this);
   }
 
-  public boolean isCalling(String resolvedModuleName, String resolvedFunctionName) {
-    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, resolvedFunctionName);
+  public boolean isCalling(String resolvedModuleName, String functionName) {
+    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, functionName);
   }
 
-  public boolean isCalling(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity) {
-    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, resolvedFunctionName, resolvedFinalArity);
+  public boolean isCalling(String resolvedModuleName, String functionName, int resolvedFinalArity) {
+    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, functionName, resolvedFinalArity);
   }
 
-  public boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName) {
-    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, resolvedFunctionName);
+  public boolean isCallingMacro(String resolvedModuleName, String functionName) {
+    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, functionName);
   }
 
-  public boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity) {
-    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, resolvedFunctionName, resolvedFinalArity);
+  public boolean isCallingMacro(String resolvedModuleName, String functionName, int resolvedFinalArity) {
+    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, functionName, resolvedFinalArity);
   }
 
   @NotNull
@@ -152,11 +152,6 @@ public class ElixirUnmatchedQualifiedNoParenthesesCallImpl extends NamedStubbedP
   @NotNull
   public IntRange resolvedFinalArityRange() {
     return ElixirPsiImplUtil.resolvedFinalArityRange(this);
-  }
-
-  @NotNull
-  public String resolvedFunctionName() {
-    return ElixirPsiImplUtil.resolvedFunctionName(this);
   }
 
   @NotNull

--- a/gen/org/elixir_lang/psi/impl/ElixirUnmatchedQualifiedParenthesesCallImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnmatchedQualifiedParenthesesCallImpl.java
@@ -140,6 +140,11 @@ public class ElixirUnmatchedQualifiedParenthesesCallImpl extends NamedStubbedPsi
   }
 
   @NotNull
+  public PsiElement qualifier() {
+    return ElixirPsiImplUtil.qualifier(this);
+  }
+
+  @NotNull
   public OtpErlangObject quote() {
     return ElixirPsiImplUtil.quote(this);
   }

--- a/gen/org/elixir_lang/psi/impl/ElixirUnmatchedQualifiedParenthesesCallImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnmatchedQualifiedParenthesesCallImpl.java
@@ -104,20 +104,20 @@ public class ElixirUnmatchedQualifiedParenthesesCallImpl extends NamedStubbedPsi
     return ElixirPsiImplUtil.getReference(this);
   }
 
-  public boolean isCalling(String resolvedModuleName, String resolvedFunctionName) {
-    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, resolvedFunctionName);
+  public boolean isCalling(String resolvedModuleName, String functionName) {
+    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, functionName);
   }
 
-  public boolean isCalling(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity) {
-    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, resolvedFunctionName, resolvedFinalArity);
+  public boolean isCalling(String resolvedModuleName, String functionName, int resolvedFinalArity) {
+    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, functionName, resolvedFinalArity);
   }
 
-  public boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName) {
-    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, resolvedFunctionName);
+  public boolean isCallingMacro(String resolvedModuleName, String functionName) {
+    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, functionName);
   }
 
-  public boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity) {
-    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, resolvedFunctionName, resolvedFinalArity);
+  public boolean isCallingMacro(String resolvedModuleName, String functionName, int resolvedFinalArity) {
+    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, functionName, resolvedFinalArity);
   }
 
   @NotNull
@@ -152,11 +152,6 @@ public class ElixirUnmatchedQualifiedParenthesesCallImpl extends NamedStubbedPsi
   @NotNull
   public IntRange resolvedFinalArityRange() {
     return ElixirPsiImplUtil.resolvedFinalArityRange(this);
-  }
-
-  @NotNull
-  public String resolvedFunctionName() {
-    return ElixirPsiImplUtil.resolvedFunctionName(this);
   }
 
   @NotNull

--- a/gen/org/elixir_lang/psi/impl/ElixirUnmatchedRelationalOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnmatchedRelationalOperationImpl.java
@@ -70,20 +70,20 @@ public class ElixirUnmatchedRelationalOperationImpl extends ElixirUnmatchedExpre
     return ElixirPsiImplUtil.hasDoBlockOrKeyword(this);
   }
 
-  public boolean isCalling(String resolvedModuleName, String resolvedFunctionName) {
-    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, resolvedFunctionName);
+  public boolean isCalling(String resolvedModuleName, String functionName) {
+    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, functionName);
   }
 
-  public boolean isCalling(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity) {
-    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, resolvedFunctionName, resolvedFinalArity);
+  public boolean isCalling(String resolvedModuleName, String functionName, int resolvedFinalArity) {
+    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, functionName, resolvedFinalArity);
   }
 
-  public boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName) {
-    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, resolvedFunctionName);
+  public boolean isCallingMacro(String resolvedModuleName, String functionName) {
+    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, functionName);
   }
 
-  public boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity) {
-    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, resolvedFunctionName, resolvedFinalArity);
+  public boolean isCallingMacro(String resolvedModuleName, String functionName, int resolvedFinalArity) {
+    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, functionName, resolvedFinalArity);
   }
 
   @Nullable
@@ -128,11 +128,6 @@ public class ElixirUnmatchedRelationalOperationImpl extends ElixirUnmatchedExpre
   @NotNull
   public IntRange resolvedFinalArityRange() {
     return ElixirPsiImplUtil.resolvedFinalArityRange(this);
-  }
-
-  @NotNull
-  public String resolvedFunctionName() {
-    return ElixirPsiImplUtil.resolvedFunctionName(this);
   }
 
   @NotNull

--- a/gen/org/elixir_lang/psi/impl/ElixirUnmatchedTwoOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnmatchedTwoOperationImpl.java
@@ -70,20 +70,20 @@ public class ElixirUnmatchedTwoOperationImpl extends ElixirUnmatchedExpressionIm
     return ElixirPsiImplUtil.hasDoBlockOrKeyword(this);
   }
 
-  public boolean isCalling(String resolvedModuleName, String resolvedFunctionName) {
-    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, resolvedFunctionName);
+  public boolean isCalling(String resolvedModuleName, String functionName) {
+    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, functionName);
   }
 
-  public boolean isCalling(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity) {
-    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, resolvedFunctionName, resolvedFinalArity);
+  public boolean isCalling(String resolvedModuleName, String functionName, int resolvedFinalArity) {
+    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, functionName, resolvedFinalArity);
   }
 
-  public boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName) {
-    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, resolvedFunctionName);
+  public boolean isCallingMacro(String resolvedModuleName, String functionName) {
+    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, functionName);
   }
 
-  public boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity) {
-    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, resolvedFunctionName, resolvedFinalArity);
+  public boolean isCallingMacro(String resolvedModuleName, String functionName, int resolvedFinalArity) {
+    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, functionName, resolvedFinalArity);
   }
 
   @Nullable
@@ -128,11 +128,6 @@ public class ElixirUnmatchedTwoOperationImpl extends ElixirUnmatchedExpressionIm
   @NotNull
   public IntRange resolvedFinalArityRange() {
     return ElixirPsiImplUtil.resolvedFinalArityRange(this);
-  }
-
-  @NotNull
-  public String resolvedFunctionName() {
-    return ElixirPsiImplUtil.resolvedFunctionName(this);
   }
 
   @NotNull

--- a/gen/org/elixir_lang/psi/impl/ElixirUnmatchedTypeOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnmatchedTypeOperationImpl.java
@@ -70,20 +70,20 @@ public class ElixirUnmatchedTypeOperationImpl extends ElixirUnmatchedExpressionI
     return ElixirPsiImplUtil.hasDoBlockOrKeyword(this);
   }
 
-  public boolean isCalling(String resolvedModuleName, String resolvedFunctionName) {
-    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, resolvedFunctionName);
+  public boolean isCalling(String resolvedModuleName, String functionName) {
+    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, functionName);
   }
 
-  public boolean isCalling(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity) {
-    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, resolvedFunctionName, resolvedFinalArity);
+  public boolean isCalling(String resolvedModuleName, String functionName, int resolvedFinalArity) {
+    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, functionName, resolvedFinalArity);
   }
 
-  public boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName) {
-    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, resolvedFunctionName);
+  public boolean isCallingMacro(String resolvedModuleName, String functionName) {
+    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, functionName);
   }
 
-  public boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity) {
-    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, resolvedFunctionName, resolvedFinalArity);
+  public boolean isCallingMacro(String resolvedModuleName, String functionName, int resolvedFinalArity) {
+    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, functionName, resolvedFinalArity);
   }
 
   @Nullable
@@ -128,11 +128,6 @@ public class ElixirUnmatchedTypeOperationImpl extends ElixirUnmatchedExpressionI
   @NotNull
   public IntRange resolvedFinalArityRange() {
     return ElixirPsiImplUtil.resolvedFinalArityRange(this);
-  }
-
-  @NotNull
-  public String resolvedFunctionName() {
-    return ElixirPsiImplUtil.resolvedFunctionName(this);
   }
 
   @NotNull

--- a/gen/org/elixir_lang/psi/impl/ElixirUnmatchedUnaryNonNumericOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnmatchedUnaryNonNumericOperationImpl.java
@@ -66,20 +66,20 @@ public class ElixirUnmatchedUnaryNonNumericOperationImpl extends ElixirUnmatched
     return ElixirPsiImplUtil.hasDoBlockOrKeyword(this);
   }
 
-  public boolean isCalling(String resolvedModuleName, String resolvedFunctionName) {
-    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, resolvedFunctionName);
+  public boolean isCalling(String resolvedModuleName, String functionName) {
+    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, functionName);
   }
 
-  public boolean isCalling(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity) {
-    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, resolvedFunctionName, resolvedFinalArity);
+  public boolean isCalling(String resolvedModuleName, String functionName, int resolvedFinalArity) {
+    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, functionName, resolvedFinalArity);
   }
 
-  public boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName) {
-    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, resolvedFunctionName);
+  public boolean isCallingMacro(String resolvedModuleName, String functionName) {
+    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, functionName);
   }
 
-  public boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity) {
-    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, resolvedFunctionName, resolvedFinalArity);
+  public boolean isCallingMacro(String resolvedModuleName, String functionName, int resolvedFinalArity) {
+    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, functionName, resolvedFinalArity);
   }
 
   @Nullable
@@ -130,11 +130,6 @@ public class ElixirUnmatchedUnaryNonNumericOperationImpl extends ElixirUnmatched
   @NotNull
   public IntRange resolvedFinalArityRange() {
     return ElixirPsiImplUtil.resolvedFinalArityRange(this);
-  }
-
-  @NotNull
-  public String resolvedFunctionName() {
-    return ElixirPsiImplUtil.resolvedFunctionName(this);
   }
 
   @NotNull

--- a/gen/org/elixir_lang/psi/impl/ElixirUnmatchedUnqualifiedNoArgumentsCallImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnmatchedUnqualifiedNoArgumentsCallImpl.java
@@ -96,20 +96,20 @@ public class ElixirUnmatchedUnqualifiedNoArgumentsCallImpl extends NamedStubbedP
     return ElixirPsiImplUtil.getUseScope(this);
   }
 
-  public boolean isCalling(String resolvedModuleName, String resolvedFunctionName) {
-    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, resolvedFunctionName);
+  public boolean isCalling(String resolvedModuleName, String functionName) {
+    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, functionName);
   }
 
-  public boolean isCalling(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity) {
-    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, resolvedFunctionName, resolvedFinalArity);
+  public boolean isCalling(String resolvedModuleName, String functionName, int resolvedFinalArity) {
+    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, functionName, resolvedFinalArity);
   }
 
-  public boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName) {
-    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, resolvedFunctionName);
+  public boolean isCallingMacro(String resolvedModuleName, String functionName) {
+    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, functionName);
   }
 
-  public boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity) {
-    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, resolvedFunctionName, resolvedFinalArity);
+  public boolean isCallingMacro(String resolvedModuleName, String functionName, int resolvedFinalArity) {
+    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, functionName, resolvedFinalArity);
   }
 
   @Nullable
@@ -144,11 +144,6 @@ public class ElixirUnmatchedUnqualifiedNoArgumentsCallImpl extends NamedStubbedP
   @NotNull
   public IntRange resolvedFinalArityRange() {
     return ElixirPsiImplUtil.resolvedFinalArityRange(this);
-  }
-
-  @NotNull
-  public String resolvedFunctionName() {
-    return ElixirPsiImplUtil.resolvedFunctionName(this);
   }
 
   @NotNull

--- a/gen/org/elixir_lang/psi/impl/ElixirUnmatchedUnqualifiedNoParenthesesCallImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnmatchedUnqualifiedNoParenthesesCallImpl.java
@@ -93,20 +93,20 @@ public class ElixirUnmatchedUnqualifiedNoParenthesesCallImpl extends NamedStubbe
     return ElixirPsiImplUtil.getReference(this);
   }
 
-  public boolean isCalling(String resolvedModuleName, String resolvedFunctionName) {
-    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, resolvedFunctionName);
+  public boolean isCalling(String resolvedModuleName, String functionName) {
+    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, functionName);
   }
 
-  public boolean isCalling(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity) {
-    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, resolvedFunctionName, resolvedFinalArity);
+  public boolean isCalling(String resolvedModuleName, String functionName, int resolvedFinalArity) {
+    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, functionName, resolvedFinalArity);
   }
 
-  public boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName) {
-    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, resolvedFunctionName);
+  public boolean isCallingMacro(String resolvedModuleName, String functionName) {
+    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, functionName);
   }
 
-  public boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity) {
-    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, resolvedFunctionName, resolvedFinalArity);
+  public boolean isCallingMacro(String resolvedModuleName, String functionName, int resolvedFinalArity) {
+    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, functionName, resolvedFinalArity);
   }
 
   @Nullable
@@ -141,11 +141,6 @@ public class ElixirUnmatchedUnqualifiedNoParenthesesCallImpl extends NamedStubbe
   @NotNull
   public IntRange resolvedFinalArityRange() {
     return ElixirPsiImplUtil.resolvedFinalArityRange(this);
-  }
-
-  @NotNull
-  public String resolvedFunctionName() {
-    return ElixirPsiImplUtil.resolvedFunctionName(this);
   }
 
   @NotNull

--- a/gen/org/elixir_lang/psi/impl/ElixirUnmatchedUnqualifiedParenthesesCallImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnmatchedUnqualifiedParenthesesCallImpl.java
@@ -93,20 +93,20 @@ public class ElixirUnmatchedUnqualifiedParenthesesCallImpl extends NamedStubbedP
     return ElixirPsiImplUtil.getReference(this);
   }
 
-  public boolean isCalling(String resolvedModuleName, String resolvedFunctionName) {
-    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, resolvedFunctionName);
+  public boolean isCalling(String resolvedModuleName, String functionName) {
+    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, functionName);
   }
 
-  public boolean isCalling(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity) {
-    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, resolvedFunctionName, resolvedFinalArity);
+  public boolean isCalling(String resolvedModuleName, String functionName, int resolvedFinalArity) {
+    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, functionName, resolvedFinalArity);
   }
 
-  public boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName) {
-    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, resolvedFunctionName);
+  public boolean isCallingMacro(String resolvedModuleName, String functionName) {
+    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, functionName);
   }
 
-  public boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity) {
-    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, resolvedFunctionName, resolvedFinalArity);
+  public boolean isCallingMacro(String resolvedModuleName, String functionName, int resolvedFinalArity) {
+    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, functionName, resolvedFinalArity);
   }
 
   @Nullable
@@ -141,11 +141,6 @@ public class ElixirUnmatchedUnqualifiedParenthesesCallImpl extends NamedStubbedP
   @NotNull
   public IntRange resolvedFinalArityRange() {
     return ElixirPsiImplUtil.resolvedFinalArityRange(this);
-  }
-
-  @NotNull
-  public String resolvedFunctionName() {
-    return ElixirPsiImplUtil.resolvedFunctionName(this);
   }
 
   @NotNull

--- a/gen/org/elixir_lang/psi/impl/ElixirUnmatchedWhenOperationImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnmatchedWhenOperationImpl.java
@@ -70,20 +70,20 @@ public class ElixirUnmatchedWhenOperationImpl extends ElixirUnmatchedExpressionI
     return ElixirPsiImplUtil.hasDoBlockOrKeyword(this);
   }
 
-  public boolean isCalling(String resolvedModuleName, String resolvedFunctionName) {
-    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, resolvedFunctionName);
+  public boolean isCalling(String resolvedModuleName, String functionName) {
+    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, functionName);
   }
 
-  public boolean isCalling(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity) {
-    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, resolvedFunctionName, resolvedFinalArity);
+  public boolean isCalling(String resolvedModuleName, String functionName, int resolvedFinalArity) {
+    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, functionName, resolvedFinalArity);
   }
 
-  public boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName) {
-    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, resolvedFunctionName);
+  public boolean isCallingMacro(String resolvedModuleName, String functionName) {
+    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, functionName);
   }
 
-  public boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity) {
-    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, resolvedFunctionName, resolvedFinalArity);
+  public boolean isCallingMacro(String resolvedModuleName, String functionName, int resolvedFinalArity) {
+    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, functionName, resolvedFinalArity);
   }
 
   @Nullable
@@ -128,11 +128,6 @@ public class ElixirUnmatchedWhenOperationImpl extends ElixirUnmatchedExpressionI
   @NotNull
   public IntRange resolvedFinalArityRange() {
     return ElixirPsiImplUtil.resolvedFinalArityRange(this);
-  }
-
-  @NotNull
-  public String resolvedFunctionName() {
-    return ElixirPsiImplUtil.resolvedFunctionName(this);
   }
 
   @NotNull

--- a/gen/org/elixir_lang/psi/impl/ElixirUnqualifiedNoParenthesesManyArgumentsCallImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnqualifiedNoParenthesesManyArgumentsCallImpl.java
@@ -117,20 +117,20 @@ public class ElixirUnqualifiedNoParenthesesManyArgumentsCallImpl extends NamedSt
     return ElixirPsiImplUtil.getReference(this);
   }
 
-  public boolean isCalling(String resolvedModuleName, String resolvedFunctionName) {
-    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, resolvedFunctionName);
+  public boolean isCalling(String resolvedModuleName, String functionName) {
+    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, functionName);
   }
 
-  public boolean isCalling(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity) {
-    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, resolvedFunctionName, resolvedFinalArity);
+  public boolean isCalling(String resolvedModuleName, String functionName, int resolvedFinalArity) {
+    return ElixirPsiImplUtil.isCalling(this, resolvedModuleName, functionName, resolvedFinalArity);
   }
 
-  public boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName) {
-    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, resolvedFunctionName);
+  public boolean isCallingMacro(String resolvedModuleName, String functionName) {
+    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, functionName);
   }
 
-  public boolean isCallingMacro(String resolvedModuleName, String resolvedFunctionName, int resolvedFinalArity) {
-    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, resolvedFunctionName, resolvedFinalArity);
+  public boolean isCallingMacro(String resolvedModuleName, String functionName, int resolvedFinalArity) {
+    return ElixirPsiImplUtil.isCallingMacro(this, resolvedModuleName, functionName, resolvedFinalArity);
   }
 
   @Nullable
@@ -165,11 +165,6 @@ public class ElixirUnqualifiedNoParenthesesManyArgumentsCallImpl extends NamedSt
   @NotNull
   public IntRange resolvedFinalArityRange() {
     return ElixirPsiImplUtil.resolvedFinalArityRange(this);
-  }
-
-  @NotNull
-  public String resolvedFunctionName() {
-    return ElixirPsiImplUtil.resolvedFunctionName(this);
   }
 
   @NotNull

--- a/src/org/elixir_lang/Elixir.bnf
+++ b/src/org/elixir_lang/Elixir.bnf
@@ -8,8 +8,8 @@
   extends("unmatched(AccessExpression|.*Operation|((((At)?Unq)|Q)ualified(No)?(Argument|Parenthese)s|Dot)Call|Qualified(Alias|MultipleAliases))")=unmatchedExpression
 
   // name identifier owner calls - no argument calls are included because in a pipeline they can have effective arguments
-  elementTypeFactory("((un)?matched((((At)?Unq)|Q)ualified(No)?(Argument|Parenthese)s|Dot)||unqualifiedNoParenthesesManyArguments)Call")="org.elixir_lang.ElementTypeFactory.factory"
-  methods(           "((un)?matched((((At)?Unq)|Q)ualified(No)?(Argument|Parenthese)s|Dot)||unqualifiedNoParenthesesManyArguments)Call")=[
+  elementTypeFactory("((un)?matched((((At)?Unq)|Q)ualified(No)?(Argument|Parenthese)s|Dot)|unqualifiedNoParenthesesManyArguments)Call")="org.elixir_lang.ElementTypeFactory.factory"
+  methods(           "((un)?matched((At)?Unqualified(No)?(Argument|Parenthese)s|Dot)|unqualifiedNoParenthesesManyArguments)Call")=[
     canonicalName
     canonicalNameSet
     functionName
@@ -27,6 +27,37 @@
     primaryArguments
     primaryArity
     processDeclarations
+    quote
+    resolvedFinalArity
+    resolvedFinalArityRange
+    resolvedModuleName
+    resolvedPrimaryArity
+    resolvedSecondaryArity
+    secondaryArguments
+    secondaryArity
+    setName
+  ]
+
+  // qualified calls that need to implement #qualifier()
+  methods("(un)?matchedQualified(No)?(Argument|Parenthese)sCall")=[
+    canonicalName
+    canonicalNameSet
+    functionName
+    functionNameElement
+    getDoBlock
+    hasDoBlockOrKeyword
+    getName
+    getNameIdentifier
+    getReference
+    getStub
+    getUseScope
+    isCalling
+    isCallingMacro
+    moduleName
+    primaryArguments
+    primaryArity
+    processDeclarations
+    qualifier
     quote
     resolvedFinalArity
     resolvedFinalArityRange
@@ -178,6 +209,15 @@
     "org.elixir_lang.psi.UnaryNonNumericOperation"
   ]
   // method set by prefix operations above
+
+  // QualifiedBracketOperation
+  implements("(un)?matchedQualifiedBracketOperation")=[
+    "org.elixir_lang.psi.QualifiedBracketOperation"
+  ]
+  methods(   "(un)?matchedQualifiedBracketOperation")=[
+    qualifier
+    quote
+  ]
 
   // QualifiedMultipleAliases
   implements("(un)?matchedQualifiedMultipleAliases")=[
@@ -1851,7 +1891,6 @@ multipleAliases ::= OPENING_CURLY EOL*
  */
 
 matchedQualifiedBracketOperation ::= matchedExpression dotInfixOperator relativeIdentifier CALL bracketArguments
-                                     { implements = "org.elixir_lang.psi.QualifiedBracketOperation" methods = [quote] }
 
 /*
  * Qualified Parentheses Call
@@ -2570,7 +2609,6 @@ unmatchedQualifiedMultipleAliases ::= unmatchedExpression dotInfixOperator multi
  */
 
 unmatchedQualifiedBracketOperation ::= unmatchedExpression dotInfixOperator relativeIdentifier CALL bracketArguments
-                                       { implements = "org.elixir_lang.psi.QualifiedBracketOperation" methods = [quote] }
 
 /*
  * Qualified Parentheses Call

--- a/src/org/elixir_lang/Elixir.bnf
+++ b/src/org/elixir_lang/Elixir.bnf
@@ -30,7 +30,6 @@
     quote
     resolvedFinalArity
     resolvedFinalArityRange
-    resolvedFunctionName
     resolvedModuleName
     resolvedPrimaryArity
     resolvedSecondaryArity
@@ -71,7 +70,6 @@
     quote
     resolvedFinalArity
     resolvedFinalArityRange
-    resolvedFunctionName
     resolvedModuleName
     resolvedPrimaryArity
     resolvedSecondaryArity
@@ -157,7 +155,6 @@
     secondaryArity
     resolvedFinalArity
     resolvedFinalArityRange
-    resolvedFunctionName
     resolvedModuleName
     resolvedPrimaryArity
     resolvedSecondaryArity

--- a/src/org/elixir_lang/annonator/Kernel.java
+++ b/src/org/elixir_lang/annonator/Kernel.java
@@ -27,7 +27,7 @@ public class Kernel implements Annotator, DumbAware {
      * CONSTANTS
      */
 
-    private static final Set<String> RESOLVED_FUNCTION_NAME_SET = new HashSet<String>(
+    private static final Set<String> FUNCTION_NAME_SET = new HashSet<String>(
             Arrays.asList(
                     new String[] {
                             "abs",
@@ -90,7 +90,7 @@ public class Kernel implements Annotator, DumbAware {
             )
     );
 
-    private static final Set<String> RESOLVED_MACRO_NAME_SET = new HashSet<String>(
+    private static final Set<String> MACRO_NAME_SET = new HashSet<String>(
             Arrays.asList(
                     new String[] {
                             "@",
@@ -138,7 +138,7 @@ public class Kernel implements Annotator, DumbAware {
             )
     );
 
-    private static final Set<String> RESOLVED_SPECIAL_FORMS_MACRO_NAME_SET = new HashSet<String>(
+    private static final Set<String> SPECIAL_FORMS_MACRO_NAME_SET = new HashSet<String>(
             Arrays.asList(
                     new String[]{
                             "__CALLER__",
@@ -204,11 +204,11 @@ public class Kernel implements Annotator, DumbAware {
                         PsiElement functionNameElement = call.functionNameElement();
 
                         if (functionNameElement != null) {
-                            String resolvedFunctionName = call.resolvedFunctionName();
+                            String functionName = call.functionName();
 
                             // a function can't take a `do` block
                             if (call.getDoBlock() == null) {
-                                if (RESOLVED_FUNCTION_NAME_SET.contains(resolvedFunctionName)) {
+                                if (FUNCTION_NAME_SET.contains(functionName)) {
                                     highlight(
                                             functionNameElement,
                                             holder,
@@ -218,8 +218,8 @@ public class Kernel implements Annotator, DumbAware {
                                 }
                             }
 
-                            if (RESOLVED_MACRO_NAME_SET.contains(resolvedFunctionName) ||
-                                    RESOLVED_SPECIAL_FORMS_MACRO_NAME_SET.contains(resolvedFunctionName)) {
+                            if (MACRO_NAME_SET.contains(functionName) ||
+                                    SPECIAL_FORMS_MACRO_NAME_SET.contains(functionName)) {
                                 highlight(
                                         functionNameElement,
                                         holder,

--- a/src/org/elixir_lang/psi/Modular.java
+++ b/src/org/elixir_lang/psi/Modular.java
@@ -1,0 +1,100 @@
+package org.elixir_lang.psi;
+
+import com.intellij.openapi.util.Pair;
+import com.intellij.psi.PsiElement;
+import com.intellij.util.Function;
+import org.apache.commons.lang.math.IntRange;
+import org.elixir_lang.psi.call.Call;
+import org.elixir_lang.psi.call.Named;
+import org.elixir_lang.structure_view.element.CallDefinitionClause;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import static org.elixir_lang.psi.impl.ElixirPsiImplUtil.macroChildCalls;
+import static org.elixir_lang.structure_view.element.CallDefinitionClause.nameArityRange;
+
+public class Modular {
+    /*
+     * Public Static Methods
+     */
+
+    public static <Result> void forEachCallDefinitionClauseNameIdentifier(
+            @NotNull Call modular,
+            @Nullable final String functionName,
+            final int resolvedFinalArity,
+            @NotNull final Function<PsiElement, Result> function
+    ) {
+        forEachCallDefinitionClauseCall(
+                modular,
+                functionName,
+                resolvedFinalArity,
+                new Function<Call, Object>() {
+                    @Override
+                    public Object fun(Call call) {
+                        if (call instanceof Named) {
+                            Named named = (Named) call;
+                            PsiElement nameIdentifier = named.getNameIdentifier();
+
+                            if (nameIdentifier != null) {
+                                function.fun(nameIdentifier);
+                            }
+                        }
+
+
+                        return null;
+                    }
+                }
+        );
+    }
+
+    /*
+     * Private Static Methods
+     */
+
+    /**
+     * @param modular
+     */
+    private static <Result> void forEachCallDefinitionClauseCall(@NotNull final Call modular,
+                                                                 @NotNull Function<Call, Result> function) {
+        Call[] childCalls = macroChildCalls(modular);
+
+        if (childCalls != null) {
+            for (Call childCall : childCalls) {
+                if (CallDefinitionClause.is(childCall)) {
+                    function.fun(childCall);
+                }
+            }
+        }
+    }
+
+    private static <Result> void forEachCallDefinitionClauseCall(@NotNull Call modular,
+                                                                 @Nullable final String functionName,
+                                                                 final int resolvedFinalArity,
+                                                                 @NotNull final Function<Call, Result> function) {
+        if (functionName != null) {
+            forEachCallDefinitionClauseCall(
+                    modular,
+                    new Function<Call, Object>() {
+                        @Override
+                        public Object fun(@NotNull Call callDefinitionClauseCall) {
+                            Pair<String, IntRange> nameArityRange = nameArityRange(callDefinitionClauseCall);
+
+                            if (nameArityRange != null) {
+                                String name = nameArityRange.first;
+
+                                if (name != null && name.equals(functionName)) {
+                                    IntRange arityRange = nameArityRange.second;
+
+                                    if (arityRange.containsInteger(resolvedFinalArity)) {
+                                        function.fun(callDefinitionClauseCall);
+                                    }
+                                }
+                            }
+
+                            return null;
+                        }
+                    }
+            );
+        }
+    }
+}

--- a/src/org/elixir_lang/psi/call/Call.java
+++ b/src/org/elixir_lang/psi/call/Call.java
@@ -42,29 +42,29 @@ public interface Call extends NavigatablePsiElement {
     boolean hasDoBlockOrKeyword();
 
     /**
-     * Whether this call is calling the given `resolvedFunctionName` in the `resolvedModuleName` with any arity
+     * Whether this call is calling the given `functionName` in the `resolvedModuleName` with any arity
      *
      * @param resolvedModuleName the expected {@link #resolvedModuleName()}
-     * @param resolvedFunctionName the expected {@link #resolvedFunctionName()}
+     * @param functionName the expected {@link #functionName()}
      * @return {@code true} if this call has non-{@code null} {@link #resolvedModuleName()} that equals
-     *   {@code resolvedModuleName} and has non-{@code null} {@link #resolvedFunctionName()} that equals
-     *   {@code resolvedFunctionName}; otherwise, {@code false}.
+     *   {@code resolvedModuleName} and has non-{@code null} {@link #functionName()} that equals
+     *   {@code functionName}; otherwise, {@code false}.
      */
-    boolean isCalling(@NotNull final String resolvedModuleName, @NotNull final String resolvedFunctionName);
+    boolean isCalling(@NotNull final String resolvedModuleName, @NotNull final String functionName);
 
     /**
-     * Whether this call is calling the given `resolvedFunctionName` in the `resolvedModuleName` with the
+     * Whether this call is calling the given `functionName` in the `resolvedModuleName` with the
      * `resolvedArity`
      *
      * @param resolvedModuleName  the expected {@link #resolvedModuleName()}
-     * @param resolvedFunctionName the expected {@link #resolvedFunctionName()}
+     * @param functionName the expected {@link #functionName()}
      * @param resolvedFinalArity the expected {@link #resolvedFinalArity()}
      * @return {@code true} if this call has non-{@code null} {@link #resolvedModuleName()} that equals
-     *   {@code resolvedModuleName} and has non-{@code null} {@link #resolvedFunctionName()} that equals
-     *   {@code resolvedFunctionName} and the {@link #resolvedFinalArity}; otherwise, {@code false}.
+     *   {@code resolvedModuleName} and has non-{@code null} {@link #functionName()} that equals
+     *   {@code functionName} and the {@link #resolvedFinalArity}; otherwise, {@code false}.
      */
     boolean isCalling(@NotNull final String resolvedModuleName,
-                      @NotNull final String resolvedFunctionName,
+                      @NotNull final String functionName,
                       final int resolvedFinalArity);
 
     /**
@@ -75,11 +75,11 @@ public interface Call extends NavigatablePsiElement {
      * forms since Erlang/Elixir doesn't support variable arity functions otherwise.)
      *
      * @param resolvedModuleName the expected {@link Call#resolvedModuleName()}
-     * @param resolvedFunctionName the expected {@link Call#resolvedFunctionName()}
+     * @param functionName the expected {@link Call#functionName()}
      * @return {@code true} if all arguments match and {@link Call#getDoBlock()} is not {@code null}; {@code false}.
      */
     boolean isCallingMacro(@NotNull final String resolvedModuleName,
-                           @NotNull final String resolvedFunctionName);
+                           @NotNull final String functionName);
 
     /**
      * Whether {@code call} is of the named macro.
@@ -89,12 +89,12 @@ public interface Call extends NavigatablePsiElement {
      * {@link #isCalling(String, String, int)} should be used instead.
      *
      * @param resolvedModuleName the expected {@link #resolvedModuleName()}
-     * @param resolvedFunctionName the expected {@link #resolvedFunctionName()}
+     * @param functionName the expected {@link #functionName()}
      * @param resolvedFinalArity the expected {@link #resolvedFinalArity()}
      * @return {@code true} if all arguments match and {@link #getDoBlock()} is not {@code null}; {@code false}.
      */
     boolean isCallingMacro(@NotNull final String resolvedModuleName,
-                           @NotNull final  String resolvedFunctionName,
+                           @NotNull final  String functionName,
                            final int resolvedFinalArity);
 
     /**
@@ -147,12 +147,6 @@ public interface Call extends NavigatablePsiElement {
      */
     @Nullable
     Integer secondaryArity();
-
-    /**
-     * @return name of the function/macro after taking into account any imports
-     */
-    @Nullable
-    String resolvedFunctionName();
 
     /**
      * @return name of the qualifying module after taking into account any aliases

--- a/src/org/elixir_lang/psi/impl/ElixirPsiImplUtil.java
+++ b/src/org/elixir_lang/psi/impl/ElixirPsiImplUtil.java
@@ -1091,6 +1091,26 @@ public class ElixirPsiImplUtil {
         return childCalls;
     }
 
+    /**
+     * Finds modular ({@code defmodule}, {@code defimpl}, or {@code defprotocol}) for the qualifier of
+     * {@code maybeQualifiedCall}.
+     *
+     * @param maybeQualifiedCall a call that may be qualified
+     * @return {@code null} if {@code maybeQualifiedCall} is not qualified OR if the modular cannot be resolved, such
+     *   as when the qualifying Alias is invalid or is an unparsed module like {@code Kernel} or {@code Enum}.
+     */
+    @Contract(pure = true)
+    @Nullable
+    public static Call maybeQualifiedCallToModular(@NotNull final Call maybeQualifiedCall) {
+        Call modular = null;
+
+        if (maybeQualifiedCall instanceof org.elixir_lang.psi.call.qualification.Qualified) {
+            modular = qualifiedToModular((org.elixir_lang.psi.call.qualification.Qualified) maybeQualifiedCall);
+        }
+
+        return modular;
+    }
+
     public static OtpErlangList metadata(ASTNode node) {
         OtpErlangObject[] keywordListElements = {
                 lineNumberKeywordTuple(node)
@@ -4944,46 +4964,6 @@ if (quoted == null) {
     }
 
     /**
-     * @param call may be either a variable, parameter, or function call
-     * @return
-     */
-    @Contract(pure = true)
-    @Nullable
-    public static Call callToModular(@NotNull final Call call) {
-        return callToModular(call, call.resolvedFinalArity());
-    }
-
-    /**
-     *
-     * @param call may be eithe a variable, parameter, or function
-     * @param resolvedFinalArity the {@link Call#resolvedFinalArity()}
-     * @return
-     */
-    @Contract(pure = true)
-    @Nullable
-    public static Call callToModular(@NotNull final Call call, final int resolvedFinalArity) {
-        Call modular = null;
-
-        if (resolvedFinalArity == 0) {
-            /* Ambiguous whether a 0-arity is a call definition clause or variable */
-        } else {
-            /* Ambiguous whether call definition clause is local, imported, or qualified */
-
-            if (call instanceof org.elixir_lang.psi.call.qualification.Qualified) {
-                /* Qualified, so resolve qualifier to module */
-
-                org.elixir_lang.psi.call.qualification.Qualified qualified =
-                        (org.elixir_lang.psi.call.qualification.Qualified) call;
-
-                PsiElement qualifier = qualified.qualifier();
-                modular = qualifierToModular(qualifier);
-            }
-        }
-
-        return modular;
-    }
-
-    /**
      * Similar to {@link moduleName}, but takes into account `alias`es and `import`s.
      *
      * @param element
@@ -5378,6 +5358,20 @@ if (quoted == null) {
         addMergedFragments(mergedNodes, fragmentType, fragmentStringBuilder, manager);
 
         return mergedNodes;
+    }
+
+    /**
+     * Finds modular ({@code defmodule}, {@code defimpl}, or {@code defprotocol}) for the qualifier of
+     * {@code qualified}.
+     *
+     * @param qualified a qualified expression
+     * @return {@code null} if the modular cannot be resolved, such as when the qualifying Alias is invalid or is an
+     *   unparsed module like {@code Kernel} or {@code Enum} OR if the qualified isn't an Alias.
+     */
+    @Contract(pure = true)
+    @Nullable
+    private static Call qualifiedToModular(@NotNull final org.elixir_lang.psi.call.qualification.Qualified qualified) {
+        return qualifierToModular(qualified.qualifier());
     }
 
     @NotNull

--- a/src/org/elixir_lang/psi/impl/ElixirPsiImplUtil.java
+++ b/src/org/elixir_lang/psi/impl/ElixirPsiImplUtil.java
@@ -799,41 +799,41 @@ public class ElixirPsiImplUtil {
     }
 
     /**
-     * Whether the {@code call} is calling the given `resolvedFunctionName` in the `resolvedModuleName` with any arity
+     * Whether the {@code call} is calling the given `functionName` in the `resolvedModuleName` with any arity
      * @param call the call element
      * @param resolvedModuleName the expected {@link Call#resolvedModuleName()}
-     * @param resolvedFunctionName the expected {@link Call#resolvedFunctionName()}
+     * @param functionName the expected {@link Call#functionName()}
      * @return {@code true} if the {@code call} has non-{@code null} {@link Call#resolvedModuleName()} that equals
-     *   {@code resolvedModuleName} and has non-{@code null} {@link Call#resolvedFunctionName()} that equals
-     *   {@code resolvedFunctionName}; otherwise, {@code false}.
+     *   {@code resolvedModuleName} and has non-{@code null} {@link Call#functionName()} that equals
+     *   {@code functionName}; otherwise, {@code false}.
      */
     public static boolean isCalling(@NotNull final Call call,
                                     @NotNull final String resolvedModuleName,
-                                    @NotNull final String resolvedFunctionName) {
+                                    @NotNull final String functionName) {
         String callResolvedModuleName = call.resolvedModuleName();
-        String callResolvedFunctionName = call.resolvedFunctionName();
+        String callFunctionName = call.functionName();
 
         return callResolvedModuleName != null && callResolvedModuleName.equals(resolvedModuleName) &&
-                callResolvedFunctionName != null && callResolvedFunctionName.equals(resolvedFunctionName);
+                callFunctionName != null && callFunctionName.equals(functionName);
     }
 
     /**
-     * Whether the {@code call} is calling the given `resolvedFunctionName` in the `resolvedModuleName` with the
+     * Whether the {@code call} is calling the given `functionName` in the `resolvedModuleName` with the
      * `resolvedFinalArity`
      *
      * @param call the call element
      * @param resolvedModuleName  the expected {@link Call#resolvedModuleName()}
-     * @param resolvedFunctionName the expected {@link Call#resolvedFunctionName()}
+     * @param functionName the expected {@link Call#functionName()}
      * @param resolvedFinalArity the expected {@link Call#resolvedFinalArity()}
      * @return {@code true} if the {@code call} has non-{@code null} {@link Call#resolvedModuleName()} that equals
-     *   {@code resolvedModuleName} and has non-{@code null} {@link Call#resolvedFunctionName()} that equals
-     *   {@code resolvedFunctionName} and the {@link Call#resolvedFinalArity()}; otherwise, {@code false}.
+     *   {@code resolvedModuleName} and has non-{@code null} {@link Call#functionName()} that equals
+     *   {@code functionName} and the {@link Call#resolvedFinalArity()}; otherwise, {@code false}.
      */
     public static boolean isCalling(@NotNull final Call call,
                                     @NotNull final String resolvedModuleName,
-                                    @NotNull final String resolvedFunctionName,
+                                    @NotNull final String functionName,
                                     final int resolvedFinalArity) {
-        return call.isCalling(resolvedModuleName, resolvedFunctionName) &&
+        return call.isCalling(resolvedModuleName, functionName) &&
                 call.resolvedFinalArity() == resolvedFinalArity;
     }
 
@@ -846,13 +846,13 @@ public class ElixirPsiImplUtil {
      *
      * @param call the call element
      * @param resolvedModuleName the expected {@link Call#resolvedModuleName()}
-     * @param resolvedFunctionName the expected {@link Call#resolvedFunctionName()}
+     * @param functionName the expected {@link Call#functionName()}
      * @return {@code true} if all arguments match and {@link Call#getDoBlock()} is not {@code null}; {@code false}.
      */
     public static boolean isCallingMacro(@NotNull final Call call,
                                          @NotNull final String resolvedModuleName,
-                                         @NotNull final String resolvedFunctionName) {
-        return call.isCalling(resolvedModuleName, resolvedFunctionName) && call.hasDoBlockOrKeyword();
+                                         @NotNull final String functionName) {
+        return call.isCalling(resolvedModuleName, functionName) && call.hasDoBlockOrKeyword();
     }
 
     /**
@@ -864,16 +864,16 @@ public class ElixirPsiImplUtil {
      *
      * @param call the call element
      * @param resolvedModuleName the expected {@link Call#resolvedModuleName()}
-     * @param resolvedFunctionName the expected {@link Call#resolvedFunctionName()}
+     * @param functionName the expected {@link Call#functionName()}
      * @param resolvedFinalArity the expected {@link Call#resolvedFinalArity()}
      * @return {@code true} if all arguments match and {@link Call#getDoBlock()} is not {@code null}; {@code false}.
      */
     @Contract(pure = true)
     public static boolean isCallingMacro(@NotNull final Call call,
                                          @NotNull final String resolvedModuleName,
-                                         @NotNull final  String resolvedFunctionName,
+                                         @NotNull final  String functionName,
                                          final int resolvedFinalArity) {
-        return call.isCalling(resolvedModuleName, resolvedFunctionName, resolvedFinalArity) &&
+        return call.isCalling(resolvedModuleName, functionName, resolvedFinalArity) &&
                 call.hasDoBlockOrKeyword();
     }
 

--- a/src/org/elixir_lang/psi/qualification/Qualified.java
+++ b/src/org/elixir_lang/psi/qualification/Qualified.java
@@ -11,5 +11,9 @@ import org.jetbrains.annotations.NotNull;
 public interface Qualified extends PsiElement {
     @Contract(pure = true)
     @NotNull
+    PsiElement qualifier();
+
+    @Contract(pure = true)
+    @NotNull
     ElixirRelativeIdentifier getRelativeIdentifier();
 }

--- a/src/org/elixir_lang/psi/stub/type/MatchedAtUnqualifiedNoParenthesesCall.java
+++ b/src/org/elixir_lang/psi/stub/type/MatchedAtUnqualifiedNoParenthesesCall.java
@@ -34,7 +34,7 @@ public class MatchedAtUnqualifiedNoParenthesesCall extends Stub<org.elixir_lang.
                 parentStub,
                 this,
                 psi.resolvedModuleName(),
-                psi.resolvedFunctionName(),
+                psi.functionName(),
                 psi.resolvedFinalArity(),
                 psi.hasDoBlockOrKeyword(),
                 StringUtil.notNullize(psi.getName(), "?"),

--- a/src/org/elixir_lang/psi/stub/type/MatchedDotCall.java
+++ b/src/org/elixir_lang/psi/stub/type/MatchedDotCall.java
@@ -34,7 +34,7 @@ public class MatchedDotCall extends Stub<org.elixir_lang.psi.stub.MatchedDotCall
                 parentStub,
                 this,
                 psi.resolvedModuleName(),
-                psi.resolvedFunctionName(),
+                psi.functionName(),
                 psi.resolvedFinalArity(),
                 psi.hasDoBlockOrKeyword(),
                 StringUtil.notNullize(psi.getName(), "?"),

--- a/src/org/elixir_lang/psi/stub/type/MatchedQualifiedNoArgumentsCall.java
+++ b/src/org/elixir_lang/psi/stub/type/MatchedQualifiedNoArgumentsCall.java
@@ -34,7 +34,7 @@ public class MatchedQualifiedNoArgumentsCall extends Stub<org.elixir_lang.psi.st
                 parentStub,
                 this,
                 psi.resolvedModuleName(),
-                psi.resolvedFunctionName(),
+                psi.functionName(),
                 psi.resolvedFinalArity(),
                 psi.hasDoBlockOrKeyword(),
                 StringUtil.notNullize(psi.getName(), "?"),

--- a/src/org/elixir_lang/psi/stub/type/MatchedQualifiedNoParenthesesCall.java
+++ b/src/org/elixir_lang/psi/stub/type/MatchedQualifiedNoParenthesesCall.java
@@ -34,7 +34,7 @@ public class MatchedQualifiedNoParenthesesCall extends Stub<org.elixir_lang.psi.
                 parentStub,
                 this,
                 psi.resolvedModuleName(),
-                psi.resolvedFunctionName(),
+                psi.functionName(),
                 psi.resolvedFinalArity(),
                 psi.hasDoBlockOrKeyword(),
                 StringUtil.notNullize(psi.getName(), "?"),

--- a/src/org/elixir_lang/psi/stub/type/MatchedQualifiedParenthesesCall.java
+++ b/src/org/elixir_lang/psi/stub/type/MatchedQualifiedParenthesesCall.java
@@ -34,7 +34,7 @@ public class MatchedQualifiedParenthesesCall extends Stub<org.elixir_lang.psi.st
                 parentStub,
                 this,
                 psi.resolvedModuleName(),
-                psi.resolvedFunctionName(),
+                psi.functionName(),
                 psi.resolvedFinalArity(),
                 psi.hasDoBlockOrKeyword(),
                 StringUtil.notNullize(psi.getName(), "?"),

--- a/src/org/elixir_lang/psi/stub/type/MatchedUnqualifiedNoArgumentsCall.java
+++ b/src/org/elixir_lang/psi/stub/type/MatchedUnqualifiedNoArgumentsCall.java
@@ -34,7 +34,7 @@ public class MatchedUnqualifiedNoArgumentsCall extends Stub<org.elixir_lang.psi.
                 parentStub,
                 this,
                 psi.resolvedModuleName(),
-                psi.resolvedFunctionName(),
+                psi.functionName(),
                 psi.resolvedFinalArity(),
                 psi.hasDoBlockOrKeyword(),
                 StringUtil.notNullize(psi.getName(), "?"),

--- a/src/org/elixir_lang/psi/stub/type/MatchedUnqualifiedNoParenthesesCall.java
+++ b/src/org/elixir_lang/psi/stub/type/MatchedUnqualifiedNoParenthesesCall.java
@@ -34,7 +34,7 @@ public class MatchedUnqualifiedNoParenthesesCall extends Stub<org.elixir_lang.ps
                 parentStub,
                 this,
                 psi.resolvedModuleName(),
-                psi.resolvedFunctionName(),
+                psi.functionName(),
                 psi.resolvedFinalArity(),
                 psi.hasDoBlockOrKeyword(),
                 StringUtil.notNullize(psi.getName(), "?"),

--- a/src/org/elixir_lang/psi/stub/type/MatchedUnqualifiedParenthesesCall.java
+++ b/src/org/elixir_lang/psi/stub/type/MatchedUnqualifiedParenthesesCall.java
@@ -34,7 +34,7 @@ public class MatchedUnqualifiedParenthesesCall extends Stub<org.elixir_lang.psi.
                 parentStub,
                 this,
                 psi.resolvedModuleName(),
-                psi.resolvedFunctionName(),
+                psi.functionName(),
                 psi.resolvedFinalArity(),
                 psi.hasDoBlockOrKeyword(),
                 StringUtil.notNullize(psi.getName(), "?"),

--- a/src/org/elixir_lang/psi/stub/type/UnmatchedAtUnqualifiedNoParenthesesCall.java
+++ b/src/org/elixir_lang/psi/stub/type/UnmatchedAtUnqualifiedNoParenthesesCall.java
@@ -34,7 +34,7 @@ public class UnmatchedAtUnqualifiedNoParenthesesCall extends Stub<org.elixir_lan
                 parentStub,
                 this,
                 psi.resolvedModuleName(),
-                psi.resolvedFunctionName(),
+                psi.functionName(),
                 psi.resolvedFinalArity(),
                 psi.hasDoBlockOrKeyword(),
                 StringUtil.notNullize(psi.getName(), "?"),

--- a/src/org/elixir_lang/psi/stub/type/UnmatchedDotCall.java
+++ b/src/org/elixir_lang/psi/stub/type/UnmatchedDotCall.java
@@ -34,7 +34,7 @@ public class UnmatchedDotCall extends Stub<org.elixir_lang.psi.stub.UnmatchedDot
                 parentStub,
                 this,
                 psi.resolvedModuleName(),
-                psi.resolvedFunctionName(),
+                psi.functionName(),
                 psi.resolvedFinalArity(),
                 psi.hasDoBlockOrKeyword(),
                 StringUtil.notNullize(psi.getName(), "?"),

--- a/src/org/elixir_lang/psi/stub/type/UnmatchedQualifiedNoArgumentsCall.java
+++ b/src/org/elixir_lang/psi/stub/type/UnmatchedQualifiedNoArgumentsCall.java
@@ -34,7 +34,7 @@ public class UnmatchedQualifiedNoArgumentsCall extends Stub<org.elixir_lang.psi.
                 parentStub,
                 this,
                 psi.resolvedModuleName(),
-                psi.resolvedFunctionName(),
+                psi.functionName(),
                 psi.resolvedFinalArity(),
                 psi.hasDoBlockOrKeyword(),
                 StringUtil.notNullize(psi.getName(), "?"),

--- a/src/org/elixir_lang/psi/stub/type/UnmatchedQualifiedNoParenthesesCall.java
+++ b/src/org/elixir_lang/psi/stub/type/UnmatchedQualifiedNoParenthesesCall.java
@@ -34,7 +34,7 @@ public class UnmatchedQualifiedNoParenthesesCall extends Stub<org.elixir_lang.ps
                 parentStub,
                 this,
                 psi.resolvedModuleName(),
-                psi.resolvedFunctionName(),
+                psi.functionName(),
                 psi.resolvedFinalArity(),
                 psi.hasDoBlockOrKeyword(),
                 StringUtil.notNullize(psi.getName(), "?"),

--- a/src/org/elixir_lang/psi/stub/type/UnmatchedQualifiedParenthesesCall.java
+++ b/src/org/elixir_lang/psi/stub/type/UnmatchedQualifiedParenthesesCall.java
@@ -34,7 +34,7 @@ public class UnmatchedQualifiedParenthesesCall extends Stub<org.elixir_lang.psi.
                 parentStub,
                 this,
                 psi.resolvedModuleName(),
-                psi.resolvedFunctionName(),
+                psi.functionName(),
                 psi.resolvedFinalArity(),
                 psi.hasDoBlockOrKeyword(),
                 StringUtil.notNullize(psi.getName(), "?"),

--- a/src/org/elixir_lang/psi/stub/type/UnmatchedUnqualifiedNoArgumentsCall.java
+++ b/src/org/elixir_lang/psi/stub/type/UnmatchedUnqualifiedNoArgumentsCall.java
@@ -34,7 +34,7 @@ public class UnmatchedUnqualifiedNoArgumentsCall extends Stub<org.elixir_lang.ps
                 parentStub,
                 this,
                 psi.resolvedModuleName(),
-                psi.resolvedFunctionName(),
+                psi.functionName(),
                 psi.resolvedFinalArity(),
                 psi.hasDoBlockOrKeyword(),
                 StringUtil.notNullize(psi.getName(), "?"),

--- a/src/org/elixir_lang/psi/stub/type/UnmatchedUnqualifiedNoParenthesesCall.java
+++ b/src/org/elixir_lang/psi/stub/type/UnmatchedUnqualifiedNoParenthesesCall.java
@@ -36,7 +36,7 @@ public class UnmatchedUnqualifiedNoParenthesesCall extends Stub<org.elixir_lang.
                 parentStub,
                 this,
                 psi.resolvedModuleName(),
-                psi.resolvedFunctionName(),
+                psi.functionName(),
                 psi.resolvedFinalArity(),
                 psi.hasDoBlockOrKeyword(),
                 StringUtil.notNullize(psi.getName(), "?"),

--- a/src/org/elixir_lang/psi/stub/type/UnmatchedUnqualifiedParenthesesCall.java
+++ b/src/org/elixir_lang/psi/stub/type/UnmatchedUnqualifiedParenthesesCall.java
@@ -39,7 +39,7 @@ public class UnmatchedUnqualifiedParenthesesCall extends Stub<org.elixir_lang.ps
                 parentStub,
                 this,
                 psi.resolvedModuleName(),
-                psi.resolvedFunctionName(),
+                psi.functionName(),
                 psi.resolvedFinalArity(),
                 psi.hasDoBlockOrKeyword(),
                 psi.getName(),

--- a/src/org/elixir_lang/psi/stub/type/UnqualifiedNoParenthesesManyArgumentsCall.java
+++ b/src/org/elixir_lang/psi/stub/type/UnqualifiedNoParenthesesManyArgumentsCall.java
@@ -34,7 +34,7 @@ public class UnqualifiedNoParenthesesManyArgumentsCall extends Stub<org.elixir_l
                 parentStub,
                 this,
                 psi.resolvedModuleName(),
-                psi.resolvedFunctionName(),
+                psi.functionName(),
                 psi.resolvedFinalArity(),
                 psi.hasDoBlockOrKeyword(),
                 StringUtil.notNullize(psi.getName(), "?"),

--- a/src/org/elixir_lang/reference/Callable.java
+++ b/src/org/elixir_lang/reference/Callable.java
@@ -2,7 +2,6 @@ package org.elixir_lang.reference;
 
 import com.google.common.collect.Sets;
 import com.intellij.codeInsight.lookup.LookupElement;
-import com.intellij.codeInsight.lookup.LookupElementBuilder;
 import com.intellij.openapi.util.TextRange;
 import com.intellij.psi.*;
 import com.intellij.psi.search.LocalSearchScope;

--- a/src/org/elixir_lang/reference/Callable.java
+++ b/src/org/elixir_lang/reference/Callable.java
@@ -610,7 +610,7 @@ public class Callable extends PsiReferenceBase<Call> implements PsiPolyVariantRe
     public ResolveResult[] multiResolve(boolean incompleteCode) {
         List<ResolveResult> resolveResultList = null;
         int resolvedFinalArity = myElement.resolvedFinalArity();
-        Call modular = callToModular(myElement, resolvedFinalArity);
+        Call modular = maybeQualifiedCallToModular(myElement);
         ResolveResult[] resolveResults;
 
         if (modular != null) {

--- a/src/org/elixir_lang/reference/Callable.java
+++ b/src/org/elixir_lang/reference/Callable.java
@@ -15,7 +15,7 @@ import org.elixir_lang.errorreport.Logger;
 import org.elixir_lang.psi.*;
 import org.elixir_lang.psi.call.Call;
 import org.elixir_lang.psi.call.Named;
-import org.elixir_lang.psi.call.name.*;
+import org.elixir_lang.psi.call.name.Function;
 import org.elixir_lang.psi.call.name.Module;
 import org.elixir_lang.psi.operation.*;
 import org.elixir_lang.psi.scope.variable.Variants;
@@ -609,37 +609,58 @@ public class Callable extends PsiReferenceBase<Call> implements PsiPolyVariantRe
     @Override
     public ResolveResult[] multiResolve(boolean incompleteCode) {
         List<ResolveResult> resolveResultList = null;
-        String name = myElement.getName();
+        int resolvedFinalArity = myElement.resolvedFinalArity();
+        Call modular = callToModular(myElement, resolvedFinalArity);
+        ResolveResult[] resolveResults;
 
-        if (name != null) {
-            int resolvedFinalArity = myElement.resolvedFinalArity();
-            List<ResolveResult> variableResolveList = null;
+        if (modular != null) {
+            final List<ResolveResult> finalResolveResultList = new ArrayList<ResolveResult>();
 
-            if (resolvedFinalArity == 0) {
-                variableResolveList = org.elixir_lang.psi.scope.variable.MultiResolve.resolveResultList(
-                        name,
-                        incompleteCode,
-                        myElement
-                );
-            }
+            Modular.forEachCallDefinitionClauseNameIdentifier(
+                    modular,
+                    myElement.functionName(),
+                    resolvedFinalArity,
+                    new com.intellij.util.Function<PsiElement, Object>() {
+                        @Override
+                        public Object fun(PsiElement nameIdentifier) {
+                            finalResolveResultList.add(new PsiElementResolveResult(nameIdentifier, true));
 
-            List<ResolveResult> callDefinitionClauseResolveResultList =
-                    org.elixir_lang.psi.scope.call_definition_clause.MultiResolve.resolveResultList(
+                            return null;
+                        }
+                    }
+            );
+
+            resolveResults = finalResolveResultList.toArray(new ResolveResult[finalResolveResultList.size()]);
+        } else {
+            String name = myElement.getName();
+
+            if (name != null) {
+                List<ResolveResult> variableResolveList = null;
+
+                if (resolvedFinalArity == 0) {
+                    variableResolveList = org.elixir_lang.psi.scope.variable.MultiResolve.resolveResultList(
                             name,
-                            resolvedFinalArity,
                             incompleteCode,
                             myElement
                     );
+                }
 
-            resolveResultList = merge(variableResolveList, callDefinitionClauseResolveResultList);
-        }
+                List<ResolveResult> callDefinitionClauseResolveResultList =
+                        org.elixir_lang.psi.scope.call_definition_clause.MultiResolve.resolveResultList(
+                                name,
+                                resolvedFinalArity,
+                                incompleteCode,
+                                myElement
+                        );
 
-        ResolveResult[] resolveResults;
+                resolveResultList = merge(variableResolveList, callDefinitionClauseResolveResultList);
+            }
 
-        if (resolveResultList == null) {
-            resolveResults = new ResolveResult[0];
-        } else {
-            resolveResults = resolveResultList.toArray(new ResolveResult[resolveResultList.size()]);
+            if (resolveResultList == null) {
+                resolveResults = new ResolveResult[0];
+            } else {
+                resolveResults = resolveResultList.toArray(new ResolveResult[resolveResultList.size()]);
+            }
         }
 
         return resolveResults;

--- a/testData/org/elixir_lang/reference/callable/issue_463/aliased_module_qualifier.ex
+++ b/testData/org/elixir_lang/reference/callable/issue_463/aliased_module_qualifier.ex
@@ -1,0 +1,5 @@
+defmodule AliasedModuleQualifier do
+  alias MyNamespace.Referenced
+
+  Referenced.<caret>changeset(%{})
+end

--- a/testData/org/elixir_lang/reference/callable/issue_463/direct_module_qualifier.ex
+++ b/testData/org/elixir_lang/reference/callable/issue_463/direct_module_qualifier.ex
@@ -1,0 +1,3 @@
+defmodule DirectModuleQualifier do
+  MyNamespace.Referenced.<caret>changeset(%{})
+end

--- a/testData/org/elixir_lang/reference/callable/issue_463/double_aliased_module_qualifier.ex
+++ b/testData/org/elixir_lang/reference/callable/issue_463/double_aliased_module_qualifier.ex
@@ -1,0 +1,6 @@
+defmodule AliasedModuleQualifier do
+  alias MyNamespace.Referenced
+  alias Referenced, as: Refd
+
+  Refd.<caret>changeset(%{})
+end

--- a/testData/org/elixir_lang/reference/callable/issue_463/map_access_qualifier.ex
+++ b/testData/org/elixir_lang/reference/callable/issue_463/map_access_qualifier.ex
@@ -1,0 +1,4 @@
+defmodule AliasedModuleQualifier do
+  referenced = %MyNamespace.Referenced{}
+  referenced.__struct__.<caret>__struct__()
+end

--- a/testData/org/elixir_lang/reference/callable/issue_463/referenced.ex
+++ b/testData/org/elixir_lang/reference/callable/issue_463/referenced.ex
@@ -1,0 +1,13 @@
+defmodule MyNamespace.Referenced do
+  use Ecto.Schema
+
+  schema "" do
+    field "name", :string
+  end
+
+  def changeset(params) do
+    %__MODULE__{}
+    |> cast(params, ~w(name))
+    |> validate_required(:name)
+  end
+end

--- a/testData/org/elixir_lang/reference/callable/issue_463/unresolved_alias_qualifier.ex
+++ b/testData/org/elixir_lang/reference/callable/issue_463/unresolved_alias_qualifier.ex
@@ -1,0 +1,3 @@
+defmodule AliasedModuleQualifier do
+  Unresolved.<caret>changeset(%{})
+end

--- a/tests/org/elixir_lang/reference/callable/Issue463Test.java
+++ b/tests/org/elixir_lang/reference/callable/Issue463Test.java
@@ -1,0 +1,149 @@
+package org.elixir_lang.reference.callable;
+
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiReference;
+import com.intellij.testFramework.fixtures.LightCodeInsightFixtureTestCase;
+import org.elixir_lang.psi.ElixirIdentifier;
+import org.elixir_lang.psi.call.Call;
+import org.elixir_lang.structure_view.element.CallDefinitionClause;
+
+public class Issue463Test extends LightCodeInsightFixtureTestCase {
+    /*
+     * Tests
+     */
+
+    public void testDirectModuleQualifier() {
+        myFixture.configureByFiles("direct_module_qualifier.ex", "referenced.ex");
+        PsiElement elementAtCaret = myFixture
+                .getFile()
+                .findElementAt(myFixture.getCaretOffset());
+
+        assertNotNull(elementAtCaret);
+
+        PsiElement grandParent = elementAtCaret.getParent().getParent();
+
+        assertNotNull(grandParent);
+        assertInstanceOf(grandParent, Call.class);
+
+        PsiReference reference = grandParent.getReference();
+
+        assertNotNull(reference);
+
+        PsiElement resolved = reference.resolve();
+
+        assertNotNull(resolved);
+
+        assertInstanceOf(resolved, ElixirIdentifier.class);
+        assertEquals(resolved.getText(), "changeset");
+
+        PsiElement maybeDefCall = resolved.getParent().getParent().getParent();
+        assertInstanceOf(maybeDefCall, Call.class);
+
+        assertTrue(CallDefinitionClause.is((Call) maybeDefCall));
+    }
+
+    public void testAliasedModuleQualifier() {
+        myFixture.configureByFiles("aliased_module_qualifier.ex", "referenced.ex");
+        PsiElement elementAtCaret = myFixture
+                .getFile()
+                .findElementAt(myFixture.getCaretOffset());
+
+        assertNotNull(elementAtCaret);
+
+        PsiElement grandParent = elementAtCaret.getParent().getParent();
+
+        assertNotNull(grandParent);
+        assertInstanceOf(grandParent, Call.class);
+
+        PsiReference reference = grandParent.getReference();
+
+        assertNotNull(reference);
+
+        PsiElement resolved = reference.resolve();
+
+        assertNotNull(resolved);
+
+        assertInstanceOf(resolved, ElixirIdentifier.class);
+        assertEquals(resolved.getText(), "changeset");
+
+        PsiElement maybeDefCall = resolved.getParent().getParent().getParent();
+        assertInstanceOf(maybeDefCall, Call.class);
+
+        assertTrue(CallDefinitionClause.is((Call) maybeDefCall));
+    }
+
+    public void testDoubleAliasesModuleQualifier() {
+        myFixture.configureByFiles("double_aliased_module_qualifier.ex", "referenced.ex");
+        PsiElement elementAtCaret = myFixture
+                .getFile()
+                .findElementAt(myFixture.getCaretOffset());
+
+        assertNotNull(elementAtCaret);
+
+        PsiElement grandParent = elementAtCaret.getParent().getParent();
+
+        assertNotNull(grandParent);
+        assertInstanceOf(grandParent, Call.class);
+
+        PsiReference reference = grandParent.getReference();
+
+        assertNotNull(reference);
+
+        PsiElement resolved = reference.resolve();
+
+        assertNull(resolved);
+    }
+
+    public void testMapAccessQualifier() {
+        myFixture.configureByFiles("map_access_qualifier.ex", "referenced.ex");
+        PsiElement elementAtCaret = myFixture
+                .getFile()
+                .findElementAt(myFixture.getCaretOffset());
+
+        assertNotNull(elementAtCaret);
+
+        PsiElement grandParent = elementAtCaret.getParent().getParent();
+
+        assertNotNull(grandParent);
+        assertInstanceOf(grandParent, Call.class);
+
+        PsiReference reference = grandParent.getReference();
+
+        assertNotNull(reference);
+
+        PsiElement resolved = reference.resolve();
+
+        assertNull(resolved);
+    }
+
+    public void testUnresolvedAliasQualifier() {
+        myFixture.configureByFiles("unresolved_alias_qualifier.ex", "referenced.ex");
+        PsiElement elementAtCaret = myFixture
+                .getFile()
+                .findElementAt(myFixture.getCaretOffset());
+
+        assertNotNull(elementAtCaret);
+
+        PsiElement grandParent = elementAtCaret.getParent().getParent();
+
+        assertNotNull(grandParent);
+        assertInstanceOf(grandParent, Call.class);
+
+        PsiReference reference = grandParent.getReference();
+
+        assertNotNull(reference);
+
+        PsiElement resolved = reference.resolve();
+
+        assertNull(resolved);
+    }
+
+    /*
+     * Protected Instance Methods
+     */
+
+    @Override
+    protected String getTestDataPath() {
+        return "testData/org/elixir_lang/reference/callable/issue_463";
+    }
+}


### PR DESCRIPTION
Fixes #463

# Enhancements
* Add `Qualified#qualifier` by extracting it from `CallDefinitionClause` `CompletionProvider`.
* Add `Modular` class with `#forEachCallDefinitionClauseNameIdentifier` to enumerate all the identifiers that could be linked to in a modular.
* Add `ElixirPsiImplUtil#maybeQualifiedCallToModular` by extracting `resolveFully` from `CallDefinitionClause` `CompletionProvider`

# Bug Fixes
* Resolves functions qualified by Aliases that are either direct Module references or one-step aliases.

# Incompatible changes
* Remove `Call#resolvedFunctionName`  because `import` can't rename functions
