### PR TITLE
Don't type highlight BracketOperations

### DIFF
--- a/src/org/elixir_lang/annonator/ModuleAttribute.java
+++ b/src/org/elixir_lang/annonator/ModuleAttribute.java
@@ -883,7 +883,8 @@ public class ModuleAttribute implements Annotator, DumbAware {
                     annotationHolder,
                     typeTextAttributesKey
             );
-        } else if (psiElement instanceof ElixirAlias ||
+        } else if (psiElement instanceof BracketOperation ||
+                psiElement instanceof ElixirAlias ||
                 psiElement instanceof ElixirAtom ||
                 psiElement instanceof ElixirAtomKeyword ||
                 psiElement instanceof ElixirBitString ||

--- a/testData/org/elixir_lang/annotator/module_attribute/issue_471.ex
+++ b/testData/org/elixir_lang/annotator/module_attribute/issue_471.ex
@@ -1,0 +1,1 @@
+@callback list(query_options) :: {}[struct]

--- a/tests/org/elixir_lang/annotator/ModuleAttributeTest.java
+++ b/tests/org/elixir_lang/annotator/ModuleAttributeTest.java
@@ -29,6 +29,11 @@ public class ModuleAttributeTest extends LightCodeInsightFixtureTestCase {
         myFixture.checkHighlighting(false, false, true);
     }
 
+    public void testIssue471() {
+        myFixture.configureByFile("issue_471.ex");
+        myFixture.checkHighlighting(false, false, true);
+    }
+
     /*
      * Protected Instance Methods
      */


### PR DESCRIPTION
Fixes #471

# Changelog
## Enhancements
* Failing regression test for #471

## Bug Fixes
* Don't type-highlight `BracketOperation`s as they occur when putting maps or structs in front of lists.