### PR TITLE
Go To Declarations for imports

### DIFF
--- a/gen/org/elixir_lang/psi/ElixirMatchedAtUnqualifiedNoParenthesesCall.java
+++ b/gen/org/elixir_lang/psi/ElixirMatchedAtUnqualifiedNoParenthesesCall.java
@@ -2,6 +2,7 @@
 package org.elixir_lang.psi;
 
 import com.ericsson.otp.erlang.OtpErlangObject;
+import com.intellij.navigation.ItemPresentation;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiReference;
 import com.intellij.psi.ResolveState;
@@ -44,6 +45,9 @@ public interface ElixirMatchedAtUnqualifiedNoParenthesesCall extends ElixirMatch
   String getName();
 
   PsiElement getNameIdentifier();
+
+  @NotNull
+  ItemPresentation getPresentation();
 
   @Nullable
   PsiReference getReference();

--- a/gen/org/elixir_lang/psi/ElixirMatchedDotCall.java
+++ b/gen/org/elixir_lang/psi/ElixirMatchedDotCall.java
@@ -2,6 +2,7 @@
 package org.elixir_lang.psi;
 
 import com.ericsson.otp.erlang.OtpErlangObject;
+import com.intellij.navigation.ItemPresentation;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiReference;
 import com.intellij.psi.ResolveState;
@@ -47,6 +48,9 @@ public interface ElixirMatchedDotCall extends ElixirMatchedExpression, DotCall<M
   String getName();
 
   PsiElement getNameIdentifier();
+
+  @NotNull
+  ItemPresentation getPresentation();
 
   @Nullable
   PsiReference getReference();

--- a/gen/org/elixir_lang/psi/ElixirMatchedQualifiedNoArgumentsCall.java
+++ b/gen/org/elixir_lang/psi/ElixirMatchedQualifiedNoArgumentsCall.java
@@ -2,6 +2,7 @@
 package org.elixir_lang.psi;
 
 import com.ericsson.otp.erlang.OtpErlangObject;
+import com.intellij.navigation.ItemPresentation;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiReference;
 import com.intellij.psi.ResolveState;
@@ -45,6 +46,9 @@ public interface ElixirMatchedQualifiedNoArgumentsCall extends ElixirMatchedExpr
   String getName();
 
   PsiElement getNameIdentifier();
+
+  @NotNull
+  ItemPresentation getPresentation();
 
   @Nullable
   PsiReference getReference();

--- a/gen/org/elixir_lang/psi/ElixirMatchedQualifiedNoParenthesesCall.java
+++ b/gen/org/elixir_lang/psi/ElixirMatchedQualifiedNoParenthesesCall.java
@@ -2,6 +2,7 @@
 package org.elixir_lang.psi;
 
 import com.ericsson.otp.erlang.OtpErlangObject;
+import com.intellij.navigation.ItemPresentation;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiReference;
 import com.intellij.psi.ResolveState;
@@ -48,6 +49,9 @@ public interface ElixirMatchedQualifiedNoParenthesesCall extends ElixirMatchedEx
   String getName();
 
   PsiElement getNameIdentifier();
+
+  @NotNull
+  ItemPresentation getPresentation();
 
   @Nullable
   PsiReference getReference();

--- a/gen/org/elixir_lang/psi/ElixirMatchedQualifiedParenthesesCall.java
+++ b/gen/org/elixir_lang/psi/ElixirMatchedQualifiedParenthesesCall.java
@@ -2,6 +2,7 @@
 package org.elixir_lang.psi;
 
 import com.ericsson.otp.erlang.OtpErlangObject;
+import com.intellij.navigation.ItemPresentation;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiReference;
 import com.intellij.psi.ResolveState;
@@ -48,6 +49,9 @@ public interface ElixirMatchedQualifiedParenthesesCall extends ElixirMatchedExpr
   String getName();
 
   PsiElement getNameIdentifier();
+
+  @NotNull
+  ItemPresentation getPresentation();
 
   @Nullable
   PsiReference getReference();

--- a/gen/org/elixir_lang/psi/ElixirMatchedUnqualifiedNoArgumentsCall.java
+++ b/gen/org/elixir_lang/psi/ElixirMatchedUnqualifiedNoArgumentsCall.java
@@ -2,6 +2,7 @@
 package org.elixir_lang.psi;
 
 import com.ericsson.otp.erlang.OtpErlangObject;
+import com.intellij.navigation.ItemPresentation;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiReference;
 import com.intellij.psi.ResolveState;
@@ -41,6 +42,9 @@ public interface ElixirMatchedUnqualifiedNoArgumentsCall extends ElixirMatchedEx
   String getName();
 
   PsiElement getNameIdentifier();
+
+  @NotNull
+  ItemPresentation getPresentation();
 
   @Nullable
   PsiReference getReference();

--- a/gen/org/elixir_lang/psi/ElixirMatchedUnqualifiedNoParenthesesCall.java
+++ b/gen/org/elixir_lang/psi/ElixirMatchedUnqualifiedNoParenthesesCall.java
@@ -2,6 +2,7 @@
 package org.elixir_lang.psi;
 
 import com.ericsson.otp.erlang.OtpErlangObject;
+import com.intellij.navigation.ItemPresentation;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiReference;
 import com.intellij.psi.ResolveState;
@@ -43,6 +44,9 @@ public interface ElixirMatchedUnqualifiedNoParenthesesCall extends ElixirMatched
   String getName();
 
   PsiElement getNameIdentifier();
+
+  @NotNull
+  ItemPresentation getPresentation();
 
   @Nullable
   PsiReference getReference();

--- a/gen/org/elixir_lang/psi/ElixirMatchedUnqualifiedParenthesesCall.java
+++ b/gen/org/elixir_lang/psi/ElixirMatchedUnqualifiedParenthesesCall.java
@@ -2,6 +2,7 @@
 package org.elixir_lang.psi;
 
 import com.ericsson.otp.erlang.OtpErlangObject;
+import com.intellij.navigation.ItemPresentation;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiReference;
 import com.intellij.psi.ResolveState;
@@ -43,6 +44,9 @@ public interface ElixirMatchedUnqualifiedParenthesesCall extends ElixirMatchedEx
   String getName();
 
   PsiElement getNameIdentifier();
+
+  @NotNull
+  ItemPresentation getPresentation();
 
   @Nullable
   PsiReference getReference();

--- a/gen/org/elixir_lang/psi/ElixirUnmatchedAtUnqualifiedNoParenthesesCall.java
+++ b/gen/org/elixir_lang/psi/ElixirUnmatchedAtUnqualifiedNoParenthesesCall.java
@@ -2,6 +2,7 @@
 package org.elixir_lang.psi;
 
 import com.ericsson.otp.erlang.OtpErlangObject;
+import com.intellij.navigation.ItemPresentation;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiReference;
 import com.intellij.psi.ResolveState;
@@ -44,6 +45,9 @@ public interface ElixirUnmatchedAtUnqualifiedNoParenthesesCall extends ElixirUnm
   String getName();
 
   PsiElement getNameIdentifier();
+
+  @NotNull
+  ItemPresentation getPresentation();
 
   @Nullable
   PsiReference getReference();

--- a/gen/org/elixir_lang/psi/ElixirUnmatchedDotCall.java
+++ b/gen/org/elixir_lang/psi/ElixirUnmatchedDotCall.java
@@ -2,6 +2,7 @@
 package org.elixir_lang.psi;
 
 import com.ericsson.otp.erlang.OtpErlangObject;
+import com.intellij.navigation.ItemPresentation;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiReference;
 import com.intellij.psi.ResolveState;
@@ -47,6 +48,9 @@ public interface ElixirUnmatchedDotCall extends ElixirUnmatchedExpression, DotCa
   String getName();
 
   PsiElement getNameIdentifier();
+
+  @NotNull
+  ItemPresentation getPresentation();
 
   @Nullable
   PsiReference getReference();

--- a/gen/org/elixir_lang/psi/ElixirUnmatchedQualifiedNoArgumentsCall.java
+++ b/gen/org/elixir_lang/psi/ElixirUnmatchedQualifiedNoArgumentsCall.java
@@ -2,6 +2,7 @@
 package org.elixir_lang.psi;
 
 import com.ericsson.otp.erlang.OtpErlangObject;
+import com.intellij.navigation.ItemPresentation;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiReference;
 import com.intellij.psi.ResolveState;
@@ -45,6 +46,9 @@ public interface ElixirUnmatchedQualifiedNoArgumentsCall extends ElixirUnmatched
   String getName();
 
   PsiElement getNameIdentifier();
+
+  @NotNull
+  ItemPresentation getPresentation();
 
   @Nullable
   PsiReference getReference();

--- a/gen/org/elixir_lang/psi/ElixirUnmatchedQualifiedNoParenthesesCall.java
+++ b/gen/org/elixir_lang/psi/ElixirUnmatchedQualifiedNoParenthesesCall.java
@@ -2,6 +2,7 @@
 package org.elixir_lang.psi;
 
 import com.ericsson.otp.erlang.OtpErlangObject;
