### PR TITLE
Improve logging for CallDefinitionClause.renderElement

### DIFF
--- a/.idea/runConfigurations/org_elixir_lang__ELIXIR_VERSION_1_1_1_.xml
+++ b/.idea/runConfigurations/org_elixir_lang__ELIXIR_VERSION_1_1_1_.xml
@@ -22,9 +22,6 @@
       <env name="ELIXIR_VERSION" value="1.1.1" />
     </envs>
     <patterns />
-    <method>
-      <option name="Make" enabled="true" />
-      <option name="ToolBeforeRunTask" enabled="true" actionId="Tool_External Tools_intellij_elixir" />
-    </method>
+    <method />
   </configuration>
 </component>

--- a/.idea/runConfigurations/org_elixir_lang__ELIXIR_VERSION_1_3_4_.xml
+++ b/.idea/runConfigurations/org_elixir_lang__ELIXIR_VERSION_1_3_4_.xml
@@ -30,9 +30,6 @@
     <RunnerSettings RunnerId="Run" />
     <ConfigurationWrapper RunnerId="Debug" />
     <ConfigurationWrapper RunnerId="Run" />
-    <method>
-      <option name="Make" enabled="true" />
-      <option name="ToolBeforeRunTask" enabled="true" actionId="Tool_External Tools_intellij_elixir" />
-    </method>
+    <method />
   </configuration>
 </component>

--- a/.idea/runConfigurations/org_elixir_lang__ELIXIR_VERSION_1_4_0_.xml
+++ b/.idea/runConfigurations/org_elixir_lang__ELIXIR_VERSION_1_4_0_.xml
@@ -22,9 +22,6 @@
       <env name="ELIXIR_VERSION" value="1.4.0" />
     </envs>
     <patterns />
-    <method>
-      <option name="Make" enabled="true" />
-      <option name="ToolBeforeRunTask" enabled="true" actionId="Tool_External Tools_intellij_elixir" />
-    </method>
+    <method />
   </configuration>
 </component>

--- a/.travis.yml
+++ b/.travis.yml
@@ -68,9 +68,9 @@ before_install:
 - tar xvfz jdk-8u112-linux-x64.tar.gz
 - export JAVA_HOME=${PWD}/jdk1.8.0_112
 - export PATH=${JAVA_HOME}/bin:${PATH}
-- wget http://www-us.apache.org/dist//ant/binaries/apache-ant-1.10.0-bin.tar.gz
-- tar xvfz apache-ant-1.10.0-bin.tar.gz
-- export PATH=${PWD}/apache-ant-1.10.0/bin:${PATH}
+- wget http://www-us.apache.org/dist//ant/binaries/apache-ant-1.10.1-bin.tar.gz
+- tar xvfz apache-ant-1.10.1-bin.tar.gz
+- export PATH=${PWD}/apache-ant-1.10.1/bin:${PATH}
 - java -version
 - ant -version
 install:

--- a/src/org/elixir_lang/annonator/Callable.java
+++ b/src/org/elixir_lang/annonator/Callable.java
@@ -11,6 +11,7 @@ import com.intellij.openapi.util.TextRange;
 import com.intellij.psi.*;
 import com.intellij.util.containers.ContainerUtil;
 import org.elixir_lang.ElixirSyntaxHighlighter;
+import org.elixir_lang.errorreport.Logger;
 import org.elixir_lang.psi.call.Call;
 import org.jetbrains.annotations.NotNull;
 
