### PR TITLE
Bug fixes

### DIFF
--- a/src/org/elixir_lang/psi/scope/call_definition_clause/Variants.java
+++ b/src/org/elixir_lang/psi/scope/call_definition_clause/Variants.java
@@ -2,20 +2,15 @@ package org.elixir_lang.psi.scope.call_definition_clause;
 
 import com.intellij.codeInsight.lookup.LookupElement;
 import com.intellij.codeInsight.lookup.LookupElementBuilder;
-import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Key;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.ResolveState;
-import com.intellij.psi.search.GlobalSearchScope;
-import com.intellij.psi.stubs.StubIndex;
 import com.intellij.psi.util.PsiTreeUtil;
 import gnu.trove.THashMap;
 import org.elixir_lang.annonator.Parameter;
-import org.elixir_lang.psi.NamedElement;
 import org.elixir_lang.psi.call.Call;
 import org.elixir_lang.psi.call.Named;
 import org.elixir_lang.psi.scope.CallDefinitionClause;
-import org.elixir_lang.psi.stub.index.AllName;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -58,7 +53,6 @@ public class Variants extends CallDefinitionClause {
         );
         List<LookupElement> lookupElementList = new ArrayList<LookupElement>();
         lookupElementList.addAll(variants.getLookupElementCollection());
-        variants.addProjectNameElementsTo(lookupElementList, entrance, entranceCallDefinitionClause);
 
         return lookupElementList;
     }
@@ -78,8 +72,6 @@ public class Variants extends CallDefinitionClause {
      * Called on every {@link Call} where {@link org.elixir_lang.structure_view.element.CallDefinitionClause#is} is
      * {@code true} when checking tree with {@link #execute(Call, ResolveState)}
      *
-     * @param element
-     * @param state
      * @return {@code true} to keep searching up tree; {@code false} to stop searching.
      */
     @Override
@@ -128,38 +120,6 @@ public class Variants extends CallDefinitionClause {
                                     nameIdentifier
                             ).withRenderer(
                                     new org.elixir_lang.code_insight.lookup.element_renderer.CallDefinitionClause(name)
-                            )
-                    );
-                }
-            }
-        }
-    }
-
-    private void addProjectNameElementsTo(@NotNull List<LookupElement> lookupElementList,
-                                          @NotNull PsiElement entrance,
-                                          @Nullable Call entranceCallDefinitionClause) {
-        Project project = entrance.getProject();
-        /* getAllKeys is not the actual keys in the actual project.  They need to be checked.
-           See https://intellij-support.jetbrains.com/hc/en-us/community/posts/207930789-StubIndex-persisting-between-test-runs-leading-to-incorrect-completions */
-        Collection<String> indexedNameCollection = StubIndex.getInstance().getAllKeys(AllName.KEY, project);
-        GlobalSearchScope scope = GlobalSearchScope.allScope(project);
-
-        for (String indexedName : indexedNameCollection) {
-            Collection<NamedElement> indexedNameNamedElementCollection = StubIndex.getElements(
-                    AllName.KEY,
-                    indexedName,
-                    project,
-                    scope,
-                    NamedElement.class
-            );
-
-            for (NamedElement indexedNameNamedElement : indexedNameNamedElementCollection) {
-                if (entranceCallDefinitionClause == null ||
-                        !indexedNameNamedElement.isEquivalentTo(entranceCallDefinitionClause)) {
-                    lookupElementList.add(
-                            org.elixir_lang.code_insight.lookup.element.CallDefinitionClause.createWithSmartPointer(
-                                    indexedName,
-                                    indexedNameNamedElement
                             )
                     );
                 }


### PR DESCRIPTION
# Changelog
## Bug Fixes
* `Variable` scope for `QualifiedMultipleAliases`, which cccurs when qualified call occurs over a line with assignment to a tuple, such as
    ```elixir
    Qualifier.
    {:ok, value} = call()
    ```
* Remove call definition clauses (function or macro) completion for bare words as it had a detrimental impact on typing feedback (the editor still took input, but it wasn't rendered until the completion returned OR `ESC` was hit to cancel the completion, which became excessive once the index of call definition clauses was expanded by the decompilation of the Elixir standard library `.beam`s, so disable it.  If bare-words completion is restored.  It will either (1) need to not use the `Reference#getVariants()` API because it generates too many objects that need to be thrown away or (2) need to only complete call definition clauses that are provably in-scope from imports or other macros.