### PR TITLE
Check parent of ElixirVariable to check if a variable

### DIFF
--- a/src/org/elixir_lang/reference/Callable.java
+++ b/src/org/elixir_lang/reference/Callable.java
@@ -271,6 +271,7 @@ public class Callable extends PsiReferenceBase<Call> implements PsiPolyVariantRe
                 ancestor instanceof ElixirStabBody ||
                 ancestor instanceof ElixirStructOperation ||
                 ancestor instanceof ElixirTuple ||
+                ancestor instanceof ElixirVariable ||
                 ancestor instanceof QualifiedAlias ||
                 ancestor instanceof Type) {
             isVariable = isVariable(ancestor.getParent());


### PR DESCRIPTION
Fixes #555

# Changelog
## Bug Fixes
Yeah, it sounds weird, but an `ElixirVariable` isn't necessarily a variable if it doesn't occur in a declaration context.  It could just be a no-parentheses function call in the wrong spot, so check the parent `PsiElement` to determine if `ElixrVariable` is a variable.