### PR TITLE
Pin string and charlist to opening " or ', so that quote handler can use it for auto-insert closing

### DIFF
--- a/gen/org/elixir_lang/parser/ElixirParser.java
+++ b/gen/org/elixir_lang/parser/ElixirParser.java
@@ -1400,7 +1400,7 @@ public class ElixirParser implements PsiParser, LightPsiParser {
     boolean r, p;
     Marker m = enter_section_(b, l, _NONE_, CHAR_LIST_HEREDOC, null);
     r = consumeTokens(b, 1, CHAR_LIST_HEREDOC_PROMOTER, EOL);
-    p = r; // pin = 1
+    p = r; // pin = CHAR_LIST_HEREDOC_PROMOTER
     r = r && report_error_(b, charListHeredoc_2(b, l + 1));
     r = p && report_error_(b, heredocPrefix(b, l + 1)) && r;
     r = p && consumeToken(b, CHAR_LIST_HEREDOC_TERMINATOR) && r;
@@ -1438,13 +1438,14 @@ public class ElixirParser implements PsiParser, LightPsiParser {
   public static boolean charListLine(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "charListLine")) return false;
     if (!nextTokenIs(b, CHAR_LIST_PROMOTER)) return false;
-    boolean r;
-    Marker m = enter_section_(b);
+    boolean r, p;
+    Marker m = enter_section_(b, l, _NONE_, CHAR_LIST_LINE, null);
     r = consumeToken(b, CHAR_LIST_PROMOTER);
-    r = r && quoteCharListBody(b, l + 1);
-    r = r && consumeToken(b, CHAR_LIST_TERMINATOR);
-    exit_section_(b, m, CHAR_LIST_LINE, r);
-    return r;
+    p = r; // pin = CHAR_LIST_PROMOTER
+    r = r && report_error_(b, quoteCharListBody(b, l + 1));
+    r = p && consumeToken(b, CHAR_LIST_TERMINATOR) && r;
+    exit_section_(b, l, m, r, p, null);
+    return r || p;
   }
 
   /* ********************************************************** */
@@ -2371,7 +2372,7 @@ public class ElixirParser implements PsiParser, LightPsiParser {
     boolean r, p;
     Marker m = enter_section_(b, l, _NONE_, INTERPOLATED_CHAR_LIST_SIGIL_HEREDOC, null);
     r = consumeTokens(b, 3, TILDE, INTERPOLATING_CHAR_LIST_SIGIL_NAME, CHAR_LIST_SIGIL_HEREDOC_PROMOTER, EOL);
-    p = r; // pin = 3
+    p = r; // pin = CHAR_LIST_SIGIL_HEREDOC_PROMOTER
     r = r && report_error_(b, interpolatedCharListSigilHeredoc_4(b, l + 1));
     r = p && report_error_(b, heredocPrefix(b, l + 1)) && r;
     r = p && report_error_(b, consumeToken(b, CHAR_LIST_SIGIL_HEREDOC_TERMINATOR)) && r;
@@ -2397,14 +2398,15 @@ public class ElixirParser implements PsiParser, LightPsiParser {
   public static boolean interpolatedCharListSigilLine(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "interpolatedCharListSigilLine")) return false;
     if (!nextTokenIs(b, TILDE)) return false;
-    boolean r;
-    Marker m = enter_section_(b);
-    r = consumeTokens(b, 0, TILDE, INTERPOLATING_CHAR_LIST_SIGIL_NAME, CHAR_LIST_SIGIL_PROMOTER);
-    r = r && interpolatedCharListBody(b, l + 1);
-    r = r && consumeToken(b, CHAR_LIST_SIGIL_TERMINATOR);
-    r = r && sigilModifiers(b, l + 1);
-    exit_section_(b, m, INTERPOLATED_CHAR_LIST_SIGIL_LINE, r);
-    return r;
+    boolean r, p;
+    Marker m = enter_section_(b, l, _NONE_, INTERPOLATED_CHAR_LIST_SIGIL_LINE, null);
+    r = consumeTokens(b, 3, TILDE, INTERPOLATING_CHAR_LIST_SIGIL_NAME, CHAR_LIST_SIGIL_PROMOTER);
+    p = r; // pin = CHAR_LIST_SIGIL_PROMOTER
+    r = r && report_error_(b, interpolatedCharListBody(b, l + 1));
+    r = p && report_error_(b, consumeToken(b, CHAR_LIST_SIGIL_TERMINATOR)) && r;
+    r = p && sigilModifiers(b, l + 1) && r;
+    exit_section_(b, l, m, r, p, null);
+    return r || p;
   }
 
   /* ********************************************************** */
@@ -2444,7 +2446,7 @@ public class ElixirParser implements PsiParser, LightPsiParser {
     boolean r, p;
     Marker m = enter_section_(b, l, _NONE_, INTERPOLATED_REGEX_HEREDOC, null);
     r = consumeTokens(b, 3, TILDE, INTERPOLATING_REGEX_SIGIL_NAME, REGEX_HEREDOC_PROMOTER, EOL);
-    p = r; // pin = 3
+    p = r; // pin = REGEX_HEREDOC_PROMOTER
     r = r && report_error_(b, interpolatedRegexHeredoc_4(b, l + 1));
     r = p && report_error_(b, heredocPrefix(b, l + 1)) && r;
     r = p && report_error_(b, consumeToken(b, REGEX_HEREDOC_TERMINATOR)) && r;
@@ -2483,14 +2485,15 @@ public class ElixirParser implements PsiParser, LightPsiParser {
   public static boolean interpolatedRegexLine(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "interpolatedRegexLine")) return false;
     if (!nextTokenIs(b, TILDE)) return false;
-    boolean r;
-    Marker m = enter_section_(b);
-    r = consumeTokens(b, 0, TILDE, INTERPOLATING_REGEX_SIGIL_NAME, REGEX_PROMOTER);
-    r = r && interpolatedRegexBody(b, l + 1);
-    r = r && consumeToken(b, REGEX_TERMINATOR);
-    r = r && sigilModifiers(b, l + 1);
-    exit_section_(b, m, INTERPOLATED_REGEX_LINE, r);
-    return r;
+    boolean r, p;
+    Marker m = enter_section_(b, l, _NONE_, INTERPOLATED_REGEX_LINE, null);
+    r = consumeTokens(b, 3, TILDE, INTERPOLATING_REGEX_SIGIL_NAME, REGEX_PROMOTER);
+    p = r; // pin = REGEX_PROMOTER
+    r = r && report_error_(b, interpolatedRegexBody(b, l + 1));
+    r = p && report_error_(b, consumeToken(b, REGEX_TERMINATOR)) && r;
+    r = p && sigilModifiers(b, l + 1) && r;
+    exit_section_(b, l, m, r, p, null);
+    return r || p;
   }
 
   /* ********************************************************** */
