### PR TITLE
CallDefinitionClause(Call) -> CallDefinitionClause.fromCall(Call)

### DIFF
--- a/src/org/elixir_lang/code_insight/lookup/element_renderer/CallDefinitionClause.java
+++ b/src/org/elixir_lang/code_insight/lookup/element_renderer/CallDefinitionClause.java
@@ -42,25 +42,28 @@ public class CallDefinitionClause extends com.intellij.codeInsight.lookup.Lookup
 
             if (org.elixir_lang.structure_view.element.CallDefinitionClause.is(call)) {
                 org.elixir_lang.structure_view.element.CallDefinitionClause structureView =
-                        new org.elixir_lang.structure_view.element.CallDefinitionClause(call);
-                ItemPresentation structureViewPresentation = structureView.getPresentation();
+                        org.elixir_lang.structure_view.element.CallDefinitionClause.fromCall(call);
 
-                presentation.setIcon(structureViewPresentation.getIcon(true));
-                String presentableText = structureViewPresentation.getPresentableText();
+                if (structureView != null) {
+                    ItemPresentation structureViewPresentation = structureView.getPresentation();
 
-                if (presentableText != null) {
-                    int nameLength = name.length();
-                    int presentableTextLength = presentableText.length();
+                    presentation.setIcon(structureViewPresentation.getIcon(true));
+                    String presentableText = structureViewPresentation.getPresentableText();
 
-                    if (nameLength <= presentableTextLength) {
-                        presentation.appendTailText(presentableText.substring(nameLength), true);
+                    if (presentableText != null) {
+                        int nameLength = name.length();
+                        int presentableTextLength = presentableText.length();
+
+                        if (nameLength <= presentableTextLength) {
+                            presentation.appendTailText(presentableText.substring(nameLength), true);
+                        }
                     }
-                }
 
-                String locationString = structureViewPresentation.getLocationString();
+                    String locationString = structureViewPresentation.getLocationString();
 
-                if (locationString != null) {
-                    presentation.appendTailText(" (" + locationString + ")", false);
+                    if (locationString != null) {
+                        presentation.appendTailText(" (" + locationString + ")", false);
+                    }
                 }
             }
         }

--- a/src/org/elixir_lang/psi/impl/ElixirPsiImplUtil.java
+++ b/src/org/elixir_lang/psi/impl/ElixirPsiImplUtil.java
@@ -2917,7 +2917,11 @@ public class ElixirPsiImplUtil {
             final NavigatablePsiElement parameterized = parameterizedParameter.parameterized;
 
             if (parameterized instanceof Call) {
-                itemPresentation = new CallDefinitionClause((Call) parameterized).getPresentation();
+                CallDefinitionClause callDefinitionClause = CallDefinitionClause.fromCall((Call) parameterized);
+
+                if (callDefinitionClause != null) {
+                    itemPresentation = callDefinitionClause.getPresentation();
+                }
             }
         }
 

--- a/src/org/elixir_lang/structure_view/element/CallDefinition.java
+++ b/src/org/elixir_lang/structure_view/element/CallDefinition.java
@@ -115,19 +115,29 @@ public class CallDefinition implements StructureViewTreeElement, Timed, Visible,
     /**
      * @param call a def(macro)?p? call
      */
-    public CallDefinition(@NotNull Call call) {
-        Pair<String, IntRange> nameArityRange = CallDefinitionClause.nameArityRange(call);
+    @Nullable
+    public static CallDefinition fromCall(@NotNull Call call) {
+        Modular modular = CallDefinitionClause.enclosingModular(call);
 
-        assert nameArityRange != null;
+        CallDefinition callDefinition = null;
 
-        /* arity is assumed to be max arity in the rane because that's how {@code h} and ExDoc treat functions with
-           defaults. */
-        this.arity = nameArityRange.second.getMaximumInteger();
-        this.modular = CallDefinitionClause.enclosingModular(call);
-        this.name = nameArityRange.first;
-        this.time = CallDefinitionClause.time(call);
+        if (modular != null) {
+            Pair<String, IntRange> nameArityRange = CallDefinitionClause.nameArityRange(call);
+
+            if (nameArityRange != null) {
+
+                String name = nameArityRange.first;
+                /* arity is assumed to be max arity in the range because that's how {@code h} and ExDoc treat functions
+                   with defaults. */
+                int arity = nameArityRange.second.getMaximumInteger();
+
+                Time time = CallDefinitionClause.time(call);
+                callDefinition = new CallDefinition(modular, time, name, arity);
+            }
+        }
+
+        return callDefinition;
     }
-
 
     public CallDefinition(@NotNull Modular modular, @NotNull Time time, @NotNull String name, int arity) {
         this.arity = arity;


### PR DESCRIPTION
Fixes #507

# Changelog
## Bug Fixes
* Convert `CallDefinitionClause(Call)` to `CallDefinitionClause.fromCall(Call)`, so that `null` can be returned when `CallDefinitionClause.enclosingModular(Call)` returns `null`.