### PR TITLE
Treat `::` the same as `:`  in `key:` after `when` in type specifications

### DIFF
--- a/src/org/elixir_lang/annonator/ModuleAttribute.java
+++ b/src/org/elixir_lang/annonator/ModuleAttribute.java
@@ -1279,6 +1279,25 @@ public class ModuleAttribute implements Annotator, DumbAware {
         return Collections.singleton(noParenthesesKeywordPair.getKeywordKey().getText());
     }
 
+    /**
+     * A type operator is an error, keyword pairs should be used for `when type: definition` for expression-local types,
+     * but using `::` is a common error, so support it.
+     */
+    @NotNull
+    private Set<String> specificationTypeParameterNameSet(Type type) {
+        PsiElement leftOperand = type.leftOperand();
+        Set<String> typeParameterNameSet;
+
+        if (leftOperand != null) {
+            typeParameterNameSet = Collections.singleton(leftOperand.getText());
+        } else {
+            error("Type does not have a left operand", type);
+            typeParameterNameSet = Collections.emptySet();
+        }
+
+        return typeParameterNameSet;
+    }
+
     private Set<String> specificationTypeParameterNameSet(@NotNull PsiElement psiElement) {
         Set<String> parameterNameSet;
 
@@ -1289,6 +1308,8 @@ public class ModuleAttribute implements Annotator, DumbAware {
             parameterNameSet = specificationTypeParameterNameSet(psiElement.getChildren());
         } else if (psiElement instanceof ElixirKeywordPair) {
             parameterNameSet = specificationTypeParameterNameSet((ElixirKeywordPair) psiElement);
+        } else if (psiElement instanceof Type) {
+            parameterNameSet = specificationTypeParameterNameSet((Type) psiElement);
         } else if (psiElement instanceof ElixirNoParenthesesKeywordPair) {
             parameterNameSet = specificationTypeParameterNameSet((ElixirNoParenthesesKeywordPair) psiElement);
         } else if (psiElement instanceof UnqualifiedNoArgumentsCall) {

--- a/src/org/elixir_lang/annonator/ModuleAttribute.java
+++ b/src/org/elixir_lang/annonator/ModuleAttribute.java
@@ -1393,7 +1393,7 @@ public class ModuleAttribute implements Annotator, DumbAware {
     }
 
     private Set<String> specificationTypeParameterNameSet(PsiElement[] psiElements) {
-        Set<String> accumulatedTypeParameterNameSet = new HashSet<String>();
+        Set<String> accumulatedTypeParameterNameSet = new HashSet<>();
 
         for (PsiElement psiElement : psiElements) {
             accumulatedTypeParameterNameSet.addAll(specificationTypeParameterNameSet(psiElement));
@@ -1467,7 +1467,7 @@ public class ModuleAttribute implements Annotator, DumbAware {
     }
 
     private Set<String> typeTypeParameterNameSet(PsiElement[] psiElements) {
-        Set<String> typeParameerNameSet = new HashSet<String>();
+        Set<String> typeParameerNameSet = new HashSet<>();
 
         for (PsiElement psiElement : psiElements) {
             typeParameerNameSet.addAll(typeTypeParameterNameSet(psiElement));

--- a/src/org/elixir_lang/annonator/ModuleAttribute.java
+++ b/src/org/elixir_lang/annonator/ModuleAttribute.java
@@ -592,7 +592,14 @@ public class ModuleAttribute implements Annotator, DumbAware {
                 }
             } else if (grandChild instanceof ElixirMatchedWhenOperation) {
                 ElixirMatchedWhenOperation matchedWhenOperation = (ElixirMatchedWhenOperation) grandChild;
-                Set<String> typeParameterNameSet = specificationTypeParameterNameSet(matchedWhenOperation.rightOperand());
+                PsiElement rightOperand = matchedWhenOperation.rightOperand();
+                Set<String> typeParameterNameSet;
+
+                if (rightOperand != null) {
+                    typeParameterNameSet = specificationTypeParameterNameSet(rightOperand);
+                } else {
+                    typeParameterNameSet = Collections.emptySet();
+                }
 
                 PsiElement leftOperand = matchedWhenOperation.leftOperand();
 
@@ -688,8 +695,6 @@ public class ModuleAttribute implements Annotator, DumbAware {
                 } else {
                     cannotHighlightTypes(leftOperand);
                 }
-
-                Quotable rightOperand = matchedWhenOperation.rightOperand();
 
                 if (rightOperand != null) {
                     highlightTypesAndSpecificationTypeParameterDeclarations(

--- a/src/org/elixir_lang/annonator/ModuleAttribute.java
+++ b/src/org/elixir_lang/annonator/ModuleAttribute.java
@@ -613,38 +613,13 @@ public class ModuleAttribute implements Annotator, DumbAware {
                     }
 
                     if (strippedTypeOperationLeftOperand instanceof Call) {
-                        Call call = (Call) strippedTypeOperationLeftOperand;
-                        PsiElement functionNameElement = call.functionNameElement();
-
-                        if (functionNameElement != null) {
-                            highlight(
-                                    functionNameElement.getTextRange(),
-                                    annotationHolder,
-                                    leftMostFunctionNameTextAttributesKey
-                            );
-                        }
-
-                        PsiElement[] primaryArguments = call.primaryArguments();
-
-                        if (primaryArguments != null) {
-                            highlightTypesAndTypeParameterUsages(
-                                    primaryArguments,
-                                    typeParameterNameSet,
-                                    annotationHolder,
-                                    leftMostFunctionArgumentsTextAttributesKey
-                            );
-                        }
-
-                        PsiElement[] secondaryArguments = call.secondaryArguments();
-
-                        if (secondaryArguments != null) {
-                            highlightTypesAndTypeParameterUsages(
-                                    secondaryArguments,
-                                    typeParameterNameSet,
-                                    annotationHolder,
-                                    leftMostFunctionArgumentsTextAttributesKey
-                            );
-                        }
+                        highlightSpecification(
+                                (Call) strippedTypeOperationLeftOperand,
+                                annotationHolder,
+                                leftMostFunctionNameTextAttributesKey,
+                                leftMostFunctionNameTextAttributesKey,
+                                typeParameterNameSet
+                        );
                     } else {
                         cannotHighlightTypes(strippedTypeOperationLeftOperand);
                     }
@@ -660,38 +635,13 @@ public class ModuleAttribute implements Annotator, DumbAware {
                         );
                     }
                 } else if (leftOperand instanceof Call) {
-                    Call call = (Call) leftOperand;
-                    PsiElement functionNameElement = call.functionNameElement();
-
-                    if (functionNameElement != null) {
-                        highlight(
-                                functionNameElement.getTextRange(),
-                                annotationHolder,
-                                leftMostFunctionNameTextAttributesKey
-                        );
-                    }
-
-                    PsiElement[] primaryArguments = call.primaryArguments();
-
-                    if (primaryArguments != null) {
-                        highlightTypesAndTypeParameterUsages(
-                                primaryArguments,
-                                typeParameterNameSet,
-                                annotationHolder,
-                                leftMostFunctionArgumentsTextAttributesKey
-                        );
-                    }
-
-                    PsiElement[] secondaryArguments = call.secondaryArguments();
-
-                    if (secondaryArguments != null) {
-                        highlightTypesAndTypeParameterUsages(
-                                secondaryArguments,
-                                typeParameterNameSet,
-                                annotationHolder,
-                                leftMostFunctionArgumentsTextAttributesKey
-                        );
-                    }
+                    highlightSpecification(
+                            (Call) leftOperand,
+                            annotationHolder,
+                            leftMostFunctionNameTextAttributesKey,
+                            leftMostFunctionNameTextAttributesKey,
+                            typeParameterNameSet
+                    );
                 } else {
                     cannotHighlightTypes(leftOperand);
                 }
@@ -705,6 +655,44 @@ public class ModuleAttribute implements Annotator, DumbAware {
                     );
                 }
             }
+        }
+    }
+
+    private void highlightSpecification(@NotNull Call call,
+                                        AnnotationHolder annotationHolder,
+                                        TextAttributesKey leftMostFunctionNameTextAttributesKey,
+                                        TextAttributesKey leftMostFunctionArgumentsTextAttributesKey,
+                                        Set<String> typeParameterNameSet) {
+        PsiElement functionNameElement = call.functionNameElement();
+
+        if (functionNameElement != null) {
+            highlight(
+                    functionNameElement.getTextRange(),
+                    annotationHolder,
+                    leftMostFunctionNameTextAttributesKey
+            );
+        }
+
+        PsiElement[] primaryArguments = call.primaryArguments();
+
+        if (primaryArguments != null) {
+            highlightTypesAndTypeParameterUsages(
+                    primaryArguments,
+                    typeParameterNameSet,
+                    annotationHolder,
+                    leftMostFunctionArgumentsTextAttributesKey
+            );
+        }
+
+        PsiElement[] secondaryArguments = call.secondaryArguments();
+
+        if (secondaryArguments != null) {
+            highlightTypesAndTypeParameterUsages(
+                    secondaryArguments,
+                    typeParameterNameSet,
+                    annotationHolder,
+                    leftMostFunctionArgumentsTextAttributesKey
+            );
         }
     }
 

--- a/src/org/elixir_lang/annonator/ModuleAttribute.java
+++ b/src/org/elixir_lang/annonator/ModuleAttribute.java
@@ -1419,12 +1419,12 @@ public class ModuleAttribute implements Annotator, DumbAware {
     }
 
     private Set<String> typeTypeParameterNameSet(PsiElement[] psiElements) {
-        Set<String> typeParameerNameSet = new HashSet<>();
+        Set<String> typeParameterNameSet = new HashSet<>();
 
         for (PsiElement psiElement : psiElements) {
-            typeParameerNameSet.addAll(typeTypeParameterNameSet(psiElement));
+            typeParameterNameSet.addAll(typeTypeParameterNameSet(psiElement));
         }
 
-        return  typeParameerNameSet;
+        return  typeParameterNameSet;
     }
 }

--- a/src/org/elixir_lang/annonator/ModuleAttribute.java
+++ b/src/org/elixir_lang/annonator/ModuleAttribute.java
@@ -409,8 +409,8 @@ public class ModuleAttribute implements Annotator, DumbAware {
         }
     }
 