@@ -2530,7 +2533,7 @@ public class ElixirParser implements PsiParser, LightPsiParser {
     boolean r, p;
     Marker m = enter_section_(b, l, _NONE_, INTERPOLATED_SIGIL_HEREDOC, null);
     r = consumeTokens(b, 3, TILDE, INTERPOLATING_SIGIL_NAME, SIGIL_HEREDOC_PROMOTER, EOL);
-    p = r; // pin = 3
+    p = r; // pin = SIGIL_HEREDOC_PROMOTER
     r = r && report_error_(b, interpolatedSigilHeredoc_4(b, l + 1));
     r = p && report_error_(b, heredocPrefix(b, l + 1)) && r;
     r = p && report_error_(b, consumeToken(b, SIGIL_HEREDOC_TERMINATOR)) && r;
@@ -2569,14 +2572,15 @@ public class ElixirParser implements PsiParser, LightPsiParser {
   public static boolean interpolatedSigilLine(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "interpolatedSigilLine")) return false;
     if (!nextTokenIs(b, TILDE)) return false;
-    boolean r;
-    Marker m = enter_section_(b);
-    r = consumeTokens(b, 0, TILDE, INTERPOLATING_SIGIL_NAME, SIGIL_PROMOTER);
-    r = r && interpolatedSigilBody(b, l + 1);
-    r = r && consumeToken(b, SIGIL_TERMINATOR);
-    r = r && sigilModifiers(b, l + 1);
-    exit_section_(b, m, INTERPOLATED_SIGIL_LINE, r);
-    return r;
+    boolean r, p;
+    Marker m = enter_section_(b, l, _NONE_, INTERPOLATED_SIGIL_LINE, null);
+    r = consumeTokens(b, 3, TILDE, INTERPOLATING_SIGIL_NAME, SIGIL_PROMOTER);
+    p = r; // pin = SIGIL_PROMOTER
+    r = r && report_error_(b, interpolatedSigilBody(b, l + 1));
+    r = p && report_error_(b, consumeToken(b, SIGIL_TERMINATOR)) && r;
+    r = p && sigilModifiers(b, l + 1) && r;
+    exit_section_(b, l, m, r, p, null);
+    return r || p;
   }
 
   /* ********************************************************** */
@@ -2629,7 +2633,7 @@ public class ElixirParser implements PsiParser, LightPsiParser {
     boolean r, p;
     Marker m = enter_section_(b, l, _NONE_, INTERPOLATED_STRING_SIGIL_HEREDOC, null);
     r = consumeTokens(b, 3, TILDE, INTERPOLATING_STRING_SIGIL_NAME, STRING_SIGIL_HEREDOC_PROMOTER, EOL);
-    p = r; // pin = 3
+    p = r; // pin = STRING_SIGIL_HEREDOC_PROMOTER
     r = r && report_error_(b, interpolatedStringSigilHeredoc_4(b, l + 1));
     r = p && report_error_(b, heredocPrefix(b, l + 1)) && r;
     r = p && report_error_(b, consumeToken(b, STRING_SIGIL_HEREDOC_TERMINATOR)) && r;
@@ -2655,14 +2659,15 @@ public class ElixirParser implements PsiParser, LightPsiParser {
   public static boolean interpolatedStringSigilLine(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "interpolatedStringSigilLine")) return false;
     if (!nextTokenIs(b, TILDE)) return false;
-    boolean r;
-    Marker m = enter_section_(b);
-    r = consumeTokens(b, 0, TILDE, INTERPOLATING_STRING_SIGIL_NAME, STRING_SIGIL_PROMOTER);
-    r = r && interpolatedStringBody(b, l + 1);
-    r = r && consumeToken(b, STRING_SIGIL_TERMINATOR);
-    r = r && sigilModifiers(b, l + 1);
-    exit_section_(b, m, INTERPOLATED_STRING_SIGIL_LINE, r);
-    return r;
+    boolean r, p;
+    Marker m = enter_section_(b, l, _NONE_, INTERPOLATED_STRING_SIGIL_LINE, null);
+    r = consumeTokens(b, 3, TILDE, INTERPOLATING_STRING_SIGIL_NAME, STRING_SIGIL_PROMOTER);
+    p = r; // pin = STRING_SIGIL_PROMOTER
+    r = r && report_error_(b, interpolatedStringBody(b, l + 1));
+    r = p && report_error_(b, consumeToken(b, STRING_SIGIL_TERMINATOR)) && r;
+    r = p && sigilModifiers(b, l + 1) && r;
+    exit_section_(b, l, m, r, p, null);
+    return r || p;
   }
 
   /* ********************************************************** */
@@ -2702,7 +2707,7 @@ public class ElixirParser implements PsiParser, LightPsiParser {
     boolean r, p;
     Marker m = enter_section_(b, l, _NONE_, INTERPOLATED_WORDS_HEREDOC, null);
     r = consumeTokens(b, 3, TILDE, INTERPOLATING_WORDS_SIGIL_NAME, WORDS_HEREDOC_PROMOTER, EOL);
-    p = r; // pin = 3
+    p = r; // pin = WORDS_HEREDOC_PROMOTER
     r = r && report_error_(b, interpolatedWordsHeredoc_4(b, l + 1));
     r = p && report_error_(b, heredocPrefix(b, l + 1)) && r;
     r = p && report_error_(b, consumeToken(b, WORDS_HEREDOC_TERMINATOR)) && r;
@@ -2741,14 +2746,15 @@ public class ElixirParser implements PsiParser, LightPsiParser {
   public static boolean interpolatedWordsLine(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "interpolatedWordsLine")) return false;
     if (!nextTokenIs(b, TILDE)) return false;
-    boolean r;
-    Marker m = enter_section_(b);
-    r = consumeTokens(b, 0, TILDE, INTERPOLATING_WORDS_SIGIL_NAME, WORDS_PROMOTER);
-    r = r && interpolatedWordsBody(b, l + 1);
-    r = r && consumeToken(b, WORDS_TERMINATOR);
-    r = r && sigilModifiers(b, l + 1);
-    exit_section_(b, m, INTERPOLATED_WORDS_LINE, r);
-    return r;
+    boolean r, p;
+    Marker m = enter_section_(b, l, _NONE_, INTERPOLATED_WORDS_LINE, null);
+    r = consumeTokens(b, 3, TILDE, INTERPOLATING_WORDS_SIGIL_NAME, WORDS_PROMOTER);
+    p = r; // pin = WORDS_PROMOTER
+    r = r && report_error_(b, interpolatedWordsBody(b, l + 1));
+    r = p && report_error_(b, consumeToken(b, WORDS_TERMINATOR)) && r;
+    r = p && sigilModifiers(b, l + 1) && r;
+    exit_section_(b, l, m, r, p, null);
+    return r || p;
   }
 
   /* ********************************************************** */