+import com.intellij.navigation.ItemPresentation;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiReference;
 import com.intellij.psi.ResolveState;
@@ -48,6 +49,9 @@ public interface ElixirUnmatchedQualifiedNoParenthesesCall extends ElixirUnmatch
   String getName();
 
   PsiElement getNameIdentifier();
+
+  @NotNull
+  ItemPresentation getPresentation();
 
   @Nullable
   PsiReference getReference();

--- a/gen/org/elixir_lang/psi/ElixirUnmatchedQualifiedParenthesesCall.java
+++ b/gen/org/elixir_lang/psi/ElixirUnmatchedQualifiedParenthesesCall.java
@@ -2,6 +2,7 @@
 package org.elixir_lang.psi;
 
 import com.ericsson.otp.erlang.OtpErlangObject;
+import com.intellij.navigation.ItemPresentation;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiReference;
 import com.intellij.psi.ResolveState;
@@ -48,6 +49,9 @@ public interface ElixirUnmatchedQualifiedParenthesesCall extends ElixirUnmatched
   String getName();
 
   PsiElement getNameIdentifier();
+
+  @NotNull
+  ItemPresentation getPresentation();
 
   @Nullable
   PsiReference getReference();

--- a/gen/org/elixir_lang/psi/ElixirUnmatchedUnqualifiedNoArgumentsCall.java
+++ b/gen/org/elixir_lang/psi/ElixirUnmatchedUnqualifiedNoArgumentsCall.java
@@ -2,6 +2,7 @@
 package org.elixir_lang.psi;
 
 import com.ericsson.otp.erlang.OtpErlangObject;
+import com.intellij.navigation.ItemPresentation;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiReference;
 import com.intellij.psi.ResolveState;
@@ -41,6 +42,9 @@ public interface ElixirUnmatchedUnqualifiedNoArgumentsCall extends ElixirUnmatch
   String getName();
 
   PsiElement getNameIdentifier();
+
+  @NotNull
+  ItemPresentation getPresentation();
 
   @Nullable
   PsiReference getReference();

--- a/gen/org/elixir_lang/psi/ElixirUnmatchedUnqualifiedNoParenthesesCall.java
+++ b/gen/org/elixir_lang/psi/ElixirUnmatchedUnqualifiedNoParenthesesCall.java
@@ -2,6 +2,7 @@
 package org.elixir_lang.psi;
 
 import com.ericsson.otp.erlang.OtpErlangObject;
+import com.intellij.navigation.ItemPresentation;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiReference;
 import com.intellij.psi.ResolveState;
@@ -43,6 +44,9 @@ public interface ElixirUnmatchedUnqualifiedNoParenthesesCall extends ElixirUnmat
   String getName();
 
   PsiElement getNameIdentifier();
+
+  @NotNull
+  ItemPresentation getPresentation();
 
   @Nullable
   PsiReference getReference();

--- a/gen/org/elixir_lang/psi/ElixirUnmatchedUnqualifiedParenthesesCall.java
+++ b/gen/org/elixir_lang/psi/ElixirUnmatchedUnqualifiedParenthesesCall.java
@@ -2,6 +2,7 @@
 package org.elixir_lang.psi;
 
 import com.ericsson.otp.erlang.OtpErlangObject;
+import com.intellij.navigation.ItemPresentation;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiReference;
 import com.intellij.psi.ResolveState;
@@ -43,6 +44,9 @@ public interface ElixirUnmatchedUnqualifiedParenthesesCall extends ElixirUnmatch
   String getName();
 
   PsiElement getNameIdentifier();
+
+  @NotNull
+  ItemPresentation getPresentation();
 
   @Nullable
   PsiReference getReference();

--- a/gen/org/elixir_lang/psi/ElixirUnqualifiedNoParenthesesManyArgumentsCall.java
+++ b/gen/org/elixir_lang/psi/ElixirUnqualifiedNoParenthesesManyArgumentsCall.java
@@ -2,6 +2,7 @@
 package org.elixir_lang.psi;
 
 import com.ericsson.otp.erlang.OtpErlangObject;
+import com.intellij.navigation.ItemPresentation;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiReference;
 import com.intellij.psi.ResolveState;
@@ -59,6 +60,9 @@ public interface ElixirUnqualifiedNoParenthesesManyArgumentsCall extends PsiElem
   String getName();
 
   PsiElement getNameIdentifier();
+
+  @NotNull
+  ItemPresentation getPresentation();
 
   @Nullable
   PsiReference getReference();

--- a/gen/org/elixir_lang/psi/impl/ElixirMatchedAtUnqualifiedNoParenthesesCallImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMatchedAtUnqualifiedNoParenthesesCallImpl.java
@@ -3,6 +3,7 @@ package org.elixir_lang.psi.impl;
 
 import com.ericsson.otp.erlang.OtpErlangObject;
 import com.intellij.lang.ASTNode;
+import com.intellij.navigation.ItemPresentation;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.PsiReference;
@@ -86,6 +87,11 @@ public class ElixirMatchedAtUnqualifiedNoParenthesesCallImpl extends NamedStubbe
 
   public PsiElement getNameIdentifier() {
     return ElixirPsiImplUtil.getNameIdentifier(this);
+  }
+
+  @NotNull
+  public ItemPresentation getPresentation() {
+    return ElixirPsiImplUtil.getPresentation(this);
   }
 
   @Nullable

--- a/gen/org/elixir_lang/psi/impl/ElixirMatchedDotCallImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMatchedDotCallImpl.java
@@ -3,6 +3,7 @@ package org.elixir_lang.psi.impl;
 
 import com.ericsson.otp.erlang.OtpErlangObject;
 import com.intellij.lang.ASTNode;
+import com.intellij.navigation.ItemPresentation;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.PsiReference;
@@ -92,6 +93,11 @@ public class ElixirMatchedDotCallImpl extends NamedStubbedPsiElementBase<Matched
 
   public PsiElement getNameIdentifier() {
     return ElixirPsiImplUtil.getNameIdentifier(this);
+  }
+
+  @NotNull
+  public ItemPresentation getPresentation() {
+    return ElixirPsiImplUtil.getPresentation(this);
   }
 
   @Nullable

--- a/gen/org/elixir_lang/psi/impl/ElixirMatchedQualifiedNoArgumentsCallImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMatchedQualifiedNoArgumentsCallImpl.java
@@ -3,6 +3,7 @@ package org.elixir_lang.psi.impl;
 
 import com.ericsson.otp.erlang.OtpErlangObject;
 import com.intellij.lang.ASTNode;
+import com.intellij.navigation.ItemPresentation;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.PsiReference;
@@ -90,6 +91,11 @@ public class ElixirMatchedQualifiedNoArgumentsCallImpl extends NamedStubbedPsiEl
 
   public PsiElement getNameIdentifier() {
     return ElixirPsiImplUtil.getNameIdentifier(this);
+  }
+
+  @NotNull
+  public ItemPresentation getPresentation() {
+    return ElixirPsiImplUtil.getPresentation(this);
   }
 
   @Nullable

--- a/gen/org/elixir_lang/psi/impl/ElixirMatchedQualifiedNoParenthesesCallImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMatchedQualifiedNoParenthesesCallImpl.java
@@ -3,6 +3,7 @@ package org.elixir_lang.psi.impl;
 
 import com.ericsson.otp.erlang.OtpErlangObject;
 import com.intellij.lang.ASTNode;
+import com.intellij.navigation.ItemPresentation;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.PsiReference;
@@ -96,6 +97,11 @@ public class ElixirMatchedQualifiedNoParenthesesCallImpl extends NamedStubbedPsi
 
   public PsiElement getNameIdentifier() {
     return ElixirPsiImplUtil.getNameIdentifier(this);
+  }
+
+  @NotNull
+  public ItemPresentation getPresentation() {
+    return ElixirPsiImplUtil.getPresentation(this);
   }
 
   @Nullable

--- a/gen/org/elixir_lang/psi/impl/ElixirMatchedQualifiedParenthesesCallImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMatchedQualifiedParenthesesCallImpl.java
@@ -3,6 +3,7 @@ package org.elixir_lang.psi.impl;
 
 import com.ericsson.otp.erlang.OtpErlangObject;
 import com.intellij.lang.ASTNode;
+import com.intellij.navigation.ItemPresentation;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.PsiReference;
@@ -96,6 +97,11 @@ public class ElixirMatchedQualifiedParenthesesCallImpl extends NamedStubbedPsiEl
 
   public PsiElement getNameIdentifier() {
     return ElixirPsiImplUtil.getNameIdentifier(this);
+  }
+
+  @NotNull
+  public ItemPresentation getPresentation() {
+    return ElixirPsiImplUtil.getPresentation(this);
   }
 
   @Nullable

--- a/gen/org/elixir_lang/psi/impl/ElixirMatchedUnqualifiedNoArgumentsCallImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMatchedUnqualifiedNoArgumentsCallImpl.java
@@ -3,6 +3,7 @@ package org.elixir_lang.psi.impl;
 
 import com.ericsson.otp.erlang.OtpErlangObject;
 import com.intellij.lang.ASTNode;
