### PR TITLE
Allow module attribute folding to be configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,6 +140,7 @@
     * `./gradlew test` (or the `test (VERSION)` Run Configurations) will run the main plugin and jps-builder tests.
     * The plugin can now be published with `./gradlew publishPlugin`, *BUT* you'll need to fill in `publish*` properties in `gradle.properties`.  This will _eventually_ allow for automated "nightlies" from successful Travis-CI builds on `master`.
 * [#638](https://github.com/KronicDeth/intellij-elixir/pull/638) - The `Callable` annotator is meant for variables, parameters, and macro and function calls and declarations.  The `ModuleAttribute` annotator handles module attribute declaration and usage, so we can save reference resolution time by skipping module attributes in `Callable`. - [@KronicDeth](https://github.com/KronicDeth)
+* [#640](https://github.com/KronicDeth/intellij-elixir/pull/640) - Allow module attribute folding to be configured. - [@KronicDeth](https://github.com/KronicDeth)
 
 ### Bug Fixes
 * [#574](https://github.com/KronicDeth/intellij-elixir/pull/574) - Fix copy-paste errors in `MatchOperatorInsteadOfTypeOperator` - [@KronicDeth](https://github.com/KronicDeth)
@@ -186,6 +187,7 @@
 ### Incompatible Changes
 * [#585](https://github.com/KronicDeth/intellij-elixir/pull/585) - Move `^^^` to its own three-operator precedence level to match `1.2`.  This does mean the parsing will be wrong for Elixir `1.1`, but is simpler than maintaining two grammars for those that are still using Elixir `1.1` - [@KronicDeth](https://github.com/KronicDeth)
 * [#504](https://github.com/KronicDeth/intellij-elixir/pull/504) - The `ant` build files have been removed.  To build the build plugin (for Install From Disk), use the `./gradlew buildPlugin`. - [@JakeBecker](https://github.com/JakeBecker)
+* [#640](https://github.com/KronicDeth/intellij-elixir/pull/640) - Change to module attribute folding to off by default. - [@KronicDeth](https://github.com/KronicDeth)
 
 ## v4.7.0
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -16,6 +16,10 @@
 
 # Upgrading
 
+## v5.0.0
+
+Module attribute folding to their value is off by default now.  If you want to re-enable the old behavior, Check Preferences > Editor > General > Code Folding > Elixir Module Attributes.
+
 ## v4.0.0
 
 ### Preferences/Settings
@@ -51,7 +55,7 @@ To take advantage of the new Project Structure Detector in IntelliJ, you will wa
 previously opened as an Empty Project.
 
 (Copied from Elixir Plugin > Features > Project > From Existing Directory in README.md)
-  
+
 1. File > New > Project From Existing Sources...
 2. Select the root directory of your project.
 3. Leave the default selection, "Create project from existing sources"
@@ -63,7 +67,7 @@ previously opened as an Empty Project.
    .idea directory.  Click Yes.
 9. You'll be prompted with a list of detected Elixir project roots to add to the project.  Each root contains a
    `mix.exs`.  Uncheck any project roots that you don't want added.
-10. Click Next.      
+10. Click Next.
 10. Select a Project SDK directory by clicking Configure.
 11. The plugin will automatically find the newest version of Elixir installed. (**NOTE: SDK detection only works for
     homebrew installs on OSX.  [Open an issue](https://github.com/KronicDeth/intellij-elixir/issues) with information

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -106,6 +106,7 @@
               declarations.  The <code>ModuleAttribute</code> annotator handles module attribute declaration and usage,
               so we can save reference resolution time by skipping module attributes in <code>Callable</code>.
             </li>
+            <li>Allow module attribute folding to be configured.</li>
           </ul>
         </li>
         <li>
@@ -242,6 +243,7 @@ Qualifier.
               The <code>ant</code> build files have been removed.  To build the build plugin (for Install From Disk),
               use the <code>./gradlew buildPlugin</code>.
             </li>
+            <li>Allow module attribute folding to be configured.</li>
           </ul>
         </li>
       </ul>

--- a/src/org/elixir_lang/folding/Builder.java
+++ b/src/org/elixir_lang/folding/Builder.java
@@ -361,7 +361,7 @@ public class Builder extends FoldingBuilderEx {
         boolean isCollapsedByDefault = false;
 
         if (element instanceof AtNonNumericOperation) {
-            isCollapsedByDefault = true;
+            isCollapsedByDefault = ElixirFoldingSettings.getInstance().isReplaceModuleAttributesWithValues();
         } else {
             PsiElement[] children = element.getChildren();
 

--- a/src/org/elixir_lang/folding/ElixirFoldingSettings.java
+++ b/src/org/elixir_lang/folding/ElixirFoldingSettings.java
@@ -20,6 +20,7 @@ public class ElixirFoldingSettings implements PersistentStateComponent<ElixirFol
      * Fields
      */
     public boolean COLLAPSE_ELIXIR_MODULE_DIRECTIVE_GROUPS = false;
+    public boolean REPLACE_MODULE_ATTRIBUTES_WITH_VALUES = false;
 
     @Nullable
     @Override
@@ -39,5 +40,9 @@ public class ElixirFoldingSettings implements PersistentStateComponent<ElixirFol
 
     public boolean isCollapseElixirModuleDirectiveGroups() {
         return COLLAPSE_ELIXIR_MODULE_DIRECTIVE_GROUPS;
+    }
+
+    public boolean isReplaceModuleAttributesWithValues() {
+        return REPLACE_MODULE_ATTRIBUTES_WITH_VALUES;
     }
 }

--- a/src/org/elixir_lang/folding/OptionsProvider.java
+++ b/src/org/elixir_lang/folding/OptionsProvider.java
@@ -6,6 +6,7 @@ import com.intellij.openapi.options.BeanConfigurable;
 public class OptionsProvider extends BeanConfigurable<ElixirFoldingSettings> implements CodeFoldingOptionsProvider {
     public OptionsProvider() {
         super(ElixirFoldingSettings.getInstance());
+        checkBox("REPLACE_MODULE_ATTRIBUTES_WITH_VALUES", "Elixir module attributes");
         checkBox(
                 "COLLAPSE_ELIXIR_MODULE_DIRECTIVE_GROUPS",
                 "Elixir Module directive (`alias`, `import`, `require` or `use`) groups"


### PR DESCRIPTION
Fixes #567

# Changelog
## Enhancements
* Allow module attribute folding to be configured.

## Incompatible Changes
* Change to module attribute folding to off by default.