### PR TITLE
Elixir.Kernel.beam decompilation

### DIFF
--- a/src/org/elixir_lang/beam/Decompiler.java
+++ b/src/org/elixir_lang/beam/Decompiler.java
@@ -135,9 +135,10 @@ public class Decompiler implements BinaryFileDecompiler {
 
     private static void appendMacroNameArity(@NotNull StringBuilder decompiled,
                                              @NotNull MacroNameArity macroNameArity) {
+        Integer arity = macroNameArity.arity;
         String name = macroNameArity.name;
 
-        if (isInfixOperator(name)) {
+        if (arity != null && arity == 2 && isInfixOperator(name)) {
             appendInfixMacroNameArity(decompiled, macroNameArity);
         } else {
             appendPrefixMacroNameArity(decompiled, macroNameArity);

--- a/src/org/elixir_lang/beam/Decompiler.java
+++ b/src/org/elixir_lang/beam/Decompiler.java
@@ -1,68 +1,32 @@
 package org.elixir_lang.beam;
 
+import com.google.common.base.Joiner;
+import com.intellij.diagnostic.LogMessageEx;
+import com.intellij.openapi.diagnostic.Attachment;
 import com.intellij.openapi.fileTypes.BinaryFileDecompiler;
 import com.intellij.openapi.util.Pair;
 import com.intellij.openapi.vfs.VirtualFile;
-import gnu.trove.THashSet;
 import org.elixir_lang.beam.chunk.Atoms;
 import org.elixir_lang.beam.chunk.Exports;
 import org.elixir_lang.beam.chunk.exports.Export;
+import org.elixir_lang.beam.decompiler.Default;
+import org.elixir_lang.beam.decompiler.InfixOperator;
+import org.elixir_lang.beam.decompiler.PrefixOperator;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.Set;
-import java.util.SortedMap;
-import java.util.SortedSet;
+import java.util.*;
 
 import static org.elixir_lang.psi.call.name.Module.ELIXIR_PREFIX;
 
 public class Decompiler implements BinaryFileDecompiler {
-    private static final Set<String> INFIX_OPERATOR_SET;
+    private static final List<org.elixir_lang.beam.decompiler.MacroNameArity> MACRO_NAME_ARITY_DECOMPILER_LIST =
+            new ArrayList<org.elixir_lang.beam.decompiler.MacroNameArity>();
 
     static {
-        INFIX_OPERATOR_SET = new THashSet<String>();
-        INFIX_OPERATOR_SET.add("!=");
-        INFIX_OPERATOR_SET.add("!==");
-        INFIX_OPERATOR_SET.add("");
-        INFIX_OPERATOR_SET.add("&&");
-        INFIX_OPERATOR_SET.add("&&&");
-        INFIX_OPERATOR_SET.add("*");
-        INFIX_OPERATOR_SET.add("+");
-        INFIX_OPERATOR_SET.add("++");
-        INFIX_OPERATOR_SET.add("-");
-        INFIX_OPERATOR_SET.add("--");
-        INFIX_OPERATOR_SET.add("--");
-        INFIX_OPERATOR_SET.add("->");
-        INFIX_OPERATOR_SET.add("..");
-        INFIX_OPERATOR_SET.add("/");
-        INFIX_OPERATOR_SET.add("::");
-        INFIX_OPERATOR_SET.add("<");
-        INFIX_OPERATOR_SET.add("<-");
-        INFIX_OPERATOR_SET.add("<<<");
-        INFIX_OPERATOR_SET.add("<<~");
-        INFIX_OPERATOR_SET.add("<=");
-        INFIX_OPERATOR_SET.add("<>");
-        INFIX_OPERATOR_SET.add("<|>");
-        INFIX_OPERATOR_SET.add("<~");
-        INFIX_OPERATOR_SET.add("<~>");
-        INFIX_OPERATOR_SET.add("=");
-        INFIX_OPERATOR_SET.add("==");
-        INFIX_OPERATOR_SET.add("===");
-        INFIX_OPERATOR_SET.add("=>");
-        INFIX_OPERATOR_SET.add(">");
-        INFIX_OPERATOR_SET.add(">=");
-        INFIX_OPERATOR_SET.add(">>>");
-        INFIX_OPERATOR_SET.add("\\\\");
-        INFIX_OPERATOR_SET.add("^");
-        INFIX_OPERATOR_SET.add("^^^");
-        INFIX_OPERATOR_SET.add("and");
-        INFIX_OPERATOR_SET.add("or");
-        INFIX_OPERATOR_SET.add("|>");
-        INFIX_OPERATOR_SET.add("||");
-        INFIX_OPERATOR_SET.add("|||");
-        INFIX_OPERATOR_SET.add("~=");
-        INFIX_OPERATOR_SET.add("~>");
-        INFIX_OPERATOR_SET.add("~>>");
+        MACRO_NAME_ARITY_DECOMPILER_LIST.add(InfixOperator.INSTANCE);
+        MACRO_NAME_ARITY_DECOMPILER_LIST.add(PrefixOperator.INSTANCE);
+        MACRO_NAME_ARITY_DECOMPILER_LIST.add(Default.INSTANCE);
     }
 
     @NotNull
@@ -135,57 +99,39 @@ public class Decompiler implements BinaryFileDecompiler {
 
     private static void appendMacroNameArity(@NotNull StringBuilder decompiled,
                                              @NotNull MacroNameArity macroNameArity) {
-        Integer arity = macroNameArity.arity;
-        String name = macroNameArity.name;
+        boolean accepted = false;
 
-        if (arity != null && arity == 2 && isInfixOperator(name)) {
-            appendInfixMacroNameArity(decompiled, macroNameArity);
-        } else {
-            appendPrefixMacroNameArity(decompiled, macroNameArity);
-        }
-    }
-
-    private static void appendInfixMacroNameArity(@NotNull StringBuilder decompiled,
-                                                  @NotNull MacroNameArity macroNameArity) {
-        decompiled
-                .append("  ")
-                .append(macroNameArity.macro)
-                .append(" left ")
-                .append(macroNameArity.name)
-                .append(" right");
-        appendBody(decompiled);
-    }
-
-    private static void appendPrefixMacroNameArity(@NotNull StringBuilder decompiled,
-                                                   @NotNull MacroNameArity macroNameArity) {
-        decompiled
-                .append("  ")
-                .append(macroNameArity.macro)
-                .append(" ")
-                .append(macroNameArity.name)
-                .append("(");
-
-        @Nullable Integer arity = macroNameArity.arity;
-
-        if (arity != null) {
-            for (int i = 0; i < arity; i++) {
-                if (i != 0) {
-                    decompiled.append(", ");
-                }
-
-                decompiled.append("p").append(i);
+        for (org.elixir_lang.beam.decompiler.MacroNameArity decompiler : MACRO_NAME_ARITY_DECOMPILER_LIST) {
+            if (decompiler.accept(macroNameArity)) {
+                decompiler.append(decompiled, macroNameArity);
+                accepted = true;
+                break;
             }
         }
 
-        decompiled.append(")");
-        appendBody(decompiled);
+        if (!accepted) {
+            error(macroNameArity);
+        }
     }
 
-    private static void appendBody(@NotNull StringBuilder decompiled) {
-        decompiled
-                .append(" do\n")
-                .append("    # body not decompiled\n")
-                .append("  end\n");
+    private static void error(@NotNull MacroNameArity macroNameArity) {
+        com.intellij.openapi.diagnostic.Logger logger = com.intellij.openapi.diagnostic.Logger.getInstance(
+                Decompiler.class
+        );
+        String fullUserMessage = "No decompiler for MacroNameArity (" + macroNameArity +")";
+        logger.error(
+                LogMessageEx.createEvent(
+                        fullUserMessage,
+                        Joiner
+                                .on("\n")
+                                .join(
+                                        new Throwable().getStackTrace()
+                                ),
+                        fullUserMessage,
+                        null,
+                        Collections.<Attachment>emptyList()
+                )
+        );
     }
 
     @NotNull
@@ -197,13 +143,6 @@ public class Decompiler implements BinaryFileDecompiler {
             defmoduleArgument = ":" + moduleName;
         }
         return defmoduleArgument;
-    }
-
-    /**
-     * @param name {@link MacroNameArity#name}
-     */
-    private static boolean isInfixOperator(@NotNull String name) {
-        return INFIX_OPERATOR_SET.contains(name);
     }
 
     @NotNull

--- a/src/org/elixir_lang/beam/Decompiler.java
+++ b/src/org/elixir_lang/beam/Decompiler.java
@@ -28,6 +28,7 @@ public class Decompiler implements BinaryFileDecompiler {
         INFIX_OPERATOR_SET.add("&&&");
         INFIX_OPERATOR_SET.add("*");
         INFIX_OPERATOR_SET.add("+");
+        INFIX_OPERATOR_SET.add("++");
         INFIX_OPERATOR_SET.add("-");
         INFIX_OPERATOR_SET.add("--");
         INFIX_OPERATOR_SET.add("--");

--- a/src/org/elixir_lang/beam/MacroNameArity.java
+++ b/src/org/elixir_lang/beam/MacroNameArity.java
@@ -1,5 +1,6 @@
 package org.elixir_lang.beam;
 
+import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -9,7 +10,7 @@ import static org.elixir_lang.psi.call.name.Function.DEFMACRO;
 /**
  * The macro ({@code def} or {@code defmacro}), name of the call definition and arity to define an export
  */
-public class MacroNameArity {
+public class MacroNameArity implements Comparable<MacroNameArity> {
     /*
      * CONSTANTS
      */
@@ -37,30 +38,79 @@ public class MacroNameArity {
      * Elixir macros are defined as Erlang functions that take an extra Caller argument, so the exportArity is +1 for
      * macros compared to this arity, which is the number of parameters to the call definition head passed to
      * {@code defmacro}.
-     *
-     * Only {@code null} if {@code exportArity} is {@code null}, which would indicate a malformed {@code .beam}.
      */
-    @Nullable
+    @NotNull
     public final Integer arity;
 
     /*
      * Constructors
      */
 
-    public MacroNameArity(@NotNull String exportName, @Nullable Integer exportArity) {
+    public MacroNameArity(@NotNull String exportName, int exportArity) {
         if (exportName.startsWith(MACRO_EXPORT_PREFIX)) {
             macro = DEFMACRO;
             name = exportName.substring(MACRO_EXPORT_PREFIX.length());
-
-            if (exportArity != null) {
-                arity = exportArity - 1;
-            } else {
-                arity = null;
-            }
+            arity = exportArity - 1;
         } else {
             macro = DEF;
             name = exportName;
             arity = exportArity;
         }
+    }
+
+    /*
+     * Instance Methods
+     */
+
+    @Override
+    public int compareTo(@NotNull MacroNameArity other) {
+        int comparison = compareMacroTo(other.macro);
+
+        if (comparison == 0) {
+            comparison = compareNameTo(other.name);
+
+            if (comparison == 0) {
+                comparison = compareArityTo(other.arity);
+            }
+        }
+
+        return comparison;
+    }
+
+    @Contract(pure = true)
+    private int compareArityTo(int otherArity) {
+        return Double.compare(arity, otherArity);
+    }
+
+    @Contract(pure = true)
+    private int compareMacroTo(@NotNull String otherMacro) {
+        int comparison;
+
+        if (macro.equals(DEFMACRO)) {
+            if (otherMacro.equals(DEFMACRO)) {
+                comparison = 0;
+            } else if (otherMacro.equals(DEF)) {
+                comparison = - 1;
+            } else {
+                throw new IllegalArgumentException("otherMacro must be \"" + DEFMACRO + "\" or \"" + DEF + "\"");
+            }
+        } else if (macro.equals(DEF)) {
+            if (otherMacro.equals(DEFMACRO)) {
+                comparison = 1;
+            } else if (otherMacro.equals(DEF)) {
+                comparison = 0;
+            } else {
+                throw new IllegalArgumentException("otherMacro must be \"" + DEFMACRO + "\" or \"" + DEF + "\"");
+            }
+        } else {
+            throw new IllegalArgumentException("macro must be \"" + DEFMACRO + "\" or \"" + DEF + "\"");
+        }
+
+        return comparison;
+    }
+
+    @Contract(pure = true)
+    private int compareNameTo(@NotNull String otherName) {
+        return name.compareTo(otherName);
     }
 }

--- a/src/org/elixir_lang/beam/decompiler/Default.java
+++ b/src/org/elixir_lang/beam/decompiler/Default.java
@@ -1,0 +1,52 @@
+package org.elixir_lang.beam.decompiler;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class Default extends MacroNameArity {
+    /*
+     * CONSTANTS
+     */
+
+    public static final MacroNameArity INSTANCE = new Default();
+
+    /**
+     * Whether the decompiler accepts the {@code macroNameArity}
+     *
+     * @return {@code true}
+     */
+    @Override
+    public boolean accept(@NotNull org.elixir_lang.beam.MacroNameArity macroNameArity) {
+        return true;
+    }
+
+    /**
+     * Append the decompiled source for {@code macroNameArity} to {@code decompiled}.
+     *
+     * @param decompiled the decompiled source so far
+     */
+    @Override
+    public void append(@NotNull StringBuilder decompiled, @NotNull org.elixir_lang.beam.MacroNameArity macroNameArity) {
+        decompiled
+                .append("  ")
+                .append(macroNameArity.macro)
+                .append(" ")
+                .append(macroNameArity.name)
+                .append("(");
+
+        @Nullable Integer arity = macroNameArity.arity;
+
+        if (arity != null) {
+            for (int i = 0; i < arity; i++) {
+                if (i != 0) {
+                    decompiled.append(", ");
+                }
+
+                decompiled.append("p").append(i);
+            }
+        }
+
+        decompiled.append(")");
+        appendBody(decompiled);
+    }
+}

--- a/src/org/elixir_lang/beam/decompiler/InfixOperator.java
+++ b/src/org/elixir_lang/beam/decompiler/InfixOperator.java
@@ -1,0 +1,105 @@
+package org.elixir_lang.beam.decompiler;
+
+import gnu.trove.THashSet;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Set;
+
+public class InfixOperator extends MacroNameArity {
+    /*
+     * CONSTANTS
+     */
+
+    private static final Set<String> INFIX_OPERATOR_SET;
+    public static final MacroNameArity INSTANCE = new InfixOperator();
+
+    static {
+        INFIX_OPERATOR_SET = new THashSet<String>();
+        INFIX_OPERATOR_SET.add("!=");
+        INFIX_OPERATOR_SET.add("!==");
+        INFIX_OPERATOR_SET.add("");
+        INFIX_OPERATOR_SET.add("&&");
+        INFIX_OPERATOR_SET.add("&&&");
+        INFIX_OPERATOR_SET.add("*");
+        INFIX_OPERATOR_SET.add("+");
+        INFIX_OPERATOR_SET.add("++");
+        INFIX_OPERATOR_SET.add("-");
+        INFIX_OPERATOR_SET.add("--");
+        INFIX_OPERATOR_SET.add("--");
+        INFIX_OPERATOR_SET.add("->");
+        INFIX_OPERATOR_SET.add("..");
+        INFIX_OPERATOR_SET.add("/");
+        INFIX_OPERATOR_SET.add("::");
+        INFIX_OPERATOR_SET.add("<");
+        INFIX_OPERATOR_SET.add("<-");
+        INFIX_OPERATOR_SET.add("<<<");
+        INFIX_OPERATOR_SET.add("<<~");
+        INFIX_OPERATOR_SET.add("<=");
+        INFIX_OPERATOR_SET.add("<>");
+        INFIX_OPERATOR_SET.add("<|>");
+        INFIX_OPERATOR_SET.add("<~");
+        INFIX_OPERATOR_SET.add("<~>");
+        INFIX_OPERATOR_SET.add("=");
+        INFIX_OPERATOR_SET.add("==");
+        INFIX_OPERATOR_SET.add("===");
+        INFIX_OPERATOR_SET.add("=>");
+        INFIX_OPERATOR_SET.add(">");
+        INFIX_OPERATOR_SET.add(">=");
+        INFIX_OPERATOR_SET.add(">>>");
+        INFIX_OPERATOR_SET.add("\\\\");
+        INFIX_OPERATOR_SET.add("^");
+        INFIX_OPERATOR_SET.add("^^^");
+        INFIX_OPERATOR_SET.add("and");
+        INFIX_OPERATOR_SET.add("or");
+        INFIX_OPERATOR_SET.add("|>");
+        INFIX_OPERATOR_SET.add("||");
+        INFIX_OPERATOR_SET.add("|||");
+        INFIX_OPERATOR_SET.add("~=");
+        INFIX_OPERATOR_SET.add("~>");
+        INFIX_OPERATOR_SET.add("~>>");
+    }
+
+    /*
+     * Static Methods
+     */
+
+    /**
+     * @param name {@link org.elixir_lang.beam.MacroNameArity#name}
+     */
+    private static boolean isInfixOperator(@NotNull String name) {
+        return INFIX_OPERATOR_SET.contains(name);
+    }
+
+    /*
+     * Instance Methods
+     */
+
+    /**
+     * Whether the decompiler accepts the {@code macroNameArity}
+     *
+     * @return {@code true} if {@link #append(StringBuilder, org.elixir_lang.beam.MacroNameArity)} should be called with
+     * {@code macroNameArity}.
+     */
+    @Override
+    public boolean accept(@NotNull org.elixir_lang.beam.MacroNameArity macroNameArity) {
+        Integer arity = macroNameArity.arity;
+
+        return arity != null && arity == 2 && isInfixOperator(macroNameArity.name);
+    }
+
+    /**
+     * Append the decompiled source for {@code macroNameArity} to {@code decompiled}.
+     *
+     * @param decompiled     the decompiled source so far
+     */
+    @Override
+    public void append(@NotNull StringBuilder decompiled, @NotNull org.elixir_lang.beam.MacroNameArity macroNameArity) {
+        decompiled
+                .append("  ")
+                .append(macroNameArity.macro)
+                .append(" left ")
+                .append(macroNameArity.name)
+                .append(" right");
+        appendBody(decompiled);
+    }
+}

--- a/src/org/elixir_lang/beam/decompiler/InfixOperator.java
+++ b/src/org/elixir_lang/beam/decompiler/InfixOperator.java
@@ -51,6 +51,7 @@ public class InfixOperator extends MacroNameArity {
         INFIX_OPERATOR_SET.add("^");
         INFIX_OPERATOR_SET.add("^^^");
         INFIX_OPERATOR_SET.add("and");
+        INFIX_OPERATOR_SET.add("in");
         INFIX_OPERATOR_SET.add("or");
         INFIX_OPERATOR_SET.add("|>");
         INFIX_OPERATOR_SET.add("||");

--- a/src/org/elixir_lang/beam/decompiler/InfixOperator.java
+++ b/src/org/elixir_lang/beam/decompiler/InfixOperator.java
@@ -43,6 +43,7 @@ public class InfixOperator extends MacroNameArity {
         INFIX_OPERATOR_SET.add("==");
         INFIX_OPERATOR_SET.add("===");
         INFIX_OPERATOR_SET.add("=>");
+        INFIX_OPERATOR_SET.add("=~");
         INFIX_OPERATOR_SET.add(">");
         INFIX_OPERATOR_SET.add(">=");
         INFIX_OPERATOR_SET.add(">>>");

--- a/src/org/elixir_lang/beam/decompiler/MacroNameArity.java
+++ b/src/org/elixir_lang/beam/decompiler/MacroNameArity.java
@@ -1,0 +1,40 @@
+package org.elixir_lang.beam.decompiler;
+
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Decompiles a {@link org.elixir_lang.beam.MacroNameArity}
+ */
+public abstract class MacroNameArity {
+    /*
+     * Static Methods
+     */
+
+    static void appendBody(@NotNull StringBuilder decompiled) {
+        decompiled
+                .append(" do\n")
+                .append("    # body not decompiled\n")
+                .append("  end\n");
+    }
+
+    /*
+     * Instance Methods
+     */
+
+
+    /**
+     * Whether the decompiler accepts the {@code macroNameArity}
+     *
+     * @return {@code true} if {@link #append(StringBuilder, org.elixir_lang.beam.MacroNameArity)} should be called with
+     *   {@code macroNameArity}.
+     */
+    public abstract boolean accept(@NotNull org.elixir_lang.beam.MacroNameArity macroNameArity);
+
+    /**
+     * Append the decompiled source for {@code macroNameArity} to {@code decompiled}.
+     *
+     * @param decompiled the decompiled source so far
+     */
+    public abstract void append(@NotNull StringBuilder decompiled,
+                                @NotNull org.elixir_lang.beam.MacroNameArity macroNameArity);
+}

--- a/src/org/elixir_lang/beam/decompiler/PrefixOperator.java
+++ b/src/org/elixir_lang/beam/decompiler/PrefixOperator.java
@@ -1,0 +1,66 @@
+package org.elixir_lang.beam.decompiler;
+
+import gnu.trove.THashSet;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Set;
+
+public class PrefixOperator extends MacroNameArity {
+    /*
+     * CONSTANTS
+     */
+
+    private static final Set<String> PREFIX_OPERATOR_SET;
+    public static final MacroNameArity INSTANCE = new PrefixOperator();
+
+    static {
+        PREFIX_OPERATOR_SET = new THashSet<String>();
+        PREFIX_OPERATOR_SET.add("+");
+        PREFIX_OPERATOR_SET.add("-");
+    }
+
+    /*
+     * Static Methods
+     */
+
+    /**
+     * @parma name {@link org.elixir_lang.beam.MacroNameArity#name}
+     */
+    private static boolean isPrefixOperator(@NotNull String name) {
+        return PREFIX_OPERATOR_SET.contains(name);
+    }
+
+    /*
+     * Instance Methods
+     */
+
+    /**
+     * Whether the decompiler accepts the {@code macroNameArity}
+     *
+     * @return {@code true} if {@link #append(StringBuilder, org.elixir_lang.beam.MacroNameArity)} should be called with
+     * {@code macroNameArity}.
+     */
+    @Override
+    public boolean accept(@NotNull org.elixir_lang.beam.MacroNameArity macroNameArity) {
+        Integer arity = macroNameArity.arity;
+
+        return arity != null && arity == 1 && isPrefixOperator(macroNameArity.name);
+    }
+
+    /**
+     * Append the decompiled source for {@code macroNameArity} to {@code decompiled}.
+     *
+     * @param decompiled     the decompiled source so far
+     * @param macroNameArity
+     */
+    @Override
+    public void append(@NotNull StringBuilder decompiled, @NotNull org.elixir_lang.beam.MacroNameArity macroNameArity) {
+        decompiled
+                .append("  ")
+                .append(macroNameArity.macro)
+                .append(" (")
+                .append(macroNameArity.name)
+                .append("value)");
+        appendBody(decompiled);
+    }
+}

--- a/src/org/elixir_lang/beam/psi/BeamFileImpl.java
+++ b/src/org/elixir_lang/beam/psi/BeamFileImpl.java
@@ -132,25 +132,10 @@ public class BeamFileImpl extends ModuleElementImpl implements ModuleOwner, PsiC
         Exports exports = beam.exports();
 
         if (exports != null) {
-            Pair<SortedMap<String, SortedMap<Integer, Export>>, SortedSet<Export>>
-                    exportByArityByNameNamelessExports = exports.exportByArityByName(atoms);
+            SortedSet<MacroNameArity> macroNameAritySortedSet = exports.macroNameAritySortedSet(atoms);
 
-            SortedMap<String, SortedMap<Integer, Export>> exportByArityByName =
-                    exportByArityByNameNamelessExports.first;
-
-            for (SortedMap.Entry<String, SortedMap<Integer, Export>> nameExportByArity :
-                    exportByArityByName.entrySet()) {
-                String exportName = nameExportByArity.getKey();
-
-                SortedMap<Integer, Export> exportByArity = nameExportByArity.getValue();
-
-                for (SortedMap.Entry<Integer, Export> arityExport : exportByArity.entrySet()) {
-                    MacroNameArity macroNameArity = new MacroNameArity(exportName, arityExport.getKey());
-
-                    if (macroNameArity.arity != null) {
-                        buildCallDefinition(parentStub, macroNameArity);
-                    }
-                }
+            for (MacroNameArity macroNameArity : macroNameAritySortedSet) {
+                buildCallDefinition(parentStub, macroNameArity);
             }
         }
     }

--- a/tests/org/elixir_lang/beam/DecompilerTest.java
+++ b/tests/org/elixir_lang/beam/DecompilerTest.java
@@ -32,6 +32,9 @@ public class DecompilerTest extends LightCodeInsightTestCase {
         assertEquals(
                 "# Source code recreated from a .beam file by IntelliJ Elixir\n" +
                 "defmodule Bitwise do\n" +
+                "\n" +
+                "  # Macros\n" +
+                "\n" +
                 "  defmacro left &&& right do\n" +
                 "    # body not decompiled\n" +
                 "  end\n" +
@@ -83,6 +86,8 @@ public class DecompilerTest extends LightCodeInsightTestCase {
                 "  defmacro ~~~(p0) do\n" +
                 "    # body not decompiled\n" +
                 "  end\n" +
+                "\n" +
+                "  # Functions\n" +
                 "\n" +
                 "  def __info__(p0) do\n" +
                 "    # body not decompiled\n" +


### PR DESCRIPTION
Fixes #581

# Changelog
## Enhancements
* Macros appears before functions in decompiled `.beam` files
  * Header for macro and function sections

## Bug Fixes
* Add `++` to `INFIX_OPERATOR_SET`.
* Only render infix operators if arity is `2`.
* Prefix operator decompilation: `+` and `-` are both binary and unary operators.  When a unary operator they need to be wrapped in parentheses, so that the call definition clause is parsed correctly.
* Add `=~` to `INFIX_OPERATOR_SET`.
* Add `in` to `INFIX_OPERATOR_SET`.