+import com.intellij.navigation.ItemPresentation;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.PsiReference;
@@ -83,6 +84,11 @@ public class ElixirMatchedUnqualifiedNoArgumentsCallImpl extends NamedStubbedPsi
 
   public PsiElement getNameIdentifier() {
     return ElixirPsiImplUtil.getNameIdentifier(this);
+  }
+
+  @NotNull
+  public ItemPresentation getPresentation() {
+    return ElixirPsiImplUtil.getPresentation(this);
   }
 
   @Nullable

--- a/gen/org/elixir_lang/psi/impl/ElixirMatchedUnqualifiedNoParenthesesCallImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMatchedUnqualifiedNoParenthesesCallImpl.java
@@ -3,6 +3,7 @@ package org.elixir_lang.psi.impl;
 
 import com.ericsson.otp.erlang.OtpErlangObject;
 import com.intellij.lang.ASTNode;
+import com.intellij.navigation.ItemPresentation;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.PsiReference;
@@ -85,6 +86,11 @@ public class ElixirMatchedUnqualifiedNoParenthesesCallImpl extends NamedStubbedP
 
   public PsiElement getNameIdentifier() {
     return ElixirPsiImplUtil.getNameIdentifier(this);
+  }
+
+  @NotNull
+  public ItemPresentation getPresentation() {
+    return ElixirPsiImplUtil.getPresentation(this);
   }
 
   @Nullable

--- a/gen/org/elixir_lang/psi/impl/ElixirMatchedUnqualifiedParenthesesCallImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMatchedUnqualifiedParenthesesCallImpl.java
@@ -3,6 +3,7 @@ package org.elixir_lang.psi.impl;
 
 import com.ericsson.otp.erlang.OtpErlangObject;
 import com.intellij.lang.ASTNode;
+import com.intellij.navigation.ItemPresentation;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.PsiReference;
@@ -85,6 +86,11 @@ public class ElixirMatchedUnqualifiedParenthesesCallImpl extends NamedStubbedPsi
 
   public PsiElement getNameIdentifier() {
     return ElixirPsiImplUtil.getNameIdentifier(this);
+  }
+
+  @NotNull
+  public ItemPresentation getPresentation() {
+    return ElixirPsiImplUtil.getPresentation(this);
   }
 
   @Nullable

--- a/gen/org/elixir_lang/psi/impl/ElixirUnmatchedAtUnqualifiedNoParenthesesCallImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnmatchedAtUnqualifiedNoParenthesesCallImpl.java
@@ -3,6 +3,7 @@ package org.elixir_lang.psi.impl;
 
 import com.ericsson.otp.erlang.OtpErlangObject;
 import com.intellij.lang.ASTNode;
+import com.intellij.navigation.ItemPresentation;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.PsiReference;
@@ -87,6 +88,11 @@ public class ElixirUnmatchedAtUnqualifiedNoParenthesesCallImpl extends NamedStub
 
   public PsiElement getNameIdentifier() {
     return ElixirPsiImplUtil.getNameIdentifier(this);
+  }
+
+  @NotNull
+  public ItemPresentation getPresentation() {
+    return ElixirPsiImplUtil.getPresentation(this);
   }
 
   @Nullable

--- a/gen/org/elixir_lang/psi/impl/ElixirUnmatchedDotCallImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnmatchedDotCallImpl.java
@@ -3,6 +3,7 @@ package org.elixir_lang.psi.impl;
 
 import com.ericsson.otp.erlang.OtpErlangObject;
 import com.intellij.lang.ASTNode;
+import com.intellij.navigation.ItemPresentation;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.PsiReference;
@@ -93,6 +94,11 @@ public class ElixirUnmatchedDotCallImpl extends NamedStubbedPsiElementBase<Unmat
 
   public PsiElement getNameIdentifier() {
     return ElixirPsiImplUtil.getNameIdentifier(this);
+  }
+
+  @NotNull
+  public ItemPresentation getPresentation() {
+    return ElixirPsiImplUtil.getPresentation(this);
   }
 
   @Nullable

--- a/gen/org/elixir_lang/psi/impl/ElixirUnmatchedQualifiedNoArgumentsCallImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnmatchedQualifiedNoArgumentsCallImpl.java
@@ -3,6 +3,7 @@ package org.elixir_lang.psi.impl;
 
 import com.ericsson.otp.erlang.OtpErlangObject;
 import com.intellij.lang.ASTNode;
+import com.intellij.navigation.ItemPresentation;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.PsiReference;
@@ -91,6 +92,11 @@ public class ElixirUnmatchedQualifiedNoArgumentsCallImpl extends NamedStubbedPsi
 
   public PsiElement getNameIdentifier() {
     return ElixirPsiImplUtil.getNameIdentifier(this);
+  }
+
+  @NotNull
+  public ItemPresentation getPresentation() {
+    return ElixirPsiImplUtil.getPresentation(this);
   }
 
   @Nullable

--- a/gen/org/elixir_lang/psi/impl/ElixirUnmatchedQualifiedNoParenthesesCallImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnmatchedQualifiedNoParenthesesCallImpl.java
@@ -3,6 +3,7 @@ package org.elixir_lang.psi.impl;
 
 import com.ericsson.otp.erlang.OtpErlangObject;
 import com.intellij.lang.ASTNode;
+import com.intellij.navigation.ItemPresentation;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.PsiReference;
@@ -97,6 +98,11 @@ public class ElixirUnmatchedQualifiedNoParenthesesCallImpl extends NamedStubbedP
 
   public PsiElement getNameIdentifier() {
     return ElixirPsiImplUtil.getNameIdentifier(this);
+  }
+
+  @NotNull
+  public ItemPresentation getPresentation() {
+    return ElixirPsiImplUtil.getPresentation(this);
   }
 
   @Nullable

--- a/gen/org/elixir_lang/psi/impl/ElixirUnmatchedQualifiedParenthesesCallImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnmatchedQualifiedParenthesesCallImpl.java
@@ -3,6 +3,7 @@ package org.elixir_lang.psi.impl;
 
 import com.ericsson.otp.erlang.OtpErlangObject;
 import com.intellij.lang.ASTNode;
+import com.intellij.navigation.ItemPresentation;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.PsiReference;
@@ -97,6 +98,11 @@ public class ElixirUnmatchedQualifiedParenthesesCallImpl extends NamedStubbedPsi
 
   public PsiElement getNameIdentifier() {
     return ElixirPsiImplUtil.getNameIdentifier(this);
+  }
+
+  @NotNull
+  public ItemPresentation getPresentation() {
+    return ElixirPsiImplUtil.getPresentation(this);
   }
 
   @Nullable

--- a/gen/org/elixir_lang/psi/impl/ElixirUnmatchedUnqualifiedNoArgumentsCallImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnmatchedUnqualifiedNoArgumentsCallImpl.java
@@ -3,6 +3,7 @@ package org.elixir_lang.psi.impl;
 
 import com.ericsson.otp.erlang.OtpErlangObject;
 import com.intellij.lang.ASTNode;
+import com.intellij.navigation.ItemPresentation;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.PsiReference;
@@ -84,6 +85,11 @@ public class ElixirUnmatchedUnqualifiedNoArgumentsCallImpl extends NamedStubbedP
 
   public PsiElement getNameIdentifier() {
     return ElixirPsiImplUtil.getNameIdentifier(this);
+  }
+
+  @NotNull
+  public ItemPresentation getPresentation() {
+    return ElixirPsiImplUtil.getPresentation(this);
   }
 
   @Nullable

--- a/gen/org/elixir_lang/psi/impl/ElixirUnmatchedUnqualifiedNoParenthesesCallImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnmatchedUnqualifiedNoParenthesesCallImpl.java
@@ -3,6 +3,7 @@ package org.elixir_lang.psi.impl;
 
 import com.ericsson.otp.erlang.OtpErlangObject;
 import com.intellij.lang.ASTNode;
+import com.intellij.navigation.ItemPresentation;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.PsiReference;
@@ -86,6 +87,11 @@ public class ElixirUnmatchedUnqualifiedNoParenthesesCallImpl extends NamedStubbe
 
   public PsiElement getNameIdentifier() {
     return ElixirPsiImplUtil.getNameIdentifier(this);
+  }
+
+  @NotNull
+  public ItemPresentation getPresentation() {
+    return ElixirPsiImplUtil.getPresentation(this);
   }
 
   @Nullable

--- a/gen/org/elixir_lang/psi/impl/ElixirUnmatchedUnqualifiedParenthesesCallImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnmatchedUnqualifiedParenthesesCallImpl.java
@@ -3,6 +3,7 @@ package org.elixir_lang.psi.impl;
 
 import com.ericsson.otp.erlang.OtpErlangObject;
 import com.intellij.lang.ASTNode;
