### PR TITLE
Quick Fix : or = in type spec to ::

### DIFF
--- a/res/inspectionDescriptions/KeywordPairColonInsteadOfTypeOperator.html
+++ b/res/inspectionDescriptions/KeywordPairColonInsteadOfTypeOperator.html
@@ -1,0 +1,20 @@
+<html>
+<body>
+Type specifications separate the name from the definition using `::`.  Replace `:` with `::`.
+<!-- tooltip end -->
+
+<code>
+<pre>
+@type name: definition
+</pre>
+</code>
+
+Replace the `:` with ` ::`
+
+<code>
+<pre>
+@type name :: definition
+</pre>
+</code>
+</body>
+</html>

--- a/res/inspectionDescriptions/MatchInsteadOfTypeOperator.html
+++ b/res/inspectionDescriptions/MatchInsteadOfTypeOperator.html
@@ -1,0 +1,20 @@
+<html>
+<body>
+Type specifications separate the name from the definition using `::`.  Replace `=` with `::`.
+<!-- tooltip end -->
+
+<code>
+<pre>
+@type name = definition
+</pre>
+</code>
+
+Replace the `=` with ` ::`
+
+<code>
+<pre>
+@type name :: definition
+</pre>
+</code>
+</body>
+</html>

--- a/src/META-INF/plugin.xml
+++ b/src/META-INF/plugin.xml
@@ -2123,6 +2123,10 @@
                      enabledByDefault="true" groupName="Elixir"
                      implementationClass="org.elixir_lang.inspection.KeywordPairColonInsteadOfTypeOperator"
                      language="Elixir" level="ERROR" shortName="KeywordPairColonInsteadOfTypeOperator"/>
+    <localInspection displayName="Match operator (=) used in type spec instead of type operator (:)"
+                     enabledByDefault="true" groupName="Elixir"
+                     implementationClass="org.elixir_lang.inspection.MatchOperatorInsteadOfTypeOperator"
+                     language="Elixir" level="ERROR" shortName="MatchOperatorInsteadOfTypeOperator"/>
 
     <!-- module attribute refactoring -->
     <renameHandler implementation="org.elixir_lang.refactoring.module_attribute.rename.Handler"/>

--- a/src/META-INF/plugin.xml
+++ b/src/META-INF/plugin.xml
@@ -2119,6 +2119,10 @@
     <localInspection displayName="Keywords Not At End" enabledByDefault="true"
                      groupName="Elixir" implementationClass="org.elixir_lang.inspection.KeywordsNotAtEnd"
                      language="Elixir" level="ERROR" shortName="KeywordsNotAtEnd"/>
+    <localInspection displayName="Keyword pair colon (:) used in type spec instead of type operator (:)"
+                     enabledByDefault="true" groupName="Elixir"
+                     implementationClass="org.elixir_lang.inspection.KeywordPairColonInsteadOfTypeOperator"
+                     language="Elixir" level="ERROR" shortName="KeywordPairColonInsteadOfTypeOperator"/>
 
     <!-- module attribute refactoring -->
     <renameHandler implementation="org.elixir_lang.refactoring.module_attribute.rename.Handler"/>

