### PR TITLE
Bug Fixes

### DIFF
--- a/src/org/elixir_lang/annonator/Callable.java
+++ b/src/org/elixir_lang/annonator/Callable.java
@@ -136,6 +136,18 @@ public class Callable implements Annotator, DumbAware {
                                     for (PsiElement resolved : resolvedCollection) {
                                         highlight(call, reference.getRangeInElement(), resolved, holder);
                                     }
+                                } else if (call.hasDoBlockOrKeyword()) {
+                                    /* Even though it can't be resolved, it is called like a macro, so highlight like
+                                       one */
+                                    PsiElement functionNameElement = call.functionNameElement();
+
+                                    if (functionNameElement != null) {
+                                        highlight(
+                                                functionNameElement.getTextRange(),
+                                                holder,
+                                                ElixirSyntaxHighlighter.MACRO_CALL
+                                        );
+                                    }
                                 }
                             } else if (isBitStreamSegmentOption(call)) {
                                 String name = call.getName();

--- a/src/org/elixir_lang/annonator/Callable.java
+++ b/src/org/elixir_lang/annonator/Callable.java
@@ -132,7 +132,7 @@ public class Callable implements Annotator, DumbAware {
                                     }
                                 }
 
-                                if (resolvedCollection != null) {
+                                if (resolvedCollection != null && resolvedCollection.size() > 0) {
                                     for (PsiElement resolved : resolvedCollection) {
                                         highlight(call, reference.getRangeInElement(), resolved, holder);
                                     }

--- a/src/org/elixir_lang/beam/psi/impl/ModuleImpl.java
+++ b/src/org/elixir_lang/beam/psi/impl/ModuleImpl.java
@@ -1,5 +1,6 @@
 package org.elixir_lang.beam.psi.impl;
 
+import com.intellij.openapi.project.Project;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.StubBasedPsiElement;
 import com.intellij.psi.impl.source.tree.TreeElement;
@@ -167,5 +168,11 @@ public class ModuleImpl<T extends StubElement> extends ModuleElementImpl impleme
     @Override
     public PsiElement getNavigationElement() {
         return getMirror();
+    }
+
+    @NotNull
+    @Override
+    public Project getProject() {
+        return getMirror().getProject();
     }
 }

--- a/src/org/elixir_lang/psi/ElixirFile.java
+++ b/src/org/elixir_lang/psi/ElixirFile.java
@@ -49,7 +49,13 @@ public class ElixirFile extends PsiFileBase implements ModuleOwner {
                                        @NotNull ResolveState state,
                                        PsiElement lastParent,
                                        @NotNull PsiElement place) {
-        return ElixirPsiImplUtil.processDeclarationsInPreviousSibling(this, processor, state, lastParent, place);
+        boolean keepProcessing = ElixirPsiImplUtil.processDeclarationsInPreviousSibling(this, processor, state, lastParent, place);
+
+        if (keepProcessing) {
+            processor.execute(this, state);
+        }
+
+        return keepProcessing;
     }
 
     /**

--- a/src/org/elixir_lang/psi/Modular.java
+++ b/src/org/elixir_lang/psi/Modular.java
@@ -18,17 +18,22 @@ public class Modular {
      * Public Static Methods
      */
 
-    public static void callDefinitionClauseCallWhile(@NotNull final Call modular,
+    public static boolean callDefinitionClauseCallWhile(@NotNull final Call modular,
                                                      @NotNull Function<Call, Boolean> function) {
         Call[] childCalls = macroChildCalls(modular);
+        boolean keepProcessing = true;
 
         if (childCalls != null) {
             for (Call childCall : childCalls) {
                 if (CallDefinitionClause.is(childCall) && !function.fun(childCall)) {
+                    keepProcessing = false;
+
                     break;
                 }
             }
         }
+
+        return keepProcessing;
     }
 
     public static void forEachCallDefinitionClauseNameIdentifier(

--- a/src/org/elixir_lang/psi/call/name/Module.java
+++ b/src/org/elixir_lang/psi/call/name/Module.java
@@ -10,6 +10,7 @@ public class Module {
      */
 
     public static final String KERNEL = "Kernel";
+    public static final String KERNEL_SPECIAL_FORMS = KERNEL + ".SpecialForms";
     public static final String ELIXIR_PREFIX = "Elixir.";
 
     /*

--- a/src/org/elixir_lang/psi/impl/ElixirPsiImplUtil.java
+++ b/src/org/elixir_lang/psi/impl/ElixirPsiImplUtil.java
@@ -2322,6 +2322,11 @@ public class ElixirPsiImplUtil {
 
                         PsiElement nextResolved = resolveResult.getElement();
 
+                        if (nextResolved != null && nextResolved instanceof Call && isModular((Call) nextResolved)) {
+                            fullyResolved = nextResolved;
+                            break;
+                        }
+
                         if (nextResolved == null || nextResolved.isEquivalentTo(currentResolved)) {
                             fullyResolved = currentResolved;
                             break;
@@ -2343,12 +2348,13 @@ public class ElixirPsiImplUtil {
                             }
                         }
 
-                        if (nextResolved == null || nextResolved.isEquivalentTo(currentResolved)) {
+                        if (nextResolved == null) {
                             fullyResolved = currentResolved;
-                            break;
                         } else {
-                            currentResolved = nextResolved;
+                            fullyResolved = nextResolved;
                         }
+
+                        break;
                     }
                 } else {
                     PsiElement nextResolved = reference.resolve();
@@ -3016,7 +3022,11 @@ public class ElixirPsiImplUtil {
             }
 
             if (reference == null) {
-                reference = new Callable(call);
+                if (CallDefinitionClause.is(call)) {
+                    reference = Callable.callDefinitionClauseDefiner(call);
+                } else {
+                    reference = new Callable(call);
+                }
             }
         }
 

--- a/src/org/elixir_lang/psi/impl/ElixirPsiImplUtil.java
+++ b/src/org/elixir_lang/psi/impl/ElixirPsiImplUtil.java
@@ -3022,8 +3022,8 @@ public class ElixirPsiImplUtil {
             }
 
             if (reference == null) {
-                if (CallDefinitionClause.is(call)) {
-                    reference = Callable.callDefinitionClauseDefiner(call);
+                if (CallDefinitionClause.is(call) || Implementation.is(call) || Module.is(call) || Protocol.is(call)) {
+                    reference = Callable.definer(call);
                 } else {
                     reference = new Callable(call);
                 }

--- a/src/org/elixir_lang/psi/scope/CallDefinitionClause.java
+++ b/src/org/elixir_lang/psi/scope/CallDefinitionClause.java
@@ -68,6 +68,7 @@ public abstract class CallDefinitionClause implements PsiScopeProcessor {
 
     /**
      * Whether to continue searching after each Module's children have been searched.
+     *
      * @return {@code true} to keep searching up the PSI tree; {@code false} to stop searching.
      */
     protected abstract boolean keepProcessing();
@@ -102,7 +103,7 @@ public abstract class CallDefinitionClause implements PsiScopeProcessor {
 
             if (childCalls != null) {
                 for (Call childCall : childCalls) {
-                    if(!execute(childCall, state)) {
+                    if (!execute(childCall, state)) {
                         break;
                     }
                 }
@@ -146,5 +147,4 @@ public abstract class CallDefinitionClause implements PsiScopeProcessor {
 
         return keepProcessing;
     }
-
 }

--- a/src/org/elixir_lang/psi/scope/call_definition_clause/ArityInterval.java
+++ b/src/org/elixir_lang/psi/scope/call_definition_clause/ArityInterval.java
@@ -1,0 +1,112 @@
+package org.elixir_lang.psi.scope.call_definition_clause;
+
+import com.intellij.openapi.util.Pair;
+import com.intellij.psi.ResolveState;
+import gnu.trove.THashMap;
+import org.apache.commons.lang.math.IntRange;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Map;
+
+import static org.elixir_lang.psi.call.name.Module.KERNEL_SPECIAL_FORMS;
+import static org.elixir_lang.psi.scope.CallDefinitionClause.MODULAR_CANONICAL_NAME;
+
+/**
+ * While an arity range for a normal function or macro is represented as an
+ * {@link org.apache.commons.lang.math.IntRange}, some special forms have no fixed arity when used because although
+ * defined in {@code Kernel.SpecialForms} as 1-arity, that one argument is effectively a splat of all the arguments, so
+ * there needs to be a way to represent that half-open interval.
+ */
+class ArityInterval {
+    /*
+     * CONSTANTS
+     */
+
+    private static final ArityInterval ONE = new ArityInterval(1);
+    private static final Map<String, ArityInterval> KERNEL_SPECIAL_FORM_ARITY_INTERVAL_BY_NAME =
+            new THashMap<String, ArityInterval>();
+
+    static {
+        KERNEL_SPECIAL_FORM_ARITY_INTERVAL_BY_NAME.put("__aliases__", ONE);
+        KERNEL_SPECIAL_FORM_ARITY_INTERVAL_BY_NAME.put("__block__", ONE);
+        KERNEL_SPECIAL_FORM_ARITY_INTERVAL_BY_NAME.put("for", ONE);
+        KERNEL_SPECIAL_FORM_ARITY_INTERVAL_BY_NAME.put("with", ONE);
+    }
+
+    /*
+     * Static Methods
+     */
+
+    static ArityInterval arityInterval(@NotNull Pair<String, IntRange> nameArityRange,
+                                       @NotNull ResolveState resolveState) {
+        @Nullable String modularCanonicalName = resolveState.get(MODULAR_CANONICAL_NAME);
+
+        IntRange arityRange = nameArityRange.second;
+        int arityRangeMinimum = arityRange.getMinimumInteger();
+        int arityRangeMaximum = arityRange.getMaximumInteger();
+        ArityInterval arityInterval = null;
+
+        if (modularCanonicalName != null && modularCanonicalName.equals(KERNEL_SPECIAL_FORMS)) {
+            String name = nameArityRange.first;
+
+            arityInterval = KERNEL_SPECIAL_FORM_ARITY_INTERVAL_BY_NAME.get(name);
+        }
+
+        if (arityInterval == null) {
+            arityInterval = new ArityInterval(arityRangeMinimum, arityRangeMaximum);
+        }
+
+        return arityInterval;
+    }
+
+    /*
+     * Fields
+     */
+
+    @NotNull
+    private final Integer minimum;
+    @Nullable
+    private final Integer maximum;
+
+    /*
+     * Constructors
+     */
+
+    /**
+     * Unlike {@link org.apache.commons.lang.math.IntRange#IntRange(int)}}, where the argument becomes the minimum AND
+     * the maximum, here the argument is ONLY the minimum and the interval has an infinite maximum.
+     *
+     * @param minimum minimum arity
+     */
+    private ArityInterval(int minimum) {
+        this.minimum = minimum;
+        this.maximum = null;
+    }
+
+    private ArityInterval(int minimum, int maximum) {
+        this.minimum = minimum;
+        this.maximum = maximum;
+    }
+
+    /*
+     * Instance Methods
+     */
+
+    boolean containsInteger(int candidate) {
+        return minimum <= candidate && (maximum == null || candidate <= maximum);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder stringBuilder = new StringBuilder("ArityInterval(").append(minimum);
+
+        if (maximum != null) {
+            stringBuilder.append(", ").append(maximum);
+        }
+
+        stringBuilder.append(")");
+
+        return stringBuilder.toString();
+    }
+}

--- a/src/org/elixir_lang/psi/scope/call_definition_clause/MultiResolve.java
+++ b/src/org/elixir_lang/psi/scope/call_definition_clause/MultiResolve.java
@@ -127,9 +127,9 @@ public class MultiResolve extends org.elixir_lang.psi.scope.CallDefinitionClause
             String name = nameArityRange.first;
 
             if (name.equals(this.name)) {
-                IntRange arityRange = nameArityRange.second;
+                ArityInterval arityInterval = ArityInterval.arityInterval(nameArityRange, state);
 
-                if (arityRange.containsInteger(resolvedFinalArity)) {
+                if (arityInterval.containsInteger(resolvedFinalArity)) {
                     keepProcessing = addToResolveResultList(element, true, state);
                 } else if (incompleteCode) {
                     keepProcessing = addToResolveResultList(element, false, state);

--- a/src/org/elixir_lang/psi/scope/call_definition_clause/MultiResolve.java
+++ b/src/org/elixir_lang/psi/scope/call_definition_clause/MultiResolve.java
@@ -97,9 +97,9 @@ public class MultiResolve extends org.elixir_lang.psi.scope.CallDefinitionClause
             PsiElement nameIdentifier = named.getNameIdentifier();
 
             if (nameIdentifier != null) {
-                /* call definition clause needs to not have a self-reference, so that OpenAPI uses Find Usages
-                   instead */
                 if (PsiTreeUtil.isAncestor(state.get(ENTRANCE), nameIdentifier, false)) {
+                    addNewToResolveResultList(nameIdentifier, validResult);
+
                     keepProcessing = false;
                 } else {
                 /* Doesn't use a Map<PsiElement, ResolveSet> so that MultiResolve's helpers that require a

--- a/src/org/elixir_lang/reference/Callable.java
+++ b/src/org/elixir_lang/reference/Callable.java
@@ -666,7 +666,9 @@ public class Callable extends PsiReferenceBase<Call> implements PsiPolyVariantRe
             String name = myElement.functionName();
 
             if (name != null) {
-                if (resolvedFinalArity == 0) {
+                // UnqualifiedNorArgumentsCall prevents `foo()` from being treated as a variable.
+                // resolvedFinalArity prevents `|> foo` from being counted as 0-arity
+                if (myElement instanceof UnqualifiedNoArgumentsCall && resolvedFinalArity == 0) {
                     List<ResolveResult> variableResolveList =
                             org.elixir_lang.psi.scope.variable.MultiResolve.resolveResultList(
                                     name,

--- a/src/org/elixir_lang/reference/Callable.java
+++ b/src/org/elixir_lang/reference/Callable.java
@@ -142,6 +142,27 @@ public class Callable extends PsiReferenceBase<Call> implements PsiPolyVariantRe
         return elementDescription;
     }
 
+    /**
+     * Callable for the {@code def}, {@code defp}, {@code defmacro}, or {@code defmacrop} that defines {@code call} as
+     * {@code new Callable(call)} will resolve to the {@code name} in {@code def name() do ...}
+     *
+     * @param call call definition clause
+     */
+    @NotNull
+    public static Callable callDefinitionClauseDefiner(@NotNull Call call) {
+        PsiElement functionNameElement = call.functionNameElement();
+
+        assert functionNameElement != null;
+
+        // Can't use `getStartOffsetInParent` because `functionNameElement` doesn't have to be a direct child of `call`
+        // Can't use `getTextOffset` because that's the offset to the navigationElement, which is nameIdentifier
+        int functionNameElementStartOffset = functionNameElement.getTextRange().getStartOffset();
+        int callStartOffset = call.getTextRange().getStartOffset();
+        int startOffset = functionNameElementStartOffset - callStartOffset;
+
+        return new Callable(call, new TextRange(startOffset, startOffset + functionNameElement.getTextLength()));
+    }
+
     public static String ignoredElementDescription(@SuppressWarnings("unused") Call call,
                                                    ElementDescriptionLocation location) {
         String elementDescription = null;
@@ -549,6 +570,10 @@ public class Callable extends PsiReferenceBase<Call> implements PsiPolyVariantRe
 
     public Callable(@NotNull Call call) {
         super(call);
+    }
+
+    private Callable(@NotNull Call call, @NotNull TextRange rangeInCall) {
+        super(call, rangeInCall);
     }
 
     @Override

--- a/src/org/elixir_lang/reference/Callable.java
+++ b/src/org/elixir_lang/reference/Callable.java
@@ -143,13 +143,22 @@ public class Callable extends PsiReferenceBase<Call> implements PsiPolyVariantRe
     }
 
     /**
-     * Callable for the {@code def}, {@code defp}, {@code defmacro}, or {@code defmacrop} that defines {@code call} as
-     * {@code new Callable(call)} will resolve to the {@code name} in {@code def name() do ...}
+     * Callable for any of the following built-in definers
      *
-     * @param call call definition clause
+     * <ul>
+     * <li>{@code def}</li>
+     * <li>{@code defimpl}</li>
+     * <li>{@code defmacro}</li>
+     * <li>{@code defmacrop}</li>
+     * <li>{@code defmodule}</li>
+     * <li>{@code defp}</li>
+     * <li>{@code defprotocol}</li>
+     * </ul>
+     *
+     * @param call definer call
      */
     @NotNull
-    public static Callable callDefinitionClauseDefiner(@NotNull Call call) {
+    public static Callable definer(@NotNull Call call) {
         PsiElement functionNameElement = call.functionNameElement();
 
         assert functionNameElement != null;

--- a/tests/org/elixir_lang/reference/callable/IntramoduleTest.java
+++ b/tests/org/elixir_lang/reference/callable/IntramoduleTest.java
@@ -106,11 +106,12 @@ public class IntramoduleTest extends LightCodeInsightFixtureTestCase {
         ResolveResult[] resolveResults = polyVariantReference.multiResolve(false);
 
         assertNotEquals("Resolved to both clauses instead of selected clause", 2, resolveResults.length);
-        assertEquals("Resolves to nothing so find usage can be used instead", 0, resolveResults.length);
+        assertEquals("Resolves to self", 1, resolveResults.length);
 
         PsiElement resolved = reference.resolve();
 
-        assertNull("Reference resolve", resolved);
+        assertNotNull("Reference not resolved", resolved);
+        assertEquals("def referenced(true) do\n  end", resolved.getParent().getParent().getParent().getText());
     }
 
     public void testParenthesesRecursiveReference() {


### PR DESCRIPTION
Various bugs found and fixed while trying to fix #578, which didn't work out due to problems with too many references.

# Changelog
## Enhancements
* Allow call definition heads to resolves to themselves for consistency with Aliases of `defmodule`.
* Generalize `Callable.callDefinitionClauseDefiner(Call)`: in addition to the current `CallDefinitionClause`, make it work for `Implementation`, `Module`, and `Protocol`.

## Bug Fixes
* Override `ModuleImpl#getProject() to prevent `StackOverflowError`.  Without overriding `#getProject()`, `IdentifierHighlighterPass` gets stuck in a loop between `getManager` and `getProject` on the target (the `ModuleImpl`) when clicking on the space between `def`s or `defmacro`s in the decompiled `.beam` files.
* Fix source formatting
* Skip looking for variables unless 0-arity AND no arguments
* Highlight unresolved macros as macro calls. Anything with a do keyword or a do block will be treated like a macro call even if it can't be resolved.  No resolved is either no resolve results or an empty list
* Implicit imports at top of file in addition to top of Module.