### PR TITLE
Only strip prefixMatcher when qualifier

### DIFF
--- a/src/org/elixir_lang/code_insight/completion/provider/CallDefinitionClause.java
+++ b/src/org/elixir_lang/code_insight/completion/provider/CallDefinitionClause.java
@@ -85,7 +85,11 @@ public class CallDefinitionClause extends CompletionProvider<CompletionParameter
                     Call modular = ElixirPsiImplUtil.maybeAliasToModular(qualifier, qualifier.getContainingFile());
 
                     if (modular != null) {
-                        resultSet.withPrefixMatcher("").addAllElements(
+                        if (resultSet.getPrefixMatcher().getPrefix().endsWith(".")) {
+                            resultSet = resultSet.withPrefixMatcher("");
+                        }
+
+                        resultSet.addAllElements(
                                 callDefinitionClauseLookupElements(modular)
                         );
                     }


### PR DESCRIPTION
Fixes #546

# Changelog
## Bug FIxes
* `CallDefinitionClause` completion provider is unexpectedly invoked both when `.` is typed, but continues to be invoked after a letter is typed after the `.`; however, once the letter is typed, the letter becomes the default prefix instead, so the prefix should only be reset to `""` when it ends in `.`.
* Disable `Callable#getVariants` unless `Unqualified` to  prevents local functions and macros being shown as completions for qualified names.