+import com.intellij.navigation.ItemPresentation;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.PsiReference;
@@ -86,6 +87,11 @@ public class ElixirUnmatchedUnqualifiedParenthesesCallImpl extends NamedStubbedP
 
   public PsiElement getNameIdentifier() {
     return ElixirPsiImplUtil.getNameIdentifier(this);
+  }
+
+  @NotNull
+  public ItemPresentation getPresentation() {
+    return ElixirPsiImplUtil.getPresentation(this);
   }
 
   @Nullable

--- a/gen/org/elixir_lang/psi/impl/ElixirUnqualifiedNoParenthesesManyArgumentsCallImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnqualifiedNoParenthesesManyArgumentsCallImpl.java
@@ -3,6 +3,7 @@ package org.elixir_lang.psi.impl;
 
 import com.ericsson.otp.erlang.OtpErlangObject;
 import com.intellij.lang.ASTNode;
+import com.intellij.navigation.ItemPresentation;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.PsiReference;
@@ -110,6 +111,11 @@ public class ElixirUnqualifiedNoParenthesesManyArgumentsCallImpl extends NamedSt
 
   public PsiElement getNameIdentifier() {
     return ElixirPsiImplUtil.getNameIdentifier(this);
+  }
+
+  @NotNull
+  public ItemPresentation getPresentation() {
+    return ElixirPsiImplUtil.getPresentation(this);
   }
 
   @Nullable

--- a/src/org/elixir_lang/Elixir.bnf
+++ b/src/org/elixir_lang/Elixir.bnf
@@ -18,6 +18,7 @@
     hasDoBlockOrKeyword
     getName
     getNameIdentifier
+    getPresentation
     getReference
     getStub
     getUseScope
@@ -48,6 +49,7 @@
     hasDoBlockOrKeyword
     getName
     getNameIdentifier
+    getPresentation
     getReference
     getStub
     getUseScope

--- a/src/org/elixir_lang/annonator/ModuleAttribute.java
+++ b/src/org/elixir_lang/annonator/ModuleAttribute.java
@@ -29,6 +29,7 @@ import java.util.Set;
 
 import static org.elixir_lang.psi.call.name.Function.UNQUOTE;
 import static org.elixir_lang.psi.call.name.Module.KERNEL;
+import static org.elixir_lang.psi.impl.ElixirPsiImplUtil.stripAccessExpression;
 import static org.elixir_lang.reference.ModuleAttribute.*;
 
 /**
@@ -1282,30 +1283,14 @@ public class ModuleAttribute implements Annotator, DumbAware {
             PsiElement firstChild = children[0];
 
             if (firstChild instanceof UnqualifiedNoArgumentsCall) {
-                PsiElement secondChild = children[1];
+                PsiElement strippedSecondChild = stripAccessExpression(children[1]);
 
-                if (secondChild instanceof ElixirAccessExpression) {
-                    PsiElement[] secondChildChildren = secondChild.getChildren();
+                if (strippedSecondChild instanceof ElixirList) {
+                    PsiElement strippedThirdChild = stripAccessExpression(children[2]);
 
-                    if (secondChildChildren.length == 1) {
-                        PsiElement secondChildChild = secondChildChildren[0];
-
-                        if (secondChildChild instanceof ElixirList) {
-                            PsiElement thirdChild = children[2];
-
-                            if (thirdChild instanceof ElixirAccessExpression) {
-                                PsiElement[] thirdChildChildren = thirdChild.getChildren();
-
-                                if (thirdChildChildren.length == 1) {
-                                    PsiElement thirdChildChild = thirdChildChildren[0];
-
-                                    if (thirdChildChild instanceof ElixirAtomKeyword &&
-                                            thirdChildChild.getText().equals("nil")) {
-                                        typeParameterNameSet = Collections.singleton(firstChild.getText());
-                                    }
-                                }
-                            }
-                        }
+                    if (strippedThirdChild instanceof ElixirAtomKeyword &&
+                            strippedThirdChild.getText().equals("nil")) {
+                        typeParameterNameSet = Collections.singleton(firstChild.getText());
                     }
                 }
             }

--- a/src/org/elixir_lang/code_insight/completion/provider/CallDefinitionClause.java
+++ b/src/org/elixir_lang/code_insight/completion/provider/CallDefinitionClause.java
@@ -9,6 +9,7 @@ import com.intellij.psi.PsiElement;
 import com.intellij.util.ProcessingContext;
 import org.apache.commons.lang.math.IntRange;
 import org.elixir_lang.psi.call.Call;
+import org.elixir_lang.psi.impl.ElixirPsiImplUtil;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
@@ -16,7 +17,6 @@ import java.util.Collections;
 import java.util.List;
 
 import static org.elixir_lang.psi.impl.ElixirPsiImplUtil.macroChildCalls;
-import static org.elixir_lang.psi.impl.ElixirPsiImplUtil.qualifierToModular;
 import static org.elixir_lang.structure_view.element.CallDefinitionClause.nameArityRange;
 
 public class CallDefinitionClause extends CompletionProvider<CompletionParameters> {
@@ -95,7 +95,7 @@ public class CallDefinitionClause extends CompletionProvider<CompletionParameter
                     org.elixir_lang.psi.qualification.Qualified qualifiedGrandParent = (org.elixir_lang.psi.qualification.Qualified) grandParent;
                     PsiElement qualifier = qualifiedGrandParent.qualifier();
 
-                    Call modular = qualifierToModular(qualifier);
+                    Call modular = ElixirPsiImplUtil.maybeAliasToModular(qualifier);
 
                     if (modular != null) {
                         resultSet.withPrefixMatcher("").addAllElements(

--- a/src/org/elixir_lang/psi/ElementDescriptionProvider.java
+++ b/src/org/elixir_lang/psi/ElementDescriptionProvider.java
@@ -179,6 +179,8 @@ public class ElementDescriptionProvider implements com.intellij.psi.ElementDescr
             elementDescription = org.elixir_lang.structure_view.element.Exception.elementDescription(call, location);
         } else if (Implementation.is(call)) {
             elementDescription = Implementation.elementDescription(call, location);
+        } else if (Import.is(call)) {
+            elementDescription = Import.elementDescription(call, location);
         } else if (Module.is(call)) {
             elementDescription = Module.elementDescription(call, location);
         } else if (Overridable.is(call)) {

--- a/src/org/elixir_lang/psi/Import.java
+++ b/src/org/elixir_lang/psi/Import.java
@@ -1,0 +1,141 @@
+package org.elixir_lang.psi;
+
+import com.intellij.ide.scratch.ScratchFileServiceImpl;
+import com.intellij.psi.PsiElement;
+import com.intellij.util.Function;
+import org.elixir_lang.psi.call.Call;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import static org.elixir_lang.psi.call.name.Function.IMPORT;
+import static org.elixir_lang.psi.call.name.Module.KERNEL;
+import static org.elixir_lang.psi.impl.ElixirPsiImplUtil.finalArguments;
+import static org.elixir_lang.psi.impl.ElixirPsiImplUtil.fullyResolveAlias;
+import static org.elixir_lang.psi.impl.ElixirPsiImplUtil.maybeAliasToModular;
+
+/**
+ * An {@code import} call
+ */
+public class Import {
+    /*
+     * CONSTANTS
+     */
+
+    private static final Function<Call, Boolean> TRUE = new Function<Call, Boolean>() {
+        @Contract(pure = true)
+        @NotNull
+        @Override
+        public Boolean fun(@NotNull @SuppressWarnings("unused") Call call) {
+            return true;
+        }
+    };
+
+    /*
+     * Public Static Methods
+     */
+
+    /**
+     * Calls {@code function} on each call definition clause imported by {@code importCall} while {@code function}
+     * returns {@code true}.  Stops the first time {@code function} returns {@code false}
+     *
+     * @param importCall an {@code import} {@link Call} (should have already been checked with {@link #is(Call)}.
+     * @param function For {@code import Module}, called on all call definition clauses in {@code Module}; for
+     *   {@code import Module, only: [...]} called on only the call definition clauses matching names in
+     *   {@code :only} list; for {@code import Module, except: [...]} called on all call definition clauses expect those
+     *   matching names in {@code :except} list.
+     */
+    public static void callDefinitionClauseCallWhile(@NotNull Call importCall,
+                                                     @NotNull final Function<Call, Boolean> function) {
+        Call modularCall = modular(importCall);
+
+        if (modularCall != null) {
+            final Function<Call, Boolean> optionsFilter = callDefinitionClauseCallFilter(importCall);
+
+            Modular.callDefinitionClauseCallWhile(
+                    modularCall,
+                    new Function<Call, Boolean>() {
+                        @Override
+                        public Boolean fun(Call call) {
+                            return !optionsFilter.fun(call) || function.fun(call);
+                        }
+                    }
+            );
+        }
+    }
+
+
+    /**
+     * Whether {@code call} is an {@code import Module} or {@code import Module, opts} call
+     */
+    public static boolean is(@NotNull Call call) {
+        boolean is = false;
+
+        if (call.isCalling(KERNEL, IMPORT)) {
+            int resolvedFinalArity = call.resolvedFinalArity();
+
+            if (1 <= resolvedFinalArity && resolvedFinalArity <= 2) {
+                is = true;
+            }
+        }
+
+        return is;
+    }
+
+    /*
+     * Private Static Methods
+     */
+
+    /**
+     * A {@link Function} that returns {@code true} for call definition clauses that are imported by {@code importCall}
+     *
+     * @param importCall {@code import} call
+     */
+    @NotNull
+    private static Function<Call, Boolean> callDefinitionClauseCallFilter(@NotNull Call importCall) {
+        PsiElement[] finalArguments = finalArguments(importCall);
+        Function<Call, Boolean> filter = TRUE;
+
+        if (finalArguments != null && finalArguments.length > 2) {
+            filter = optionsCallDefinitionClauseCallFilter(finalArguments[0]);
+        }
+
+        return filter;
+    }
+
+    /**
+     * The modular that is imported by {@code importCall}.
+     * @param importCall a {@link Call} where {@link #is} is {@code true}.
+     * @return {@code defmodule}, {@code defimpl}, or {@code defprotocol} imported by {@code importCall}.  It can be
+     *   {@code null} if Alias passed to {@code importCall} cannot be resolved.
+     */
+    @Nullable
+    private static Call modular(@NotNull Call importCall) {
+        PsiElement[] finalArguments = finalArguments(importCall);
+        Call modular = null;
+
+        if (finalArguments != null && finalArguments.length >= 1) {
+            modular = maybeAliasToModular(finalArguments[0]);
+        }
+
+        return modular;
+    }
+
+
+    /**
+     * A {@link Function} that returns {@code true} for call definition clauses that are imported by {@code importCall}
+     *
+     * @param options options (second argument) to an {@code import Module, ...} call.
+     */
+    @Nullable
+    private static Function<Call, Boolean> optionsCallDefinitionClauseCallFilter(@Nullable PsiElement options) {
+        Function<Call, Boolean> filter = TRUE;
+
+        if (options != null) {
+            assert options != null;
+        }
+
+        return filter;
+    }
+
+}

