### PR TITLE
LocalSearchScope.EMPTY for ElixirMapUpdateArguments variableUseScope

### DIFF
--- a/src/org/elixir_lang/reference/Callable.java
+++ b/src/org/elixir_lang/reference/Callable.java
@@ -531,8 +531,8 @@ public class Callable extends PsiReferenceBase<Call> implements PsiPolyVariantRe
             useScope = variableUseScope((Match) ancestor);
         } else if (ancestor instanceof Call) {
             useScope = variableUseScope((Call) ancestor);
-        } else if (ancestor instanceof ElixirInterpolation) {
-            /* no variable can be declared inside an interpolation, so this is a variable usage missing a declaration,
+        } else if (ancestor instanceof ElixirMapUpdateArguments || ancestor instanceof ElixirInterpolation) {
+            /* no variable can be declared inside these classes, so this is a variable usage missing a declaration,
                so it has no use scope */
             useScope = LocalSearchScope.EMPTY;
         } else {

--- a/testData/org/elixir_lang/reference/callable/issue_517/variable_use_scope.ex
+++ b/testData/org/elixir_lang/reference/callable/issue_517/variable_use_scope.ex
@@ -1,0 +1,8 @@
+defmodle Pooly.Server do
+  def handle_cast({:checkin, worker}, %{workers: workers, monitors: monitors} = state) do
+    case :ets.lookup(monitors, worker) do
+      [{pid, ref}] ->
+        {:noreply, %{state | workers: [pid|wo<caret>kers]}}
+    end
+  end
+end

--- a/tests/org/elixir_lang/reference/callable/Issue517Test.java
+++ b/tests/org/elixir_lang/reference/callable/Issue517Test.java
@@ -1,0 +1,38 @@
+package org.elixir_lang.reference.callable;
+
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.search.LocalSearchScope;
+import com.intellij.testFramework.fixtures.LightCodeInsightFixtureTestCase;
+import org.elixir_lang.psi.UnqualifiedNoArgumentsCall;
+
+import static org.elixir_lang.reference.Callable.variableUseScope;
+
+public class Issue517Test extends LightCodeInsightFixtureTestCase {
+    /*
+     * Tests
+     */
+
+    public void testVariableUseScope() {
+        myFixture.configureByFiles("variable_use_scope.ex");
+        @SuppressWarnings("ConstantConditions") PsiElement callable = myFixture
+                .getFile()
+                .findElementAt(myFixture.getCaretOffset())
+                .getParent()
+                .getParent();
+
+        assertInstanceOf(callable, UnqualifiedNoArgumentsCall.class);
+        assertEquals(
+                LocalSearchScope.EMPTY,
+                variableUseScope((UnqualifiedNoArgumentsCall) callable)
+        );
+    }
+
+    /*
+     * Protected Instance Methods
+     */
+
+    @Override
+    protected String getTestDataPath() {
+        return "testData/org/elixir_lang/reference/callable/issue_517";
+    }
+}


### PR DESCRIPTION
Fixes #517

# Changelog
## Enhancements
* Regression test for #517

## Bug Fixes
* A variable cannot be declared in update arguments, so return `LocalSearchScope.EMPTY`, the same as interpolation.