### PR TITLE
Prevent StackOverflow when resolving import aliases by limiting scope to parent

### DIFF
--- a/src/org/elixir_lang/code_insight/completion/provider/CallDefinitionClause.java
+++ b/src/org/elixir_lang/code_insight/completion/provider/CallDefinitionClause.java
@@ -95,7 +95,7 @@ public class CallDefinitionClause extends CompletionProvider<CompletionParameter
                     org.elixir_lang.psi.qualification.Qualified qualifiedGrandParent = (org.elixir_lang.psi.qualification.Qualified) grandParent;
                     PsiElement qualifier = qualifiedGrandParent.qualifier();
 
-                    Call modular = ElixirPsiImplUtil.maybeAliasToModular(qualifier);
+                    Call modular = ElixirPsiImplUtil.maybeAliasToModular(qualifier, qualifier.getContainingFile());
 
                     if (modular != null) {
                         resultSet.withPrefixMatcher("").addAllElements(

--- a/src/org/elixir_lang/psi/Import.java
+++ b/src/org/elixir_lang/psi/Import.java
@@ -264,7 +264,7 @@ public class Import {
         Call modular = null;
 
         if (finalArguments != null && finalArguments.length >= 1) {
-            modular = maybeAliasToModular(finalArguments[0]);
+            modular = maybeAliasToModular(finalArguments[0], importCall.getParent());
         }
 
         return modular;

--- a/src/org/elixir_lang/psi/impl/ElixirPsiImplUtil.java
+++ b/src/org/elixir_lang/psi/impl/ElixirPsiImplUtil.java
@@ -1125,26 +1125,6 @@ public class ElixirPsiImplUtil {
         return childCalls;
     }
 
-    /**
-     * Finds modular ({@code defmodule}, {@code defimpl}, or {@code defprotocol}) for the qualifier of
-     * {@code maybeQualifiedCall}.
-     *
-     * @param maybeQualifiedCall a call that may be qualified
-     * @return {@code null} if {@code maybeQualifiedCall} is not qualified OR if the modular cannot be resolved, such
-     *   as when the qualifying Alias is invalid or is an unparsed module like {@code Kernel} or {@code Enum}.
-     */
-    @Contract(pure = true)
-    @Nullable
-    public static Call maybeQualifiedCallToModular(@NotNull final Call maybeQualifiedCall) {
-        Call modular = null;
-
-        if (maybeQualifiedCall instanceof org.elixir_lang.psi.call.qualification.Qualified) {
-            modular = qualifiedToModular((org.elixir_lang.psi.call.qualification.Qualified) maybeQualifiedCall);
-        }
-
-        return modular;
-    }
-
     public static OtpErlangList metadata(ASTNode node) {
         OtpErlangObject[] keywordListElements = {
                 lineNumberKeywordTuple(node)
@@ -5393,7 +5373,7 @@ if (quoted == null) {
      */
     @Contract(pure = true)
     @Nullable
-    private static Call qualifiedToModular(@NotNull final org.elixir_lang.psi.call.qualification.Qualified qualified) {
+    public static Call qualifiedToModular(@NotNull final org.elixir_lang.psi.call.qualification.Qualified qualified) {
         return maybeAliasToModular(qualified.qualifier());
     }
 

--- a/src/org/elixir_lang/psi/impl/ElixirPsiImplUtil.java
+++ b/src/org/elixir_lang/psi/impl/ElixirPsiImplUtil.java
@@ -2958,7 +2958,7 @@ public class ElixirPsiImplUtil {
         PsiReference reference = null;
 
         if (isOutermostQualifiableAlias(qualifiableAlias)) {
-            reference = new org.elixir_lang.reference.Module(qualifiableAlias);
+            reference = new org.elixir_lang.reference.Module(qualifiableAlias, qualifiableAlias.getContainingFile());
         }
 
         return reference;
@@ -5374,7 +5374,7 @@ if (quoted == null) {
     @Contract(pure = true)
     @Nullable
     public static Call qualifiedToModular(@NotNull final org.elixir_lang.psi.call.qualification.Qualified qualified) {
-        return maybeAliasToModular(qualified.qualifier());
+        return maybeAliasToModular(qualified.qualifier(), qualified.getContainingFile());
     }
 
     @NotNull
@@ -5504,10 +5504,8 @@ if (quoted == null) {
      */
     @Contract(pure = true)
     @Nullable
-    public static Call maybeAliasToModular(@NotNull final PsiElement maybeAlias) {
-        PsiElement maybeQualifiableAlias = maybeAlias;
-
-        maybeQualifiableAlias = stripAccessExpression(maybeAlias);
+    public static Call maybeAliasToModular(@NotNull final PsiElement maybeAlias, @NotNull PsiElement maxScope) {
+        PsiElement maybeQualifiableAlias = stripAccessExpression(maybeAlias);
 
         Call modular = null;
 
@@ -5515,7 +5513,7 @@ if (quoted == null) {
             QualifiableAlias qualifiableAlias = (QualifiableAlias) maybeQualifiableAlias;
             /* need to construct reference directly as qualified aliases don't return a
                reference except for the outermost */
-            PsiPolyVariantReference reference = new org.elixir_lang.reference.Module(qualifiableAlias);
+            PsiPolyVariantReference reference = new org.elixir_lang.reference.Module(qualifiableAlias, maxScope);
             modular = aliasToModular(qualifiableAlias, reference);
         }
 
@@ -5524,8 +5522,8 @@ if (quoted == null) {
 
     @Contract(pure = true)
     @Nullable
-    public static Call aliasToModular(@NotNull QualifiableAlias alias,
-                                      @NotNull PsiReference startingReference) {
+    private static Call aliasToModular(@NotNull QualifiableAlias alias,
+                                       @NotNull PsiReference startingReference) {
         PsiElement fullyResolvedAlias = fullyResolveAlias(alias, startingReference);
         Call modular = null;
 

--- a/src/org/elixir_lang/psi/scope/module/MultiResolve.java
+++ b/src/org/elixir_lang/psi/scope/module/MultiResolve.java
@@ -29,8 +29,9 @@ public class MultiResolve extends Module {
     @Nullable
     public static List<ResolveResult> resolveResultList(@NotNull String name,
                                                         boolean incompleteCode,
-                                                        @NotNull PsiElement entrance) {
-      return resolveResultList(name, incompleteCode, entrance, ResolveState.initial());
+                                                        @NotNull PsiElement entrance,
+                                                        @NotNull PsiElement maxScope) {
+      return resolveResultList(name, incompleteCode, entrance, maxScope, ResolveState.initial());
     }
 
     /*
@@ -54,12 +55,13 @@ public class MultiResolve extends Module {
     private static List<ResolveResult> resolveResultList(@NotNull String name,
                                                          boolean incompleteCode,
                                                          @NotNull PsiElement entrance,
+                                                         @NotNull PsiElement maxScope,
                                                          @NotNull ResolveState state) {
         MultiResolve multiResolve = new MultiResolve(name, incompleteCode);
         PsiTreeUtil.treeWalkUp(
                 multiResolve,
                 entrance,
-                entrance.getContainingFile(),
+                maxScope,
                 state.put(ENTRANCE, entrance)
         );
         return multiResolve.getResolveResultList();

--- a/src/org/elixir_lang/reference/Callable.java
+++ b/src/org/elixir_lang/reference/Callable.java
@@ -610,44 +610,47 @@ public class Callable extends PsiReferenceBase<Call> implements PsiPolyVariantRe
     @NotNull
     @Override
     public ResolveResult[] multiResolve(boolean incompleteCode) {
-        List<ResolveResult> resolveResultList = null;
+        final List<ResolveResult> resolveResultList = new ArrayList<ResolveResult>();
         int resolvedFinalArity = myElement.resolvedFinalArity();
-        Call modular = maybeQualifiedCallToModular(myElement);
-        ResolveResult[] resolveResults;
 
-        if (modular != null) {
-            final List<ResolveResult> finalResolveResultList = new ArrayList<ResolveResult>();
+        if (myElement instanceof org.elixir_lang.psi.call.qualification.Qualified) {
+            Call modular = qualifiedToModular((org.elixir_lang.psi.call.qualification.Qualified) myElement);
 
-            Modular.forEachCallDefinitionClauseNameIdentifier(
-                    modular,
-                    myElement.functionName(),
-                    resolvedFinalArity,
-                    new com.intellij.util.Function<PsiElement, Boolean>() {
-                        @Override
-                        public Boolean fun(PsiElement nameIdentifier) {
-                            finalResolveResultList.add(new PsiElementResolveResult(nameIdentifier, true));
+            /* If modular cannot be found then it means that either the qualifier has a typo or its part of
+               .beam-only Module.  Since .beam-only Modules aren't resolvable at this time, assume typo and mark all
+                ResolveResults with `validResult` `false.  Finally, it could also be a variable. */
+            if (modular != null) {
+                Modular.forEachCallDefinitionClauseNameIdentifier(
+                        modular,
+                        myElement.functionName(),
+                        resolvedFinalArity,
+                        new com.intellij.util.Function<PsiElement, Boolean>() {
+                            @Override
+                            public Boolean fun(PsiElement nameIdentifier) {
+                                resolveResultList.add(new PsiElementResolveResult(nameIdentifier, true));
 
-                            return true;
+                                return true;
+                            }
                         }
-                    }
-            );
-
-            resolveResults = finalResolveResultList.toArray(new ResolveResult[finalResolveResultList.size()]);
-        }
-        else {
+                );
+            }
+        } else {
             /* DO NOT use `getName()` as it will return the NameIdentifier's text, which for `defmodule` is the Alias,
                not `defmodule` */
             String name = myElement.functionName();
 
             if (name != null) {
-                List<ResolveResult> variableResolveList = null;
-
                 if (resolvedFinalArity == 0) {
-                    variableResolveList = org.elixir_lang.psi.scope.variable.MultiResolve.resolveResultList(
-                            name,
-                            incompleteCode,
-                            myElement
-                    );
+                    List<ResolveResult> variableResolveList =
+                            org.elixir_lang.psi.scope.variable.MultiResolve.resolveResultList(
+                                    name,
+                                    incompleteCode,
+                                    myElement
+                            );
+
+                    if (variableResolveList != null) {
+                        resolveResultList.addAll(variableResolveList);
+                    }
                 }
 
                 List<ResolveResult> callDefinitionClauseResolveResultList =
@@ -658,17 +661,14 @@ public class Callable extends PsiReferenceBase<Call> implements PsiPolyVariantRe
                                 myElement
                         );
 
-                resolveResultList = merge(variableResolveList, callDefinitionClauseResolveResultList);
+                if (callDefinitionClauseResolveResultList != null) {
+                    resolveResultList.addAll(callDefinitionClauseResolveResultList);
+                }
             }
 
-            if (resolveResultList == null) {
-                resolveResults = new ResolveResult[0];
-            } else {
-                resolveResults = resolveResultList.toArray(new ResolveResult[resolveResultList.size()]);
-            }
         }
 
-        return resolveResults;
+        return resolveResultList.toArray(new ResolveResult[resolveResultList.size()]);
     }
 
     /**

--- a/src/org/elixir_lang/reference/Callable.java
+++ b/src/org/elixir_lang/reference/Callable.java
@@ -633,8 +633,11 @@ public class Callable extends PsiReferenceBase<Call> implements PsiPolyVariantRe
             );
 
             resolveResults = finalResolveResultList.toArray(new ResolveResult[finalResolveResultList.size()]);
-        } else {
-            String name = myElement.getName();
+        }
+        else {
+            /* DO NOT use `getName()` as it will return the NameIdentifier's text, which for `defmodule` is the Alias,
+               not `defmodule` */
+            String name = myElement.functionName();
 
             if (name != null) {
                 List<ResolveResult> variableResolveList = null;

--- a/src/org/elixir_lang/reference/Module.java
+++ b/src/org/elixir_lang/reference/Module.java
@@ -20,22 +20,16 @@ import java.util.List;
 import static org.elixir_lang.reference.module.ResolvableName.resolvableName;
 
 public class Module extends PsiReferenceBase<QualifiableAlias> implements PsiPolyVariantReference {
-    /*
-     *
-     * Static Methods
-     *
-     */
-
-    /*
-     * Private Static Methods
-     */
+    @NotNull
+    private PsiElement maxScope;
 
     /*
      * Constructors
      */
 
-    public Module(@NotNull QualifiableAlias qualifiableAlias) {
+    public Module(@NotNull QualifiableAlias qualifiableAlias, @NotNull PsiElement maxScope) {
         super(qualifiableAlias, TextRange.create(0, qualifiableAlias.getTextLength()));
+        this.maxScope = maxScope;
     }
 
     /*
@@ -55,7 +49,7 @@ public class Module extends PsiReferenceBase<QualifiableAlias> implements PsiPol
         final String name = resolvableName(myElement);
 
         if (name != null) {
-            resolveResultList = MultiResolve.resolveResultList(name, incompleteCode, myElement);
+            resolveResultList = MultiResolve.resolveResultList(name, incompleteCode, myElement, maxScope);
 
             if (resolveResultList == null || resolveResultList.isEmpty()) {
                 resolveResultList = multiResolveProject(


### PR DESCRIPTION
Fixes #511
Fixes #512
Fixes #529
Fixes #538

# Changelog
## Bug Fixes
* Use `functionName` instead of `getName` when multiresolving unqualified functions because `getName` will return the Alias when called on `defmodule`.
* `maybeQualifiedCallToModular` returned `null` BOTH (1) if the call was unqualified OR (2) if the call was qualified, but its modular could not be resolved, so qualified calls to `.beam`-only modules, like `File.read!` returned `null` because `File` could not be resolved to a modular.  Remove `maybeqQualifiedToModular` and call `qualifiedToModular` when `myElement` is qualified.  If the modular is `null`, then return an empty `ResolveResult[]` instead of looking for unqualified matches.
* Pass `maxScope` to `Module` reference.  `maxScope` is generally the containing file for the element, but when using `Module` to resolve `import`s, it is the `import` call's parent element, so that the resolve doesn't ricochet between the `defmodule` and its child, the `import` call until `StackOverflowError`.