--- a/src/org/elixir_lang/psi/Import.java
+++ b/src/org/elixir_lang/psi/Import.java
@@ -1,7 +1,10 @@
 package org.elixir_lang.psi;
 
 import com.intellij.ide.scratch.ScratchFileServiceImpl;
+import com.intellij.psi.ElementDescriptionLocation;
 import com.intellij.psi.PsiElement;
+import com.intellij.usageView.UsageViewNodeTextLocation;
+import com.intellij.usageView.UsageViewTypeLocation;
 import com.intellij.util.Function;
 import org.elixir_lang.psi.call.Call;
 import org.jetbrains.annotations.Contract;
@@ -64,6 +67,18 @@ public class Import {
         }
     }
 
+    @Nullable
+    public static String elementDescription(@NotNull Call call, @NotNull ElementDescriptionLocation location) {
+        String elementDescription = null;
+
+        if (location == UsageViewTypeLocation.INSTANCE) {
+            elementDescription = "import";
+        } else if (location == UsageViewNodeTextLocation.INSTANCE) {
+            elementDescription = call.getText();
+        }
+
+        return elementDescription;
+    }
 
     /**
      * Whether {@code call} is an {@code import Module} or {@code import Module, opts} call
@@ -137,5 +152,4 @@ public class Import {
 
         return filter;
     }
-
 }

--- a/src/org/elixir_lang/psi/Modular.java
+++ b/src/org/elixir_lang/psi/Modular.java
@@ -18,30 +18,48 @@ public class Modular {
      * Public Static Methods
      */
 