@@ -3039,7 +3045,7 @@ public class ElixirParser implements PsiParser, LightPsiParser {
     boolean r, p;
     Marker m = enter_section_(b, l, _NONE_, LITERAL_CHAR_LIST_SIGIL_HEREDOC, null);
     r = consumeTokens(b, 3, TILDE, LITERAL_CHAR_LIST_SIGIL_NAME, CHAR_LIST_SIGIL_HEREDOC_PROMOTER, EOL);
-    p = r; // pin = 3
+    p = r; // pin = CHAR_LIST_SIGIL_HEREDOC_PROMOTER
     r = r && report_error_(b, literalCharListSigilHeredoc_4(b, l + 1));
     r = p && report_error_(b, heredocPrefix(b, l + 1)) && r;
     r = p && report_error_(b, consumeToken(b, CHAR_LIST_SIGIL_HEREDOC_TERMINATOR)) && r;
@@ -3065,14 +3071,15 @@ public class ElixirParser implements PsiParser, LightPsiParser {
   public static boolean literalCharListSigilLine(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "literalCharListSigilLine")) return false;
     if (!nextTokenIs(b, TILDE)) return false;
-    boolean r;
-    Marker m = enter_section_(b);
-    r = consumeTokens(b, 0, TILDE, LITERAL_CHAR_LIST_SIGIL_NAME, CHAR_LIST_SIGIL_PROMOTER);
-    r = r && literalCharListBody(b, l + 1);
-    r = r && consumeToken(b, CHAR_LIST_SIGIL_TERMINATOR);
-    r = r && sigilModifiers(b, l + 1);
-    exit_section_(b, m, LITERAL_CHAR_LIST_SIGIL_LINE, r);
-    return r;
+    boolean r, p;
+    Marker m = enter_section_(b, l, _NONE_, LITERAL_CHAR_LIST_SIGIL_LINE, null);
+    r = consumeTokens(b, 3, TILDE, LITERAL_CHAR_LIST_SIGIL_NAME, CHAR_LIST_SIGIL_PROMOTER);
+    p = r; // pin = CHAR_LIST_SIGIL_PROMOTER
+    r = r && report_error_(b, literalCharListBody(b, l + 1));
+    r = p && report_error_(b, consumeToken(b, CHAR_LIST_SIGIL_TERMINATOR)) && r;
+    r = p && sigilModifiers(b, l + 1) && r;
+    exit_section_(b, l, m, r, p, null);
+    return r || p;
   }
 
   /* ********************************************************** */
@@ -3111,7 +3118,7 @@ public class ElixirParser implements PsiParser, LightPsiParser {
     boolean r, p;
     Marker m = enter_section_(b, l, _NONE_, LITERAL_REGEX_HEREDOC, null);
     r = consumeTokens(b, 3, TILDE, LITERAL_REGEX_SIGIL_NAME, REGEX_HEREDOC_PROMOTER, EOL);
-    p = r; // pin = 3
+    p = r; // pin = REGEX_HEREDOC_PROMOTER
     r = r && report_error_(b, literalRegexHeredoc_4(b, l + 1));
     r = p && report_error_(b, heredocPrefix(b, l + 1)) && r;
     r = p && report_error_(b, consumeToken(b, REGEX_HEREDOC_TERMINATOR)) && r;
@@ -3150,14 +3157,15 @@ public class ElixirParser implements PsiParser, LightPsiParser {
   public static boolean literalRegexLine(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "literalRegexLine")) return false;
     if (!nextTokenIs(b, TILDE)) return false;
-    boolean r;
-    Marker m = enter_section_(b);
-    r = consumeTokens(b, 0, TILDE, LITERAL_REGEX_SIGIL_NAME, REGEX_PROMOTER);
-    r = r && literalRegexBody(b, l + 1);
-    r = r && consumeToken(b, REGEX_TERMINATOR);
-    r = r && sigilModifiers(b, l + 1);
-    exit_section_(b, m, LITERAL_REGEX_LINE, r);
-    return r;
+    boolean r, p;
+    Marker m = enter_section_(b, l, _NONE_, LITERAL_REGEX_LINE, null);
+    r = consumeTokens(b, 3, TILDE, LITERAL_REGEX_SIGIL_NAME, REGEX_PROMOTER);
+    p = r; // pin = REGEX_PROMOTER
+    r = r && report_error_(b, literalRegexBody(b, l + 1));
+    r = p && report_error_(b, consumeToken(b, REGEX_TERMINATOR)) && r;
+    r = p && sigilModifiers(b, l + 1) && r;
+    exit_section_(b, l, m, r, p, null);
+    return r || p;
   }
 
   /* ********************************************************** */
@@ -3196,7 +3204,7 @@ public class ElixirParser implements PsiParser, LightPsiParser {
     boolean r, p;
     Marker m = enter_section_(b, l, _NONE_, LITERAL_SIGIL_HEREDOC, null);
     r = consumeTokens(b, 3, TILDE, LITERAL_SIGIL_NAME, SIGIL_HEREDOC_PROMOTER, EOL);
-    p = r; // pin = 3
+    p = r; // pin = SIGIL_HEREDOC_PROMOTER
     r = r && report_error_(b, literalSigilHeredoc_4(b, l + 1));
     r = p && report_error_(b, heredocPrefix(b, l + 1)) && r;
     r = p && report_error_(b, consumeToken(b, SIGIL_HEREDOC_TERMINATOR)) && r;
@@ -3235,14 +3243,15 @@ public class ElixirParser implements PsiParser, LightPsiParser {
   public static boolean literalSigilLine(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "literalSigilLine")) return false;
     if (!nextTokenIs(b, TILDE)) return false;
-    boolean r;
-    Marker m = enter_section_(b);
-    r = consumeTokens(b, 0, TILDE, LITERAL_SIGIL_NAME, SIGIL_PROMOTER);
-    r = r && literalSigilBody(b, l + 1);
-    r = r && consumeToken(b, SIGIL_TERMINATOR);
-    r = r && sigilModifiers(b, l + 1);
-    exit_section_(b, m, LITERAL_SIGIL_LINE, r);
-    return r;
+    boolean r, p;
+    Marker m = enter_section_(b, l, _NONE_, LITERAL_SIGIL_LINE, null);
+    r = consumeTokens(b, 3, TILDE, LITERAL_SIGIL_NAME, SIGIL_PROMOTER);
+    p = r; // pin = SIGIL_PROMOTER
+    r = r && report_error_(b, literalSigilBody(b, l + 1));
+    r = p && report_error_(b, consumeToken(b, SIGIL_TERMINATOR)) && r;
+    r = p && sigilModifiers(b, l + 1) && r;
+    exit_section_(b, l, m, r, p, null);
+    return r || p;
   }
 
   /* ********************************************************** */
@@ -3294,7 +3303,7 @@ public class ElixirParser implements PsiParser, LightPsiParser {
     boolean r, p;
     Marker m = enter_section_(b, l, _NONE_, LITERAL_STRING_SIGIL_HEREDOC, null);
     r = consumeTokens(b, 3, TILDE, LITERAL_STRING_SIGIL_NAME, STRING_SIGIL_HEREDOC_PROMOTER, EOL);
-    p = r; // pin = 3
+    p = r; // pin = STRING_SIGIL_HEREDOC_PROMOTER
     r = r && report_error_(b, literalStringSigilHeredoc_4(b, l + 1));
     r = p && report_error_(b, heredocPrefix(b, l + 1)) && r;
     r = p && report_error_(b, consumeToken(b, STRING_SIGIL_HEREDOC_TERMINATOR)) && r;
@@ -3320,14 +3329,15 @@ public class ElixirParser implements PsiParser, LightPsiParser {
   public static boolean literalStringSigilLine(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "literalStringSigilLine")) return false;
     if (!nextTokenIs(b, TILDE)) return false;
-    boolean r;
-    Marker m = enter_section_(b);
-    r = consumeTokens(b, 0, TILDE, LITERAL_STRING_SIGIL_NAME, STRING_SIGIL_PROMOTER);
-    r = r && literalStringBody(b, l + 1);
-    r = r && consumeToken(b, STRING_SIGIL_TERMINATOR);
-    r = r && sigilModifiers(b, l + 1);
-    exit_section_(b, m, LITERAL_STRING_SIGIL_LINE, r);
-    return r;
+    boolean r, p;
+    Marker m = enter_section_(b, l, _NONE_, LITERAL_STRING_SIGIL_LINE, null);
+    r = consumeTokens(b, 3, TILDE, LITERAL_STRING_SIGIL_NAME, STRING_SIGIL_PROMOTER);
+    p = r; // pin = STRING_SIGIL_PROMOTER
+    r = r && report_error_(b, literalStringBody(b, l + 1));
+    r = p && report_error_(b, consumeToken(b, STRING_SIGIL_TERMINATOR)) && r;
+    r = p && sigilModifiers(b, l + 1) && r;
+    exit_section_(b, l, m, r, p, null);
+    return r || p;
   }
 
   /* ********************************************************** */
