### PR TITLE
Update 0xdbe to DataGrip.

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@
 [![Build Status](https://travis-ci.org/KronicDeth/intellij-elixir.svg?branch=master)](https://travis-ci.org/KronicDeth/intellij-elixir)
 
 This is a plugin that adds support for [Elixir](http://elixir-lang.org/) to JetBrains IntelliJ IDEA platform IDEs
-([0xDBE](http://www.jetbrains.com/dbe/), [AppCode](http://www.jetbrains.com/objc/),
+([DataGrip](http://www.jetbrains.com/datagrip/), [AppCode](http://www.jetbrains.com/objc/),
 [IntelliJ IDEA](http://www.jetbrains.com/idea/), [PHPStorm](http://www.jetbrains.com/phpstorm/),
 [PyCharm](http://www.jetbrains.com/pycharm/), [Rubymine](http://www.jetbrains.com/ruby/),
 [WebStorm](http://www.jetbrains.com/webstorm/)).


### PR DESCRIPTION
Since DataGrip (0xdbe) is no longer in early access, it's known as DataGrip.