### PR TITLE
Don't log error when name length exceeds presentable text length

### DIFF
--- a/src/org/elixir_lang/code_insight/lookup/element_renderer/CallDefinitionClause.java
+++ b/src/org/elixir_lang/code_insight/lookup/element_renderer/CallDefinitionClause.java
@@ -54,12 +54,6 @@ public class CallDefinitionClause extends com.intellij.codeInsight.lookup.Lookup
 
                     if (nameLength <= presentableTextLength) {
                         presentation.appendTailText(presentableText.substring(nameLength), true);
-                    } else {
-                        Logger.error(
-                                CallDefinitionClause.class,
-                                "name (`" + name + "`) is longer than the presentable test (`" + presentableText + "`)",
-                                psiElement
-                        );
                     }
                 }
 

--- a/tests/org/elixir_lang/code_insight/lookup/element_renderer/CallDefinitionClauseTest.java
+++ b/tests/org/elixir_lang/code_insight/lookup/element_renderer/CallDefinitionClauseTest.java
@@ -32,18 +32,14 @@ public class CallDefinitionClauseTest extends LightPlatformCodeInsightFixtureTes
         assertEquals(name, lookupElementPresentation.getItemText());
     }
 
-    public void testIssue457LongerName() {
-        LookupElement lookupElement = lookupElement("fooo");
+    public void testIssue457LongerNameIssue503() {
+        String name = "fooo";
+        LookupElement lookupElement = lookupElement(name);
         LookupElementPresentation lookupElementPresentation = new LookupElementPresentation();
-        boolean assertionErrorThrown = false;
 
-        try {
-            lookupElement.renderElement(lookupElementPresentation);
-        } catch (AssertionError e) {
-            assertionErrorThrown = true;
-        }
+        lookupElement.renderElement(lookupElementPresentation);
 
-        assertTrue(assertionErrorThrown);
+        assertEquals(name, lookupElementPresentation.getItemText());
     }
 
     /*


### PR DESCRIPTION
Fixes #503

# Changelog
## Bug Fixes
* Don't log error when name length exceeds presentable text length because it appears to be common for normal users and not a development environment artifact.