### PR TITLE
Check if resolve results are null in ModuleAttribute#multiresolve before addAll

### DIFF
--- a/src/org/elixir_lang/psi/scope/module_attribute/implemetation/For.java
+++ b/src/org/elixir_lang/psi/scope/module_attribute/implemetation/For.java
@@ -27,6 +27,7 @@ public class For implements PsiScopeProcessor {
      *
      */
 
+    @Nullable
     public static List<ResolveResult> resolveResultList(boolean validResult, @NotNull PsiElement entrance) {
         For scopeProcessor = new For(validResult);
         PsiTreeUtil.treeWalkUp(

--- a/src/org/elixir_lang/psi/scope/module_attribute/implemetation/Protocol.java
+++ b/src/org/elixir_lang/psi/scope/module_attribute/implemetation/Protocol.java
@@ -24,6 +24,7 @@ public class Protocol implements PsiScopeProcessor {
      *
      */
 
+    @Nullable
     public static List<ResolveResult> resolveResultList(boolean validResult, @NotNull PsiElement entrance) {
         Protocol protocol = new Protocol(validResult);
         PsiTreeUtil.treeWalkUp(

--- a/src/org/elixir_lang/reference/ModuleAttribute.java
+++ b/src/org/elixir_lang/reference/ModuleAttribute.java
@@ -12,6 +12,7 @@ import org.elixir_lang.psi.*;
 import org.elixir_lang.psi.call.Call;
 import org.elixir_lang.psi.impl.ElixirPsiImplUtil;
 import org.elixir_lang.psi.scope.module_attribute.implemetation.For;
+import org.elixir_lang.psi.scope.module_attribute.implemetation.Protocol;
 import org.elixir_lang.structure_view.element.modular.Implementation;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -209,17 +210,21 @@ public class ModuleAttribute extends PsiPolyVariantReferenceBase<PsiElement> {
             validResult = validResult("@protocol", incompleteCode);
 
             if (validResult != null) {
-                resultList.addAll(org.elixir_lang.psi.scope.module_attribute.implemetation.Protocol.resolveResultList(validResult, myElement));
+                List<ResolveResult> resolveResultList = Protocol.resolveResultList(validResult, myElement);
+
+                if (resolveResultList != null) {
+                    resultList.addAll(resolveResultList);
+                }
             }
 
             if (incompleteCode || !ContainerUtil.exists(resultList, HAS_VALID_RESULT_CONDITION)) {
                 validResult = validResult("@for", incompleteCode);
 
                 if (validResult != null) {
-                    List<ResolveResult> resolveResults = For.resolveResultList(validResult, myElement);
+                    List<ResolveResult> resolveResultList = For.resolveResultList(validResult, myElement);
 
-                    if (resolveResults != null) {
-                        resultList.addAll(resolveResults);
+                    if (resolveResultList != null) {
+                        resultList.addAll(resolveResultList);
                     }
                 }
 

--- a/src/org/elixir_lang/reference/ModuleAttribute.java
+++ b/src/org/elixir_lang/reference/ModuleAttribute.java
@@ -11,6 +11,7 @@ import org.apache.commons.lang.NotImplementedException;
 import org.elixir_lang.psi.*;
 import org.elixir_lang.psi.call.Call;
 import org.elixir_lang.psi.impl.ElixirPsiImplUtil;
+import org.elixir_lang.psi.scope.module_attribute.implemetation.For;
 import org.elixir_lang.structure_view.element.modular.Implementation;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -215,7 +216,11 @@ public class ModuleAttribute extends PsiPolyVariantReferenceBase<PsiElement> {
                 validResult = validResult("@for", incompleteCode);
 
                 if (validResult != null) {
-                    resultList.addAll(org.elixir_lang.psi.scope.module_attribute.implemetation.For.resolveResultList(validResult, myElement));
+                    List<ResolveResult> resolveResults = For.resolveResultList(validResult, myElement);
+
+                    if (resolveResults != null) {
+                        resultList.addAll(resolveResults);
+                    }
                 }
 
                 if (incompleteCode || !ContainerUtil.exists(resultList, HAS_VALID_RESULT_CONDITION)) {
@@ -251,6 +256,7 @@ public class ModuleAttribute extends PsiPolyVariantReferenceBase<PsiElement> {
         return resultList;
     }
 
+    @NotNull
     private List<ResolveResult> multiResolveUpFromElement(@NotNull final PsiElement element, boolean incompleteCode) {
         List<ResolveResult> resultList = new ArrayList<ResolveResult>();
         PsiElement lastSibling = element;


### PR DESCRIPTION
Fixes #631

# Changelog
## Bug Fixes
* Check if resolve results are `null` for `For.resolveResultList`
* Check if `Protocol.resolveResultList` is `null`