-    public static <Result> void forEachCallDefinitionClauseNameIdentifier(
+    public static void callDefinitionClauseCallWhile(@NotNull final Call modular,
+                                                     @NotNull Function<Call, Boolean> function) {
+        Call[] childCalls = macroChildCalls(modular);
+
+        if (childCalls != null) {
+            for (Call childCall : childCalls) {
+                if (CallDefinitionClause.is(childCall)) {
+                    if (!function.fun(childCall)) {
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    public static void forEachCallDefinitionClauseNameIdentifier(
             @NotNull Call modular,
             @Nullable final String functionName,
             final int resolvedFinalArity,
-            @NotNull final Function<PsiElement, Result> function
+            @NotNull final Function<PsiElement, Boolean> function
     ) {
-        forEachCallDefinitionClauseCall(
+        callDefinitionClauseCallWhile(
                 modular,
                 functionName,
                 resolvedFinalArity,
-                new Function<Call, Object>() {
+                new Function<Call, Boolean>() {
                     @Override
-                    public Object fun(Call call) {
+                    public Boolean fun(Call call) {
+                        boolean keepProcessing = true;
+
                         if (call instanceof Named) {
                             Named named = (Named) call;
                             PsiElement nameIdentifier = named.getNameIdentifier();
 
                             if (nameIdentifier != null) {
-                                function.fun(nameIdentifier);
+                                if (!function.fun(nameIdentifier)) {
+                                    keepProcessing = false;
+                                }
                             }
                         }
 
-
-                        return null;
+                        return keepProcessing;
                     }
                 }
         );
@@ -51,33 +69,18 @@ public class Modular {
      * Private Static Methods
      */
 
-    /**
-     * @param modular
-     */
-    private static <Result> void forEachCallDefinitionClauseCall(@NotNull final Call modular,
-                                                                 @NotNull Function<Call, Result> function) {
-        Call[] childCalls = macroChildCalls(modular);
-
-        if (childCalls != null) {
-            for (Call childCall : childCalls) {
-                if (CallDefinitionClause.is(childCall)) {
-                    function.fun(childCall);
-                }
-            }
-        }
-    }
-
-    private static <Result> void forEachCallDefinitionClauseCall(@NotNull Call modular,
-                                                                 @Nullable final String functionName,
-                                                                 final int resolvedFinalArity,
-                                                                 @NotNull final Function<Call, Result> function) {
+    private static void callDefinitionClauseCallWhile(@NotNull Call modular,
+                                                               @Nullable final String functionName,
+                                                               final int resolvedFinalArity,
+                                                               @NotNull final Function<Call, Boolean> function) {
         if (functionName != null) {
-            forEachCallDefinitionClauseCall(
+            callDefinitionClauseCallWhile(
                     modular,
-                    new Function<Call, Object>() {
+                    new Function<Call, Boolean>() {
                         @Override
-                        public Object fun(@NotNull Call callDefinitionClauseCall) {
+                        public Boolean fun(@NotNull Call callDefinitionClauseCall) {
                             Pair<String, IntRange> nameArityRange = nameArityRange(callDefinitionClauseCall);
+                            boolean keepProcessing = true;
 
                             if (nameArityRange != null) {
                                 String name = nameArityRange.first;
@@ -86,12 +89,14 @@ public class Modular {
                                     IntRange arityRange = nameArityRange.second;
 
                                     if (arityRange.containsInteger(resolvedFinalArity)) {
-                                        function.fun(callDefinitionClauseCall);
+                                        if (!function.fun(callDefinitionClauseCall)) {
+                                            keepProcessing = false;
+                                        }
                                     }
                                 }
                             }
 
-                            return null;
+                            return keepProcessing;
                         }
                     }
             );

--- a/src/org/elixir_lang/psi/Modular.java
+++ b/src/org/elixir_lang/psi/Modular.java
@@ -24,10 +24,8 @@ public class Modular {
 
         if (childCalls != null) {
             for (Call childCall : childCalls) {
-                if (CallDefinitionClause.is(childCall)) {
-                    if (!function.fun(childCall)) {
-                        break;
-                    }
+                if (CallDefinitionClause.is(childCall) && !function.fun(childCall)) {
+                    break;
                 }
             }
         }
@@ -52,10 +50,8 @@ public class Modular {
                             Named named = (Named) call;
                             PsiElement nameIdentifier = named.getNameIdentifier();
 
-                            if (nameIdentifier != null) {
-                                if (!function.fun(nameIdentifier)) {
-                                    keepProcessing = false;
-                                }
+                            if (nameIdentifier != null && !function.fun(nameIdentifier)) {
+                                keepProcessing = false;
                             }
                         }
 
@@ -88,10 +84,9 @@ public class Modular {
                                 if (name != null && name.equals(functionName)) {
                                     IntRange arityRange = nameArityRange.second;
 
-                                    if (arityRange.containsInteger(resolvedFinalArity)) {
-                                        if (!function.fun(callDefinitionClauseCall)) {
-                                            keepProcessing = false;
-                                        }
+                                    if (arityRange.containsInteger(resolvedFinalArity) &&
+                                            !function.fun(callDefinitionClauseCall)) {
+                                        keepProcessing = false;
                                     }
                                 }
                             }

--- a/src/org/elixir_lang/psi/scope/CallDefinitionClause.java
+++ b/src/org/elixir_lang/psi/scope/CallDefinitionClause.java
@@ -4,6 +4,8 @@ import com.intellij.openapi.util.Key;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.ResolveState;
 import com.intellij.psi.scope.PsiScopeProcessor;
+import com.intellij.util.Function;
+import org.elixir_lang.psi.Import;
 import org.elixir_lang.psi.call.Call;
 import org.elixir_lang.structure_view.element.modular.Module;
 import org.jetbrains.annotations.NotNull;
@@ -64,11 +66,21 @@ public abstract class CallDefinitionClause implements PsiScopeProcessor {
      * Private Instance Methods
      */
 
-    private boolean execute(@NotNull Call element, @NotNull ResolveState state) {
+    protected boolean execute(@NotNull Call element, @NotNull final ResolveState state) {
         boolean keepProcessing = true;
 
         if (org.elixir_lang.structure_view.element.CallDefinitionClause.is(element)) {
             keepProcessing = executeOnCallDefinitionClause(element, state);
+        } else if (Import.is(element)) {
+            Import.callDefinitionClauseCallWhile(
+                    element,
+                    new Function<Call,Boolean>() {
+                        @Override
+                        public Boolean fun(Call callDefinitionClause) {
+                            return executeOnCallDefinitionClause(callDefinitionClause, state);
+                        }
+                    }
+            );
         } else if (Module.is(element)) {
             Call[] childCalls = macroChildCalls(element);
 

--- a/src/org/elixir_lang/psi/scope/CallDefinitionClause.java
+++ b/src/org/elixir_lang/psi/scope/CallDefinitionClause.java
@@ -15,6 +15,12 @@ import static org.elixir_lang.psi.impl.ElixirPsiImplUtil.macroChildCalls;
 
 public abstract class CallDefinitionClause implements PsiScopeProcessor {
     /*
+     * CONSTANTS
+     */
+
+    protected static final Key<Call> IMPORT_CALL = new Key<Call>("IMPORT_CALL");
+
+    /*
      * Public Instance Methods
      */
 
@@ -72,12 +78,14 @@ public abstract class CallDefinitionClause implements PsiScopeProcessor {
         if (org.elixir_lang.structure_view.element.CallDefinitionClause.is(element)) {
             keepProcessing = executeOnCallDefinitionClause(element, state);
         } else if (Import.is(element)) {
+            final ResolveState importState = state.put(IMPORT_CALL, element);
+
             Import.callDefinitionClauseCallWhile(
                     element,
                     new Function<Call,Boolean>() {
                         @Override
                         public Boolean fun(Call callDefinitionClause) {
-                            return executeOnCallDefinitionClause(callDefinitionClause, state);
+                            return executeOnCallDefinitionClause(callDefinitionClause, importState);
                         }
                     }
             );

--- a/src/org/elixir_lang/psi/scope/Variable.java
+++ b/src/org/elixir_lang/psi/scope/Variable.java
@@ -289,27 +289,23 @@ public abstract class Variable implements PsiScopeProcessor {
             PsiElement bindQuoted = ElixirPsiImplUtil.keywordArgument(match, "bind_quoted");
 
             if (bindQuoted instanceof ElixirAccessExpression) {
-                PsiElement[] children = bindQuoted.getChildren();
+                PsiElement child = stripAccessExpression(bindQuoted);
 
-                if (children.length == 1) {
-                    PsiElement child = children[0];
+                if (child instanceof ElixirList) {
+                    ElixirList list = (ElixirList) child;
 
-                    if (child instanceof ElixirList) {
-                        ElixirList list = (ElixirList) child;
+                    PsiElement[] listChildren = list.getChildren();
 
-                        PsiElement[] listChildren = list.getChildren();
+                    if (listChildren.length == 1) {
+                        PsiElement listChild = listChildren[0];
 
-                        if (listChildren.length == 1) {
-                            PsiElement listChild = listChildren[0];
+                        if (listChild instanceof ElixirKeywords) {
+                            ElixirKeywords bindQuotedKeywords = (ElixirKeywords) listChild;
 
-                            if (listChild instanceof ElixirKeywords) {
-                                ElixirKeywords bindQuotedKeywords = (ElixirKeywords) listChild;
+                            List<ElixirKeywordPair> keywordPairList = bindQuotedKeywords.getKeywordPairList();
 
-                                List<ElixirKeywordPair> keywordPairList = bindQuotedKeywords.getKeywordPairList();
-
-                                for (ElixirKeywordPair keywordPair : keywordPairList) {
-                                    keepProcessing = executeOnVariable(keywordPair.getKeywordKey(), state);
-                                }
+                            for (ElixirKeywordPair keywordPair : keywordPairList) {
+                                keepProcessing = executeOnVariable(keywordPair.getKeywordKey(), state);
                             }
                         }
                     }

--- a/src/org/elixir_lang/psi/scope/call_definition_clause/MultiResolve.java
+++ b/src/org/elixir_lang/psi/scope/call_definition_clause/MultiResolve.java
@@ -104,17 +104,12 @@ public class MultiResolve extends org.elixir_lang.psi.scope.CallDefinitionClause
                 } else {
                 /* Doesn't use a Map<PsiElement, ResolveSet> so that MultiResolve's helpers that require a
                    List<ResolveResult> can still work */
-                    if (resolvedSet == null || !resolvedSet.contains(nameIdentifier)) {
-                        resolveResultList = org.elixir_lang.psi.scope.MultiResolve.addToResolveResultList(
-                                resolveResultList, new PsiElementResolveResult(nameIdentifier, validResult)
-                        );
+                    addNewToResolveResultList(nameIdentifier, validResult);
 
-                        if (resolvedSet == null) {
-                            resolvedSet = new THashSet<PsiElement>();
-                        }
+                    Call importCall = state.get(IMPORT_CALL);
 
-                        resolvedSet.add(nameIdentifier);
-
+                    if (importCall != null) {
+                        addNewToResolveResultList(importCall, validResult);
                     }
                 }
             }
@@ -152,5 +147,23 @@ public class MultiResolve extends org.elixir_lang.psi.scope.CallDefinitionClause
     @Override
     protected boolean keepProcessing() {
         return org.elixir_lang.psi.scope.MultiResolve.keepProcessing(incompleteCode, resolveResultList);
+    }
+
+    /*
+     * Private Instance Methods
+     */
+
+    private void addNewToResolveResultList(@NotNull PsiElement element, boolean validResult) {
+        if (resolvedSet == null || !resolvedSet.contains(element)) {
+            resolveResultList = org.elixir_lang.psi.scope.MultiResolve.addToResolveResultList(
+                    resolveResultList, new PsiElementResolveResult(element, validResult)
+            );
+
+            if (resolvedSet == null) {
+                resolvedSet = new THashSet<PsiElement>();
+            }
+
+            resolvedSet.add(element);
+        }
     }
 }

--- a/src/org/elixir_lang/reference/Callable.java
+++ b/src/org/elixir_lang/reference/Callable.java
@@ -620,12 +620,12 @@ public class Callable extends PsiReferenceBase<Call> implements PsiPolyVariantRe
                     modular,
                     myElement.functionName(),
                     resolvedFinalArity,
-                    new com.intellij.util.Function<PsiElement, Object>() {
+                    new com.intellij.util.Function<PsiElement, Boolean>() {
                         @Override
-                        public Object fun(PsiElement nameIdentifier) {
+                        public Boolean fun(PsiElement nameIdentifier) {
                             finalResolveResultList.add(new PsiElementResolveResult(nameIdentifier, true));
 
-                            return null;
+                            return true;
                         }
                     }
             );

--- a/src/org/elixir_lang/structure_view/element/CallDefinitionHead.java
+++ b/src/org/elixir_lang/structure_view/element/CallDefinitionHead.java
@@ -13,6 +13,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import static com.intellij.openapi.util.Pair.pair;
+import static org.elixir_lang.psi.impl.ElixirPsiImplUtil.stripAccessExpression;
 import static org.elixir_lang.psi.operation.Normalized.operatorIndex;
 
 public class CallDefinitionHead extends Element<Call> implements Presentable, Visible {
@@ -200,39 +201,31 @@ public class CallDefinitionHead extends Element<Call> implements Presentable, Vi
      */
     @NotNull
     public static PsiElement stripOuterParentheses(PsiElement head) {
-        PsiElement stripped = head;
+        PsiElement stripped = stripAccessExpression(head);
 
-        if (head instanceof ElixirAccessExpression) {
-            PsiElement[] headChildren = head.getChildren();
+        if (stripped instanceof ElixirParentheticalStab) {
+            ElixirParentheticalStab parentheticalStab = (ElixirParentheticalStab) stripped;
 
-            if (headChildren.length == 1) {
-                PsiElement headChild = headChildren[0];
+            PsiElement[] parentheticalStabChildren = parentheticalStab.getChildren();
 
-                if (headChild instanceof ElixirParentheticalStab) {
-                    ElixirParentheticalStab parentheticalStab = (ElixirParentheticalStab) headChild;
+            if (parentheticalStabChildren.length == 1) {
+                PsiElement parentheticalStabChild = parentheticalStabChildren[0];
 
-                    PsiElement[] parentheticalStabChildren = parentheticalStab.getChildren();
+                if (parentheticalStabChild instanceof ElixirStab) {
+                    ElixirStab stab = (ElixirStab) parentheticalStabChild;
 
-                    if (parentheticalStabChildren.length == 1) {
-                        PsiElement parentheticalStabChild = parentheticalStabChildren[0];
+                    PsiElement[] stabChildren = stab.getChildren();
 
-                        if (parentheticalStabChild instanceof ElixirStab) {
-                            ElixirStab stab = (ElixirStab) parentheticalStabChild;
+                    if (stabChildren.length == 1) {
+                        PsiElement stabChild = stabChildren[0];
 
-                            PsiElement[] stabChildren = stab.getChildren();
+                        if (stabChild instanceof ElixirStabBody) {
+                            ElixirStabBody stabBody = (ElixirStabBody) stabChild;
 
-                            if (stabChildren.length == 1) {
-                                PsiElement stabChild = stabChildren[0];
+                            PsiElement[] stabBodyChildren = stabBody.getChildren();
 
-                                if (stabChild instanceof ElixirStabBody) {
-                                    ElixirStabBody stabBody = (ElixirStabBody) stabChild;
-
-                                    PsiElement[] stabBodyChildren = stabBody.getChildren();
-
-                                    if (stabBodyChildren.length == 1) {
-                                        stripped = stabBodyChildren[0];
-                                    }
-                                }
+                            if (stabBodyChildren.length == 1) {
+                                stripped = stabBodyChildren[0];
                             }
                         }
                     }

--- a/src/org/elixir_lang/structure_view/element/Delegation.java
+++ b/src/org/elixir_lang/structure_view/element/Delegation.java
@@ -21,6 +21,7 @@ import java.util.List;
 
 import static org.elixir_lang.psi.call.name.Function.DEFDELEGATE;
 import static org.elixir_lang.psi.call.name.Module.KERNEL;
+import static org.elixir_lang.psi.impl.ElixirPsiImplUtil.stripAccessExpression;
 
 public class Delegation extends Element<Call>  {
     /*
@@ -47,19 +48,13 @@ public class Delegation extends Element<Call>  {
         PsiElement firstFinalArgument = finalArguments[0];
 
         if (firstFinalArgument instanceof ElixirAccessExpression) {
-            ElixirAccessExpression accessExpression = (ElixirAccessExpression) firstFinalArgument;
+            PsiElement accessExpressionChild = stripAccessExpression(firstFinalArgument);
 
-            PsiElement[] accessExpressionChildren = accessExpression.getChildren();
+            if (accessExpressionChild instanceof ElixirList) {
+                ElixirList list = (ElixirList) accessExpressionChild;
 
-            if (accessExpressionChildren.length == 1) {
-                PsiElement accessExpressionChild = accessExpressionChildren[0];
-
-                if (accessExpressionChild instanceof ElixirList) {
-                    ElixirList list = (ElixirList) accessExpressionChild;
-
-                    Call[] listCalls = PsiTreeUtil.getChildrenOfType(list, Call.class);
-                    callDefinitionHeadCallList = filterCallDefinitionHeadCallList(listCalls);
-                }
+                Call[] listCalls = PsiTreeUtil.getChildrenOfType(list, Call.class);
+                callDefinitionHeadCallList = filterCallDefinitionHeadCallList(listCalls);
             }
         } else if (firstFinalArgument instanceof Call) {
             Call call = (Call) firstFinalArgument;

--- a/src/org/elixir_lang/structure_view/element/Exception.java
+++ b/src/org/elixir_lang/structure_view/element/Exception.java
@@ -26,6 +26,7 @@ import java.util.Map;
 
 import static org.elixir_lang.psi.call.name.Function.DEFEXCEPTION;
 import static org.elixir_lang.psi.call.name.Module.KERNEL;
+import static org.elixir_lang.psi.impl.ElixirPsiImplUtil.stripAccessExpression;
 
 /**
  * A `defexception` with its fields and the callbacks `exception/1` and `message/1` if overridden.
@@ -112,12 +113,7 @@ public class Exception extends Element<Call> {
         Map<PsiElement, PsiElement> defaultValueElementByKeyElement = new HashMap<PsiElement, PsiElement>(finalArguments.length);
 
         if (finalArgument instanceof ElixirAccessExpression) {
-            ElixirAccessExpression accessExpression = (ElixirAccessExpression) finalArgument;
-            PsiElement[] accessExpressionChildren = accessExpression.getChildren();
-
-            assert accessExpressionChildren.length == 1;
-
-            PsiElement accessExpressionChild = accessExpressionChildren[0];
+            PsiElement accessExpressionChild = stripAccessExpression(finalArgument);
 
             assert accessExpressionChild instanceof ElixirList;
 

--- a/src/org/elixir_lang/structure_view/element/modular/Implementation.java
+++ b/src/org/elixir_lang/structure_view/element/modular/Implementation.java
@@ -19,6 +19,7 @@ import java.util.Collections;
 import static org.elixir_lang.psi.call.name.Function.DEFIMPL;
 import static org.elixir_lang.psi.call.name.Function.FOR;
 import static org.elixir_lang.psi.call.name.Module.KERNEL;
+import static org.elixir_lang.psi.impl.ElixirPsiImplUtil.stripAccessExpression;
 
 public class Implementation extends Module {
     /*
@@ -226,15 +227,10 @@ public class Implementation extends Module {
             PsiElement firstFinalArgument = finalArguments[0];
 
             if (firstFinalArgument instanceof ElixirAccessExpression) {
-                ElixirAccessExpression accessExpression = (ElixirAccessExpression) firstFinalArgument;
-                PsiElement[] accessExpressionChildren = accessExpression.getChildren();
+                PsiElement accessExpressionChild = stripAccessExpression(firstFinalArgument);
 
-                if (accessExpressionChildren.length == 1) {
-                    PsiElement accessExpressionChild = accessExpressionChildren[0];
-
-                    if (accessExpressionChild instanceof QualifiableAlias) {
-                        protocolNameElement = (QualifiableAlias) accessExpressionChild;
-                    }
+                if (accessExpressionChild instanceof QualifiableAlias) {
+                    protocolNameElement = (QualifiableAlias) accessExpressionChild;
                 }
             } else if (firstFinalArgument instanceof QualifiableAlias) {
                 protocolNameElement = (QualifiableAlias) firstFinalArgument;

--- a/testData/org/elixir_lang/psi/import/import_module.ex
+++ b/testData/org/elixir_lang/psi/import/import_module.ex
@@ -1,0 +1,3 @@
+defmodule ImportModule do
+  <caret>import Imported
+end

--- a/testData/org/elixir_lang/psi/import/import_module_except_name_arity.ex
+++ b/testData/org/elixir_lang/psi/import/import_module_except_name_arity.ex
@@ -1,0 +1,3 @@
+defmodule ImportModule do
+  <caret>import Imported, except: [unimported: 0]
+end

--- a/testData/org/elixir_lang/psi/import/import_module_only_name_arity.ex
+++ b/testData/org/elixir_lang/psi/import/import_module_only_name_arity.ex
@@ -1,0 +1,3 @@
+defmodule ImportModule do
+  <caret>import Imported, only: [imported: 0]
+end

--- a/testData/org/elixir_lang/psi/import/imported.ex
+++ b/testData/org/elixir_lang/psi/import/imported.ex
@@ -1,0 +1,12 @@
+defmodule Imported do
+  def imported() do
+    imported(1)
+  end
+
+  def unimported() do
+  end
+
+  defp imported(1) do
+    :ok
+  end
+end

--- a/testData/org/elixir_lang/reference/callable/import/import_module.ex
+++ b/testData/org/elixir_lang/reference/callable/import/import_module.ex
@@ -1,0 +1,5 @@
+defmodule ImportModule do
+  import Imported
+
+  <caret>imported()
+end

--- a/testData/org/elixir_lang/reference/callable/import/import_module_except_name_arity.ex
+++ b/testData/org/elixir_lang/reference/callable/import/import_module_except_name_arity.ex
@@ -1,0 +1,5 @@
+defmodule ImportModule do
+  import Imported, except: [unimported: 0]
+
+  <caret>imported()
+end

--- a/testData/org/elixir_lang/reference/callable/import/import_module_only_name_arity.ex
+++ b/testData/org/elixir_lang/reference/callable/import/import_module_only_name_arity.ex
@@ -1,0 +1,5 @@
+defmodule ImportModule do
+  import Imported, only: [imported: 0]
+
+  <caret>imported()
+end

--- a/testData/org/elixir_lang/reference/callable/import/imported.ex
+++ b/testData/org/elixir_lang/reference/callable/import/imported.ex
@@ -1,0 +1,12 @@
+defmodule Imported do
+  def imported() do
+    imported(1)
+  end
+
+  def unimported() do
+  end
+
+  defp imported(1) do
+    :ok
+  end
+end

--- a/tests/org/elixir_lang/psi/ImportTest.java
+++ b/tests/org/elixir_lang/psi/ImportTest.java
@@ -1,0 +1,132 @@
+package org.elixir_lang.psi;
+
+import com.intellij.openapi.util.Pair;
+import com.intellij.psi.PsiElement;
+import com.intellij.testFramework.fixtures.LightPlatformCodeInsightFixtureTestCase;
+import com.intellij.util.Function;
+import com.intellij.util.containers.ContainerUtil;
+import org.apache.commons.lang.math.IntRange;
+import org.elixir_lang.psi.call.Call;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static com.intellij.openapi.util.Pair.pair;
+import static org.elixir_lang.structure_view.element.CallDefinitionClause.nameArityRange;
+
+
+public class ImportTest extends LightPlatformCodeInsightFixtureTestCase {
+    /*
+     * Tests
+     */
+
+    public void testCallDefinitionClauseCallWhileImportModule() {
+        myFixture.configureByFiles("import_module.ex", "imported.ex");
+        PsiElement elementAtCaret = myFixture.getFile().findElementAt(myFixture.getCaretOffset());
+
+        assertNotNull(elementAtCaret);
+
+        PsiElement maybeCall = elementAtCaret.getParent().getParent();
+
+        assertInstanceOf(maybeCall, Call.class);
+
+        Call call = (Call) maybeCall;
+        assertTrue(Import.is(call));
+
+        final ArrayList importedCallList = new ArrayList<Call>();
+
+        Import.callDefinitionClauseCallWhile(call, new Function<Call, Boolean>() {
+            @Override
+            public Boolean fun(Call call) {
+                importedCallList.add(call);
+                return true;
+            }
+        });
+
+        assertEquals(3, importedCallList.size());
+    }
+
+    public void testCallDefinitionClauseCallWhileImportModuleExceptNameArity() {
+        myFixture.configureByFiles("import_module_except_name_arity.ex", "imported.ex");
+        PsiElement elementAtCaret = myFixture.getFile().findElementAt(myFixture.getCaretOffset());
+
+        assertNotNull(elementAtCaret);
+
+        PsiElement maybeCall = elementAtCaret.getParent().getParent();
+
+        assertInstanceOf(maybeCall, Call.class);
+
+        Call call = (Call) maybeCall;
+        assertTrue(Import.is(call));
+
+        final ArrayList<Call> importedCallList = new ArrayList<Call>();
+
+        Import.callDefinitionClauseCallWhile(call, new Function<Call, Boolean>() {
+            @Override
+            public Boolean fun(Call call) {
+                importedCallList.add(call);
+                return true;
+            }
+        });
+
+        assertEquals(2, importedCallList.size());
+
+        List<Pair<String, IntRange>> nameArityRangeList = ContainerUtil.map(
+                importedCallList,
+                new Function<Call, Pair<String, IntRange>>() {
+                    @Override
+                    public Pair<String, IntRange> fun(Call call) {
+                        return nameArityRange(call);
+                    }
+                }
+        );
+
+        assertContainsElements(
+                Arrays.asList(
+                        pair("imported", new IntRange(1)),
+                        pair("imported", new IntRange(0))
+                ),
+                nameArityRangeList
+        );
+    }
+
+    public void testCallDefinitionClauseCallWhileImportModuleOnlyNameArity() {
+        myFixture.configureByFiles("import_module_only_name_arity.ex", "imported.ex");
+        PsiElement elementAtCaret = myFixture.getFile().findElementAt(myFixture.getCaretOffset());
+
+        assertNotNull(elementAtCaret);
+
+        PsiElement maybeCall = elementAtCaret.getParent().getParent();
+
+        assertInstanceOf(maybeCall, Call.class);
+
+        Call call = (Call) maybeCall;
+        assertTrue(Import.is(call));
+
+        final ArrayList<Call> importedCallList = new ArrayList<Call>();
+
+        Import.callDefinitionClauseCallWhile(call, new Function<Call, Boolean>() {
+            @Override
+            public Boolean fun(Call call) {
+                importedCallList.add(call);
+                return true;
+            }
+        });
+
+        assertEquals(1, importedCallList.size());
+
+        Call importedCall = importedCallList.get(0);
+
+        assertEquals(pair("imported", new IntRange(0)), nameArityRange(importedCall));
+    }
+
+    /*
+     * Protected Instance Methods
+     */
+
+    @Override
+    protected String getTestDataPath() {
+        return "testData/org/elixir_lang/psi/import";
+    }
+}

--- a/tests/org/elixir_lang/reference/callable/ImportTest.java
+++ b/tests/org/elixir_lang/reference/callable/ImportTest.java
@@ -37,13 +37,56 @@ public class ImportTest extends LightPlatformCodeInsightFixtureTestCase {
 
         assertEquals(2, resolveResults.length);
     }
+    public void testImportModuleExceptNameArity() {
+        myFixture.configureByFiles("import_module_except_name_arity.ex", "imported.ex");
+        PsiElement elementAtCaret = myFixture.getFile().findElementAt(myFixture.getCaretOffset());
 
-    public void testImportModuleOnlyNameArity() {
+        assertNotNull(elementAtCaret);
 
+        PsiElement maybeCall = elementAtCaret.getParent().getParent();
+
+        assertInstanceOf(maybeCall, Call.class);
+
+        Call call = (Call) maybeCall;
+        assertEquals("imported", call.functionName());
+        assertEquals(0, call.resolvedFinalArity());
+
+        PsiReference reference = call.getReference();
+
+        assertNotNull(reference);
+        assertInstanceOf(reference, PsiPolyVariantReference.class);
+
+        PsiPolyVariantReference polyVariantReference = (PsiPolyVariantReference) reference;
+
+        ResolveResult[] resolveResults = polyVariantReference.multiResolve(false);
+
+        assertEquals(2, resolveResults.length);
     }
 
-    public void testImportModuleExceptNameArity() {
+    public void testImportModuleOnlyNameArity() {
+        myFixture.configureByFiles("import_module_only_name_arity.ex", "imported.ex");
+        PsiElement elementAtCaret = myFixture.getFile().findElementAt(myFixture.getCaretOffset());
 
+        assertNotNull(elementAtCaret);
+
+        PsiElement maybeCall = elementAtCaret.getParent().getParent();
+
+        assertInstanceOf(maybeCall, Call.class);
+
+        Call call = (Call) maybeCall;
+        assertEquals("imported", call.functionName());
+        assertEquals(0, call.resolvedFinalArity());
+
+        PsiReference reference = call.getReference();
+
+        assertNotNull(reference);
+        assertInstanceOf(reference, PsiPolyVariantReference.class);
+
+        PsiPolyVariantReference polyVariantReference = (PsiPolyVariantReference) reference;
+
+        ResolveResult[] resolveResults = polyVariantReference.multiResolve(false);
+
+        assertEquals(2, resolveResults.length);
     }
 
     /*

--- a/tests/org/elixir_lang/reference/callable/ImportTest.java
+++ b/tests/org/elixir_lang/reference/callable/ImportTest.java
@@ -1,0 +1,57 @@
+package org.elixir_lang.reference.callable;
+
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiPolyVariantReference;
+import com.intellij.psi.PsiReference;
+import com.intellij.psi.ResolveResult;
+import com.intellij.testFramework.fixtures.LightPlatformCodeInsightFixtureTestCase;
+import org.elixir_lang.psi.call.Call;
+
+public class ImportTest extends LightPlatformCodeInsightFixtureTestCase {
+    /*
+     * Tests
+     */
+
+    public void testImportModule() {
+        myFixture.configureByFiles("import_module.ex", "imported.ex");
+        PsiElement elementAtCaret = myFixture.getFile().findElementAt(myFixture.getCaretOffset());
+
+        assertNotNull(elementAtCaret);
+
+        PsiElement maybeCall = elementAtCaret.getParent().getParent();
+
+        assertInstanceOf(maybeCall, Call.class);
+
+        Call call = (Call) maybeCall;
+        assertEquals("imported", call.functionName());
+        assertEquals(0, call.resolvedFinalArity());
+
+        PsiReference reference = call.getReference();
+
+        assertNotNull(reference);
+        assertInstanceOf(reference, PsiPolyVariantReference.class);
+
+        PsiPolyVariantReference polyVariantReference = (PsiPolyVariantReference) reference;
+
+        ResolveResult[] resolveResults = polyVariantReference.multiResolve(false);
+
+        assertEquals(2, resolveResults.length);
+    }
+
+    public void testImportModuleOnlyNameArity() {
+
+    }
+
+    public void testImportModuleExceptNameArity() {
+
+    }
+
+    /*
+     * Protected Instance Methods
+     */
+
+    @Override
+    protected String getTestDataPath() {
+        return "testData/org/elixir_lang/reference/callable/import";
+    }
+}


### PR DESCRIPTION
Fixes #487 

# Changelog
## Bug Fixes
* Go To Declaration resolves through `import`
  * for `import MyModule` 
    * the `import` statement
    * the call definition clause in the imported Module. 
  * for `import MyModule, only: [name: arity]`
    * the `import` statement
    * the call definition clause in the imported Module. 
  * for `import MyModule, except: [name: arity]` _if_ reference is _not_ `name/arity`.
    * the `import` statement
    * the call definition clause in the imported Module. 

