### PR TITLE
575

### DIFF
--- a/src/org/elixir_lang/beam/MacroNameArity.java
+++ b/src/org/elixir_lang/beam/MacroNameArity.java
@@ -1,0 +1,66 @@
+package org.elixir_lang.beam;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import static org.elixir_lang.psi.call.name.Function.DEF;
+import static org.elixir_lang.psi.call.name.Function.DEFMACRO;
+
+/**
+ * The macro ({@code def} or {@code defmacro}), name of the call definition and arity to define an export
+ */
+public class MacroNameArity {
+    /*
+     * CONSTANTS
+     */
+
+    private static final String MACRO_EXPORT_PREFIX = "MACRO-";
+
+    /*
+     * Fields
+     */
+
+    /**
+     * {@code defmacro} if exportArity is prefixed with {@code MACRO-}; otherwise, {@code def}.
+     */
+    @NotNull
+    public final String macro;
+
+    /**
+     * Elixir macros are defined as Erlang functions with names prefixed by {@code MACRO-}.  That prefix is stripped
+     * from this name as it is the call definition name passed to {@code def} or {@code defmacro}.
+     */
+    @NotNull
+    public final String name;
+
+    /**
+     * Elixir macros are defined as Erlang functions that take an extra Caller argument, so the exportArity is +1 for
+     * macros compared to this arity, which is the number of parameters to the call definition head passed to
+     * {@code defmacro}.
+     *
+     * Only {@code null} if {@code exportArity} is {@code null}, which would indicate a malformed {@code .beam}.
+     */
+    @Nullable
+    public final Integer arity;
+
+    /*
+     * Constructors
+     */
+
+    public MacroNameArity(@NotNull String exportName, @Nullable Integer exportArity) {
+        if (exportName.startsWith(MACRO_EXPORT_PREFIX)) {
+            macro = DEFMACRO;
+            name = exportName.substring(MACRO_EXPORT_PREFIX.length());
+
+            if (exportArity != null) {
+                arity = exportArity - 1;
+            } else {
+                arity = null;
+            }
+        } else {
+            macro = DEF;
+            name = exportName;
+            arity = exportArity;
+        }
+    }
+}

