### PR TITLE
Working directory and Environment Variables for Mix Run Configurations

### DIFF
--- a/src/org/elixir_lang/mix/runner/MixRunConfigurationBase.java
+++ b/src/org/elixir_lang/mix/runner/MixRunConfigurationBase.java
@@ -19,12 +19,14 @@ import com.intellij.util.xmlb.Accessor;
 import com.intellij.util.xmlb.SerializationFilter;
 import com.intellij.util.xmlb.XmlSerializer;
 import org.elixir_lang.runconfig.ElixirModuleBasedConfiguration;
+import org.jdom.Attribute;
 import org.jdom.Element;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -121,6 +123,24 @@ abstract class MixRunConfigurationBase extends ModuleBasedConfiguration<ElixirMo
     super.readExternal(element);
     XmlSerializer.deserializeInto(this, element);
     EnvironmentVariablesComponent.readExternal(element, getEnvs());
+
+    /*
+     * Reading <= 4.6.0 format
+     */
+
+    List<Element> options = element.getChildren("option");
+
+    for (Element option : options) {
+      Attribute nameAttribute = option.getAttribute("name");
+
+      if (nameAttribute.getValue().equals("command")) {
+        Attribute valueAttribute = option.getAttribute("value");
+
+        setProgramParameters(valueAttribute.getValue()) ;
+
+        break;
+      }
+    }
   }
 
   @Override

--- a/src/org/elixir_lang/mix/runner/MixRunConfigurationBase.java
+++ b/src/org/elixir_lang/mix/runner/MixRunConfigurationBase.java
@@ -1,7 +1,10 @@
 package org.elixir_lang.mix.runner;
 
+import com.intellij.execution.CommonProgramRunConfigurationParameters;
 import com.intellij.execution.ExecutionException;
 import com.intellij.execution.Executor;
+import com.intellij.execution.ExternalizablePath;
+import com.intellij.execution.configuration.EnvironmentVariablesComponent;
 import com.intellij.execution.configurations.*;
 import com.intellij.execution.runners.ExecutionEnvironment;
 import com.intellij.execution.runners.RunConfigurationWithSuppressedDefaultRunAction;
@@ -11,6 +14,9 @@ import com.intellij.openapi.options.SettingsEditor;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.InvalidDataException;
 import com.intellij.openapi.util.WriteExternalException;
+import com.intellij.util.containers.hash.LinkedHashMap;
+import com.intellij.util.xmlb.Accessor;
+import com.intellij.util.xmlb.SerializationFilter;
 import com.intellij.util.xmlb.XmlSerializer;
 import org.elixir_lang.runconfig.ElixirModuleBasedConfiguration;
 import org.jdom.Element;
@@ -19,32 +25,72 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Map;
 
 /**
- * Created by zyuyou on 15/7/8.
  * https://github.com/ignatov/intellij-erlang/blob/master/src/org/intellij/erlang/rebar/runner/RebarRunConfigurationBase.java
  */