@@ -3366,7 +3376,7 @@ public class ElixirParser implements PsiParser, LightPsiParser {
     boolean r, p;
     Marker m = enter_section_(b, l, _NONE_, LITERAL_WORDS_HEREDOC, null);
     r = consumeTokens(b, 3, TILDE, LITERAL_WORDS_SIGIL_NAME, WORDS_HEREDOC_PROMOTER, EOL);
-    p = r; // pin = 3
+    p = r; // pin = WORDS_HEREDOC_PROMOTER
     r = r && report_error_(b, literalWordsHeredoc_4(b, l + 1));
     r = p && report_error_(b, heredocPrefix(b, l + 1)) && r;
     r = p && report_error_(b, consumeToken(b, WORDS_HEREDOC_TERMINATOR)) && r;
@@ -3405,14 +3415,15 @@ public class ElixirParser implements PsiParser, LightPsiParser {
   public static boolean literalWordsLine(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "literalWordsLine")) return false;
     if (!nextTokenIs(b, TILDE)) return false;
-    boolean r;
-    Marker m = enter_section_(b);
-    r = consumeTokens(b, 0, TILDE, LITERAL_WORDS_SIGIL_NAME, WORDS_PROMOTER);
-    r = r && literalWordsBody(b, l + 1);
-    r = r && consumeToken(b, WORDS_TERMINATOR);
-    r = r && sigilModifiers(b, l + 1);
-    exit_section_(b, m, LITERAL_WORDS_LINE, r);
-    return r;
+    boolean r, p;
+    Marker m = enter_section_(b, l, _NONE_, LITERAL_WORDS_LINE, null);
+    r = consumeTokens(b, 3, TILDE, LITERAL_WORDS_SIGIL_NAME, WORDS_PROMOTER);
+    p = r; // pin = WORDS_PROMOTER
+    r = r && report_error_(b, literalWordsBody(b, l + 1));
+    r = p && report_error_(b, consumeToken(b, WORDS_TERMINATOR)) && r;
+    r = p && sigilModifiers(b, l + 1) && r;
+    exit_section_(b, l, m, r, p, null);
+    return r || p;
   }
 
   /* ********************************************************** */
@@ -5150,7 +5161,7 @@ public class ElixirParser implements PsiParser, LightPsiParser {
     boolean r, p;
     Marker m = enter_section_(b, l, _NONE_, STRING_HEREDOC, null);
     r = consumeTokens(b, 1, STRING_HEREDOC_PROMOTER, EOL);
-    p = r; // pin = 1
+    p = r; // pin = STRING_HEREDOC_PROMOTER
     r = r && report_error_(b, stringHeredoc_2(b, l + 1));
     r = p && report_error_(b, heredocPrefix(b, l + 1)) && r;
     r = p && consumeToken(b, STRING_HEREDOC_TERMINATOR) && r;
@@ -5188,13 +5199,14 @@ public class ElixirParser implements PsiParser, LightPsiParser {
   public static boolean stringLine(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "stringLine")) return false;
     if (!nextTokenIs(b, STRING_PROMOTER)) return false;
-    boolean r;
-    Marker m = enter_section_(b);
+    boolean r, p;
+    Marker m = enter_section_(b, l, _NONE_, STRING_LINE, null);
     r = consumeToken(b, STRING_PROMOTER);
-    r = r && quoteStringBody(b, l + 1);
-    r = r && consumeToken(b, STRING_TERMINATOR);
-    exit_section_(b, m, STRING_LINE, r);
-    return r;
+    p = r; // pin = STRING_PROMOTER
+    r = r && report_error_(b, quoteStringBody(b, l + 1));
+    r = p && consumeToken(b, STRING_TERMINATOR) && r;
+    exit_section_(b, l, m, r, p, null);
+    return r || p;
   }
 
   /* ********************************************************** */

