### PR TITLE
Changed default colors

### DIFF
--- a/resources/colorSchemes/ElixirDefault.xml
+++ b/resources/colorSchemes/ElixirDefault.xml
@@ -4,6 +4,7 @@
         <value>
             <option name="FOREGROUND" value="310066" />
             <option name="FONT_TYPE" value="1" />
+            <option name="EFFECT_TYPE" value="5" />
         </value>
     </option>
     <option name="ELIXIR_BIT">
@@ -18,35 +19,34 @@
     </option>
     <option name="ELIXIR_BRACKET">
         <value>
-            <option name="FOREGROUND" value="99570b" />
+            <option name="FOREGROUND" value="1ca06e" />
         </value>
     </option>
     <option name="ELIXIR_CALLBACK">
         <value>
-            <option name="FOREGROUND" value="301d99" />
+            <option name="FOREGROUND" value="237eaf" />
             <option name="FONT_TYPE" value="1" />
+            <option name="EFFECT_TYPE" value="4" />
         </value>
     </option>
     <option name="ELIXIR_CHAR_LIST">
         <value>
-            <option name="FOREGROUND" value="803380" />
-            <option name="FONT_TYPE" value="1" />
+            <option name="FOREGROUND" value="a521a5" />
         </value>
     </option>
     <option name="ELIXIR_CHAR_TOKEN">
         <value>
-            <option name="FOREGROUND" value="441a66" />
-            <option name="FONT_TYPE" value="1" />
+            <option name="FOREGROUND" value="a0a349" />
         </value>
     </option>
     <option name="ELIXIR_DOT">
         <value>
-            <option name="FOREGROUND" value="990d0b" />
+            <option name="FOREGROUND" value="5e3a7c" />
         </value>
     </option>
     <option name="ELIXIR_EXPRESSION_SUBSTITUTION_MARK">
         <value>
-            <option name="FOREGROUND" value="990b4d" />
+            <option name="FOREGROUND" value="af135c" />
         </value>
     </option>
     <option name="ELIXIR_FUNCTION_CALL">
@@ -59,6 +59,18 @@
             <option name="FOREGROUND" value="727272" />
         </value>
     </option>
+    <option name="ELIXIR_INTERPOLATION">
+        <value>
+            <option name="FOREGROUND" value="49e649" />
+        </value>
+    </option>
+    <option name="ELIXIR_KERNEL_MACRO">
+        <value>
+            <option name="FOREGROUND" value="cc7832" />
+            <option name="FONT_TYPE" value="3" />
+            <option name="EFFECT_TYPE" value="4" />
+        </value>
+    </option>
     <option name="ELIXIR_MACRO_CALL">
         <value>
             <option name="FONT_TYPE" value="3" />
@@ -66,27 +78,28 @@
     </option>
     <option name="ELIXIR_MAP">
         <value>
-            <option name="FOREGROUND" value="92990b" />
+            <option name="FOREGROUND" value="223e59" />
         </value>
     </option>
     <option name="ELIXIR_OPERATION_SIGN">
         <value>
-            <option name="FOREGROUND" value="990b92" />
+            <option name="FOREGROUND" value="a50d9e" />
         </value>
     </option>
     <option name="ELIXIR_PARAMETER">
         <value>
-            <option name="FOREGROUND" value="6993a" />
+            <option name="FOREGROUND" value="aa34c1" />
         </value>
     </option>
     <option name="ELIXIR_PARENTHESES">
         <value>
-            <option name="FOREGROUND" value="662b99" />
+            <option name="FOREGROUND" value="b53693" />
         </value>
     </option>
     <option name="ELIXIR_PREDEFINED">
         <value>
-            <option name="FOREGROUND" value="80" />
+            <option name="FOREGROUND" value="cc7832" />
+            <option name="EFFECT_TYPE" value="1" />
         </value>
     </option>
     <option name="ELIXIR_SIGIL">
@@ -97,23 +110,17 @@
     </option>
     <option name="ELIXIR_SPECIFICATION">
         <value>
-            <option name="FOREGROUND" value="301d99" />
-        </value>
-    </option>
-    <option name="ELIXIR_STRING">
-        <value>
-            <option name="FOREGROUND" value="660f58" />
-            <option name="FONT_TYPE" value="1" />
+            <option name="FOREGROUND" value="b72c51" />
         </value>
     </option>
     <option name="ELIXIR_STRUCT">
         <value>
-            <option name="FOREGROUND" value="996e0b" />
+            <option name="FOREGROUND" value="8e0477" />
         </value>
     </option>
     <option name="ELIXIR_TYPE">
         <value>
-            <option name="FOREGROUND" value="4a0099" />
+            <option name="FOREGROUND" value="009600" />
         </value>
     </option>
     <option name="ELIXIR_TYPE_PARAMETER">
@@ -123,13 +130,13 @@
     </option>
     <option name="ELIXIR_VALID_ESCAPE_SEQUENCE">
         <value>
-            <option name="FOREGROUND" value="2c993d" />
             <option name="FONT_TYPE" value="1" />
+            <option name="FOREGROUND" value="53ba63" />
         </value>
     </option>
     <option name="ELIXIR_VARIABLE">
         <value>
-            <option name="FOREGROUND" value="179906" />
+            <option name="FOREGROUND" value="05995e" />
         </value>
     </option>
 </list>


### PR DESCRIPTION
Fixes #569

# Changelog
## Bug Fixes
* Among many other tweaks, the String color is now green, so that Atom and String are no longer close to one another, which was the original issue in #569
    <img width="760" alt="screen shot 2017-04-09 at 9 44 06 pm" src="https://cloud.githubusercontent.com/assets/298259/24844071/b1c9b51a-1d6d-11e7-8647-46a5075b12d9.png">
  * `Alias` now has `underscored` effect
  * `Brackets` are now greenish instead of brownish
  * `Callbacks` are now a lighter blue and has `underscored` effect
  * `CharList` is little lighter
  * `CharToken` is dark yellow now instead of dark purple
  * `Dot` is now purple instead of dark red
  * `Expression Substituion Mark` is a little lighter
  * `Interpolation` is now lime green
  * `Kernel Macros` are a burnt orange
  * `Map` is now a dark blue instead of a dark yellow
  * `Operation Sign` is a little ligher
  * `Paramters` are a little darker
  * `Parentheses` are redder
  * `Predefined` is orange instead of blue
  * `Specification` is now red instead of purple
  * `Struct` is now purple instead of yellow
  * `Type` is now green instead of dark purple
  * `Variable` is more tealish