-    private void highlightTypeError(@NotNull PsiElement element, @NotNull AnnotationHolder annotationHolder, @NotNull String message) {
-        annotationHolder.createErrorAnnotation(element, message);
+    private void highlightTypeError(@NotNull PsiElement element, @NotNull AnnotationHolder annotationHolder) {
+        annotationHolder.createErrorAnnotation(element, "Strings aren't allowed in types");
     }
 
     private Set<String> highlightTypeLeftOperand(@NotNull final ElixirMatchedUnqualifiedParenthesesCall call,
@@ -1053,7 +1053,7 @@ public class ModuleAttribute implements Annotator, DumbAware {
                     typeTextAttributesKey
             );
         } else if (psiElement instanceof InterpolatedString) {
-            highlightTypeError(psiElement, annotationHolder, "Strings aren't allowed in types");
+            highlightTypeError(psiElement, annotationHolder);
         } else if (psiElement instanceof Infix && !(psiElement instanceof When)) {
             highlightTypesAndTypeParameterUsages(
                     (Infix) psiElement,

--- a/src/org/elixir_lang/annonator/ModuleAttribute.java
+++ b/src/org/elixir_lang/annonator/ModuleAttribute.java
@@ -309,7 +309,7 @@ public class ModuleAttribute implements Annotator, DumbAware {
                 // seen as `unquote(ast)`, but could also be just the beginning of typing
                 ElixirMatchedUnqualifiedParenthesesCall matchedUnqualifiedParenthesesCall = (ElixirMatchedUnqualifiedParenthesesCall) grandChild;
 
-                if (matchedUnqualifiedParenthesesCall.functionName().equals(UNQUOTE)) {
+                if (UNQUOTE.equals(matchedUnqualifiedParenthesesCall.functionName())) {
                     PsiElement[] secondaryArguments = matchedUnqualifiedParenthesesCall.secondaryArguments();
 
                     if (secondaryArguments != null) {

--- a/src/org/elixir_lang/annonator/ModuleAttribute.java
+++ b/src/org/elixir_lang/annonator/ModuleAttribute.java
@@ -926,14 +926,7 @@ public class ModuleAttribute implements Annotator, DumbAware {
                     annotationHolder,
                     typeTextAttributesKey
             );
-        } else if (children.length == 3) {
-            highlightTypesAndTypeParameterUsages(
-                    (When) stabParenthesesSignature,
-                    typeParameterNameSet,
-                    annotationHolder,
-                    typeTextAttributesKey
-            );
-        } else {
+        } else if (children.length != 3) {
             error("Cannot highlight types and type parameter usages", stabParenthesesSignature);
         }
     }
@@ -1061,16 +1054,7 @@ public class ModuleAttribute implements Annotator, DumbAware {
             );
         } else if (psiElement instanceof InterpolatedString) {
             highlightTypeError(psiElement, annotationHolder, "Strings aren't allowed in types");
-        } else if (psiElement instanceof When) {
-            /* NOTE: MUST be before `Infix` as `When` is a subinterface of
-              `Infix` */
-            highlightTypesAndTypeParameterUsages(
-                    (When) psiElement,
-                    typeParameterNameSet,
-                    annotationHolder,
-                    typeTextAttributesKey
-            );
-        } else if (psiElement instanceof Infix) {
+        } else if (psiElement instanceof Infix && !(psiElement instanceof When)) {
             highlightTypesAndTypeParameterUsages(
                     (Infix) psiElement,
                     typeParameterNameSet,
@@ -1123,19 +1107,20 @@ public class ModuleAttribute implements Annotator, DumbAware {
                 /* Occurs in the case of typing a {@code @type name ::} above a {@code @doc <HEREDOC>} and the
                    {@code @doc <HEREDOC>} is interpreted as the right-operand of {@code ::} */
                 psiElement instanceof AtUnqualifiedNoParenthesesCall ||
-                // leave normal highlighting
-                psiElement instanceof BracketOperation ||
-                psiElement instanceof ElixirAlias ||
-                psiElement instanceof ElixirAtom ||
-                psiElement instanceof ElixirAtomKeyword ||
-                psiElement instanceof ElixirBitString ||
-                psiElement instanceof ElixirCharToken ||
-                psiElement instanceof ElixirDecimalWholeNumber ||
-                psiElement instanceof ElixirKeywordKey ||
-                /* happens when :: is typed in `@spec` above function clause that uses `do:` */
-                psiElement instanceof ElixirNoParenthesesKeywords ||
-                psiElement instanceof ElixirUnaryNumericOperation ||
-                psiElement instanceof ElixirVariable
+                        // leave normal highlighting
+                        psiElement instanceof BracketOperation ||
+                        psiElement instanceof ElixirAlias ||
+                        psiElement instanceof ElixirAtom ||
+                        psiElement instanceof ElixirAtomKeyword ||
+                        psiElement instanceof ElixirBitString ||
+                        psiElement instanceof ElixirCharToken ||
+                        psiElement instanceof ElixirDecimalWholeNumber ||
+                        psiElement instanceof ElixirKeywordKey ||
+                        /* happens when :: is typed in `@spec` above function clause that uses `do:` */
+                        psiElement instanceof ElixirNoParenthesesKeywords ||
+                        psiElement instanceof ElixirUnaryNumericOperation ||
+                        psiElement instanceof ElixirVariable ||
+                        psiElement instanceof When
         )) {
             cannotHighlightTypes(psiElement);
         }
@@ -1311,14 +1296,6 @@ public class ModuleAttribute implements Annotator, DumbAware {
                 error("Cannot highlight types and type parameter usages", unqualifiedParenthesesCall);
             }
         }
-    }
-
-    private void highlightTypesAndTypeParameterUsages(
-            When when,
-            Set<String> typeParameterNameSet,
-            AnnotationHolder annotationHolder,
-            TextAttributesKey typeTextAttributesKey) {
-        return;
     }
 
     private void highlightTypesAndSpecificationTypeParameterDeclarations(

--- a/src/org/elixir_lang/annonator/ModuleAttribute.java
+++ b/src/org/elixir_lang/annonator/ModuleAttribute.java
@@ -357,7 +357,7 @@ public class ModuleAttribute implements Annotator, DumbAware {
 
                     highlightTypesAndTypeParameterUsages(
                             quotableKeywordValue,
-                            Collections.<String>emptySet(),
+                            Collections.emptySet(),
                             annotationHolder,
                             ElixirSyntaxHighlighter.TYPE
                     );
@@ -399,7 +399,7 @@ public class ModuleAttribute implements Annotator, DumbAware {
 
                 highlightTypesAndTypeParameterUsages(
                         unqualifiedNoParenthesesCall.getNoParenthesesOneArgument(),
-                        Collections.<String>emptySet(),
+                        Collections.emptySet(),
                         annotationHolder,
                         ElixirSyntaxHighlighter.TYPE
                 );
@@ -428,7 +428,7 @@ public class ModuleAttribute implements Annotator, DumbAware {
                     primaryArguments,
                     /* as stated above, if there are secondary arguments, then the primary arguments are
                        to quote or some equivalent metaprogramming. */
-                    Collections.<String>emptySet(),
+                    Collections.emptySet(),
                     annotationHolder,
                     ElixirSyntaxHighlighter.TYPE
             );

--- a/src/org/elixir_lang/annonator/ModuleAttribute.java
+++ b/src/org/elixir_lang/annonator/ModuleAttribute.java
@@ -244,9 +244,6 @@ public class ModuleAttribute implements Annotator, DumbAware {
 
     /**
      * Highlights the function call name as a `ElixirSyntaxHighlighter.SPECIFICATION
-     *
-     * @param atUnqualifiedNoParenthesesCall
-     * @param annotationHolder
      */
     private void highlightSpecification(@NotNull final AtUnqualifiedNoParenthesesCall atUnqualifiedNoParenthesesCall,
                                         @NotNull final AnnotationHolder annotationHolder) {
@@ -527,8 +524,6 @@ public class ModuleAttribute implements Annotator, DumbAware {
     /**
      * Recursively highlights the types under `atUnqualifiedNoParenthesesCall`.
      *
-     * @param atUnqualifiedNoParenthesesCall
-     * @param annotationHolder
      * @param leftMostFunctionNameTextAttributesKey      the {@link ElixirSyntaxHighlighter} {@link TextAttributesKey} for the
      *                                                   name of the callback, type, or function being declared
      * @param leftMostFunctionArgumentsTextAttributesKey the {@link ElixirSyntaxHighlighter} {@link TextAttributesKey} for the

--- a/src/org/elixir_lang/annonator/ModuleAttribute.java
+++ b/src/org/elixir_lang/annonator/ModuleAttribute.java
@@ -1298,30 +1298,6 @@ public class ModuleAttribute implements Annotator, DumbAware {
         }
     }
 
-    private void highlightTypesAndSpecificationTypeParameterDeclarations(
-            ElixirUnmatchedUnqualifiedNoArgumentsCall unmatchedUnqualifiedNoArgumentsCall,
-            Set<String> typeParameterNameSet,
-            AnnotationHolder annotationHolder,
-            TextAttributesKey textAttributesKey
-    ) {
-        String variable = unmatchedUnqualifiedNoArgumentsCall.getText();
-
-        if (typeParameterNameSet.contains(variable)) {
-            highlight(
-                    unmatchedUnqualifiedNoArgumentsCall.getTextRange(),
-                    annotationHolder,
-                    ElixirSyntaxHighlighter.TYPE_PARAMETER
-            );
-        } else {
-            highlightTypesAndTypeParameterUsages(
-                    unmatchedUnqualifiedNoArgumentsCall,
-                    typeParameterNameSet,
-                    annotationHolder,
-                    textAttributesKey
-            );
-        }
-    }
-
     @NotNull
     private Set<String> specificationTypeParameterNameSet(ElixirKeywordPair keywordPair) {
         return Collections.singleton(keywordPair.getKeywordKey().getText());

--- a/src/org/elixir_lang/annonator/ModuleAttribute.java
+++ b/src/org/elixir_lang/annonator/ModuleAttribute.java
@@ -10,6 +10,7 @@ import com.intellij.openapi.project.DumbAware;
 import com.intellij.openapi.util.TextRange;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiRecursiveElementVisitor;
+import com.intellij.psi.PsiReference;
 import com.intellij.psi.tree.TokenSet;
 import org.elixir_lang.ElixirSyntaxHighlighter;
 import org.elixir_lang.errorreport.Logger;
@@ -120,9 +121,12 @@ public class ModuleAttribute implements Annotator, DumbAware {
                                 ElixirSyntaxHighlighter.MODULE_ATTRIBUTE
                         );
 
-                        if (!isNonReferencing(atNonNumericOperation) &&
-                                atNonNumericOperation.getReference().resolve() == null) {
-                            holder.createErrorAnnotation(atNonNumericOperation, "Unresolved module attribute");
+                        if (!isNonReferencing(atNonNumericOperation)) {
+                            PsiReference reference = atNonNumericOperation.getReference();
+
+                            if (reference != null && reference.resolve() == null) {
+                                holder.createErrorAnnotation(atNonNumericOperation, "Unresolved module attribute");
+                            }
                         }
                     }
                 }

--- a/src/org/elixir_lang/annonator/ModuleAttribute.java
+++ b/src/org/elixir_lang/annonator/ModuleAttribute.java
@@ -562,7 +562,7 @@ public class ModuleAttribute implements Annotator, DumbAware {
                     if (primaryArguments != null) {
                         highlightTypesAndTypeParameterUsages(
                                 primaryArguments,
-                                Collections.EMPTY_SET,
+                                Collections.emptySet(),
                                 annotationHolder,
                                 leftMostFunctionArgumentsTextAttributesKey
                         );
@@ -573,7 +573,7 @@ public class ModuleAttribute implements Annotator, DumbAware {
                     if (secondaryArguments != null) {
                         highlightTypesAndTypeParameterUsages(
                                 secondaryArguments,
-                                Collections.EMPTY_SET,
+                                Collections.emptySet(),
                                 annotationHolder,
                                 leftMostFunctionArgumentsTextAttributesKey
                         );
@@ -585,7 +585,7 @@ public class ModuleAttribute implements Annotator, DumbAware {
                 if (rightOperand != null) {
                     highlightTypesAndTypeParameterUsages(
                             rightOperand,
-                            Collections.EMPTY_SET,
+                            Collections.emptySet(),
                             annotationHolder,
                             ElixirSyntaxHighlighter.TYPE
                     );

--- a/src/org/elixir_lang/annonator/ModuleAttribute.java
+++ b/src/org/elixir_lang/annonator/ModuleAttribute.java
@@ -283,14 +283,12 @@ public class ModuleAttribute implements Annotator, DumbAware {
 
                     highlightTypeName(call, annotationHolder);
 
-                    if (call instanceof ElixirMatchedUnqualifiedNoArgumentsCall) {
-                        // no arguments, so nothing else to do
-                    } else if (call instanceof ElixirMatchedUnqualifiedParenthesesCall) {
+                    if (call instanceof ElixirMatchedUnqualifiedParenthesesCall) {
                         typeParameterNameSet = highlightTypeLeftOperand(
                                 (ElixirMatchedUnqualifiedParenthesesCall) call,
                                 annotationHolder
                         );
-                    } else {
+                    } else if (!(call instanceof ElixirMatchedUnqualifiedNoArgumentsCall)) {
                         cannotHighlightTypes(call);
                     }
                 } else {
@@ -988,9 +986,6 @@ public class ModuleAttribute implements Annotator, DumbAware {
                     annotationHolder,
                     typeTextAttributesKey
             );
-        } else if (psiElement instanceof AtUnqualifiedNoParenthesesCall) {
-            /* Occurs in the case of typing a {@code @type name ::} above a {@code @doc <HEREDOC>} and the
-               {@code @doc <HEREDOC>} is interpreted as the right-operand of {@code ::} */
         } else if (psiElement instanceof ElixirAccessExpression ||
                 psiElement instanceof ElixirAssociationsBase ||
                 psiElement instanceof ElixirAssociations ||
@@ -1012,21 +1007,7 @@ public class ModuleAttribute implements Annotator, DumbAware {
                     annotationHolder,
                     typeTextAttributesKey
             );
-        } else if (psiElement instanceof BracketOperation ||
-                psiElement instanceof ElixirAlias ||
-                psiElement instanceof ElixirAtom ||
-                psiElement instanceof ElixirAtomKeyword ||
-                psiElement instanceof ElixirBitString ||
-                psiElement instanceof ElixirCharToken ||
-                psiElement instanceof ElixirDecimalWholeNumber ||
-                psiElement instanceof ElixirKeywordKey ||
-                /* happens when :: is typed in `@spec` above function clause that uses `do:` */
-                psiElement instanceof ElixirNoParenthesesKeywords ||
-                psiElement instanceof ElixirStringLine ||
-                psiElement instanceof ElixirUnaryNumericOperation ||
-                psiElement instanceof ElixirVariable) {
-            // leave normal highlighting
-        }  else if (psiElement instanceof ElixirMapOperation) {
+        } else if (psiElement instanceof ElixirMapOperation) {
             highlightTypesAndTypeParameterUsages(
                     (ElixirMapOperation) psiElement,
                     typeParameterNameSet,
@@ -1134,7 +1115,24 @@ public class ModuleAttribute implements Annotator, DumbAware {
                     annotationHolder,
                     typeTextAttributesKey
             );
-        } else {
+        } else if (!(
+                /* Occurs in the case of typing a {@code @type name ::} above a {@code @doc <HEREDOC>} and the
+                   {@code @doc <HEREDOC>} is interpreted as the right-operand of {@code ::} */
+                psiElement instanceof AtUnqualifiedNoParenthesesCall ||
+                // leave normal highlighting
+                psiElement instanceof BracketOperation ||
+                psiElement instanceof ElixirAlias ||
+                psiElement instanceof ElixirAtom ||
+                psiElement instanceof ElixirAtomKeyword ||
+                psiElement instanceof ElixirBitString ||
+                psiElement instanceof ElixirCharToken ||
+                psiElement instanceof ElixirDecimalWholeNumber ||
+                psiElement instanceof ElixirKeywordKey ||
+                /* happens when :: is typed in `@spec` above function clause that uses `do:` */
+                psiElement instanceof ElixirNoParenthesesKeywords ||
+                psiElement instanceof ElixirUnaryNumericOperation ||
+                psiElement instanceof ElixirVariable
+        )) {
             cannotHighlightTypes(psiElement);
         }
     }

--- a/src/org/elixir_lang/annonator/ModuleAttribute.java
+++ b/src/org/elixir_lang/annonator/ModuleAttribute.java
@@ -956,12 +956,16 @@ public class ModuleAttribute implements Annotator, DumbAware {
             Set<String> typeParameterNameSet,
             AnnotationHolder annotationHolder,
             TextAttributesKey typeTextAttributesKey) {
-        highlightTypesAndTypeParameterUsages(
-                infix.leftOperand(),
-                typeParameterNameSet,
-                annotationHolder,
-                typeTextAttributesKey
-        );
+        PsiElement leftOperand = infix.leftOperand();
+
+        if (leftOperand != null) {
+            highlightTypesAndTypeParameterUsages(
+                    leftOperand,
+                    typeParameterNameSet,
+                    annotationHolder,
+                    typeTextAttributesKey
+            );
+        }
 
         PsiElement rightOperand = infix.rightOperand();
 

--- a/src/org/elixir_lang/annonator/ModuleAttribute.java
+++ b/src/org/elixir_lang/annonator/ModuleAttribute.java
@@ -259,8 +259,8 @@ public class ModuleAttribute implements Annotator, DumbAware {
     }
 
     /**
-     * Highlights the function name of the declared @type, @typep, or @opaque as an {@link ElixirSyntaxHighlighter.TYPE}
-     * and the its parameters as {@link ElixirSyntaxHighlighter.TYPE_PARAMETER}.
+     * Highlights the function name of the declared @type, @typep, or @opaque as an {@link ElixirSyntaxHighlighter#TYPE}
+     * and the its parameters as {@link ElixirSyntaxHighlighter#TYPE_PARAMETER}.
      */
     private void highlightType(@NotNull final AtUnqualifiedNoParenthesesCall atUnqualifiedNoParenthesesCall,
                                @NotNull final AnnotationHolder annotationHolder) {

--- a/testData/org/elixir_lang/annotator/module_attribute/issue_557.ex
+++ b/testData/org/elixir_lang/annotator/module_attribute/issue_557.ex
@@ -1,0 +1,3 @@
+defmodule Calcinator.View do
+  @callback show_relationship(related, %{optional(:params) => params, optional(:related) => related,}) when related :: struct | nil
+end

--- a/testData/org/elixir_lang/annotator/module_attribute/typespec_test.exs
+++ b/testData/org/elixir_lang/annotator/module_attribute/typespec_test.exs
@@ -50,7 +50,7 @@ defmodule Kernel.TypespecTest do
   test "unexpected expression in typespec" do
     assert_raise CompileError, ~r"unexpected expression in typespec: \"foobar\"", fn ->
       test_module do
-        @type mytype :: "foobar"
+        @type mytype :: <error descr="Strings aren't allowed in types">"foobar"</error>
       end
     end
   end

--- a/tests/org/elixir_lang/annotator/ModuleAttributeTest.java
+++ b/tests/org/elixir_lang/annotator/ModuleAttributeTest.java
@@ -39,6 +39,11 @@ public class ModuleAttributeTest extends LightCodeInsightFixtureTestCase {
         myFixture.checkHighlighting(false, false, true);
     }
 
+    public void testIssue557() {
+        myFixture.configureByFile("issue_557.ex");
+        myFixture.checkHighlighting(false, false, false);
+    }
+
     public void testIssue559() {
         myFixture.configureByFile("issue_559.ex");
         myFixture.checkHighlighting(false, false, true);


### PR DESCRIPTION
Fixes #557

# Changelog
## Bug Fixes
* Treat `::` the same as `:`  in `key:` after `when` in type specifications as it's a realistic error.
* Change `.` to `#` when referring to constants in javadocs
* Remove `@param` without descriptions
* Remove explicit type from generics when the type can be inferred.
* Check if `atNonNumericOperation` reference is non-`null` before resolving
* Swap empty branches to inverted conditions for final `else`.
* Check if `Type` `leftOperand` is `null` before using it.
* Remove empty `highlightTypesAndTypeParameterUsages(When...)`
* Remove unused `highlightTypesAndSpecificationTypeParameterDeclarations`
* Flip `equals` to eliminate need for `null` check
* Remove redundant type arguments (`<...>`)
* Change `Collections.EMPTY_SET` to `Collections.emptySet()` to prevent uncheck cast warnings.
* Inline constant argument for errors.
* Check if `when` `rightOperand` is non-`null` before scanning it for parameter names.
* Fix typos