--- a/gen/org/elixir_lang/psi/ElixirCharListLine.java
+++ b/gen/org/elixir_lang/psi/ElixirCharListLine.java
@@ -6,12 +6,13 @@ import com.ericsson.otp.erlang.OtpErlangTuple;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.tree.IElementType;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 
 public interface ElixirCharListLine extends Atomable, InterpolatedCharList, Line, Quotable {
 
-  @NotNull
+  @Nullable
   ElixirQuoteCharListBody getQuoteCharListBody();
 
   @NotNull

--- a/gen/org/elixir_lang/psi/ElixirInterpolatedCharListSigilLine.java
+++ b/gen/org/elixir_lang/psi/ElixirInterpolatedCharListSigilLine.java
@@ -6,15 +6,16 @@ import com.ericsson.otp.erlang.OtpErlangTuple;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.tree.IElementType;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 
 public interface ElixirInterpolatedCharListSigilLine extends CharListFragmented, InterpolatedSigilLine {
 
-  @NotNull
+  @Nullable
   ElixirInterpolatedCharListBody getInterpolatedCharListBody();
 
-  @NotNull
+  @Nullable
   ElixirSigilModifiers getSigilModifiers();
 
   @NotNull

--- a/gen/org/elixir_lang/psi/ElixirInterpolatedRegexLine.java
+++ b/gen/org/elixir_lang/psi/ElixirInterpolatedRegexLine.java
@@ -6,15 +6,16 @@ import com.ericsson.otp.erlang.OtpErlangTuple;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.tree.IElementType;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 
 public interface ElixirInterpolatedRegexLine extends RegexFragmented, InterpolatedSigilLine {
 
-  @NotNull
+  @Nullable
   ElixirInterpolatedRegexBody getInterpolatedRegexBody();
 
-  @NotNull
+  @Nullable
   ElixirSigilModifiers getSigilModifiers();
 
   @NotNull

--- a/gen/org/elixir_lang/psi/ElixirInterpolatedSigilLine.java
+++ b/gen/org/elixir_lang/psi/ElixirInterpolatedSigilLine.java
@@ -6,15 +6,16 @@ import com.ericsson.otp.erlang.OtpErlangTuple;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.tree.IElementType;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 
 public interface ElixirInterpolatedSigilLine extends SigilFragmented, InterpolatedSigilLine {
 
-  @NotNull
+  @Nullable
   ElixirInterpolatedSigilBody getInterpolatedSigilBody();
 
-  @NotNull
+  @Nullable
   ElixirSigilModifiers getSigilModifiers();
 
   @NotNull

--- a/gen/org/elixir_lang/psi/ElixirInterpolatedStringSigilLine.java
+++ b/gen/org/elixir_lang/psi/ElixirInterpolatedStringSigilLine.java
@@ -6,15 +6,16 @@ import com.ericsson.otp.erlang.OtpErlangTuple;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.tree.IElementType;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 
 public interface ElixirInterpolatedStringSigilLine extends StringFragmented, InterpolatedSigilLine {
 
-  @NotNull
+  @Nullable
   ElixirInterpolatedStringBody getInterpolatedStringBody();
 
-  @NotNull
+  @Nullable
   ElixirSigilModifiers getSigilModifiers();
 
   @NotNull

--- a/gen/org/elixir_lang/psi/ElixirInterpolatedWordsLine.java
+++ b/gen/org/elixir_lang/psi/ElixirInterpolatedWordsLine.java
@@ -6,15 +6,16 @@ import com.ericsson.otp.erlang.OtpErlangTuple;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.tree.IElementType;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 
 public interface ElixirInterpolatedWordsLine extends WordsFragmented, InterpolatedSigilLine {
 
-  @NotNull
+  @Nullable
   ElixirInterpolatedWordsBody getInterpolatedWordsBody();
 
-  @NotNull
+  @Nullable
   ElixirSigilModifiers getSigilModifiers();
 
   @NotNull

--- a/gen/org/elixir_lang/psi/ElixirLiteralCharListSigilLine.java
+++ b/gen/org/elixir_lang/psi/ElixirLiteralCharListSigilLine.java
@@ -6,15 +6,16 @@ import com.ericsson.otp.erlang.OtpErlangTuple;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.tree.IElementType;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 
 public interface ElixirLiteralCharListSigilLine extends CharListFragmented, LiteralSigilLine {
 
-  @NotNull
+  @Nullable
   ElixirLiteralCharListBody getLiteralCharListBody();
 
-  @NotNull
+  @Nullable
   ElixirSigilModifiers getSigilModifiers();
 
   @NotNull

--- a/gen/org/elixir_lang/psi/ElixirLiteralRegexLine.java
+++ b/gen/org/elixir_lang/psi/ElixirLiteralRegexLine.java
@@ -6,15 +6,16 @@ import com.ericsson.otp.erlang.OtpErlangTuple;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.tree.IElementType;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 
 public interface ElixirLiteralRegexLine extends RegexFragmented, LiteralSigilLine {
 
-  @NotNull
+  @Nullable
   ElixirLiteralRegexBody getLiteralRegexBody();
 
-  @NotNull
+  @Nullable
   ElixirSigilModifiers getSigilModifiers();
 
   @NotNull

--- a/gen/org/elixir_lang/psi/ElixirLiteralSigilLine.java
+++ b/gen/org/elixir_lang/psi/ElixirLiteralSigilLine.java
@@ -6,15 +6,16 @@ import com.ericsson.otp.erlang.OtpErlangTuple;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.tree.IElementType;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 
 public interface ElixirLiteralSigilLine extends LiteralSigilLine, SigilFragmented {
 
-  @NotNull
+  @Nullable
   ElixirLiteralSigilBody getLiteralSigilBody();
 
-  @NotNull
+  @Nullable
   ElixirSigilModifiers getSigilModifiers();
 
   @NotNull

--- a/gen/org/elixir_lang/psi/ElixirLiteralStringSigilLine.java
+++ b/gen/org/elixir_lang/psi/ElixirLiteralStringSigilLine.java
@@ -6,15 +6,16 @@ import com.ericsson.otp.erlang.OtpErlangTuple;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.tree.IElementType;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 
 public interface ElixirLiteralStringSigilLine extends StringFragmented, LiteralSigilLine {
 
-  @NotNull
+  @Nullable
   ElixirLiteralStringBody getLiteralStringBody();
 
-  @NotNull
+  @Nullable
   ElixirSigilModifiers getSigilModifiers();
 
   @NotNull

--- a/gen/org/elixir_lang/psi/ElixirLiteralWordsLine.java
+++ b/gen/org/elixir_lang/psi/ElixirLiteralWordsLine.java
@@ -6,15 +6,16 @@ import com.ericsson.otp.erlang.OtpErlangTuple;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.tree.IElementType;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 
 public interface ElixirLiteralWordsLine extends WordsFragmented, LiteralSigilLine {
 
-  @NotNull
+  @Nullable
   ElixirLiteralWordsBody getLiteralWordsBody();
 
-  @NotNull
+  @Nullable
   ElixirSigilModifiers getSigilModifiers();
 
   @NotNull

--- a/gen/org/elixir_lang/psi/ElixirStringLine.java
+++ b/gen/org/elixir_lang/psi/ElixirStringLine.java
@@ -6,12 +6,13 @@ import com.ericsson.otp.erlang.OtpErlangTuple;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.tree.IElementType;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 
 public interface ElixirStringLine extends Atomable, InterpolatedString, Line, Quotable {
 
-  @NotNull
+  @Nullable
   ElixirQuoteStringBody getQuoteStringBody();
 
   @NotNull

--- a/gen/org/elixir_lang/psi/impl/ElixirCharListLineImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirCharListLineImpl.java
@@ -13,6 +13,7 @@ import org.elixir_lang.psi.ElixirCharListLine;
 import org.elixir_lang.psi.ElixirQuoteCharListBody;
 import org.elixir_lang.psi.ElixirVisitor;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 
@@ -32,9 +33,9 @@ public class ElixirCharListLineImpl extends ASTWrapperPsiElement implements Elix
   }
 
   @Override
-  @NotNull
+  @Nullable
   public ElixirQuoteCharListBody getQuoteCharListBody() {
-    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirQuoteCharListBody.class));
+    return PsiTreeUtil.getChildOfType(this, ElixirQuoteCharListBody.class);
   }
 
   @NotNull

--- a/gen/org/elixir_lang/psi/impl/ElixirInterpolatedCharListSigilLineImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirInterpolatedCharListSigilLineImpl.java
@@ -10,6 +10,7 @@ import com.intellij.psi.tree.IElementType;
 import com.intellij.psi.util.PsiTreeUtil;
 import org.elixir_lang.psi.*;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 
@@ -29,15 +30,15 @@ public class ElixirInterpolatedCharListSigilLineImpl extends ASTWrapperPsiElemen
   }
 
   @Override
-  @NotNull
+  @Nullable
   public ElixirInterpolatedCharListBody getInterpolatedCharListBody() {
-    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirInterpolatedCharListBody.class));
+    return PsiTreeUtil.getChildOfType(this, ElixirInterpolatedCharListBody.class);
   }
 
   @Override
-  @NotNull
+  @Nullable
   public ElixirSigilModifiers getSigilModifiers() {
-    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirSigilModifiers.class));
+    return PsiTreeUtil.getChildOfType(this, ElixirSigilModifiers.class);
   }
 
   @NotNull

--- a/gen/org/elixir_lang/psi/impl/ElixirInterpolatedRegexLineImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirInterpolatedRegexLineImpl.java
@@ -10,6 +10,7 @@ import com.intellij.psi.tree.IElementType;
 import com.intellij.psi.util.PsiTreeUtil;
 import org.elixir_lang.psi.*;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 
@@ -29,15 +30,15 @@ public class ElixirInterpolatedRegexLineImpl extends ASTWrapperPsiElement implem
   }
 
   @Override
-  @NotNull
+  @Nullable
   public ElixirInterpolatedRegexBody getInterpolatedRegexBody() {
-    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirInterpolatedRegexBody.class));
+    return PsiTreeUtil.getChildOfType(this, ElixirInterpolatedRegexBody.class);
   }
 
   @Override
-  @NotNull
+  @Nullable
   public ElixirSigilModifiers getSigilModifiers() {
-    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirSigilModifiers.class));
+    return PsiTreeUtil.getChildOfType(this, ElixirSigilModifiers.class);
   }
 
   @NotNull

