### PR TITLE
Blacklist filter for debugger

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@
       - [Steps](#steps)
       - [Basics](#basics)
         - [Keyboard Shortcuts](#keyboard-shortcuts)
+        - [Environment Variables](#environment-variables)
       - [Breakpoints](#breakpoints)
         - [Accessing Breakpoint Properties](#accessing-breakpoint-properties)
           - [Viewing all breakpoints](#viewing-all-breakpoints)
@@ -1378,6 +1379,12 @@ After you have configured a [run configuration](#run-configuration) for your pro
 | Step Over                               | `F8`             |
 | Step Into                               | `F7`             |
 | View breakpoint details/all breakpoints | `Shift+Cmd+F8`   |
+
+##### Environment Variables
+
+| Variable              | Example    | Description                     |
+| ----------------------|------------| --------------------------------|
+| MIX\_DEBUG\_BLACKLIST | iconv,some | Excluding modules from debugger |
 
 #### Breakpoints
 

--- a/README.md
+++ b/README.md
@@ -1382,9 +1382,9 @@ After you have configured a [run configuration](#run-configuration) for your pro
 
 ##### Environment Variables
 
-| Variable              | Example    | Description                     |
-| ----------------------|------------| --------------------------------|
-| MIX\_DEBUG\_BLACKLIST | iconv,some | Excluding modules from debugger |
+| Variable                           | Example    | Description                     |
+| -----------------------------------|------------| --------------------------------|
+| INTELLIJ\_ELIXIR\_DEBUG\_BLACKLIST | iconv,some | Excluding modules from debugger |
 
 #### Breakpoints
 

--- a/resources/debugger/lib/debug_task.ex
+++ b/resources/debugger/lib/debug_task.ex
@@ -67,7 +67,7 @@ defmodule Mix.Tasks.IntellijElixir.DebugTask do
   end
 
   defp get_blacklist() do
-    blacklist = System.get_env("MIX_DEBUG_BLACKLIST") || ""
+    blacklist = System.get_env("INTELLIJ_ELIXIR_DEBUG_BLACKLIST") || ""
     blacklist
       |> String.split(",")
       |> Enum.map(&(String.to_atom(&1)))

--- a/resources/debugger/lib/debug_task.ex
+++ b/resources/debugger/lib/debug_task.ex
@@ -56,12 +56,21 @@ defmodule Mix.Tasks.IntellijElixir.DebugTask do
   end
 
   defp interpret_modules_in(path) do
+    blacklist = get_blacklist()
     path
     |> Path.join("**/*.beam")
     |> Path.wildcard
     |> Enum.map(&(Path.basename(&1, ".beam") |> String.to_atom))
     |> Enum.filter(&(:int.interpretable(&1) == true && !:code.is_sticky(&1) && &1 != __MODULE__))
+    |> Enum.filter(&(!Enum.any?(blacklist, fn(x) -> &1 == x end)))
     |> Enum.each(&(:int.ni(&1)))
+  end
+
+  defp get_blacklist() do
+    blacklist = System.get_env("MIX_DEBUG_BLACKLIST") || ""
+    blacklist
+      |> String.split(",")
+      |> Enum.map(&(String.to_atom(&1)))
   end
 
   defp get_task(["-" <> _ | _]) do


### PR DESCRIPTION
# Changelog
## Enhancements
* `INTELLIJ_ELIXIR_DEBUG_BLACKLIST` environment variable can be set with a comma-separated list of module names that should not be interpreted with `:int.ni`.