### PR TITLE
resolvedFinalArity takes into account piping

### DIFF
--- a/gen/org/elixir_lang/psi/ElixirMatchedArrowOperation.java
+++ b/gen/org/elixir_lang/psi/ElixirMatchedArrowOperation.java
@@ -7,13 +7,13 @@ import com.intellij.psi.ResolveState;
 import com.intellij.psi.scope.PsiScopeProcessor;
 import org.apache.commons.lang.math.IntRange;
 import org.elixir_lang.psi.call.Named;
-import org.elixir_lang.psi.operation.Infix;
+import org.elixir_lang.psi.operation.Arrow;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 
-public interface ElixirMatchedArrowOperation extends ElixirMatchedExpression, Named, Infix {
+public interface ElixirMatchedArrowOperation extends ElixirMatchedExpression, Named, Arrow {
 
   @NotNull
   ElixirArrowInfixOperator getArrowInfixOperator();

--- a/gen/org/elixir_lang/psi/ElixirUnmatchedArrowOperation.java
+++ b/gen/org/elixir_lang/psi/ElixirUnmatchedArrowOperation.java
@@ -7,13 +7,13 @@ import com.intellij.psi.ResolveState;
 import com.intellij.psi.scope.PsiScopeProcessor;
 import org.apache.commons.lang.math.IntRange;
 import org.elixir_lang.psi.call.Named;
-import org.elixir_lang.psi.operation.Infix;
+import org.elixir_lang.psi.operation.Arrow;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 
-public interface ElixirUnmatchedArrowOperation extends ElixirUnmatchedExpression, Named, Infix {
+public interface ElixirUnmatchedArrowOperation extends ElixirUnmatchedExpression, Named, Arrow {
 
   @NotNull
   ElixirArrowInfixOperator getArrowInfixOperator();

--- a/gen/org/elixir_lang/psi/ElixirVisitor.java
+++ b/gen/org/elixir_lang/psi/ElixirVisitor.java
@@ -463,7 +463,7 @@ public class ElixirVisitor extends PsiElementVisitor {
   public void visitMatchedArrowOperation(@NotNull ElixirMatchedArrowOperation o) {
     visitMatchedExpression(o);
     // visitNamed(o);
-    // visitInfix(o);
+    // visitArrow(o);
   }
 
   public void visitMatchedAtNonNumericOperation(@NotNull ElixirMatchedAtNonNumericOperation o) {
@@ -816,7 +816,7 @@ public class ElixirVisitor extends PsiElementVisitor {
   public void visitUnmatchedArrowOperation(@NotNull ElixirUnmatchedArrowOperation o) {
     visitUnmatchedExpression(o);
     // visitNamed(o);
-    // visitInfix(o);
+    // visitArrow(o);
   }
 
   public void visitUnmatchedAtNonNumericOperation(@NotNull ElixirUnmatchedAtNonNumericOperation o) {

--- a/src/org/elixir_lang/Elixir.bnf
+++ b/src/org/elixir_lang/Elixir.bnf
@@ -79,7 +79,7 @@
   /* infix operations that work as name identifier owner calls - specifically support getNameIdentifier so they can
      return their operator, so it is easy to use a different operator when making customer operators like in Bitwise or
      the free arrow operators */
-  implements(        "(un)?matched(Arrow|Comparison|Multiplication|Or|Relational)Operation")=[
+  implements(        "(un)?matched(Comparison|Multiplication|Or|Relational)Operation")=[
     "org.elixir_lang.psi.call.Named"
     "org.elixir_lang.psi.operation.Infix"
   ]
@@ -121,6 +121,11 @@
     "org.elixir_lang.psi.operation.And"
   ]
   // methods set by infix operations above
+
+  implements("(un)?matchedArrowOperation")=[
+    "org.elixir_lang.psi.call.Named"
+    "org.elixir_lang.psi.operation.Arrow"
+  ]
 
   implements("(un)?matchedInMatchOperation")=[
     "org.elixir_lang.psi.call.Named"

--- a/src/org/elixir_lang/psi/operation/Arrow.java
+++ b/src/org/elixir_lang/psi/operation/Arrow.java
@@ -1,0 +1,7 @@
+package org.elixir_lang.psi.operation;
+
+/**
+ * <expression> arrowInfixOperator <expression>
+ */
+public interface Arrow extends Infix {
+}

--- a/testData/org/elixir_lang/reference/callable/issue_480/aliased_module_qualifier.ex
+++ b/testData/org/elixir_lang/reference/callable/issue_480/aliased_module_qualifier.ex
@@ -1,0 +1,6 @@
+defmodule AliasedModuleQualifier do
+  alias MyNamespace.Referenced
+
+  %{}
+  |> Referenced.<caret>changeset()
+end

--- a/testData/org/elixir_lang/reference/callable/issue_480/direct_module_qualifier.ex
+++ b/testData/org/elixir_lang/reference/callable/issue_480/direct_module_qualifier.ex
@@ -1,0 +1,4 @@
+defmodule DirectModuleQualifier do
+  %{}
+  |> MyNamespace.Referenced.<caret>changeset()
+end

--- a/testData/org/elixir_lang/reference/callable/issue_480/double_aliased_module_qualifier.ex
+++ b/testData/org/elixir_lang/reference/callable/issue_480/double_aliased_module_qualifier.ex
@@ -1,0 +1,7 @@
+defmodule AliasedModuleQualifier do
+  alias MyNamespace.Referenced
+  alias Referenced, as: Refd
+
+  %{}
+  |> Refd.<caret>changeset()
+end

--- a/testData/org/elixir_lang/reference/callable/issue_480/local.ex
+++ b/testData/org/elixir_lang/reference/callable/issue_480/local.ex
@@ -1,0 +1,18 @@
+defmodule MyNamespace.Local do
+  use Ecto.Schema
+
+  schema "" do
+    field "name", :string
+  end
+
+  def changeset(params) do
+    %__MODULE__{}
+    |> <caret>changeset(params)
+  end
+
+  def changeset(data, params) do
+    data
+    |> cast(params, ~w(name))
+    |> validate_required(:name)
+  end
+end

--- a/testData/org/elixir_lang/reference/callable/issue_480/map_access_qualifier.ex
+++ b/testData/org/elixir_lang/reference/callable/issue_480/map_access_qualifier.ex
@@ -1,0 +1,6 @@
+defmodule AliasedModuleQualifier do
+  referenced = %MyNamespace.Referenced{}
+
+  %{}
+  |> referenced.__struct__.<caret>__struct__()
+end

--- a/testData/org/elixir_lang/reference/callable/issue_480/referenced.ex
+++ b/testData/org/elixir_lang/reference/callable/issue_480/referenced.ex
@@ -1,0 +1,13 @@
+defmodule MyNamespace.Referenced do
+  use Ecto.Schema
+
+  schema "" do
+    field "name", :string
+  end
+
+  def changeset(params) do
+    %__MODULE__{}
+    |> cast(params, ~w(name))
+    |> validate_required(:name)
+  end
+end

--- a/testData/org/elixir_lang/reference/callable/issue_480/remote.ex
+++ b/testData/org/elixir_lang/reference/callable/issue_480/remote.ex
@@ -1,0 +1,6 @@
+defmodule AliasedModuleQualifier do
+  import MyNamespace.Referenced
+
+  %{}
+  |> <caret>changeset()
+end

--- a/testData/org/elixir_lang/reference/callable/issue_480/unresolved_alias_qualifier.ex
+++ b/testData/org/elixir_lang/reference/callable/issue_480/unresolved_alias_qualifier.ex
@@ -1,0 +1,4 @@
+defmodule AliasedModuleQualifier do
+  %{}
+  |> Unresolved.<caret>changeset()
+end

--- a/tests/org/elixir_lang/reference/callable/Issue480Test.java
+++ b/tests/org/elixir_lang/reference/callable/Issue480Test.java
@@ -1,0 +1,134 @@
+package org.elixir_lang.reference.callable;
+
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiReference;
+import com.intellij.testFramework.fixtures.LightCodeInsightFixtureTestCase;
+import org.apache.commons.lang.math.IntRange;
+import org.elixir_lang.psi.ElixirIdentifier;
+import org.elixir_lang.psi.call.Call;
+import org.elixir_lang.structure_view.element.CallDefinitionClause;
+import org.jetbrains.annotations.NotNull;
+
+import static com.intellij.openapi.util.Pair.pair;
+import static org.elixir_lang.structure_view.element.CallDefinitionClause.nameArityRange;
+
+public class Issue480Test extends LightCodeInsightFixtureTestCase {
+    /*
+     * Tests
+     */
+
+    public void testLocal() {
+        myFixture.configureByFiles("local.ex", "referenced.ex");
+        assertReferenceAndResolvedNameArityRange("changeset", 2);
+    }
+
+    public void testRemote() {
+        myFixture.configureByFiles("remote.ex", "referenced.ex");
+        assertUnresolvableReferenceNameArityRange("changeset", 1);
+    }
+
+    public void testDirectModuleQualifier() {
+        myFixture.configureByFiles("direct_module_qualifier.ex", "referenced.ex");
+        assertReferenceAndResolvedNameArityRange("changeset", 1);
+    }
+
+    public void testAliasedModuleQualifier() {
+        myFixture.configureByFiles("aliased_module_qualifier.ex", "referenced.ex");
+        assertReferenceAndResolvedNameArityRange("changeset", 1);
+    }
+
+    public void testDoubleAliasesModuleQualifier() {
+        myFixture.configureByFiles("double_aliased_module_qualifier.ex", "referenced.ex");
+        assertUnresolvableReferenceNameArityRange("changeset", 1);
+    }
+
+    public void testMapAccessQualifier() {
+        myFixture.configureByFiles("map_access_qualifier.ex", "referenced.ex");
+        assertUnresolvableReferenceNameArityRange("__struct__", 1);
+    }
+
+    public void testUnresolvedAliasQualifier() {
+        myFixture.configureByFiles("unresolved_alias_qualifier.ex", "referenced.ex");
+        assertUnresolvableReferenceNameArityRange("changeset", 1);
+    }
+
+    /*
+     * Protected Instance Methods
+     */
+
+    @Override
+    protected String getTestDataPath() {
+        return "testData/org/elixir_lang/reference/callable/issue_480";
+    }
+
+    /*
+     * Private Instance Methods
+     */
+
+    private void assertUnresolvableReferenceNameArityRange(@NotNull String name, int arity) {
+        PsiElement elementAtCaret = myFixture
+                .getFile()
+                .findElementAt(myFixture.getCaretOffset());
+
+        assertNotNull(elementAtCaret);
+
+        PsiElement grandParent = elementAtCaret.getParent().getParent();
+
+        assertNotNull(grandParent);
+        assertInstanceOf(grandParent, Call.class);
+
+        Call grandParentCall = (Call) grandParent;
+
+        assertEquals(name, grandParentCall.functionName());
+        assertEquals(arity, grandParentCall.resolvedFinalArity());
+
+        PsiReference reference = grandParent.getReference();
+
+        assertNotNull(reference);
+
+        PsiElement resolved = reference.resolve();
+
+        assertNull(resolved);
+    }
+
+    private void assertReferenceAndResolvedNameArityRange(@NotNull String name, int arity) {
+        PsiElement elementAtCaret = myFixture
+                .getFile()
+                .findElementAt(myFixture.getCaretOffset());
+
+        assertNotNull(elementAtCaret);
+
+        PsiElement grandParent = elementAtCaret.getParent().getParent();
+
+        assertNotNull(grandParent);
+        assertInstanceOf(grandParent, Call.class);
+
+        Call grandParentCall = (Call) grandParent;
+
+        assertEquals(name, grandParentCall.functionName());
+        assertEquals(arity, grandParentCall.resolvedFinalArity());
+
+        assertResolvedNameArityRange(grandParentCall, name, arity);
+    }
+
+    private void assertResolvedNameArityRange(@NotNull PsiElement element, @NotNull String name, int arity) {
+        PsiReference reference = element.getReference();
+
+        assertNotNull(reference);
+
+        PsiElement resolved = reference.resolve();
+
+        assertNotNull(resolved);
+
+        assertInstanceOf(resolved, ElixirIdentifier.class);
+
+        PsiElement maybeDefMaybeCall = resolved.getParent().getParent().getParent();
+        assertInstanceOf(maybeDefMaybeCall, Call.class);
+
+        Call maybeDefCall = (Call) maybeDefMaybeCall;
+
+        assertTrue(CallDefinitionClause.is(maybeDefCall));
+
+        assertEquals(pair(name, new IntRange(arity)), nameArityRange(maybeDefCall));
+    }
+}


### PR DESCRIPTION
Fixes #480

# Changelog
## Enhancements
* Extract `Arrow` interface for `*ArrowOperation`s.
* Regression tests for #480

## Bug Fixes
* Increase `resolvedFinalArity` by `1` for piping.