-public abstract class MixRunConfigurationBase extends ModuleBasedConfiguration<ElixirModuleBasedConfiguration>
-    implements RunConfigurationWithSuppressedDefaultRunAction, RunConfigurationWithSuppressedDefaultDebugAction {
+abstract class MixRunConfigurationBase extends ModuleBasedConfiguration<ElixirModuleBasedConfiguration>
+        implements CommonProgramRunConfigurationParameters,
+        RunConfigurationWithSuppressedDefaultRunAction,
+        RunConfigurationWithSuppressedDefaultDebugAction {
+  /*
+   * CONSTANTS
+   */
+
+  private static final SerializationFilter SERIALIZATION_FILTER = new SerializationFilter() {
+    @Override
+    public boolean accepts(@NotNull Accessor accessor, @NotNull @SuppressWarnings("unused") Object bean) {
+      return !accessor.getName().equals("envs");
+    }
+  };
+
+  /*
+   * Fields
+   */
 
   @NotNull
-  private String myCommand = "";
+  private final Map<String, String> envs = new LinkedHashMap<String, String>();
   private boolean mySkipDependencies = false;
+  private boolean passParentEnvs = false;
+  @Nullable
+  private String programParameters = null;
+  @Nullable
+  private String workingDirectory;
 
-  protected MixRunConfigurationBase(@NotNull String name , @NotNull Project project, @NotNull ConfigurationFactory configurationFactory){
+  /*
+   * Constructors
+   */
+
+  MixRunConfigurationBase(@NotNull String name, @NotNull Project project, @NotNull ConfigurationFactory configurationFactory){
     super(name, new ElixirModuleBasedConfiguration(project), configurationFactory);
   }
 
+  /*
+   * Public Instance Methods
+   */
+
   @Override
-  public Collection<Module> getValidModules() {
-    Module[] modules = ModuleManager.getInstance(getProject()).getModules();
-    return Arrays.asList(modules);
+  public void checkConfiguration() throws RuntimeConfigurationException {
+    // todo: parse mix command line to check if it is valid
   }
 
   @NotNull
   @Override
   public SettingsEditor<? extends RunConfiguration> getConfigurationEditor() {
     return new MixRunConfigurationEditorForm();
+  }
+
+  @NotNull
+  @Override
+  public Map<String, String> getEnvs() {
+    return envs;
+  }
+
+  @Nullable
+  @Override
+  public String getProgramParameters() {
+    return programParameters;
   }
 
   @Nullable
@@ -54,36 +100,70 @@ public abstract class MixRunConfigurationBase extends ModuleBasedConfiguration<E
   }
 
   @Override
-  public void checkConfiguration() throws RuntimeConfigurationException {
-    // todo: parse mix command line to check if it is valid
+  public Collection<Module> getValidModules() {
+    Module[] modules = ModuleManager.getInstance(getProject()).getModules();
+    return Arrays.asList(modules);
+  }
+
+  @Nullable
+  @Override
+  public String getWorkingDirectory() {
+    return ExternalizablePath.localPathValue(workingDirectory);
   }
 
   @Override
-  public void writeExternal(@NotNull Element element) throws WriteExternalException{
-    super.writeExternal(element);
-    XmlSerializer.serializeInto(this, element);
+  public boolean isPassParentEnvs() {
+    return passParentEnvs;
   }
 
   @Override
   public void readExternal(Element element) throws InvalidDataException {
     super.readExternal(element);
     XmlSerializer.deserializeInto(this, element);
+    EnvironmentVariablesComponent.readExternal(element, getEnvs());
   }
 
-  @NotNull
-  public String getCommand(){
-    return myCommand;
+  @Override
+  public void setEnvs(@NotNull Map<String, String> envs) {
+    this.envs.clear();
+    this.envs.putAll(envs);
   }
 
-  public void setCommand(@NotNull String command){
-    myCommand = command;
+  @Override
+  public void setPassParentEnvs(boolean passParentEnvs) {
+    this.passParentEnvs = passParentEnvs;
   }
 
-  public boolean isSkipDependencies(){
+  @Override
+  public void setProgramParameters(@Nullable String programParameters) {
+    this.programParameters = programParameters;
+  }
+
+  @Override
+  public void setWorkingDirectory(@Nullable String workingDirectory) {
+    this.workingDirectory = ExternalizablePath.urlValue(workingDirectory);
+  }
+
+  @Override
+  public void writeExternal(@NotNull Element element) throws WriteExternalException{
+    super.writeExternal(element);
+    XmlSerializer.serializeInto(
+            this,
+            element,
+            SERIALIZATION_FILTER
+    );
+    EnvironmentVariablesComponent.writeExternal(element, getEnvs());
+  }
+
+  /*
+   * Package Instance Methods
+   */
+
+  boolean isSkipDependencies(){
     return mySkipDependencies;
   }
 
-  public void setSkipDependencies(boolean skipDeps){
+  void setSkipDependencies(boolean skipDeps){
     mySkipDependencies = skipDeps;
   }
 }

--- a/src/org/elixir_lang/mix/runner/MixRunConfigurationEditorForm.form
+++ b/src/org/elixir_lang/mix/runner/MixRunConfigurationEditorForm.form
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="org.elixir_lang.mix.runner.MixRunConfigurationEditorForm">
-  <grid id="27dc6" binding="myComponent" layout-manager="GridLayoutManager" row-count="2" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="27dc6" binding="myComponent" layout-manager="GridLayoutManager" row-count="4" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
       <xy x="20" y="20" width="500" height="400"/>
@@ -8,59 +8,43 @@
     <properties/>
     <border type="none"/>
     <children>
-      <grid id="77064" layout-manager="GridLayoutManager" row-count="3" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
-        <margin top="0" left="0" bottom="0" right="0"/>
-        <constraints>
-          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
-        </constraints>
-        <properties/>
-        <border type="none"/>
-        <children>
-          <component id="7c645" class="javax.swing.JLabel">
-            <constraints>
-              <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-            </constraints>
-            <properties>
-              <text value="&amp;Command:"/>
-            </properties>
-          </component>
-          <component id="96b7c" class="javax.swing.JTextField" binding="myCommandText">
-            <constraints>
-              <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
-                <preferred-size width="150" height="-1"/>
-              </grid>
-            </constraints>
-            <properties/>
-          </component>
-          <component id="b594" class="javax.swing.JCheckBox" binding="myRunInModuleChekcBox">
-            <constraints>
-              <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-            </constraints>
-            <properties>
-              <text value="&amp;Run in module"/>
-            </properties>
-          </component>
-          <component id="fcba3" class="javax.swing.JCheckBox" binding="mySkipDependenciesCheckBox">
-            <constraints>
-              <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-            </constraints>
-            <properties>
-              <text value="Skip &amp;dependencies"/>
-            </properties>
-          </component>
-          <component id="a5de8" class="com.intellij.application.options.ModulesComboBox" binding="myModulesComboBox">
-            <constraints>
-              <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
-            </constraints>
-            <properties/>
-          </component>
-        </children>
-      </grid>
       <vspacer id="9ff80">
         <constraints>
-          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+          <grid row="3" column="0" row-span="1" col-span="2" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
         </constraints>
       </vspacer>
+      <component id="32967" class="com.intellij.execution.ui.CommonProgramParametersPanel" binding="commonProgramParametersPanel">
+        <constraints>
+          <grid row="0" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="7" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties/>
+      </component>
+      <component id="b594" class="javax.swing.JCheckBox" binding="myRunInModuleChekcBox">
+        <constraints>
+          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false">
+            <preferred-size width="300" height="20"/>
+          </grid>
+        </constraints>
+        <properties>
+          <text value="&amp;Run in module"/>
+        </properties>
+      </component>
+      <component id="fcba3" class="javax.swing.JCheckBox" binding="mySkipDependenciesCheckBox">
+        <constraints>
+          <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false">
+            <preferred-size width="300" height="20"/>
+          </grid>
+        </constraints>
+        <properties>
+          <text value="Skip &amp;dependencies"/>
+        </properties>
+      </component>
+      <component id="a5de8" class="com.intellij.application.options.ModulesComboBox" binding="myModulesComboBox">
+        <constraints>
+          <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties/>
+      </component>
     </children>
   </grid>
 </form>

--- a/src/org/elixir_lang/mix/runner/MixRunConfigurationEditorForm.form
+++ b/src/org/elixir_lang/mix/runner/MixRunConfigurationEditorForm.form
@@ -19,7 +19,7 @@
         </constraints>
         <properties/>
       </component>
-      <component id="b594" class="javax.swing.JCheckBox" binding="myRunInModuleChekcBox">
+      <component id="b594" class="javax.swing.JCheckBox" binding="myRunInModuleCheckBox">
         <constraints>
           <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false">
             <preferred-size width="300" height="20"/>

--- a/src/org/elixir_lang/mix/runner/MixRunConfigurationEditorForm.java
+++ b/src/org/elixir_lang/mix/runner/MixRunConfigurationEditorForm.java
@@ -20,21 +20,21 @@ import java.awt.event.ActionListener;
  */
 final class MixRunConfigurationEditorForm extends SettingsEditor<MixRunConfigurationBase>{
   private JPanel myComponent;
-  private JCheckBox myRunInModuleChekcBox;
+  private JCheckBox myRunInModuleCheckBox;
   private JCheckBox mySkipDependenciesCheckBox;
   private ModulesComboBox myModulesComboBox;
   private CommonProgramParametersPanel commonProgramParametersPanel;
 
   MixRunConfigurationEditorForm(){
-    myRunInModuleChekcBox.addActionListener(new ActionListener() {
+    myRunInModuleCheckBox.addActionListener(new ActionListener() {
       @Override
       public void actionPerformed(ActionEvent e) {
-        myModulesComboBox.setEnabled(myRunInModuleChekcBox.isSelected());
+        myModulesComboBox.setEnabled(myRunInModuleCheckBox.isSelected());
       }
     });
 
     myModulesComboBox.setVisible(!ElixirSystemUtil.isSmallIde());
-    myRunInModuleChekcBox.setVisible(!ElixirSystemUtil.isSmallIde());
+    myRunInModuleCheckBox.setVisible(!ElixirSystemUtil.isSmallIde());
   }
 
   @Override
@@ -58,7 +58,7 @@ final class MixRunConfigurationEditorForm extends SettingsEditor<MixRunConfigura
 
   @Override
   protected void applyEditorTo(@NotNull MixRunConfigurationBase mixRunConfiguration) throws ConfigurationException {
-    Module selectedModule = myRunInModuleChekcBox.isSelected() ? myModulesComboBox.getSelectedModule() : null;
+    Module selectedModule = myRunInModuleCheckBox.isSelected() ? myModulesComboBox.getSelectedModule() : null;
     mixRunConfiguration.setModule(selectedModule);
 
     mixRunConfiguration.setSkipDependencies(mySkipDependenciesCheckBox.isSelected());
@@ -78,12 +78,12 @@ final class MixRunConfigurationEditorForm extends SettingsEditor<MixRunConfigura
 
   private void setRunInModuleSelected(boolean b){
     if(b){
-      if(!myRunInModuleChekcBox.isSelected()){
-        myRunInModuleChekcBox.doClick();
+      if(!myRunInModuleCheckBox.isSelected()){
+        myRunInModuleCheckBox.doClick();
       }
     }else{
-      if(myRunInModuleChekcBox.isSelected()){
-        myRunInModuleChekcBox.doClick();
+      if(myRunInModuleCheckBox.isSelected()){
+        myRunInModuleCheckBox.doClick();
       }
     }
   }

--- a/src/org/elixir_lang/mix/runner/MixRunConfigurationEditorForm.java
+++ b/src/org/elixir_lang/mix/runner/MixRunConfigurationEditorForm.java
@@ -1,6 +1,7 @@
 package org.elixir_lang.mix.runner;
 
 import com.intellij.application.options.ModulesComboBox;
+import com.intellij.execution.ui.CommonProgramParametersPanel;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.options.ConfigurationException;
 import com.intellij.openapi.options.SettingsEditor;
@@ -19,10 +20,10 @@ import java.awt.event.ActionListener;
  */
 final class MixRunConfigurationEditorForm extends SettingsEditor<MixRunConfigurationBase>{
   private JPanel myComponent;
-  private JTextField myCommandText;
   private JCheckBox myRunInModuleChekcBox;
   private JCheckBox mySkipDependenciesCheckBox;
   private ModulesComboBox myModulesComboBox;
+  private CommonProgramParametersPanel commonProgramParametersPanel;
 
   MixRunConfigurationEditorForm(){
     myRunInModuleChekcBox.addActionListener(new ActionListener() {
@@ -38,7 +39,6 @@ final class MixRunConfigurationEditorForm extends SettingsEditor<MixRunConfigura
 
   @Override
   protected void resetEditorFrom(@NotNull MixRunConfigurationBase configuration) {
-    myCommandText.setText(configuration.getCommand());
     mySkipDependenciesCheckBox.setSelected(configuration.isSkipDependencies());
     Module module = null;
     if(!ElixirSystemUtil.isSmallIde()){
@@ -52,14 +52,17 @@ final class MixRunConfigurationEditorForm extends SettingsEditor<MixRunConfigura
     }else{
       setRunInModuleSelected(false);
     }
+
+    commonProgramParametersPanel.reset(configuration);
   }
 
   @Override
   protected void applyEditorTo(@NotNull MixRunConfigurationBase mixRunConfiguration) throws ConfigurationException {
-    mixRunConfiguration.setCommand(myCommandText.getText());
-    mixRunConfiguration.setSkipDependencies(mySkipDependenciesCheckBox.isSelected());
     Module selectedModule = myRunInModuleChekcBox.isSelected() ? myModulesComboBox.getSelectedModule() : null;
     mixRunConfiguration.setModule(selectedModule);
+
+    mixRunConfiguration.setSkipDependencies(mySkipDependenciesCheckBox.isSelected());
+    commonProgramParametersPanel.applyTo(mixRunConfiguration);
   }
 
   @NotNull


### PR DESCRIPTION
Fixes #216 
Fixes #502 

# Changelog
## Enhancements
* Use the `CommonProgramParametersPanel` to get the working directory and environment variables the same way the JUnit form does.  Replace the custom "Command" input with the "Program arguments" input built into the `CommonProgramParametersPanel`. `CommonProgramParametersPanel` expects to store the "Program Arguments" in a "ProgramParameters" field, so old run
configurations will lose their "Command" option value and it will be migrated to the new "ProgramParameters".

## Bug Fixes
* Fix typo: `myRunInModuleChekcBox` => `myRunInModuleCheckBox`