--- a/src/org/elixir_lang/beam/StubBuilder.java
+++ b/src/org/elixir_lang/beam/StubBuilder.java
@@ -25,10 +25,9 @@ public class StubBuilder implements BinaryFileStubBuilder {
     @Nullable
     @Override
     public Stub buildStubTree(FileContent fileContent) {
-        VirtualFile file = fileContent.getFile();
         byte[] content = fileContent.getContent();
 
-        PsiFileStub<?> stub = BeamFileImpl.buildFileStub(file, content);
+        PsiFileStub<?> stub = BeamFileImpl.buildFileStub(content);
 
         if (stub == null) {
             LOGGER.info("No stub built for file " + fileContent);

--- a/src/org/elixir_lang/beam/psi/BeamFileImpl.java
+++ b/src/org/elixir_lang/beam/psi/BeamFileImpl.java
@@ -250,6 +250,7 @@ public class BeamFileImpl extends ModuleElementImpl implements ModuleOwner, PsiC
         return modulars();
     }
 
+    @NotNull
     public CanonicallyNamed[] modulars() {
         return (CanonicallyNamed[]) getStub().getChildrenByType(MODULE, new ModuleImpl[1]);
     }
@@ -313,7 +314,7 @@ public class BeamFileImpl extends ModuleElementImpl implements ModuleOwner, PsiC
      */
     @Override
     public PsiElement getFirstChild() {
-        final List<StubElement> children = getStub().getChildrenStubs();
+        @SuppressWarnings("unchecked") final List<StubElement> children = getStub().getChildrenStubs();
         PsiElement firstChild = null;
 
         if (!children.isEmpty()) {
@@ -330,7 +331,7 @@ public class BeamFileImpl extends ModuleElementImpl implements ModuleOwner, PsiC
      */
     @Override
     public PsiElement getLastChild() {
-        final List<StubElement> children = getStub().getChildrenStubs();
+        @SuppressWarnings("unchecked") final List<StubElement> children = getStub().getChildrenStubs();
         PsiElement lastChild = null;
 
         if (!children.isEmpty()) {
@@ -347,7 +348,7 @@ public class BeamFileImpl extends ModuleElementImpl implements ModuleOwner, PsiC
      */
     @Override
     public PsiElement getNextSibling() {
-        final PsiElement[] siblings = getParent().getChildren();
+        @SuppressWarnings("ConstantConditions") final PsiElement[] siblings = getParent().getChildren();
         final int i = ArrayUtil.indexOf(siblings, this);
         PsiElement nextSibling;
 
@@ -367,7 +368,7 @@ public class BeamFileImpl extends ModuleElementImpl implements ModuleOwner, PsiC
      */
     @Override
     public PsiElement getPrevSibling() {
-        final PsiElement[] siblings = getParent().getChildren();
+        @SuppressWarnings("ConstantConditions") final PsiElement[] siblings = getParent().getChildren();
         final int i = ArrayUtil.indexOf(siblings, this);
         PsiElement prevSibling;
 
@@ -461,7 +462,6 @@ public class BeamFileImpl extends ModuleElementImpl implements ModuleOwner, PsiC
      * for processing to the specified scope processor.
      *
      * @param processor  the processor receiving the declarations.
-     * @param state
      * @param lastParent the child of this element has been processed during the previous
      *                   step of the tree up walk (declarations under this element do not need
      *                   to be processed again)

--- a/src/org/elixir_lang/beam/psi/BeamFileImpl.java
+++ b/src/org/elixir_lang/beam/psi/BeamFileImpl.java
@@ -28,7 +28,7 @@ import com.intellij.util.ArrayUtil;
 import com.intellij.util.IncorrectOperationException;
 import org.elixir_lang.ElixirLanguage;
 import org.elixir_lang.beam.Beam;
-import org.elixir_lang.beam.Decompiler;
+import org.elixir_lang.beam.MacroNameArity;
 import org.elixir_lang.beam.chunk.Atoms;
 import org.elixir_lang.beam.chunk.Exports;
 import org.elixir_lang.beam.chunk.exports.Export;
@@ -140,13 +140,16 @@ public class BeamFileImpl extends ModuleElementImpl implements ModuleOwner, PsiC
 
             for (SortedMap.Entry<String, SortedMap<Integer, Export>> nameExportByArity :
                     exportByArityByName.entrySet()) {
-                String name = nameExportByArity.getKey();
-                Pair<String, String> macroArgument = Decompiler.macroArgument(name);
+                String exportName = nameExportByArity.getKey();
 
                 SortedMap<Integer, Export> exportByArity = nameExportByArity.getValue();
 
                 for (SortedMap.Entry<Integer, Export> arityExport : exportByArity.entrySet()) {
-                    buildCallDefinition(parentStub, macroArgument, arityExport.getKey());
+                    MacroNameArity macroNameArity = new MacroNameArity(exportName, arityExport.getKey());
+
+                    if (macroNameArity.arity != null) {
+                        buildCallDefinition(parentStub, macroNameArity);
+                    }
                 }
             }
         }
@@ -154,16 +157,16 @@ public class BeamFileImpl extends ModuleElementImpl implements ModuleOwner, PsiC
 
     @NotNull
     private static CallDefinitionStub buildCallDefinition(@NotNull ModuleStub parentStub,
-                                                          @NotNull Pair<String, String> macroArgument,
-                                                          int arity) {
-        return buildCallDefinition(parentStub, macroArgument.first, macroArgument.second, arity);
+                                                          @NotNull MacroNameArity macroNameArity) {
+        //noinspection ConstantConditions
+        return buildCallDefinition(parentStub, macroNameArity.macro, macroNameArity.name, macroNameArity.arity);
     }
 
     @NotNull
     private static CallDefinitionStub buildCallDefinition(@NotNull ModuleStub parentStub,
                                                           @NotNull String macro,
                                                           @NotNull String name,
-                                                          int arity) {
+                                                          @NotNull Integer arity) {
         return new CallDefinitionStubImpl(parentStub, macro, name, arity);
     }
 

--- a/src/org/elixir_lang/beam/psi/BeamFileImpl.java
+++ b/src/org/elixir_lang/beam/psi/BeamFileImpl.java
@@ -84,7 +84,7 @@ public class BeamFileImpl extends ModuleElementImpl implements ModuleOwner, PsiC
         this.isForDecompiling = isForDecompiling;
     }
 
-    public static PsiFileStub<?> buildFileStub(VirtualFile file, byte[] bytes) {
+    public static PsiFileStub<?> buildFileStub(byte[] bytes) {
         ElixirFileStubImpl stub = new ElixirFileStubImpl();
 
         Beam beam = null;

--- a/src/org/elixir_lang/beam/psi/stubs/ModuleElementType.java
+++ b/src/org/elixir_lang/beam/psi/stubs/ModuleElementType.java
@@ -3,7 +3,6 @@ package org.elixir_lang.beam.psi.stubs;
 import com.intellij.lang.ASTNode;
 import com.intellij.lang.LighterAST;
 import com.intellij.lang.LighterASTNode;
-import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.stubs.*;
 import org.elixir_lang.psi.stub.call.Stubbic;
@@ -18,7 +17,7 @@ import static org.elixir_lang.psi.stub.type.call.Stub.serializeStubbic;
  *
  * @param <S> The stub element that {@link #serialize(StubElement, StubOutputStream)} and
  *   {@link #indexStub(StubElement, IndexSink)} should accept.  These stubs should be created by
- *   {@link org.elixir_lang.beam.psi.BeamFileImpl#buildFileStub(VirtualFile, byte[])}.
+ *   {@link org.elixir_lang.beam.psi.BeamFileImpl#buildFileStub(byte[])}.
  * @param <P> The PSI element that should be returned by {@link #createPsi(StubElement)} in subclasses
  */
 public abstract class ModuleElementType<S extends StubElement & Stubbic, P extends PsiElement>
@@ -26,7 +25,7 @@ public abstract class ModuleElementType<S extends StubElement & Stubbic, P exten
     /**
      * @throws IllegalArgumentException stubs should never be created from {@link LighterAST} and
      *   {@link LighterASTNode}:  Stubs should be created by
-     *   {@link org.elixir_lang.beam.psi.BeamFileImpl#buildFileStub(VirtualFile, byte[])}.
+     *   {@link org.elixir_lang.beam.psi.BeamFileImpl#buildFileStub(byte[])}.
      */
     @Override
     public S createStub(LighterAST tree, LighterASTNode node, StubElement parentStub) {
@@ -60,7 +59,7 @@ public abstract class ModuleElementType<S extends StubElement & Stubbic, P exten
     /**
      * Serializes {@code stub} as a {@link Stubbic}.
      *
-     * @param stub created by {@link org.elixir_lang.beam.psi.BeamFileImpl#buildFileStub(VirtualFile, byte[])}
+     * @param stub created by {@link org.elixir_lang.beam.psi.BeamFileImpl#buildFileStub(byte[])}
      * @param dataStream stream to write {@code stub} to
      * @throws IOException if {@code dataStream} cannot be written to
      */
@@ -72,7 +71,7 @@ public abstract class ModuleElementType<S extends StubElement & Stubbic, P exten
     /**
      * Indexes {@code stub} as a {@link Stubbic}.
      *
-     * @param stub created by {@link org.elixir_lang.beam.psi.BeamFileImpl#buildFileStub(VirtualFile, byte[])}
+     * @param stub created by {@link org.elixir_lang.beam.psi.BeamFileImpl#buildFileStub(byte[])}
      * @param sink stub index
      */
     @Override

--- a/tests/org/elixir_lang/beam/DecompilerTest.java
+++ b/tests/org/elixir_lang/beam/DecompilerTest.java
@@ -1,0 +1,114 @@
+package org.elixir_lang.beam;
+
+import com.ericsson.otp.erlang.OtpErlangDecodeException;
+import com.intellij.openapi.vfs.LocalFileSystem;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.openapi.vfs.newvfs.impl.VfsRootAccess;
+import com.intellij.testFramework.LightCodeInsightTestCase;
+
+import java.io.*;
+
+public class DecompilerTest extends LightCodeInsightTestCase {
+    /*
+     * Tests
+     */
+
+    public void testIssue575() throws IOException, OtpErlangDecodeException {
+        String ebinDirectory = ebinDirectory();
+
+        VfsRootAccess.allowRootAccess(ebinDirectory);
+
+        VirtualFile virtualFile = LocalFileSystem
+                .getInstance()
+                .findFileByIoFile(
+                        new File(ebinDirectory + "Elixir.Bitwise.beam")
+                );
+
+        assertNotNull(virtualFile);
+
+        Decompiler decompiler = new Decompiler();
+        CharSequence decompiled = decompiler.decompile(virtualFile);
+
+        assertEquals(
+                "# Source code recreated from a .beam file by IntelliJ Elixir\n" +
+                "defmodule Bitwise do\n" +
+                "  defmacro left &&& right do\n" +
+                "    # body not decompiled\n" +
+                "  end\n" +
+                "\n" +
+                "  defmacro left <<< right do\n" +
+                "    # body not decompiled\n" +
+                "  end\n" +
+                "\n" +
+                "  defmacro left >>> right do\n" +
+                "    # body not decompiled\n" +
+                "  end\n" +
+                "\n" +
+                "  defmacro left ^^^ right do\n" +
+                "    # body not decompiled\n" +
+                "  end\n" +
+                "\n" +
+                "  defmacro __using__(p0) do\n" +
+                "    # body not decompiled\n" +
+                "  end\n" +
+                "\n" +
+                "  defmacro band(p0, p1) do\n" +
+                "    # body not decompiled\n" +
+                "  end\n" +
+                "\n" +
+                "  defmacro bnot(p0) do\n" +
+                "    # body not decompiled\n" +
+                "  end\n" +
+                "\n" +
+                "  defmacro bor(p0, p1) do\n" +
+                "    # body not decompiled\n" +
+                "  end\n" +
+                "\n" +
+                "  defmacro bsl(p0, p1) do\n" +
+                "    # body not decompiled\n" +
+                "  end\n" +
+                "\n" +
+                "  defmacro bsr(p0, p1) do\n" +
+                "    # body not decompiled\n" +
+                "  end\n" +
+                "\n" +
+                "  defmacro bxor(p0, p1) do\n" +
+                "    # body not decompiled\n" +
+                "  end\n" +
+                "\n" +
+                "  defmacro left ||| right do\n" +
+                "    # body not decompiled\n" +
+                "  end\n" +
+                "\n" +
+                "  defmacro ~~~(p0) do\n" +
+                "    # body not decompiled\n" +
+                "  end\n" +
+                "\n" +
+                "  def __info__(p0) do\n" +
+                "    # body not decompiled\n" +
+                "  end\n" +
+                "\n" +
+                "  def module_info() do\n" +
+                "    # body not decompiled\n" +
+                "  end\n" +
+                "\n" +
+                "  def module_info(p0) do\n" +
+                "    # body not decompiled\n" +
+                "  end\n" +
+                "end\n",
+                decompiled.toString()
+        );
+    }
+
+    /*
+     * Instance Methods
+     */
+
+    private String ebinDirectory() {
+        String ebinDirectory = System.getenv("ELIXIR_EBIN_DIRECTORY");
+
+        assertNotNull("ELIXIR_EBIN_DIRECTORY is not set", ebinDirectory);
+
+        return ebinDirectory;
+    }
+}


### PR DESCRIPTION
# Changelog
## Enhancements
* Regression test for #575.

## Bug Fixes
* Substract 1 from arity in `.beam` file when decompiling to `defmacro` calls because the Erlang function for Elixir macros has one addition argument: the first argument is the `Caller` of the macro.
* If the name of the decompiled macro/function is an infix operator, then decompile the head as a binary operation instead of a normal prefix name as infix operators aren't valid prefix names and led to parsing errors, which was the root cause of #575.
* Fix IntelliJ warnings in `BeamFileImpl`
* Remove unused `VirtualFile` argument to `BeamFileImpl#buildFileStub`.