### PR TITLE
Don't highlight resolved callable if in a different file

### DIFF
--- a/intellij-elixir.iml
+++ b/intellij-elixir.iml
@@ -14,7 +14,7 @@
       <excludeFolder url="file://$MODULE_DIR$/dependencies" />
       <excludeFolder url="file://$MODULE_DIR$/tmp" />
     </content>
-    <orderEntry type="jdk" jdkName="IntelliJ IDEA Community Edition IC-141.3056.4" jdkType="IDEA JDK" />
+    <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="module-library">
       <library name="JUnit4">


### PR DESCRIPTION
Fixes #619
Fixes #625
Fixes #626

# Changelog
## Bug Fixes
* Annotations can only be applied to the single, active file, which belongs to the `referrer` `Callable`.  The `resolved` may be outside the file if it is a cross-file function or macro usage, in which case it's `TextRange` should not be highlighted because it is referring to offsets in a different file.