### PR TITLE
Use separate formatter for Elixir >= 1.4.0

### DIFF
--- a/resources/exunit/1.1.0/team_city_ex_unit_formatter.ex
+++ b/resources/exunit/1.1.0/team_city_ex_unit_formatter.ex
@@ -1,0 +1,22 @@
+# Originally based on https://github.com/lixhq/teamcity-exunit-formatter, but it did not work for parallel tests: IDEA
+# does not honor flowId, so needed to use the nodeId/parentNodeIde system
+#
+# nodeId and parentNodeId system is documented in
+# https://intellij-support.jetbrains.com/hc/en-us/community/posts/115000389550/comments/115000330464
+defmodule TeamCityExUnitFormatter do
+  @moduledoc false
+
+  use GenEvent
+
+  # Functions
+
+  ## GenEvent Callbacks
+
+  def handle_event(event, state) do
+    updated_state = TeamCityExUnitFormatting.put_event(state, event)
+
+    {:ok, updated_state}
+  end
+
+  def init(opts), do: {:ok, TeamCityExUnitFormatting.new(opts)}
+end

--- a/resources/exunit/1.4.0/team_city_ex_unit_formatter.ex
+++ b/resources/exunit/1.4.0/team_city_ex_unit_formatter.ex
@@ -1,0 +1,17 @@
+defmodule TeamCityExUnitFormatter do
+  @moduledoc false
+
+  use GenServer
+
+  # Functions
+
+  ## GenServer Callbacks
+
+  def handle_cast(event, state) do
+    updated_state = TeamCityExUnitFormatting.put_event(state, event)
+
+    {:noreply, updated_state}
+  end
+
+  def init(opts), do: {:ok, TeamCityExUnitFormatting.new(opts)}
+end

--- a/src/org/elixir_lang/debugger/xdebug/ElixirXDebugProcess.java
+++ b/src/org/elixir_lang/debugger/xdebug/ElixirXDebugProcess.java
@@ -20,7 +20,9 @@ package org.elixir_lang.debugger.xdebug;
 
 import com.ericsson.otp.erlang.OtpErlangPid;
 import com.intellij.execution.ExecutionException;
+import com.intellij.execution.RunnerAndConfigurationSettings;
 import com.intellij.execution.configurations.GeneralCommandLine;
+import com.intellij.execution.configurations.RunConfiguration;
 import com.intellij.execution.process.OSProcessHandler;
 import com.intellij.execution.process.ProcessHandler;
 import com.intellij.execution.runners.ExecutionEnvironment;
@@ -342,7 +344,14 @@ class ElixirXDebugProcess extends XDebugProcess implements ElixirDebuggerEventLi
     LOG.debug("Preparing to run debug target.");
 
     ArrayList<String> elixirParams = new ArrayList<>();
-    elixirParams.addAll(myRunningState.setupElixirParams());
+    RunnerAndConfigurationSettings runnerAndConfigurationSettings = myExecutionEnvironment.getRunnerAndConfigurationSettings();
+    RunConfiguration runConfiguration = null;
+
+    if (runnerAndConfigurationSettings != null) {
+      runConfiguration = runnerAndConfigurationSettings.getConfiguration();
+    }
+
+    elixirParams.addAll(myRunningState.setupElixirParams(runConfiguration));
     elixirParams.addAll(setUpElixirDebuggerCodePath());
 
     List<String> mixParams = new ArrayList<>();

--- a/src/org/elixir_lang/exunit/ElixirModules.java
+++ b/src/org/elixir_lang/exunit/ElixirModules.java
@@ -1,43 +1,73 @@
 package org.elixir_lang.exunit;
 
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.projectRoots.Sdk;
+import com.intellij.openapi.roots.ProjectRootManager;
 import com.intellij.openapi.util.io.FileUtil;
 import com.intellij.util.ResourceUtil;
 import com.intellij.util.io.URLUtil;
