### PR TITLE
Decompile SpecialForms

### DIFF
--- a/src/org/elixir_lang/beam/Decompiler.java
+++ b/src/org/elixir_lang/beam/Decompiler.java
@@ -12,6 +12,7 @@ import org.elixir_lang.beam.chunk.exports.Export;
 import org.elixir_lang.beam.decompiler.Default;
 import org.elixir_lang.beam.decompiler.InfixOperator;
 import org.elixir_lang.beam.decompiler.PrefixOperator;
+import org.elixir_lang.beam.decompiler.SpecialForm;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -28,6 +29,7 @@ public class Decompiler implements BinaryFileDecompiler {
     static {
         MACRO_NAME_ARITY_DECOMPILER_LIST.add(InfixOperator.INSTANCE);
         MACRO_NAME_ARITY_DECOMPILER_LIST.add(PrefixOperator.INSTANCE);
+        MACRO_NAME_ARITY_DECOMPILER_LIST.add(SpecialForm.INSTANCE);
         MACRO_NAME_ARITY_DECOMPILER_LIST.add(Default.INSTANCE);
     }
 

--- a/src/org/elixir_lang/beam/decompiler/Default.java
+++ b/src/org/elixir_lang/beam/decompiler/Default.java
@@ -10,6 +10,29 @@ public class Default extends MacroNameArity {
 
     public static final MacroNameArity INSTANCE = new Default();
 
+    /*
+     * Static Methods
+     */
+
+    static void appendParameters(@NotNull StringBuilder decompiled,
+                                 @NotNull org.elixir_lang.beam.MacroNameArity macroNameArity) {
+        decompiled.append("(");
+
+        @Nullable Integer arity = macroNameArity.arity;
+
+        if (arity != null) {
+            for (int i = 0; i < arity; i++) {
+                if (i != 0) {
+                    decompiled.append(", ");
+                }
+
+                decompiled.append("p").append(i);
+            }
+        }
+
+        decompiled.append(")");
+    }
+
     /**
      * Whether the decompiler accepts the {@code macroNameArity}
      *
@@ -31,22 +54,9 @@ public class Default extends MacroNameArity {
                 .append("  ")
                 .append(macroNameArity.macro)
                 .append(" ")
-                .append(macroNameArity.name)
-                .append("(");
+                .append(macroNameArity.name);
 
-        @Nullable Integer arity = macroNameArity.arity;
-
-        if (arity != null) {
-            for (int i = 0; i < arity; i++) {
-                if (i != 0) {
-                    decompiled.append(", ");
-                }
-
-                decompiled.append("p").append(i);
-            }
-        }
-
-        decompiled.append(")");
+        appendParameters(decompiled, macroNameArity);
         appendBody(decompiled);
     }
 }

--- a/src/org/elixir_lang/beam/decompiler/SpecialForm.java
+++ b/src/org/elixir_lang/beam/decompiler/SpecialForm.java
@@ -1,0 +1,73 @@
+package org.elixir_lang.beam.decompiler;
+
+import gnu.trove.THashSet;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Set;
+
+import static org.elixir_lang.beam.decompiler.Default.appendParameters;
+
+public class SpecialForm extends MacroNameArity {
+    /*
+     * CONSTANTS
+     */
+
+    private static final Set<String> SPECIAL_FORM_NAME_SET;
+    public static final MacroNameArity INSTANCE = new SpecialForm();
+
+    static {
+        SPECIAL_FORM_NAME_SET = new THashSet<String>();
+        SPECIAL_FORM_NAME_SET.add("%");
+        SPECIAL_FORM_NAME_SET.add("%{}");
+        SPECIAL_FORM_NAME_SET.add("&");
+        SPECIAL_FORM_NAME_SET.add(".");
+        SPECIAL_FORM_NAME_SET.add("<<>>");
+        SPECIAL_FORM_NAME_SET.add("fn");
+        SPECIAL_FORM_NAME_SET.add("unquote");
+        SPECIAL_FORM_NAME_SET.add("unquote_splicing");
+        SPECIAL_FORM_NAME_SET.add("{}");
+    }
+
+    /*
+     * Static Methods
+     */
+
+    /**
+     * @param name {@link org.elixir_lang.beam.MacroNameArity#name}
+     */
+    private static boolean isSpecialForm(@NotNull String name) {
+        return SPECIAL_FORM_NAME_SET.contains(name);
+    }
+
+    /*
+     * Instance Methods
+     */
+
+    /**
+     * Wehther the decompiler accepts the {@code macroNameArity}.
+     *
+     * @return {@code true} if {@link #append(StringBuilder, org.elixir_lang.beam.MacroNameArity)} should be called with
+     *   {@code macroNameArity}.
+     */
+    @Override
+    public boolean accept(@NotNull org.elixir_lang.beam.MacroNameArity macroNameArity) {
+        return isSpecialForm(macroNameArity.name);
+    }
+
+    /**
+     * Append the decompiled source for {@code macroNameArity} to {@code decompiled}.
+     *
+     * @param decompiled the decompiled source so far
+     */
+    @Override
+    public void append(@NotNull StringBuilder decompiled, @NotNull org.elixir_lang.beam.MacroNameArity macroNameArity) {
+        decompiled
+                .append("  ")
+                .append(macroNameArity.macro)
+                .append(" unquote(:")
+                .append(macroNameArity.name)
+                .append(")");
+        appendParameters(decompiled, macroNameArity);
+        appendBody(decompiled);
+    }
+}


### PR DESCRIPTION
Fixes #594

# Changelog
## Bug Fixes
* Some SpecialForms don't work as literals as they would be interpreted as metaprogramming, so their name needs to be wrapped as an atom to `unquote`.