### PR TITLE
Check parent of `ElixirMultipleAliases` for `isVariable`

### DIFF
--- a/src/org/elixir_lang/reference/Callable.java
+++ b/src/org/elixir_lang/reference/Callable.java
@@ -254,6 +254,8 @@ public class Callable extends PsiReferenceBase<Call> implements PsiPolyVariantRe
                 /* parenthesesArguments can be used in @spec other type declarations, so may not be variable until
                    ancestor call is checked */
                 ancestor instanceof ElixirMatchedParenthesesArguments ||
+                /* Happens when tuple is after `MyAlias.` when add qualified call above line with pre-existing tuple */
+                ancestor instanceof ElixirMultipleAliases ||
                 ancestor instanceof ElixirNoParenthesesOneArgument ||
                 ancestor instanceof ElixirNoParenthesesArguments ||
                 ancestor instanceof ElixirNoParenthesesKeywordPair ||

--- a/testData/org/elixir_lang/reference/callable/issue_500/is_variable.ex
+++ b/testData/org/elixir_lang/reference/callable/issue_500/is_variable.ex
@@ -1,0 +1,6 @@
+   def handle_response({:ok, %{status_code: 200, body: body}}) do
+       Logger.info "Successful response"
+       Logger.debug fn -> inspect(body) end
+       Logger.
+       { :ok, :jsx.decode(bo<caret>dy) }
+   end

--- a/tests/org/elixir_lang/reference/callable/Issue500Test.java
+++ b/tests/org/elixir_lang/reference/callable/Issue500Test.java
@@ -1,0 +1,34 @@
+package org.elixir_lang.reference.callable;
+
+import com.intellij.psi.PsiElement;
+import com.intellij.testFramework.fixtures.LightCodeInsightFixtureTestCase;
+import org.elixir_lang.psi.call.Call;
+
+import static org.elixir_lang.reference.Callable.isVariable;
+
+public class Issue500Test extends LightCodeInsightFixtureTestCase {
+    /*
+     * Tests
+     */
+
+    public void testIsVariable() {
+        myFixture.configureByFiles("is_variable.ex");
+        @SuppressWarnings("ConstantConditions") PsiElement callable = myFixture
+                .getFile()
+                .findElementAt(myFixture.getCaretOffset())
+                .getParent()
+                .getParent();
+
+        assertInstanceOf(callable, Call.class);
+        assertFalse("parameter in tuple after Alias dot is incorrectly marked as a variable", isVariable(callable));
+    }
+
+    /*
+     * Protected Instance Methods
+     */
+
+    @Override
+    protected String getTestDataPath() {
+        return "testData/org/elixir_lang/reference/callable/issue_500";
+    }
+}


### PR DESCRIPTION
# Changelog
## Enhancements
* Regression test for #500

## Bug Fixes
* Check parent of `ElixirMultipleAliases` for `isVariable` because `ElixirMultipleAliases` can be hit in `isVariable` when `MyAlias.` is added on a line above a pre-existing tuple, such as when typing a new qualified call.