--- a/gen/org/elixir_lang/psi/impl/ElixirInterpolatedSigilLineImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirInterpolatedSigilLineImpl.java
@@ -10,6 +10,7 @@ import com.intellij.psi.tree.IElementType;
 import com.intellij.psi.util.PsiTreeUtil;
 import org.elixir_lang.psi.*;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 
@@ -29,15 +30,15 @@ public class ElixirInterpolatedSigilLineImpl extends ASTWrapperPsiElement implem
   }
 
   @Override
-  @NotNull
+  @Nullable
   public ElixirInterpolatedSigilBody getInterpolatedSigilBody() {
-    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirInterpolatedSigilBody.class));
+    return PsiTreeUtil.getChildOfType(this, ElixirInterpolatedSigilBody.class);
   }
 
   @Override
-  @NotNull
+  @Nullable
   public ElixirSigilModifiers getSigilModifiers() {
-    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirSigilModifiers.class));
+    return PsiTreeUtil.getChildOfType(this, ElixirSigilModifiers.class);
   }
 
   @NotNull

--- a/gen/org/elixir_lang/psi/impl/ElixirInterpolatedStringSigilLineImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirInterpolatedStringSigilLineImpl.java
@@ -10,6 +10,7 @@ import com.intellij.psi.tree.IElementType;
 import com.intellij.psi.util.PsiTreeUtil;
 import org.elixir_lang.psi.*;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 
@@ -29,15 +30,15 @@ public class ElixirInterpolatedStringSigilLineImpl extends ASTWrapperPsiElement 
   }
 
   @Override
-  @NotNull
+  @Nullable
   public ElixirInterpolatedStringBody getInterpolatedStringBody() {
-    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirInterpolatedStringBody.class));
+    return PsiTreeUtil.getChildOfType(this, ElixirInterpolatedStringBody.class);
   }
 
   @Override
-  @NotNull
+  @Nullable
   public ElixirSigilModifiers getSigilModifiers() {
-    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirSigilModifiers.class));
+    return PsiTreeUtil.getChildOfType(this, ElixirSigilModifiers.class);
   }
 
   @NotNull

--- a/gen/org/elixir_lang/psi/impl/ElixirInterpolatedWordsLineImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirInterpolatedWordsLineImpl.java
@@ -10,6 +10,7 @@ import com.intellij.psi.tree.IElementType;
 import com.intellij.psi.util.PsiTreeUtil;
 import org.elixir_lang.psi.*;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 
@@ -29,15 +30,15 @@ public class ElixirInterpolatedWordsLineImpl extends ASTWrapperPsiElement implem
   }
 
   @Override
-  @NotNull
+  @Nullable
   public ElixirInterpolatedWordsBody getInterpolatedWordsBody() {
-    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirInterpolatedWordsBody.class));
+    return PsiTreeUtil.getChildOfType(this, ElixirInterpolatedWordsBody.class);
   }
 
   @Override
-  @NotNull
+  @Nullable
   public ElixirSigilModifiers getSigilModifiers() {
-    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirSigilModifiers.class));
+    return PsiTreeUtil.getChildOfType(this, ElixirSigilModifiers.class);
   }
 
   @NotNull

--- a/gen/org/elixir_lang/psi/impl/ElixirLiteralCharListSigilLineImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirLiteralCharListSigilLineImpl.java
@@ -10,6 +10,7 @@ import com.intellij.psi.tree.IElementType;
 import com.intellij.psi.util.PsiTreeUtil;
 import org.elixir_lang.psi.*;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 
@@ -29,15 +30,15 @@ public class ElixirLiteralCharListSigilLineImpl extends ASTWrapperPsiElement imp
   }
 
   @Override
-  @NotNull
+  @Nullable
   public ElixirLiteralCharListBody getLiteralCharListBody() {
-    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirLiteralCharListBody.class));
+    return PsiTreeUtil.getChildOfType(this, ElixirLiteralCharListBody.class);
   }
 
   @Override
-  @NotNull
+  @Nullable
   public ElixirSigilModifiers getSigilModifiers() {
-    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirSigilModifiers.class));
+    return PsiTreeUtil.getChildOfType(this, ElixirSigilModifiers.class);
   }
 
   @NotNull

--- a/gen/org/elixir_lang/psi/impl/ElixirLiteralRegexLineImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirLiteralRegexLineImpl.java
@@ -10,6 +10,7 @@ import com.intellij.psi.tree.IElementType;
 import com.intellij.psi.util.PsiTreeUtil;
 import org.elixir_lang.psi.*;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 
@@ -29,15 +30,15 @@ public class ElixirLiteralRegexLineImpl extends ASTWrapperPsiElement implements 
   }
 
   @Override
-  @NotNull
+  @Nullable
   public ElixirLiteralRegexBody getLiteralRegexBody() {
-    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirLiteralRegexBody.class));
+    return PsiTreeUtil.getChildOfType(this, ElixirLiteralRegexBody.class);
   }
 
   @Override
-  @NotNull
+  @Nullable
   public ElixirSigilModifiers getSigilModifiers() {
-    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirSigilModifiers.class));
+    return PsiTreeUtil.getChildOfType(this, ElixirSigilModifiers.class);
   }
 
   @NotNull

--- a/gen/org/elixir_lang/psi/impl/ElixirLiteralSigilLineImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirLiteralSigilLineImpl.java
@@ -10,6 +10,7 @@ import com.intellij.psi.tree.IElementType;
 import com.intellij.psi.util.PsiTreeUtil;
 import org.elixir_lang.psi.*;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 
@@ -29,15 +30,15 @@ public class ElixirLiteralSigilLineImpl extends ASTWrapperPsiElement implements 
   }
 
   @Override
-  @NotNull
+  @Nullable
   public ElixirLiteralSigilBody getLiteralSigilBody() {
-    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirLiteralSigilBody.class));
+    return PsiTreeUtil.getChildOfType(this, ElixirLiteralSigilBody.class);
   }
 
   @Override
-  @NotNull
+  @Nullable
   public ElixirSigilModifiers getSigilModifiers() {
-    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirSigilModifiers.class));
+    return PsiTreeUtil.getChildOfType(this, ElixirSigilModifiers.class);
   }
 
   @NotNull

--- a/gen/org/elixir_lang/psi/impl/ElixirLiteralStringSigilLineImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirLiteralStringSigilLineImpl.java
@@ -10,6 +10,7 @@ import com.intellij.psi.tree.IElementType;
 import com.intellij.psi.util.PsiTreeUtil;
 import org.elixir_lang.psi.*;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 
@@ -29,15 +30,15 @@ public class ElixirLiteralStringSigilLineImpl extends ASTWrapperPsiElement imple
   }
 
   @Override
-  @NotNull
+  @Nullable
   public ElixirLiteralStringBody getLiteralStringBody() {
-    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirLiteralStringBody.class));
+    return PsiTreeUtil.getChildOfType(this, ElixirLiteralStringBody.class);
   }
 
   @Override
-  @NotNull
+  @Nullable
   public ElixirSigilModifiers getSigilModifiers() {
-    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirSigilModifiers.class));
+    return PsiTreeUtil.getChildOfType(this, ElixirSigilModifiers.class);
   }
 
   @NotNull

