### PR TITLE
Test output improvements

### DIFF
--- a/resources/exunit/team_city_ex_unit_formatting.ex
+++ b/resources/exunit/team_city_ex_unit_formatting.ex
@@ -24,12 +24,9 @@ defmodule TeamCityExUnitFormatting do
   def formatter(_color, msg), do: msg
 
   def new(opts) do
-    {
-      :ok,
-      %__MODULE__{
-        seed: opts[:seed],
-        trace: opts[:trace]
-      }
+    %__MODULE__{
+      seed: opts[:seed],
+      trace: opts[:trace]
     }
   end
 

--- a/resources/exunit/team_city_ex_unit_formatting.ex
+++ b/resources/exunit/team_city_ex_unit_formatting.ex
@@ -185,7 +185,12 @@ defmodule TeamCityExUnitFormatting do
     state
   end
 
-  def put_event(_, state), do: state
+  def put_event(state = %__MODULE__{}, event) do
+    IO.warn "#{inspect(__MODULE__)} does not know how to process event (#{inspect(event)}).  " <>
+            "Please report this message to https://github.com/KronicDeth/intellij-elixir/issues/new."
+
+    state
+  end
 
   ## Private Functions
 

--- a/resources/exunit/team_city_ex_unit_formatting.ex
+++ b/resources/exunit/team_city_ex_unit_formatting.ex
@@ -42,6 +42,16 @@ defmodule TeamCityExUnitFormatting do
     state
   end
 
+  def put_event(state = %__MODULE__{}, {:suite_finished, _run_us, _load_us}), do: state
+
+  def put_event(state = %__MODULE__{}, {:suite_started, opts}) do
+    seed = opts[:seed]
+
+    IO.puts "Suite started with seed #{seed}"
+
+    %__MODULE__{state | seed: seed, trace: opts[:trace]}
+  end
+
   def put_event(
         state = %__MODULE{
           failures_counter: failures_counter,

--- a/resources/exunit/team_city_ex_unit_formatting.ex
+++ b/resources/exunit/team_city_ex_unit_formatting.ex
@@ -30,13 +30,13 @@ defmodule TeamCityExUnitFormatting do
     }
   end
 
-  def put_event(state, {:case_finished, test_case = %ExUnit.TestCase{}}) do
+  def put_event(state = %__MODULE__{}, {:case_finished, test_case = %ExUnit.TestCase{}}) do
     put_formatted :test_suite_finished, attributes(test_case)
 
     state
   end
 
-  def put_event(state, {:case_started, test_case = %ExUnit.TestCase{}}) do
+  def put_event(state = %__MODULE__{}, {:case_started, test_case = %ExUnit.TestCase{}}) do
     put_formatted :test_suite_started, attributes(test_case)
 
     state
@@ -146,7 +146,7 @@ defmodule TeamCityExUnitFormatting do
   end
 
   def put_event(
-        state,
+        state = %__MODULE__{},
         {
           :test_finished,
           test = %ExUnit.Test{
@@ -164,7 +164,7 @@ defmodule TeamCityExUnitFormatting do
     state
   end
 
-  def put_event(state, {:test_started, test = %ExUnit.Test{tags: tags}}) do
+  def put_event(state = %__MODULE__{}, {:test_started, test = %ExUnit.Test{tags: tags}}) do
     put_formatted :test_started,
                   test
                   |> attributes()

--- a/src/org/elixir_lang/console/FileReferenceFilter.java
+++ b/src/org/elixir_lang/console/FileReferenceFilter.java
@@ -53,15 +53,15 @@ public final class FileReferenceFilter implements Filter {
         }
         TreeMap<Integer, String> map = new TreeMap<>();
         map.put(filePathIndex, PATH_MACROS);
-        expression = StringUtil.replace(expression, PATH_MACROS, FILE_PATH_REGEXP);
+        String regex = StringUtil.replace(expression, PATH_MACROS, FILE_PATH_REGEXP);
 
         if (lineIndex != -1) {
-            expression = StringUtil.replace(expression, LINE_MACROS, NUMBER_REGEXP);
+            regex = StringUtil.replace(regex, LINE_MACROS, NUMBER_REGEXP);
             map.put(lineIndex, LINE_MACROS);
         }
 
         if (columnIndex != -1) {
-            expression = StringUtil.replace(expression, COLUMN_MACROS, NUMBER_REGEXP);
+            regex = StringUtil.replace(regex, COLUMN_MACROS, NUMBER_REGEXP);
             map.put(columnIndex, COLUMN_MACROS);
         }
 
@@ -83,7 +83,7 @@ public final class FileReferenceFilter implements Filter {
         myFileMatchGroup = filePathIndex;
         myLineMatchGroup = lineIndex;
         myColumnMatchGroup = columnIndex;
-        myPattern = Pattern.compile(expression, Pattern.MULTILINE);
+        myPattern = Pattern.compile(regex, Pattern.MULTILINE);
     }
 
     private static int matchGroupToNumber(@NotNull Matcher matcher, int matchGroup) {

--- a/src/org/elixir_lang/console/FileReferenceFilter.java
+++ b/src/org/elixir_lang/console/FileReferenceFilter.java
@@ -33,7 +33,7 @@ public final class FileReferenceFilter implements Filter {
   private static final String FILE_PATH_REGEXP = "\\s*([0-9 a-z_A-Z\\-\\\\./]+)";
   private static final String NUMBER_REGEXP = "([0-9]+)";
 
-  private static final Pattern PATTERN_FILENAME = Pattern.compile("[/\\\\]?([^/\\\\]*?\\.ex)$");
+  private static final Pattern PATTERN_FILENAME = Pattern.compile("[/\\\\]?([^/\\\\]*?\\.exs?)$");
 
   private final Pattern myPattern;
   private final Project myProject;

--- a/src/org/elixir_lang/console/FileReferenceFilter.java
+++ b/src/org/elixir_lang/console/FileReferenceFilter.java
@@ -101,8 +101,8 @@ public final class FileReferenceFilter implements Filter {
     int fileLine = matchGroupToNumber(matcher, myLineMatchGroup);
     int fileColumn = matchGroupToNumber(matcher, myColumnMatchGroup);
 
-    int highlightStartOffset = entireLength - line.length() + matcher.start(0) + 1;
-    int highlightEndOffset = highlightStartOffset + matcher.end(0) - matcher.start(0) - 1;
+    int highlightStartOffset = entireLength - line.length() + matcher.start(1);
+    int highlightEndOffset = highlightStartOffset + matcher.end(matcher.groupCount()) - matcher.start(1);
 
     VirtualFile absolutePath = resolveAbsolutePath(filePath);
     HyperlinkInfo hyperlinkInfo = absolutePath != null ? new OpenFileHyperlinkInfo(myProject, absolutePath, fileLine, fileColumn) : null;

--- a/src/org/elixir_lang/console/FileReferenceFilter.java
+++ b/src/org/elixir_lang/console/FileReferenceFilter.java
@@ -21,178 +21,191 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
- * Created by zyuyou on 15/7/8.
  * https://github.com/ignatov/intellij-erlang/blob/master/src/org/intellij/erlang/console/FileReferenceFilter.java
  */
 public final class FileReferenceFilter implements Filter {
-  public static final String PATH_MACROS = "$FILE_PATH$";
-  public static final String LINE_MACROS = "$LINE$";
-  public static final String COLUMN_MACROS = "$COLUMN$";
+    static final String LINE_MACROS = "$LINE$";
+    static final String PATH_MACROS = "$FILE_PATH$";
+    private static final String COLUMN_MACROS = "$COLUMN$";
+    private static final String FILE_PATH_REGEXP = "\\s*([0-9 a-z_A-Z\\-\\\\./]+)";
+    private static final String NUMBER_REGEXP = "([0-9]+)";
 
-  private static final String FILE_PATH_REGEXP = "\\s*([0-9 a-z_A-Z\\-\\\\./]+)";
-  private static final String NUMBER_REGEXP = "([0-9]+)";
+    private static final Pattern PATTERN_FILENAME = Pattern.compile("[/\\\\]?([^/\\\\]*?\\.exs?)$");
+    private final int myColumnMatchGroup;
+    private final int myFileMatchGroup;
+    private final int myLineMatchGroup;
+    private final Pattern myPattern;
+    private final Project myProject;
 
-  private static final Pattern PATTERN_FILENAME = Pattern.compile("[/\\\\]?([^/\\\\]*?\\.exs?)$");
+    FileReferenceFilter(@NotNull Project project, @NonNls @NotNull String expression) {
+        myProject = project;
 
-  private final Pattern myPattern;
-  private final Project myProject;
-  private final int myFileMatchGroup;
-  private final int myLineMatchGroup;
-  private final int myColumnMatchGroup;
-
-  public FileReferenceFilter(@NotNull Project project, @NonNls @NotNull String expression){
-    myProject = project;
-
-    if(StringUtil.isEmpty(expression)){
-      throw new InvalidExpressionException("expression is empty.");
-    }
-
-    int filePathIndex = expression.indexOf(PATH_MACROS);
-    int lineIndex = expression.indexOf(LINE_MACROS);
-    int columnIndex = expression.indexOf(COLUMN_MACROS);
-
-    if(filePathIndex == -1){
-      throw new InvalidExpressionException("Expression must contain " + PATH_MACROS + " marcos.");
-    }
-    TreeMap<Integer, String> map = new TreeMap<Integer, String>();
-    map.put(filePathIndex, PATH_MACROS);
-    expression = StringUtil.replace(expression, PATH_MACROS, FILE_PATH_REGEXP);
-
-    if(lineIndex != -1){
-      expression = StringUtil.replace(expression, LINE_MACROS, NUMBER_REGEXP);
-      map.put(lineIndex, LINE_MACROS);
-    }
-
-    if(columnIndex != -1){
-      expression = StringUtil.replace(expression, COLUMN_MACROS, NUMBER_REGEXP);
-      map.put(columnIndex, COLUMN_MACROS);
-    }
-
-    // The block below determines the registers based on the sorted map.
-    int count = 0;
-    for (Integer integer : map.keySet()){
-      count++;
-      String s = map.get(integer);
-
-      if(PATH_MACROS.equals(s)){
-        filePathIndex = count;
-      }else if(LINE_MACROS.equals(s)){
-        lineIndex = count;
-      }else if(COLUMN_MACROS.equals(s)){
-        columnIndex = count;
-      }
-    }
-
-    myFileMatchGroup = filePathIndex;
-    myLineMatchGroup = lineIndex;
-    myColumnMatchGroup = columnIndex;
-    myPattern = Pattern.compile(expression, Pattern.MULTILINE);
-  }
-
-  @Nullable
-  @Override
-  public Result applyFilter(@NotNull String line, int entireLength) {
-    Matcher matcher = myPattern.matcher(line);
-    Result result = null;
-
-    if (matcher.find()) {
-      String filePath = matcher.group(myFileMatchGroup);
-      Collection<VirtualFile> virtualFileCollection = resolveVirtualFileCollection(filePath);
-
-      if (virtualFileCollection.size() > 0) {
-        List<ResultItem> resultItemList = new ArrayList<>(virtualFileCollection.size());
-        int highlightStartOffset = entireLength - line.length() + matcher.start(1);
-        int highlightEndOffset = highlightStartOffset + matcher.end(matcher.groupCount()) - matcher.start(1);
-        int fileLine = matchGroupToNumber(matcher, myLineMatchGroup);
-        int fileColumn = matchGroupToNumber(matcher, myColumnMatchGroup);
-
-        for (VirtualFile virtualFile : virtualFileCollection) {
-          resultItemList.add(
-                  new ResultItem(
-                          highlightStartOffset,
-                          highlightEndOffset,
-                          new OpenFileHyperlinkInfo(myProject, virtualFile, fileLine, fileColumn)
-                  )
-          );
+        if (StringUtil.isEmpty(expression)) {
+            throw new InvalidExpressionException("expression is empty.");
         }
 
-        result = new Result(resultItemList);
-      }
-    }
+        int filePathIndex = expression.indexOf(PATH_MACROS);
+        int lineIndex = expression.indexOf(LINE_MACROS);
+        int columnIndex = expression.indexOf(COLUMN_MACROS);
 
-    return result;
-  }
-
-  private static int matchGroupToNumber(@NotNull Matcher matcher, int matchGroup){
-    int number = 0;
-    if(matchGroup != -1){
-      try{
-        number = Integer.parseInt(matcher.group(matchGroup));
-      }catch (NumberFormatException ignored){
-      }
-    }
-    return number > 0 ? number - 1 : 0;
-  }
-
-  @NotNull
-  private Collection<VirtualFile> resolveVirtualFileCollection(@NotNull String path){
-    VirtualFile asIsFile = pathToVirtualFile(path);
-    if(asIsFile != null){
-      return Collections.singleton(asIsFile);
-    }
-
-    String projectBasedPath = path.startsWith(myProject.getBasePath()) ? path : new File(myProject.getBasePath(), path).getAbsolutePath();
-    VirtualFile projectBasedFile = pathToVirtualFile(projectBasedPath);
-    Collection<VirtualFile> virtualFileCollection = null;
-
-    if (projectBasedFile != null){
-      virtualFileCollection = Collections.singleton(projectBasedFile);
-    } else {
-      Matcher filenameMatcher = PATTERN_FILENAME.matcher(path);
-
-      if (filenameMatcher.find()) {
-        String filename = filenameMatcher.group(1);
-        GlobalSearchScope projectScope = ProjectScope.getProjectScope(myProject);
-        virtualFileCollection = resolveVirtualFileCollection(path, filename, projectScope);
-
-        if (virtualFileCollection.size() < 1) {
-          GlobalSearchScope libraryScope = ProjectScope.getLibrariesScope(myProject);
-
-          virtualFileCollection = resolveVirtualFileCollection(path, filename, libraryScope);
+        if (filePathIndex == -1) {
+            throw new InvalidExpressionException("Expression must contain " + PATH_MACROS + " marcos.");
         }
-      }
+        TreeMap<Integer, String> map = new TreeMap<>();
+        map.put(filePathIndex, PATH_MACROS);
+        expression = StringUtil.replace(expression, PATH_MACROS, FILE_PATH_REGEXP);
+
+        if (lineIndex != -1) {
+            expression = StringUtil.replace(expression, LINE_MACROS, NUMBER_REGEXP);
+            map.put(lineIndex, LINE_MACROS);
+        }
+
+        if (columnIndex != -1) {
+            expression = StringUtil.replace(expression, COLUMN_MACROS, NUMBER_REGEXP);
+            map.put(columnIndex, COLUMN_MACROS);
+        }
+
+        // The block below determines the registers based on the sorted map.
+        int count = 0;
+        for (Integer integer : map.keySet()) {
+            count++;
+            String s = map.get(integer);
+
+            if (PATH_MACROS.equals(s)) {
+                filePathIndex = count;
+            } else if (LINE_MACROS.equals(s)) {
+                lineIndex = count;
+            } else if (COLUMN_MACROS.equals(s)) {
+                columnIndex = count;
+            }
+        }
+
+        myFileMatchGroup = filePathIndex;
+        myLineMatchGroup = lineIndex;
+        myColumnMatchGroup = columnIndex;
+        myPattern = Pattern.compile(expression, Pattern.MULTILINE);
     }
 
-    if (virtualFileCollection == null) {
-      virtualFileCollection = Collections.emptySet();
+    private static int matchGroupToNumber(@NotNull Matcher matcher, int matchGroup) {
+        int number = 0;
+
+        if (matchGroup != -1) {
+            try {
+                number = Integer.parseInt(matcher.group(matchGroup));
+            } catch (NumberFormatException ignored) {
+            }
+        }
+
+        return number > 0 ? number - 1 : 0;
     }
 
-    return virtualFileCollection;
-  }
+    @Nullable
+    private static VirtualFile pathToVirtualFile(@NotNull String path) {
+        String normalizedPath = path.replace(File.separatorChar, '/');
 
-  @NotNull
-  private Collection<VirtualFile> resolveVirtualFileCollection(@NotNull String path, @NotNull String basename, @NotNull GlobalSearchScope scope) {
-    List<VirtualFile> suffixedVirtualFiles = new ArrayList<>();
-    PsiFile[] projectFilesWithBaseName = FilenameIndex.getFilesByName(myProject, basename, scope);
-
-    for (PsiFile projectFileWithBaseName : projectFilesWithBaseName) {
-      VirtualFile virtualFile = projectFileWithBaseName.getVirtualFile();
-      String virtualFilePath = virtualFile.getPath();
-
-      if (virtualFilePath.endsWith(path)) {
-        suffixedVirtualFiles.add(virtualFile);
-      }
+        return LocalFileSystem.getInstance().findFileByPath(normalizedPath);
     }
 
-    return suffixedVirtualFiles;
-  }
+    @Nullable
+    @Override
+    public Result applyFilter(@NotNull String line, int entireLength) {
+        Matcher matcher = myPattern.matcher(line);
+        Result result = null;
 
+        if (matcher.find()) {
+            String filePath = matcher.group(myFileMatchGroup);
+            Collection<VirtualFile> virtualFileCollection = resolveVirtualFileCollection(filePath);
 
-  @Nullable
-  private static VirtualFile pathToVirtualFile(@NotNull String path){
-    String normalizedPath = path.replace(File.separatorChar, '/');
-    return LocalFileSystem.getInstance().findFileByPath(normalizedPath);
+            if (virtualFileCollection.size() > 0) {
+                List<ResultItem> resultItemList = new ArrayList<>(virtualFileCollection.size());
+                int highlightStartOffset = entireLength - line.length() + matcher.start(1);
+                int highlightEndOffset = highlightStartOffset + matcher.end(matcher.groupCount()) - matcher.start(1);
+                int fileLine = matchGroupToNumber(matcher, myLineMatchGroup);
+                int fileColumn = matchGroupToNumber(matcher, myColumnMatchGroup);
 
+                for (VirtualFile virtualFile : virtualFileCollection) {
+                    resultItemList.add(
+                            new ResultItem(
+                                    highlightStartOffset,
+                                    highlightEndOffset,
+                                    new OpenFileHyperlinkInfo(myProject, virtualFile, fileLine, fileColumn)
+                            )
+                    );
+                }
 
-  }
+                result = new Result(resultItemList);
+            }
+        }
+
+        return result;
+    }
+
+    @NotNull
+    private Collection<VirtualFile> resolveVirtualFileCollection(@NotNull String path) {
+        VirtualFile asIsFile = pathToVirtualFile(path);
+
+        if (asIsFile != null) {
+            return Collections.singleton(asIsFile);
+        }
+
+        String basePath = myProject.getBasePath();
+        VirtualFile projectBasedFile = null;
+
+        if (basePath != null) {
+            String projectBasedPath;
+
+            if (path.startsWith(basePath)) {
+                projectBasedPath = path;
+            } else {
+                projectBasedPath = new File(basePath, path).getAbsolutePath();
+            }
+
+            projectBasedFile = pathToVirtualFile(projectBasedPath);
+        }
+
+        Collection<VirtualFile> virtualFileCollection = null;
+
+        if (projectBasedFile != null) {
+            virtualFileCollection = Collections.singleton(projectBasedFile);
+        } else {
+            Matcher filenameMatcher = PATTERN_FILENAME.matcher(path);
+
+            if (filenameMatcher.find()) {
+                String filename = filenameMatcher.group(1);
+                GlobalSearchScope projectScope = ProjectScope.getProjectScope(myProject);
+                virtualFileCollection = resolveVirtualFileCollection(path, filename, projectScope);
+
+                if (virtualFileCollection.size() < 1) {
+                    GlobalSearchScope libraryScope = ProjectScope.getLibrariesScope(myProject);
+
+                    virtualFileCollection = resolveVirtualFileCollection(path, filename, libraryScope);
+                }
+            }
+        }
+
+        if (virtualFileCollection == null) {
+            virtualFileCollection = Collections.emptySet();
+        }
+
+        return virtualFileCollection;
+    }
+
+    @NotNull
+    private Collection<VirtualFile> resolveVirtualFileCollection(@NotNull String path,
+                                                                 @NotNull String basename,
+                                                                 @NotNull GlobalSearchScope scope) {
+        List<VirtualFile> suffixedVirtualFiles = new ArrayList<>();
+        PsiFile[] projectFilesWithBaseName = FilenameIndex.getFilesByName(myProject, basename, scope);
+
+        for (PsiFile projectFileWithBaseName : projectFilesWithBaseName) {
+            VirtualFile virtualFile = projectFileWithBaseName.getVirtualFile();
+            String virtualFilePath = virtualFile.getPath();
+
+            if (virtualFilePath.endsWith(path)) {
+                suffixedVirtualFiles.add(virtualFile);
+            }
+        }
+
+        return suffixedVirtualFiles;
+    }
 }


### PR DESCRIPTION
# Changelog
## Enhancements
*  `TeamCityExUnitFormatting.put_event`
  * Always match on `%__MODULE__{}` for state in clauses to prevent state update errors
  * Match on `:suite_finished` and `:suite_started` events, so that only events added to the interface will be unknown and `IO.warn` can be used tell anyone spotting the new event to file an issue.

## Bug Fixes
* `TeamCityExUnitFormatting.new` should return struct only because none of the formatters expects an `:ok` tuple.
* Fix order of `TeamCityExUnitFormatting.put_Event` catchall parameters.
* `FileReferenceFilter`
  * Add `.exs` to pattern for stacktrace linking.
  * Highlight only stacktrace path and line umber instead of entire line
  * Better path match in stacktraces
    * Only accept VirtualFile if it has a suffix matching the stacktrace's path instead of accepting the first index file with a matching basename.
    * Allow multiple VirtualFiles to be linked if it turns out there is a true file path collision between two OTP apps in the Project or Libraries.
  * Format and fix warnings