--- a/src/org/elixir_lang/annonator/ModuleAttribute.java
+++ b/src/org/elixir_lang/annonator/ModuleAttribute.java
@@ -270,8 +270,8 @@ public class ModuleAttribute implements Annotator, DumbAware {
         if (grandChildren.length == 1) {
             PsiElement grandChild = grandChildren[0];
 
-            if (grandChild instanceof Match /* Match is invalid.  It will be marked by MatchInsteadOfTypeOperator
-                                               inspection as an error */
+            if (grandChild instanceof Match /* Match is invalid.  It will be marked by
+                                               MatchOperatorInsteadOfTypeOperator inspection as an error */
                     || grandChild instanceof Type) {
                 Infix infix = (Infix) grandChild;
                 PsiElement leftOperand = infix.leftOperand();

--- a/src/org/elixir_lang/annonator/ModuleAttribute.java
+++ b/src/org/elixir_lang/annonator/ModuleAttribute.java
@@ -367,6 +367,36 @@ public class ModuleAttribute implements Annotator, DumbAware {
                 } else {
                     cannotHighlightTypes(matchedUnqualifiedParenthesesCall);
                 }
+            } else if (grandChild instanceof QuotableKeywordList) {
+                QuotableKeywordList quotableKeywordList = (QuotableKeywordList) grandChild;
+                List<QuotableKeywordPair> quotableKeywordPairList = quotableKeywordList.quotableKeywordPairList();
+
+                // occurs when user does `my_type: definition` instead of `my_type :: definition`
+                if (quotableKeywordPairList.size() == 1) {
+                    QuotableKeywordPair quotableKeywordPair = quotableKeywordPairList.get(0);
+
+                    Quotable quotableKeywordKey = quotableKeywordPair.getKeywordKey();
+
+                    if (quotableKeywordKey instanceof ElixirKeywordKey) {
+                        ElixirKeywordKey keywordKey = (ElixirKeywordKey) quotableKeywordKey;
+
+                        highlight(
+                                keywordKey.getTextRange(),
+                                annotationHolder,
+                                ElixirSyntaxHighlighter.TYPE
+                        );
+                    }
+
+                    Quotable quotableKeywordValue = quotableKeywordPair.getKeywordValue();
+
+                    highlightTypesAndTypeParameterUsages(
+                            quotableKeywordValue,
+                            Collections.<String>emptySet(),
+                            annotationHolder,
+                            ElixirSyntaxHighlighter.TYPE
+                    );
+                }
+                // Otherwise, allow the normal, non-type highlighting
             } else if (grandChild instanceof UnqualifiedNoArgumentsCall) {
                 // assume it's a type name that is being typed
                 Call grandChildCall = (Call) grandChild;

--- a/src/org/elixir_lang/annonator/ModuleAttribute.java
+++ b/src/org/elixir_lang/annonator/ModuleAttribute.java
@@ -270,9 +270,9 @@ public class ModuleAttribute implements Annotator, DumbAware {
         if (grandChildren.length == 1) {
             PsiElement grandChild = grandChildren[0];
 
-            if (grandChild instanceof Match) {
-                // TODO LocalInspectionTool with quick fix to "Use `::`, not `=`, to separate types declarations from their definitions"
-            } else if (grandChild instanceof Type) {
+            if (grandChild instanceof Match /* Match is invalid.  It will be marked by MatchInsteadOfTypeOperator
+                                               inspection as an error */
+                    || grandChild instanceof Type) {
                 Infix infix = (Infix) grandChild;
                 PsiElement leftOperand = infix.leftOperand();
                 Set<String> typeParameterNameSet = Collections.emptySet();

--- a/src/org/elixir_lang/annonator/ModuleAttribute.java
+++ b/src/org/elixir_lang/annonator/ModuleAttribute.java
@@ -29,6 +29,7 @@ import java.util.Set;
 
 import static org.elixir_lang.psi.call.name.Function.UNQUOTE;
 import static org.elixir_lang.psi.call.name.Module.KERNEL;
+import static org.elixir_lang.psi.impl.ElixirPsiImplUtil.identifierName;
 import static org.elixir_lang.psi.impl.ElixirPsiImplUtil.stripAccessExpression;
 import static org.elixir_lang.reference.ModuleAttribute.*;
 
@@ -80,13 +81,7 @@ public class ModuleAttribute implements Annotator, DumbAware {
                         ElixirAtIdentifier atIdentifier = atUnqualifiedNoParenthesesCall.getAtIdentifier();
                         TextRange textRange = atIdentifier.getTextRange();
 
-                        ASTNode node = atIdentifier.getNode();
-                        ASTNode[] identifierNodes = node.getChildren(ElixirPsiImplUtil.IDENTIFIER_TOKEN_SET);
-
-                        assert identifierNodes.length == 1;
-
-                        ASTNode identifierNode = identifierNodes[0];
-                        String identifier = identifierNode.getText();
+                        String identifier = identifierName(atIdentifier);
 
                         if (isCallbackName(identifier)) {
                             highlight(textRange, holder, ElixirSyntaxHighlighter.MODULE_ATTRIBUTE);

--- a/src/org/elixir_lang/inspection/KeywordPairColonInsteadOfTypeOperator.java
+++ b/src/org/elixir_lang/inspection/KeywordPairColonInsteadOfTypeOperator.java
@@ -1,0 +1,112 @@
+package org.elixir_lang.inspection;
+
+import com.intellij.codeInspection.*;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.PsiRecursiveElementWalkingVisitor;
+import org.elixir_lang.local_quick_fix.ConvertKeywordPairToTypeOperation;
+import org.elixir_lang.psi.*;
+import org.jetbrains.annotations.Nls;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+
+import static org.elixir_lang.psi.impl.ElixirPsiImplUtil.identifierName;
+import static org.elixir_lang.reference.ModuleAttribute.isTypeName;
+
+public class KeywordPairColonInsteadOfTypeOperator extends LocalInspectionTool {
+    /*
+     * Instance Methods
+     */
+
+    @NotNull
+    @Override
+    public ProblemDescriptor[] checkFile(@NotNull PsiFile file,
+                                         @NotNull InspectionManager manager,
+                                         boolean isOnTheFly) {
+        final ProblemsHolder problemsHolder = new ProblemsHolder(manager, file, isOnTheFly);
+
+        file.accept(
+                new PsiRecursiveElementWalkingVisitor() {
+                    @Override
+                    public void visitElement(@NotNull final PsiElement element) {
+                        // See org.elixir_lang.annotator.ModuleAttribute.annotate for path of checks
+                        if (element instanceof AtUnqualifiedNoParenthesesCall) {
+                            visitAtUnqualifiedNoParenthesesCall((AtUnqualifiedNoParenthesesCall) element);
+                        }
+
+                        super.visitElement(element);
+                    }
+
+                    private void visitAtUnqualifiedNoParenthesesCall(
+                            @NotNull final AtUnqualifiedNoParenthesesCall atUnqualifiedNoParenthesesCall
+                    ) {
+                        ElixirAtIdentifier atIdentifier = atUnqualifiedNoParenthesesCall.getAtIdentifier();
+                        String identifier = identifierName(atIdentifier);
+
+                        if (isTypeName(identifier)) {
+                            PsiElement child = atUnqualifiedNoParenthesesCall.getNoParenthesesOneArgument();
+                            PsiElement[] grandChildren = child.getChildren();
+
+                            if (grandChildren.length == 1) {
+                                PsiElement grandChild = grandChildren[0];
+
+                                if (grandChild instanceof QuotableKeywordList) {
+                                    QuotableKeywordList quotableKeywordList = (QuotableKeywordList) grandChild;
+                                    List<QuotableKeywordPair> quotableKeywordPairList =
+                                            quotableKeywordList.quotableKeywordPairList();
+
+                                    if (quotableKeywordPairList.size() == 1) {
+                                        QuotableKeywordPair quotableKeywordPair = quotableKeywordPairList.get(0);
+                                        Quotable keywordKey = quotableKeywordPair.getKeywordKey();
+                                        PsiElement keywordPairColon = keywordKey.getNextSibling();
+
+                                        LocalQuickFix localQuickFix = new ConvertKeywordPairToTypeOperation(
+                                                /* Can't be KEYWORD_PAIR_COLON because caret is never on the single
+                                                   character in editor mode, only to left or right */
+                                                keywordPairColon
+                                        );
+
+                                        problemsHolder.registerProblem(
+                                                keywordPairColon,
+                                                "Type specifications separate the name from the definition using `::`, not `:`",
+                                                ProblemHighlightType.ERROR,
+                                                localQuickFix
+                                        );
+                                    }
+                                }
+                            }
+                        }
+
+                    }
+                }
+        );
+
+        return problemsHolder.getResultsArray();
+    }
+
+    @Nls
+    @NotNull
+    @Override
+    public String getDisplayName() {
+        return "Keyword pair colon (:) used in type spec instead of type operator (:)";
+    }
+
+    @Nls
+    @NotNull
+    @Override
+    public String getGroupDisplayName() {
+        return "Elixir";
+    }
+
+    @NotNull
+    @Override
+    public String getShortName() {
+        return "KeywordPairColonInsteadOfTypeOperator";
+    }
+
+    @Override
+    public boolean isEnabledByDefault() {
+        return true;
+    }
+}

--- a/src/org/elixir_lang/inspection/MatchOperatorInsteadOfTypeOperator.java
+++ b/src/org/elixir_lang/inspection/MatchOperatorInsteadOfTypeOperator.java
@@ -1,0 +1,115 @@
+package org.elixir_lang.inspection;
+
+import com.intellij.codeInspection.*;
+import com.intellij.lang.ASTNode;
+import com.intellij.openapi.util.TextRange;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.PsiRecursiveElementWalkingVisitor;
+import org.elixir_lang.local_quick_fix.ConvertMatchToTypeOperation;
+import org.elixir_lang.psi.*;
+import org.elixir_lang.psi.operation.Infix;
+import org.elixir_lang.psi.operation.Match;
+import org.jetbrains.annotations.Nls;
+import org.jetbrains.annotations.NotNull;
+
+import static org.elixir_lang.psi.impl.ElixirPsiImplUtil.identifierName;
+import static org.elixir_lang.psi.impl.ElixirPsiImplUtil.operatorTokenNode;
+import static org.elixir_lang.reference.ModuleAttribute.isTypeName;
+
+public class MatchOperatorInsteadOfTypeOperator extends LocalInspectionTool {
+    /*
+     * Instance Methods
+     */
+
+    @NotNull
+    @Override
+    public ProblemDescriptor[] checkFile(@NotNull PsiFile file,
+                                         @NotNull InspectionManager manager,
+                                         boolean isOnTheFly) {
+        final ProblemsHolder problemsHolder = new ProblemsHolder(manager, file, isOnTheFly);
+
+        file.accept(
+                new PsiRecursiveElementWalkingVisitor() {
+                    @Override
+                    public void visitElement(@NotNull final PsiElement element) {
+                        // See org.elixir_lang.annotator.ModuleAttribute.annotate for path of checks
+                        if (element instanceof AtUnqualifiedNoParenthesesCall) {
+                            visitAtUnqualifiedNoParenthesesCall((AtUnqualifiedNoParenthesesCall) element);
+                        }
+
+                        super.visitElement(element);
+                    }
+
+                    private void visitAtUnqualifiedNoParenthesesCall(
+                            @NotNull final AtUnqualifiedNoParenthesesCall atUnqualifiedNoParenthesesCall
+                    ) {
+                        ElixirAtIdentifier atIdentifier = atUnqualifiedNoParenthesesCall.getAtIdentifier();
+                        String identifier = identifierName(atIdentifier);
+
+                        if (isTypeName(identifier)) {
+                            PsiElement child = atUnqualifiedNoParenthesesCall.getNoParenthesesOneArgument();
+                            PsiElement[] grandChildren = child.getChildren();
+
+                            if (grandChildren.length == 1) {
+                                PsiElement grandChild = grandChildren[0];
+
+                                if (grandChild instanceof Match) {
+                                    Infix infix = (Infix) grandChild;
+                                    Operator operator = infix.operator();
+                                    int elementStartOffset = operator.getTextOffset();
+
+                                    ASTNode astNode = operatorTokenNode(operator);
+                                    int nodeStartOffset = astNode.getStartOffset();
+                                    int nodeTextLength = astNode.getTextLength();
+                                    int relativeStart = nodeStartOffset - elementStartOffset;
+                                    TextRange relativeTextRange = new TextRange(
+                                            relativeStart,
+                                            relativeStart + nodeTextLength
+                                    );
+
+                                    LocalQuickFix localQuickFix = new ConvertMatchToTypeOperation(astNode);
+
+                                    problemsHolder.registerProblem(
+                                            operator,
+                                            "Type specifications separate the name from the definition using `::`, not `=`",
+                                            ProblemHighlightType.ERROR,
+                                            relativeTextRange,
+                                            localQuickFix
+                                    );
+                                }
+                            }
+                        }
+
+                    }
+                }
+        );
+
+        return problemsHolder.getResultsArray();
+    }
+
+    @Nls
+    @NotNull
+    @Override
+    public String getDisplayName() {
+        return "Keyword pair colon (:) used in type spec instead of type operator (:)";
+    }
+
+    @Nls
+    @NotNull
+    @Override
+    public String getGroupDisplayName() {
+        return "Elixir";
+    }
+
+    @NotNull
+    @Override
+    public String getShortName() {
+        return "KeywordPairColonInsteadOfTypeOperator";
+    }
+
+    @Override
+    public boolean isEnabledByDefault() {
+        return true;
+    }
+}

--- a/src/org/elixir_lang/local_quick_fix/ConvertKeywordPairToTypeOperation.java
+++ b/src/org/elixir_lang/local_quick_fix/ConvertKeywordPairToTypeOperation.java
@@ -1,0 +1,55 @@
+package org.elixir_lang.local_quick_fix;
+
+import com.intellij.codeInspection.LocalQuickFixOnPsiElement;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.TextRange;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.text.BlockSupport;
+import org.jetbrains.annotations.NotNull;
+
+public class ConvertKeywordPairToTypeOperation extends LocalQuickFixOnPsiElement {
+    /*
+     * Constructors
+     */
+
+    public ConvertKeywordPairToTypeOperation(@NotNull PsiElement keywordPairColon) {
+        super(keywordPairColon);
+    }
+
+    /*
+     * Instance Methods
+     */
+
+    /**
+     * @return text to appear in "Apply Fix" popup when multiple Quick Fixes exist (in the results of batch code
+     * inspection). For example, * if the name of the quickfix is "Create template &lt;filename&gt", the return value of
+     * getFamilyName() should be "Create template". * If the name of the quickfix does not depend on a specific element,
+     * simply return getName().
+     */
+    @NotNull
+    @Override
+    public String getFamilyName() {
+        return "Fix type specification";
+    }
+
+    @NotNull
+    @Override
+    public String getText() {
+        return "Replace `:` in keyword pair with ` ::` to convert to a valid type specification";
+    }
+
+    @Override
+    public void invoke(@NotNull Project project,
+                       @NotNull PsiFile file,
+                       @NotNull PsiElement startElement,
+                       @NotNull PsiElement endElement) {
+        assert startElement == endElement;
+
+        BlockSupport blockSupport = BlockSupport.getInstance(project);
+        TextRange textRange = startElement.getTextRange();
+        int startOffset = textRange.getStartOffset();
+        int endOffset = textRange.getEndOffset();
+        blockSupport.reparseRange(file, startOffset, endOffset, " ::");
+    }
+}

--- a/src/org/elixir_lang/local_quick_fix/ConvertMatchToTypeOperation.java
+++ b/src/org/elixir_lang/local_quick_fix/ConvertMatchToTypeOperation.java
@@ -1,0 +1,63 @@
+package org.elixir_lang.local_quick_fix;
+
+import com.intellij.codeInspection.LocalQuickFix;
+import com.intellij.codeInspection.ProblemDescriptor;
+import com.intellij.lang.ASTNode;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.TextRange;
+import com.intellij.psi.text.BlockSupport;
+import org.jetbrains.annotations.NotNull;
+
+public class ConvertMatchToTypeOperation implements LocalQuickFix {
+    @NotNull
+    private final ASTNode matchOperatorASTNode;
+
+    /*
+     * Constructors
+     */
+
+    public ConvertMatchToTypeOperation(@NotNull ASTNode matchOperatorASTNode) {
+        this.matchOperatorASTNode = matchOperatorASTNode;
+    }
+
+    /*
+     * Instance Methods
+     */
+
+    /**
+     * Called to apply the fix.
+     *
+     * @param project    {@link Project}
+     * @param descriptor problem reported by the tool which provided this quick fix action
+     */
+    @Override
+    public void applyFix(@NotNull Project project, @NotNull ProblemDescriptor descriptor) {
+        BlockSupport blockSupport = BlockSupport.getInstance(project);
+        TextRange textRange = matchOperatorASTNode.getTextRange();
+        blockSupport.reparseRange(
+                matchOperatorASTNode.getPsi().getContainingFile(),
+                textRange.getStartOffset(),
+                textRange.getEndOffset(),
+                "::"
+        );
+    }
+
+    /**
+     * @return text to appear in "Apply Fix" popup when multiple Quick Fixes exist (in the results of batch code
+     * inspection). For example, * if the name of the quickfix is "Create template &lt;filename&gt", the return value of
+     * getFamilyName() should be "Create template". * If the name of the quickfix does not depend on a specific element,
+     * simply return getName().
+     */
+    @NotNull
+    @Override
+    public String getFamilyName() {
+        return "Fix type specification";
+    }
+
+
+    @NotNull
+    @Override
+    public String getName() {
+        return "Replace `=` in keyword pair with `::` to convert to a valid type specification";
+    }
+}

--- a/src/org/elixir_lang/psi/impl/ElixirPsiImplUtil.java
+++ b/src/org/elixir_lang/psi/impl/ElixirPsiImplUtil.java
@@ -560,7 +560,11 @@ public class ElixirPsiImplUtil {
     public static UseScopeSelector useScopeSelector(@NotNull PsiElement element) {
         UseScopeSelector useScopeSelector = UseScopeSelector.PARENT;
 
-        if (element instanceof ElixirAnonymousFunction) {
+        if (element instanceof AtUnqualifiedNoParenthesesCall) {
+            /* Module Attribute declarations can't declare variables, so this is a variable usage without declaration,
+               so limit to SELF */
+            useScopeSelector = UseScopeSelector.SELF;
+        } else if (element instanceof ElixirAnonymousFunction) {
             useScopeSelector = UseScopeSelector.SELF;
         } else if (element instanceof Call) {
             Call call = (Call) element;

--- a/src/org/elixir_lang/psi/impl/ElixirPsiImplUtil.java
+++ b/src/org/elixir_lang/psi/impl/ElixirPsiImplUtil.java
@@ -671,6 +671,17 @@ public class ElixirPsiImplUtil {
         return fileViewProvider.getDocument();
     }
 
+    @NotNull
+    public static String identifierName(ElixirAtIdentifier atIdentifier) {
+        ASTNode node = atIdentifier.getNode();
+        ASTNode[] identifierNodes = node.getChildren(ElixirPsiImplUtil.IDENTIFIER_TOKEN_SET);
+
+        assert identifierNodes.length == 1;
+
+        ASTNode identifierNode = identifierNodes[0];
+        return identifierNode.getText();
+    }
+
     /**
      * The keyword arguments for {@code call}.
      * @param call call to search for keyword arguments.

--- a/testData/org/elixir_lang/annotator/module_attribute/issue_525.ex
+++ b/testData/org/elixir_lang/annotator/module_attribute/issue_525.ex
@@ -1,0 +1,1 @@
+@type status_effects: [any]

--- a/testData/org/elixir_lang/annotator/module_attribute/match.ex
+++ b/testData/org/elixir_lang/annotator/module_attribute/match.ex
@@ -1,0 +1,1 @@
+@type status_effects = [any]

--- a/testData/org/elixir_lang/inspection/keyword_pair_colon_instead_of_type_operator_test_case/issue_525.ex
+++ b/testData/org/elixir_lang/inspection/keyword_pair_colon_instead_of_type_operator_test_case/issue_525.ex
@@ -1,0 +1,1 @@
+@type status_effects<error descr="Type specifications separate the name from the definition using `::`, not `:`">:</error> [any]

--- a/testData/org/elixir_lang/inspection/match_operator_instead_of_type_operator_test_case/match_operator.ex
+++ b/testData/org/elixir_lang/inspection/match_operator_instead_of_type_operator_test_case/match_operator.ex
@@ -1,0 +1,1 @@
+@type status_effects<error descr="Type specifications separate the name from the definition using `::`, not `=`">=</error> [any]

--- a/tests/org/elixir_lang/annotator/ModuleAttributeTest.java
+++ b/tests/org/elixir_lang/annotator/ModuleAttributeTest.java
@@ -34,6 +34,11 @@ public class ModuleAttributeTest extends LightCodeInsightFixtureTestCase {
         myFixture.checkHighlighting(false, false, true);
     }
 
+    public void testIssue525() {
+        myFixture.configureByFile("issue_525.ex");
+        myFixture.checkHighlighting(false, false, true);
+    }
+
     /*
      * Protected Instance Methods
      */

--- a/tests/org/elixir_lang/annotator/ModuleAttributeTest.java
+++ b/tests/org/elixir_lang/annotator/ModuleAttributeTest.java
@@ -39,6 +39,11 @@ public class ModuleAttributeTest extends LightCodeInsightFixtureTestCase {
         myFixture.checkHighlighting(false, false, true);
     }
 
+    public void testMatch() {
+        myFixture.configureByFile("match.ex");
+        myFixture.checkHighlighting(false, false, true);
+    }
+
     /*
      * Protected Instance Methods
      */

--- a/tests/org/elixir_lang/inspection/KeywordPairColonInsteadOfTypeOperatorTestCase.java
+++ b/tests/org/elixir_lang/inspection/KeywordPairColonInsteadOfTypeOperatorTestCase.java
@@ -1,0 +1,19 @@
+package org.elixir_lang.inspection;
+
+import com.intellij.testFramework.fixtures.LightCodeInsightFixtureTestCase;
+
+/**
+ * Created by luke.imhoff on 12/5/14.
+ */
+public class KeywordPairColonInsteadOfTypeOperatorTestCase extends LightCodeInsightFixtureTestCase {
+    public void testIssue525() {
+        myFixture.configureByFiles("issue_525.ex");
+        myFixture.enableInspections(KeywordPairColonInsteadOfTypeOperator.class);
+        myFixture.checkHighlighting();
+    }
+
+    @Override
+    protected String getTestDataPath() {
+        return "testData/org/elixir_lang/inspection/keyword_pair_colon_instead_of_type_operator_test_case";
+    }
+}

--- a/tests/org/elixir_lang/inspection/KeywordPairColonInsteadOfTypeOperatorTestCase.java
+++ b/tests/org/elixir_lang/inspection/KeywordPairColonInsteadOfTypeOperatorTestCase.java
@@ -2,9 +2,6 @@ package org.elixir_lang.inspection;
 
 import com.intellij.testFramework.fixtures.LightCodeInsightFixtureTestCase;
 
-/**
- * Created by luke.imhoff on 12/5/14.
- */
 public class KeywordPairColonInsteadOfTypeOperatorTestCase extends LightCodeInsightFixtureTestCase {
     public void testIssue525() {
         myFixture.configureByFiles("issue_525.ex");

--- a/tests/org/elixir_lang/inspection/MatchOperatorInsteadOfTypeOperatorTestCase.java
+++ b/tests/org/elixir_lang/inspection/MatchOperatorInsteadOfTypeOperatorTestCase.java
@@ -1,0 +1,16 @@
+package org.elixir_lang.inspection;
+
+import com.intellij.testFramework.fixtures.LightCodeInsightFixtureTestCase;
+
+public class MatchOperatorInsteadOfTypeOperatorTestCase extends LightCodeInsightFixtureTestCase {
+    public void testMatchOperator() {
+        myFixture.configureByFiles("match_operator.ex");
+        myFixture.enableInspections(MatchOperatorInsteadOfTypeOperator.class);
+        myFixture.checkHighlighting();
+    }
+
+    @Override
+    protected String getTestDataPath() {
+        return "testData/org/elixir_lang/inspection/match_operator_instead_of_type_operator_test_case";
+    }
+}


### PR DESCRIPTION
Fixes #525

# Changelog
## Enhancements
* Regression test for #525
* If `:` is used instead of `::` for a type specification, mark it as an error with a Quick Fix to convert `:` to ` ::`.
* Highlight `=` operands the same as `::` operands in type specifications.
* If `=` is used instead of `::` in a type specification, mark it as an error with a Quick Fix to convert `=` to `::`.

## Bug Fixes
* If a single keyword pair is used for a type spec, treat `:` as a type for `::`
* Limit variable use scope for variables "declared" in module attributes to the module attribute because the variable can't be declared there and it is really a variable usage without declaration.