--- a/gen/org/elixir_lang/psi/impl/ElixirLiteralWordsLineImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirLiteralWordsLineImpl.java
@@ -10,6 +10,7 @@ import com.intellij.psi.tree.IElementType;
 import com.intellij.psi.util.PsiTreeUtil;
 import org.elixir_lang.psi.*;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 
@@ -29,15 +30,15 @@ public class ElixirLiteralWordsLineImpl extends ASTWrapperPsiElement implements 
   }
 
   @Override
-  @NotNull
+  @Nullable
   public ElixirLiteralWordsBody getLiteralWordsBody() {
-    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirLiteralWordsBody.class));
+    return PsiTreeUtil.getChildOfType(this, ElixirLiteralWordsBody.class);
   }
 
   @Override
-  @NotNull
+  @Nullable
   public ElixirSigilModifiers getSigilModifiers() {
-    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirSigilModifiers.class));
+    return PsiTreeUtil.getChildOfType(this, ElixirSigilModifiers.class);
   }
 
   @NotNull

--- a/gen/org/elixir_lang/psi/impl/ElixirStringLineImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirStringLineImpl.java
@@ -13,6 +13,7 @@ import org.elixir_lang.psi.ElixirQuoteStringBody;
 import org.elixir_lang.psi.ElixirStringLine;
 import org.elixir_lang.psi.ElixirVisitor;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 
@@ -32,9 +33,9 @@ public class ElixirStringLineImpl extends ASTWrapperPsiElement implements Elixir
   }
 
   @Override
-  @NotNull
+  @Nullable
   public ElixirQuoteStringBody getQuoteStringBody() {
-    return notNullChild(PsiTreeUtil.getChildOfType(this, ElixirQuoteStringBody.class));
+    return PsiTreeUtil.getChildOfType(this, ElixirQuoteStringBody.class);
   }
 
   @NotNull

--- a/src/org/elixir_lang/Elixir.bnf
+++ b/src/org/elixir_lang/Elixir.bnf
@@ -646,7 +646,7 @@ charListHeredoc ::= CHAR_LIST_HEREDOC_PROMOTER EOL
                         "org.elixir_lang.psi.InterpolatedCharList"
                         "org.elixir_lang.psi.Quote"
                       ]
-                      pin = 1
+                      pin = CHAR_LIST_HEREDOC_PROMOTER
                     }
 charListHeredocLine ::= heredocLinePrefix quoteCharListBody EOL
                         {
@@ -671,7 +671,7 @@ stringHeredoc ::= STRING_HEREDOC_PROMOTER EOL
                       "org.elixir_lang.psi.Heredoc"
                       "org.elixir_lang.psi.InterpolatedString"
                     ]
-                    pin = 1
+                    pin = STRING_HEREDOC_PROMOTER
                   }
 stringHeredocLine ::= heredocLinePrefix quoteStringBody EOL
                       {
@@ -701,7 +701,7 @@ interpolatedCharListSigilHeredoc ::= TILDE INTERPOLATING_CHAR_LIST_SIGIL_NAME CH
                                          "org.elixir_lang.psi.InterpolatedCharListHeredocLined"
                                          "org.elixir_lang.psi.InterpolatedSigilHeredoc"
                                        ]
-                                       pin = 3
+                                       pin = CHAR_LIST_SIGIL_HEREDOC_PROMOTER
                                      }
 interpolatedCharListHeredocLine ::= heredocLinePrefix interpolatedCharListBody EOL
                                     {
@@ -724,7 +724,7 @@ interpolatedRegexHeredoc ::= TILDE INTERPOLATING_REGEX_SIGIL_NAME REGEX_HEREDOC_
                                  "org.elixir_lang.psi.RegexFragmented"
                                  "org.elixir_lang.psi.InterpolatedSigilHeredoc"
                                ]
-                               pin = 3
+                               pin = REGEX_HEREDOC_PROMOTER
                              }
 interpolatedRegexHeredocLine ::= heredocLinePrefix interpolatedRegexBody EOL
                                  {
@@ -747,7 +747,7 @@ interpolatedSigilHeredoc ::= TILDE INTERPOLATING_SIGIL_NAME SIGIL_HEREDOC_PROMOT
                                  "org.elixir_lang.psi.InterpolatedSigilHeredoc"
                                  "org.elixir_lang.psi.SigilFragmented"
                                ]
-                               pin = 3
+                               pin = SIGIL_HEREDOC_PROMOTER
                              }
 interpolatedSigilHeredocLine ::= heredocLinePrefix interpolatedSigilBody EOL
                                  {
@@ -771,7 +771,7 @@ interpolatedStringSigilHeredoc ::= TILDE INTERPOLATING_STRING_SIGIL_NAME STRING_
                                        "org.elixir_lang.psi.InterpolatedSigilHeredoc"
                                        "org.elixir_lang.psi.InterpolatedStringHeredocLined"
                                      ]
-                                     pin = 3
+                                     pin = STRING_SIGIL_HEREDOC_PROMOTER
                                    }
 interpolatedStringHeredocLine ::= heredocLinePrefix interpolatedStringBody EOL
                                   {
@@ -794,7 +794,7 @@ interpolatedWordsHeredoc ::= TILDE INTERPOLATING_WORDS_SIGIL_NAME WORDS_HEREDOC_
                                  "org.elixir_lang.psi.WordsFragmented"
                                  "org.elixir_lang.psi.InterpolatedSigilHeredoc"
                                ]
-                               pin = 3
+                               pin = WORDS_HEREDOC_PROMOTER
                              }
 interpolatedWordsHeredocLine ::= heredocLinePrefix interpolatedWordsBody EOL
                                  {
@@ -821,7 +821,7 @@ literalCharListSigilHeredoc ::= TILDE LITERAL_CHAR_LIST_SIGIL_NAME CHAR_LIST_SIG
                                     "org.elixir_lang.psi.CharListFragmented"
                                     "org.elixir_lang.psi.LiteralSigilHeredoc"
                                   ]
-                                  pin = 3
+                                  pin = CHAR_LIST_SIGIL_HEREDOC_PROMOTER
                                 }
 literalCharListHeredocLine ::= heredocLinePrefix literalCharListBody EOL
                                {
@@ -845,7 +845,7 @@ literalRegexHeredoc ::= TILDE LITERAL_REGEX_SIGIL_NAME REGEX_HEREDOC_PROMOTER EO
                             "org.elixir_lang.psi.RegexFragmented"
                             "org.elixir_lang.psi.LiteralSigilHeredoc"
                           ]
-                          pin = 3
+                          pin = REGEX_HEREDOC_PROMOTER
                         }
 literalRegexHeredocLine ::= heredocLinePrefix literalRegexBody EOL
                             {
@@ -869,7 +869,7 @@ literalSigilHeredoc ::= TILDE LITERAL_SIGIL_NAME SIGIL_HEREDOC_PROMOTER EOL
                             "org.elixir_lang.psi.SigilFragmented"
                             "org.elixir_lang.psi.LiteralSigilHeredoc"
                           ]
-                          pin = 3
+                          pin = SIGIL_HEREDOC_PROMOTER
                         }
 literalSigilHeredocLine ::= heredocLinePrefix literalSigilBody EOL
                             {
@@ -893,7 +893,7 @@ literalStringSigilHeredoc ::= TILDE LITERAL_STRING_SIGIL_NAME STRING_SIGIL_HERED
                                   "org.elixir_lang.psi.StringFragmented"
                                   "org.elixir_lang.psi.LiteralSigilHeredoc"
                                 ]