+import org.elixir_lang.sdk.ElixirSdkRelease;
+import org.elixir_lang.sdk.ElixirSdkType;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.io.*;
 import java.net.URL;
 
 public class ElixirModules {
-  private static final String FORMATTER_FILE_NAME = "team_city_ex_unit_formatter.ex";
-  private static final String MIX_TASK_FILE_NAME = "test_with_formatter.ex";
+    private static final String FORMATTER_FILE_NAME = "team_city_ex_unit_formatter.ex";
+    private static final String FORMATTING_FILE_NAME = "team_city_ex_unit_formatting.ex";
+    private static final String MIX_TASK_FILE_NAME = "test_with_formatter.ex";
 
-  private ElixirModules() {
-  }
-
-  private static File putFile(@NotNull String fileName, @NotNull File directory) throws IOException {
-    URL moduleUrl = ResourceUtil.getResource(ElixirModules.class, "/exunit", fileName);
-    if (moduleUrl == null) {
-      throw new IOException("Failed to locate Elixir module " + fileName);
+    private ElixirModules() {
     }
 
-    BufferedInputStream inputStream = new BufferedInputStream(URLUtil.openStream(moduleUrl));
-    File file = new File(directory, fileName);
-    BufferedOutputStream outputStream = new BufferedOutputStream(new FileOutputStream(file));
-    try {
-      FileUtil.copy(inputStream, outputStream);
-      return file;
-    } finally {
-      inputStream.close();
-      outputStream.close();
+    private static File putFile(@NotNull String relativePath, @NotNull File directory) throws IOException {
+        URL moduleUrl = ResourceUtil.getResource(ElixirModules.class, "/exunit", relativePath);
+
+        if (moduleUrl == null) {
+            throw new IOException("Failed to locate Elixir module " + relativePath);
+        }
+
+        try (BufferedInputStream inputStream = new BufferedInputStream(URLUtil.openStream(moduleUrl))) {
+            File file = new File(directory, relativePath);
+            file.getParentFile().mkdirs();
+
+            try (BufferedOutputStream outputStream = new BufferedOutputStream(new FileOutputStream(file))) {
+                FileUtil.copy(inputStream, outputStream);
+                return file;
+            }
+        }
     }
-  }
 
-  public static File putFormatterTo(@NotNull File directory) throws IOException {
-    return putFile(FORMATTER_FILE_NAME, directory);
-  }
+    public static File putFormatterTo(@NotNull File directory, @Nullable Project project) throws IOException {
+        Sdk sdk = null;
 
-  public static File putMixTaskTo(@NotNull File directory) throws IOException {
-    return putFile(MIX_TASK_FILE_NAME, directory);
-  }
+        if (project != null) {
+            sdk = ProjectRootManager.getInstance(project).getProjectSdk();
+        }
+
+        return putFormatterTo(directory, sdk);
+    }
+
+    private static File putFormatterTo(@NotNull File directory, @Nullable Sdk sdk) throws IOException {
+        String versionDirectory = "1.4.0";
+
+        ElixirSdkRelease release = ElixirSdkType.getRelease(sdk);
+
+        if (release != null && release.compareTo(ElixirSdkRelease.V_1_4) < 0) {
+            versionDirectory = "1.1.0";
+        }
+
+        String source = versionDirectory + "/" + FORMATTER_FILE_NAME;
+        return putFile(source, directory);
+    }
+
+    public static File putFormattingTo(@NotNull File directory) throws IOException {
+        return putFile(FORMATTING_FILE_NAME, directory);
+    }
+
+    public static File putMixTaskTo(@NotNull File directory) throws IOException {
+        return putFile(MIX_TASK_FILE_NAME, directory);
+    }
 }

--- a/src/org/elixir_lang/mix/runner/MixRunningState.java
+++ b/src/org/elixir_lang/mix/runner/MixRunningState.java
@@ -5,6 +5,7 @@ import com.intellij.execution.ExecutionResult;
 import com.intellij.execution.Executor;
 import com.intellij.execution.configurations.CommandLineState;
 import com.intellij.execution.configurations.GeneralCommandLine;
+import com.intellij.execution.configurations.RunConfiguration;
 import com.intellij.execution.filters.TextConsoleBuilder;
 import com.intellij.execution.filters.TextConsoleBuilderFactory;
 import com.intellij.execution.filters.TextConsoleBuilderImpl;
@@ -14,6 +15,7 @@ import com.intellij.execution.runners.ProgramRunner;
 import com.intellij.execution.ui.ConsoleView;
 import org.elixir_lang.console.ElixirConsoleUtil;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -51,7 +53,7 @@ public class MixRunningState extends CommandLineState {
   @Override
   protected ProcessHandler startProcess() throws ExecutionException {
     GeneralCommandLine commandLine = MixRunningStateUtil.commandLine(
-      myConfiguration, setupElixirParams(), myConfiguration.getMixArgs()
+      myConfiguration, setupElixirParams(myConfiguration), myConfiguration.getMixArgs()
     );
     return runMix(myConfiguration.getProject(), commandLine);
   }
@@ -63,7 +65,7 @@ public class MixRunningState extends CommandLineState {
   }
 
   @NotNull
-  public List<String> setupElixirParams() throws ExecutionException {
+  public List<String> setupElixirParams(@Nullable RunConfiguration runConfiguration) throws ExecutionException {
     return new ArrayList<>();
   }
 }

--- a/src/org/elixir_lang/mix/runner/exunit/MixExUnitRunningState.java
+++ b/src/org/elixir_lang/mix/runner/exunit/MixExUnitRunningState.java
@@ -4,6 +4,7 @@ import com.intellij.execution.DefaultExecutionResult;
 import com.intellij.execution.ExecutionException;
 import com.intellij.execution.ExecutionResult;
 import com.intellij.execution.Executor;
+import com.intellij.execution.configurations.RunConfiguration;
 import com.intellij.execution.process.ProcessHandler;
 import com.intellij.execution.runners.ExecutionEnvironment;
 import com.intellij.execution.runners.ProgramRunner;
@@ -11,6 +12,7 @@ import com.intellij.execution.testframework.TestConsoleProperties;
 import com.intellij.execution.testframework.sm.SMTestRunnerConnectionUtil;
 import com.intellij.execution.ui.ConsoleView;
 import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.io.FileUtil;
 import org.elixir_lang.console.ElixirConsoleUtil;
 import org.elixir_lang.exunit.ElixirModules;
@@ -18,6 +20,7 @@ import org.elixir_lang.mix.runner.MixRunningState;
 import org.elixir_lang.mix.runner.MixTestConsoleProperties;
 import org.elixir_lang.mix.settings.MixSettings;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.io.File;
 import java.io.IOException;
@@ -151,13 +154,21 @@ final class MixExUnitRunningState extends MixRunningState {
   }
 
   @NotNull
-  public List<String> setupElixirParams() throws ExecutionException {
+  public List<String> setupElixirParams(@Nullable RunConfiguration runConfiguration) throws ExecutionException {
     List<File> elixirModuleFileList = new ArrayList<>();
 
     try {
       File elixirModulesDir = createElixirModulesDirectory();
 
-      elixirModuleFileList.add(ElixirModules.putFormatterTo(elixirModulesDir));
+      elixirModuleFileList.add(ElixirModules.putFormattingTo(elixirModulesDir));
+
+      Project project = null;
+
+      if (runConfiguration != null) {
+        project = runConfiguration.getProject();
+      }
+
+      elixirModuleFileList.add(ElixirModules.putFormatterTo(elixirModulesDir, project));
 
       // Support for the --formatter option was recently added to Mix. Older versions of Elixir will need to use the
       // custom task we've included in order to support this option


### PR DESCRIPTION
Fixes #676

# Changelog
## Bug Fixes
* Use a separate formatter, one GenEvent-based and one GenServer-based, depending on whether the SDK is >= 1.4.0 as that's when GenEvent was deprecated and GenServer was preferred.