### PR TITLE
Allow ElixirSystemUtil.getProcessOutput workDir to be null

### DIFF
--- a/src/org/elixir_lang/sdk/ElixirSystemUtil.java
+++ b/src/org/elixir_lang/sdk/ElixirSystemUtil.java
@@ -70,10 +70,10 @@ public class ElixirSystemUtil {
 
   @NotNull
   public static ProcessOutput getProcessOutput(int timeout,
-                                               @NotNull String workDir,
+                                               @Nullable String workDir,
                                                @NotNull String exePath,
                                                @NotNull String... arguments) throws ExecutionException{
-    if(!new File(workDir).isDirectory() || !new File(exePath).canExecute()){
+    if(workDir == null || !new File(workDir).isDirectory() || !new File(exePath).canExecute()){
       return new ProcessOutput();
     }
 

--- a/tests/org/elixir_lang/sdk/ElixirSystemUtilTest.java
+++ b/tests/org/elixir_lang/sdk/ElixirSystemUtilTest.java
@@ -1,0 +1,24 @@
+package org.elixir_lang.sdk;
+
+import com.intellij.execution.ExecutionException;
+import junit.framework.TestCase;
+
+public class ElixirSystemUtilTest extends TestCase {
+    /*
+     * Tests
+     */
+
+    public void testIssue521() throws ExecutionException {
+        assertEquals(
+                -1,
+                ElixirSystemUtil
+                        .getProcessOutput(
+                                1,
+                                null,
+                                "/exe-path",
+                                new String[0]
+                        )
+                        .getExitCode()
+        );
+    }
+}


### PR DESCRIPTION
Fixes #521

# Changelog
## Enhancements
* Regression test for #521

## Bug Fixes
* `ElixirSystemUtil.getProcessOutput` already allowed for an empty, invalid `ProcessOutput` when the `workDir` wasn't a directory, so allow it to also be null and return the empty `ProcessOutput`.