### PR TITLE
Highlight parameterized type head the same as full type definition

### DIFF
--- a/testData/org/elixir_lang/annotator/module_attribute/issue_559.ex
+++ b/testData/org/elixir_lang/annotator/module_attribute/issue_559.ex
@@ -1,0 +1,1 @@
+@typep maybe(t)

--- a/tests/org/elixir_lang/annotator/ModuleAttributeTest.java
+++ b/tests/org/elixir_lang/annotator/ModuleAttributeTest.java
@@ -39,6 +39,11 @@ public class ModuleAttributeTest extends LightCodeInsightFixtureTestCase {
         myFixture.checkHighlighting(false, false, true);
     }
 
+    public void testIssue559() {
+        myFixture.configureByFile("issue_559.ex");
+        myFixture.checkHighlighting(false, false, true);
+    }
+
     public void testIssue605() {
         myFixture.configureByFile("issue_605.ex");
         myFixture.checkHighlighting(false, false, true);


### PR DESCRIPTION
# Changelog
## Enhancements
* Regression test for #559

## Bug Fixes
* Highlight parameterized type head (`maybe(t)` in `@type maybe(t)`) the same as a full type definition (`maybe(t)` in `@type maybe(t) :: t | nil`)