@@ -66,7 +67,15 @@ public class Callable implements Annotator, DumbAware {
                             if (reference instanceof PsiPolyVariantReference) {
                                 PsiPolyVariantReference polyVariantReference = (PsiPolyVariantReference) reference;
 
-                                ResolveResult[] resolveResults = polyVariantReference.multiResolve(false);
+                                ResolveResult[] resolveResults;
+
+                                try {
+                                    resolveResults = polyVariantReference.multiResolve(false);
+                                } catch (StackOverflowError stackOverflowError) {
+                                    Logger.error(Callable.class, "StackOverflowError when annotating Call", call);
+                                    resolveResults = new ResolveResult[0];
+                                }
+
                                 List<ResolveResult> validResolveResults = ContainerUtil.filter(
                                         resolveResults,
                                         new Condition<ResolveResult>() {

--- a/src/org/elixir_lang/annonator/ModuleAttribute.java
+++ b/src/org/elixir_lang/annonator/ModuleAttribute.java
@@ -32,6 +32,7 @@ import static org.elixir_lang.psi.call.name.Module.KERNEL;
 import static org.elixir_lang.psi.impl.ElixirPsiImplUtil.identifierName;
 import static org.elixir_lang.psi.impl.ElixirPsiImplUtil.stripAccessExpression;
 import static org.elixir_lang.reference.ModuleAttribute.*;
+import static org.elixir_lang.structure_view.element.CallDefinitionHead.stripAllOuterParentheses;
 
 /**
  * Annotates module attributes.
@@ -578,9 +579,14 @@ public class ModuleAttribute implements Annotator, DumbAware {
                 if (leftOperand instanceof Type) {
                     Type typeOperation = (Type) leftOperand;
                     PsiElement typeOperationLeftOperand = typeOperation.leftOperand();
+                    PsiElement strippedTypeOperationLeftOperand = null;
 
-                    if (typeOperationLeftOperand instanceof Call) {
-                        Call call = (Call) typeOperationLeftOperand;
+                    if (typeOperationLeftOperand != null) {
+                        strippedTypeOperationLeftOperand = stripAllOuterParentheses(typeOperationLeftOperand);
+                    }
+
+                    if (strippedTypeOperationLeftOperand instanceof Call) {
+                        Call call = (Call) strippedTypeOperationLeftOperand;
                         PsiElement functionNameElement = call.functionNameElement();
 
                         if (functionNameElement != null) {
@@ -613,7 +619,7 @@ public class ModuleAttribute implements Annotator, DumbAware {
                             );
                         }
                     } else {
-                        cannotHighlightTypes(typeOperationLeftOperand);
+                        cannotHighlightTypes(strippedTypeOperationLeftOperand);
                     }
 
                     PsiElement matchedTypeOperationRightOperand = typeOperation.rightOperand();

--- a/src/org/elixir_lang/errorreport/Logger.java
+++ b/src/org/elixir_lang/errorreport/Logger.java
@@ -112,6 +112,14 @@ public class Logger {
             excerptBuilder.append(startingLine);
             excerptBuilder.append('-');
             excerptBuilder.append(endingLine);
+
+            VirtualFile virtualFile = containingFile.getVirtualFile();
+
+            if (virtualFile != null) {
+                excerptBuilder.append(" in ");
+                excerptBuilder.append(virtualFile.getPath());
+            }
+
             excerptBuilder.append("\n");
         }
 

--- a/src/org/elixir_lang/psi/Import.java
+++ b/src/org/elixir_lang/psi/Import.java
@@ -60,7 +60,14 @@ public class Import {
      */
     public static void callDefinitionClauseCallWhile(@NotNull Call importCall,
                                                      @NotNull final Function<Call, Boolean> function) {
-        Call modularCall = modular(importCall);
+        Call modularCall;
+
+        try {
+            modularCall = modular(importCall);
+        } catch (StackOverflowError stackOverflowError) {
+            Logger.error(Import.class, "StackvoerflowError while finding modular for import", importCall);
+            modularCall = null;
+        }
 
         if (modularCall != null) {
             final Function<Call, Boolean> optionsFilter = callDefinitionClauseCallFilter(importCall);

--- a/src/org/elixir_lang/psi/impl/ElixirPsiImplUtil.java
+++ b/src/org/elixir_lang/psi/impl/ElixirPsiImplUtil.java
@@ -4909,6 +4909,25 @@ if (quoted == null) {
 
     @Contract(pure = true)
     @NotNull
+    public static boolean recursiveKernelImport(@NotNull QualifiableAlias qualifiableAlias,
+                                                @NotNull PsiElement maxScope) {
+        boolean recursiveKernelImport = false;
+
+        if (maxScope instanceof ElixirFile) {
+            ElixirFile elixirFile = (ElixirFile) maxScope;
+
+            if (elixirFile.getName().equals("kernel.ex")) {
+                String qualifiableAliasName = qualifiableAlias.getName();
+
+                recursiveKernelImport = qualifiableAliasName != null && qualifiableAliasName.equals(KERNEL);
+            }
+        }
+
+        return recursiveKernelImport;
+    }
+
+    @Contract(pure = true)
+    @NotNull
     public static int resolvedFinalArity(@NotNull final Call call) {
         Integer resolvedFinalArity = call.resolvedSecondaryArity();
 
@@ -5631,10 +5650,13 @@ if (quoted == null) {
 
         if (maybeQualifiableAlias instanceof QualifiableAlias) {
             QualifiableAlias qualifiableAlias = (QualifiableAlias) maybeQualifiableAlias;
-            /* need to construct reference directly as qualified aliases don't return a
-               reference except for the outermost */
-            PsiPolyVariantReference reference = new org.elixir_lang.reference.Module(qualifiableAlias, maxScope);
-            modular = aliasToModular(qualifiableAlias, reference);
+
+            if (!recursiveKernelImport(qualifiableAlias, maxScope)) {
+                /* need to construct reference directly as qualified aliases don't return a reference except for the
+                   outermost */
+                PsiPolyVariantReference reference = new org.elixir_lang.reference.Module(qualifiableAlias, maxScope);
+                modular = aliasToModular(qualifiableAlias, reference);
+            }
         }
 
         return modular;

--- a/src/org/elixir_lang/psi/scope/CallDefinitionClause.java
+++ b/src/org/elixir_lang/psi/scope/CallDefinitionClause.java
@@ -5,6 +5,7 @@ import com.intellij.psi.PsiElement;
 import com.intellij.psi.ResolveState;
 import com.intellij.psi.scope.PsiScopeProcessor;
 import com.intellij.util.Function;
+import org.elixir_lang.errorreport.Logger;
 import org.elixir_lang.psi.Import;
 import org.elixir_lang.psi.call.Call;
 import org.elixir_lang.structure_view.element.modular.Module;
@@ -80,15 +81,19 @@ public abstract class CallDefinitionClause implements PsiScopeProcessor {
         } else if (Import.is(element)) {
             final ResolveState importState = state.put(IMPORT_CALL, element);
 
-            Import.callDefinitionClauseCallWhile(
-                    element,
-                    new Function<Call,Boolean>() {
-                        @Override
-                        public Boolean fun(Call callDefinitionClause) {
-                            return executeOnCallDefinitionClause(callDefinitionClause, importState);
+            try {
+                Import.callDefinitionClauseCallWhile(
+                        element,
+                        new Function<Call, Boolean>() {
+                            @Override
+                            public Boolean fun(Call callDefinitionClause) {
+                                return executeOnCallDefinitionClause(callDefinitionClause, importState);
+                            }
                         }
-                    }
-            );
+                );
+            } catch (StackOverflowError stackOverflowError) {
+                Logger.error(CallDefinitionClause.class, "StackOverflowError while processing import", element);
+            }
         } else if (Module.is(element)) {
             Call[] childCalls = macroChildCalls(element);
 

--- a/src/org/elixir_lang/psi/scope/module/MultiResolve.java
+++ b/src/org/elixir_lang/psi/scope/module/MultiResolve.java
@@ -1,5 +1,6 @@
 package org.elixir_lang.psi.scope.module;
 
+import com.intellij.openapi.project.DumbService;
 import com.intellij.openapi.project.Project;
 import com.intellij.psi.*;
 import com.intellij.psi.search.GlobalSearchScope;
@@ -15,6 +16,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
 import static org.elixir_lang.Module.concat;
@@ -42,13 +44,21 @@ public class MultiResolve extends Module {
     private static Collection<NamedElement> indexedNamedElements(@NotNull PsiNamedElement match,
                                                                  @NotNull String unaliasedName) {
         Project project = match.getProject();
-        return StubIndex.getElements(
-                AllName.KEY,
-                unaliasedName,
-                project,
-                GlobalSearchScope.allScope(project),
-                NamedElement.class
-        );
+        Collection<NamedElement> indexNamedElementCollection;
+
+        if (DumbService.isDumb(project)) {
+            indexNamedElementCollection = Collections.emptyList();
+        } else {
+            indexNamedElementCollection = StubIndex.getElements(
+                    AllName.KEY,
+                    unaliasedName,
+                    project,
+                    GlobalSearchScope.allScope(project),
+                    NamedElement.class
+            );
+        }
+
+        return indexNamedElementCollection;
     }
 
     @Nullable

--- a/src/org/elixir_lang/reference/Module.java
+++ b/src/org/elixir_lang/reference/Module.java
@@ -1,6 +1,7 @@
 package org.elixir_lang.reference;
 
 import com.intellij.codeInsight.lookup.LookupElement;
+import com.intellij.openapi.project.DumbService;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.TextRange;
 import com.intellij.psi.*;
@@ -16,6 +17,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
 import static org.elixir_lang.reference.module.ResolvableName.resolvableName;
@@ -79,13 +81,19 @@ public class Module extends PsiReferenceBase<QualifiableAlias> implements PsiPol
                                                     @NotNull String name) {
         List<ResolveResult> results = new ArrayList<ResolveResult>();
 
-        Collection<NamedElement> namedElementCollection = StubIndex.getElements(
-                AllName.KEY,
-                name,
-                project,
-                GlobalSearchScope.allScope(project),
-                NamedElement.class
-        );
+        Collection<NamedElement> namedElementCollection;
+
+        if (DumbService.isDumb(project)) {
+            namedElementCollection = Collections.emptyList();
+        } else {
+            namedElementCollection = StubIndex.getElements(
+                    AllName.KEY,
+                    name,
+                    project,
+                    GlobalSearchScope.allScope(project),
+                    NamedElement.class
+            );
+        }
 
         for (NamedElement namedElement : namedElementCollection) {
             /* The NamedElement may be a ModuleImpl from a .beam.  Using #getNaviationElement() ensures a source

--- a/testData/org/elixir_lang/annotator/module_attribute/issue_605.ex
+++ b/testData/org/elixir_lang/annotator/module_attribute/issue_605.ex
@@ -1,0 +1,1 @@
+@spec (+value) :: value when value: number

--- a/tests/org/elixir_lang/annotator/ModuleAttributeTest.java
+++ b/tests/org/elixir_lang/annotator/ModuleAttributeTest.java
@@ -39,6 +39,11 @@ public class ModuleAttributeTest extends LightCodeInsightFixtureTestCase {
         myFixture.checkHighlighting(false, false, true);
     }
 
+    public void testIssue605() {
+        myFixture.configureByFile("issue_605.ex");
+        myFixture.checkHighlighting(false, false, true);
+    }
+
     public void testMatch() {
         myFixture.configureByFile("match.ex");
         myFixture.checkHighlighting(false, false, true);


### PR DESCRIPTION
Resolves #563 

# Changelog
## Enhancements
* If `multiResolve` causes a `StackOverflow` for `org.elixir_lang.annotator.Callable.visitCall`, then `catch` it and use `errorreport` logger to log the element.
* Include file path in `errorreport` excerpt
* Log element for `StackOverflow` related to `import`s
* Regression test for #605.
* Log `LookupElement#getObject` when `LookupElement#getPsiElement` is `null` to track down how it was `null` in #563.

## Bug Fixes
* Skip `import Kernel` in `kernel.ex` to prevent stack overflow due to recursive `import`
* Strip all outer parentheses for left type operand, so that `(+value)` can be see as `+` operator type spec.
* Use advice from `IndexNotReadyException` documentation and check `DumbService.isDumb(Project)` before calling `StubIndex.getElements` in `Module` and `module.MultiREsolve.indexNameElements`.
* Don't `assert` that `LookupElement#getPsiElement` is not `null` in `CallDefinitionCluase.renderElement`
* Update to `ant` `1.10.1` because `1.10.0` is no longer hosted.