### PR TITLE
Document workaround for viewing Embedded Elixir

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@
           - [Time](#time)
           - [Visibility](#visibility)
         - [Call to Element](#call-to-element)
+  - [Viewing Embedded Elixir Templates](#viewing-embedded-elixir-templates)
   - [Installation](#installation)
     - [Inside IDE using JetBrains repository](#inside-ide-using-jetbrains-repository)
     - [Inside IDE using Github releases](#inside-ide-using-github-releases)
@@ -3223,6 +3224,26 @@ The Visibility icons indicated whether the element is usable outside its definin
     </tr>
   </tbody>
 </table>
+
+## Viewing Embedded Elixir Templates
+
+There is currently no direct support for Embedded Elixir (`*.eex`) templates.
+
+However, because the Elixir syntax is so similar to Ruby, you can use
+the Ruby language support for RHTML/ERB to get some syntax highlighting support
+in `*.eex` views.  Some non-Ruby syntax (e.g. `->`) will still show as an
+error, and of course none of the native Elixir support works, but most
+things will highlight reasonably well.
+
+Note that this involves disabling some of the support for Ruby, but
+if you don't write Ruby, or if you write it in a different IDE (e.g. RubyMine),
+it won't matter.
+
+Here's the steps in Preferences (for OSX, other platforms may differ):
+  * Install the [standard Jetbrains Ruby plugin](https://confluence.jetbrains.com/display/RUBYDEV/RubyMine+and+IntelliJ+IDEA+Ruby+Plugin)
+  * Editor -> File Types -> RHTML: Add "*.eex" as type
+  * Editor -> Inspections -> Ruby -> Unresolved Ruby Reference: Uncheck
+  * Editor -> Inspections -> Ruby -> Double Quoted String: Uncheck
 
 ## Installation
 


### PR DESCRIPTION
templates can be viewed as ruby to get somewhat
decent highlighting.