### PR TITLE
Handle MultipleAliases when resolving variables and parameters

### DIFF
--- a/src/org/elixir_lang/annonator/Parameter.java
+++ b/src/org/elixir_lang/annonator/Parameter.java
@@ -173,6 +173,7 @@ public class Parameter {
                     parent instanceof ElixirDoBlock ||
                     parent instanceof ElixirInterpolation ||
                     parent instanceof ElixirMapUpdateArguments ||
+                    parent instanceof ElixirMultipleAliases ||
                     parent instanceof ElixirQuoteStringBody ||
                     parent instanceof PsiFile ||
                     parent instanceof QualifiedAlias ||

--- a/src/org/elixir_lang/psi/scope/Variable.java
+++ b/src/org/elixir_lang/psi/scope/Variable.java
@@ -61,6 +61,7 @@ public abstract class Variable implements PsiScopeProcessor {
                 element instanceof ElixirBitString ||
                 element instanceof ElixirList ||
                 element instanceof ElixirMapConstructionArguments ||
+                element instanceof ElixirMultipleAliases ||
                 element instanceof ElixirNoParenthesesArguments ||
                 element instanceof ElixirNoParenthesesOneArgument ||
                 element instanceof ElixirParenthesesArguments ||


### PR DESCRIPTION
Fixes #568

# Changelog
## Bug Fixes
* Check children of `MultipleAliases` for variable declarations.
* Treat any variable declared in a `MultipleAliases` as invalid.