-                                pin = 3
+                                pin = STRING_SIGIL_HEREDOC_PROMOTER
                               }
 literalStringHeredocLine ::= heredocLinePrefix literalStringBody EOL
                              {
@@ -917,7 +917,7 @@ literalWordsHeredoc ::= TILDE LITERAL_WORDS_SIGIL_NAME WORDS_HEREDOC_PROMOTER EO
                             "org.elixir_lang.psi.WordsFragmented"
                             "org.elixir_lang.psi.LiteralSigilHeredoc"
                           ]
-                          pin = 3
+                          pin = WORDS_HEREDOC_PROMOTER
                         }
 literalWordsHeredocLine ::= heredocLinePrefix literalWordsBody EOL
                             {
@@ -958,6 +958,7 @@ charListLine ::= CHAR_LIST_PROMOTER quoteCharListBody CHAR_LIST_TERMINATOR
                      "org.elixir_lang.psi.Line"
                      "org.elixir_lang.psi.Quotable"
                    ]
+                   pin = CHAR_LIST_PROMOTER
                  }
 
 quoteStringBody ::=  (interpolation | STRING_FRAGMENT | quoteEscapeSequence)*
@@ -970,6 +971,7 @@ stringLine ::= STRING_PROMOTER quoteStringBody STRING_TERMINATOR
                    "org.elixir_lang.psi.Line"
                    "org.elixir_lang.psi.Quotable"
                  ]
+                 pin = STRING_PROMOTER
                }
 
 /*
@@ -988,6 +990,7 @@ interpolatedCharListSigilLine ::= TILDE INTERPOLATING_CHAR_LIST_SIGIL_NAME CHAR_
                                       "org.elixir_lang.psi.CharListFragmented"
                                       "org.elixir_lang.psi.InterpolatedSigilLine"
                                     ]
+                                    pin = CHAR_LIST_SIGIL_PROMOTER
                                   }
 
 interpolatedRegexLine ::= TILDE INTERPOLATING_REGEX_SIGIL_NAME REGEX_PROMOTER interpolatedRegexBody REGEX_TERMINATOR sigilModifiers
@@ -996,6 +999,7 @@ interpolatedRegexLine ::= TILDE INTERPOLATING_REGEX_SIGIL_NAME REGEX_PROMOTER in
                               "org.elixir_lang.psi.RegexFragmented"
                               "org.elixir_lang.psi.InterpolatedSigilLine"
                             ]
+                            pin = REGEX_PROMOTER
                           }
 
 interpolatedSigilLine ::= TILDE INTERPOLATING_SIGIL_NAME SIGIL_PROMOTER interpolatedSigilBody SIGIL_TERMINATOR sigilModifiers
@@ -1004,6 +1008,7 @@ interpolatedSigilLine ::= TILDE INTERPOLATING_SIGIL_NAME SIGIL_PROMOTER interpol
                               "org.elixir_lang.psi.SigilFragmented"
                               "org.elixir_lang.psi.InterpolatedSigilLine"
                             ]
+                            pin = SIGIL_PROMOTER
                           }
 
 interpolatedStringSigilLine ::= TILDE INTERPOLATING_STRING_SIGIL_NAME STRING_SIGIL_PROMOTER interpolatedStringBody STRING_SIGIL_TERMINATOR sigilModifiers
@@ -1012,6 +1017,7 @@ interpolatedStringSigilLine ::= TILDE INTERPOLATING_STRING_SIGIL_NAME STRING_SIG
                                     "org.elixir_lang.psi.StringFragmented"
                                     "org.elixir_lang.psi.InterpolatedSigilLine"
                                   ]
+                                  pin = STRING_SIGIL_PROMOTER
                                 }
 
 interpolatedWordsLine ::= TILDE INTERPOLATING_WORDS_SIGIL_NAME WORDS_PROMOTER interpolatedWordsBody WORDS_TERMINATOR sigilModifiers
@@ -1020,6 +1026,7 @@ interpolatedWordsLine ::= TILDE INTERPOLATING_WORDS_SIGIL_NAME WORDS_PROMOTER in
                               "org.elixir_lang.psi.WordsFragmented"
                               "org.elixir_lang.psi.InterpolatedSigilLine"
                             ]
+                            pin = WORDS_PROMOTER
                           }
 /*
  * Literal Sigils
@@ -1031,6 +1038,7 @@ literalCharListSigilLine ::= TILDE LITERAL_CHAR_LIST_SIGIL_NAME CHAR_LIST_SIGIL_
                                  "org.elixir_lang.psi.CharListFragmented"
                                  "org.elixir_lang.psi.LiteralSigilLine"
                                ]
+                               pin = CHAR_LIST_SIGIL_PROMOTER
                              }
 
 literalRegexLine ::= TILDE LITERAL_REGEX_SIGIL_NAME REGEX_PROMOTER literalRegexBody REGEX_TERMINATOR sigilModifiers
@@ -1039,6 +1047,7 @@ literalRegexLine ::= TILDE LITERAL_REGEX_SIGIL_NAME REGEX_PROMOTER literalRegexB
                          "org.elixir_lang.psi.RegexFragmented"
                          "org.elixir_lang.psi.LiteralSigilLine"
                        ]
+                       pin = REGEX_PROMOTER
                      }
 
 literalSigilLine ::= TILDE LITERAL_SIGIL_NAME SIGIL_PROMOTER literalSigilBody SIGIL_TERMINATOR sigilModifiers
@@ -1047,6 +1056,7 @@ literalSigilLine ::= TILDE LITERAL_SIGIL_NAME SIGIL_PROMOTER literalSigilBody SI
                          "org.elixir_lang.psi.LiteralSigilLine"
                          "org.elixir_lang.psi.SigilFragmented"
                        ]
+                       pin = SIGIL_PROMOTER
                      }
 
 literalStringSigilLine ::= TILDE LITERAL_STRING_SIGIL_NAME STRING_SIGIL_PROMOTER literalStringBody STRING_SIGIL_TERMINATOR sigilModifiers
@@ -1055,6 +1065,7 @@ literalStringSigilLine ::= TILDE LITERAL_STRING_SIGIL_NAME STRING_SIGIL_PROMOTER
                                "org.elixir_lang.psi.StringFragmented"
                                "org.elixir_lang.psi.LiteralSigilLine"
                              ]
+                             pin = STRING_SIGIL_PROMOTER
                            }
 
 literalWordsLine ::=  TILDE LITERAL_WORDS_SIGIL_NAME WORDS_PROMOTER literalWordsBody WORDS_TERMINATOR sigilModifiers
@@ -1063,6 +1074,7 @@ literalWordsLine ::=  TILDE LITERAL_WORDS_SIGIL_NAME WORDS_PROMOTER literalWords
                           "org.elixir_lang.psi.WordsFragmented"
                           "org.elixir_lang.psi.LiteralSigilLine"
                         ]
+                        pin = WORDS_PROMOTER
                       }
 
 /*


### PR DESCRIPTION
Fixes #582 

# Changelog
## Enhancements
* Instead of pinning position (`1` for lines or `3` for heredocs), `pin` `*_PROMOTER` token, so it's more obvious the pattern is that the promoter is pinned.

## Bug Fixes
* Pin promoter for all quotes, including the previously missing `stringLine` and `charListLine`.
* Only insert closing quote if previous token was an opening quote.