### PR TITLE
Additional unquote handling

### DIFF
--- a/gen/org/elixir_lang/psi/ElixirMatchedOrOperation.java
+++ b/gen/org/elixir_lang/psi/ElixirMatchedOrOperation.java
@@ -7,13 +7,13 @@ import com.intellij.psi.ResolveState;
 import com.intellij.psi.scope.PsiScopeProcessor;
 import org.apache.commons.lang.math.IntRange;
 import org.elixir_lang.psi.call.Named;
-import org.elixir_lang.psi.operation.Infix;
+import org.elixir_lang.psi.operation.Or;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 
-public interface ElixirMatchedOrOperation extends ElixirMatchedExpression, Named, Infix {
+public interface ElixirMatchedOrOperation extends ElixirMatchedExpression, Named, Or {
 
   @NotNull
   List<ElixirMatchedExpression> getMatchedExpressionList();

--- a/gen/org/elixir_lang/psi/ElixirUnmatchedOrOperation.java
+++ b/gen/org/elixir_lang/psi/ElixirUnmatchedOrOperation.java
@@ -7,13 +7,13 @@ import com.intellij.psi.ResolveState;
 import com.intellij.psi.scope.PsiScopeProcessor;
 import org.apache.commons.lang.math.IntRange;
 import org.elixir_lang.psi.call.Named;
-import org.elixir_lang.psi.operation.Infix;
+import org.elixir_lang.psi.operation.Or;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 
-public interface ElixirUnmatchedOrOperation extends ElixirUnmatchedExpression, Named, Infix {
+public interface ElixirUnmatchedOrOperation extends ElixirUnmatchedExpression, Named, Or {
 
   @NotNull
   ElixirOrInfixOperator getOrInfixOperator();

--- a/gen/org/elixir_lang/psi/ElixirVisitor.java
+++ b/gen/org/elixir_lang/psi/ElixirVisitor.java
@@ -536,7 +536,7 @@ public class ElixirVisitor extends PsiElementVisitor {
   public void visitMatchedOrOperation(@NotNull ElixirMatchedOrOperation o) {
     visitMatchedExpression(o);
     // visitNamed(o);
-    // visitInfix(o);
+    // visitOr(o);
   }
 
   public void visitMatchedParenthesesArguments(@NotNull ElixirMatchedParenthesesArguments o) {
@@ -897,7 +897,7 @@ public class ElixirVisitor extends PsiElementVisitor {
   public void visitUnmatchedOrOperation(@NotNull ElixirUnmatchedOrOperation o) {
     visitUnmatchedExpression(o);
     // visitNamed(o);
-    // visitInfix(o);
+    // visitOr(o);
   }
 
   public void visitUnmatchedPipeOperation(@NotNull ElixirUnmatchedPipeOperation o) {

--- a/src/org/elixir_lang/Elixir.bnf
+++ b/src/org/elixir_lang/Elixir.bnf
@@ -81,7 +81,7 @@
   /* infix operations that work as name identifier owner calls - specifically support getNameIdentifier so they can
      return their operator, so it is easy to use a different operator when making customer operators like in Bitwise or
      the free arrow operators */
-  implements(        "(un)?matched(Comparison|Multiplication|Or|Relational)Operation")=[
+  implements(        "(un)?matched(Comparison|Multiplication|Relational)Operation")=[
     "org.elixir_lang.psi.call.Named"
     "org.elixir_lang.psi.operation.Infix"
   ]
@@ -138,6 +138,12 @@
   implements("(un)?matchedMatchOperation")=[
     "org.elixir_lang.psi.call.Named"
     "org.elixir_lang.psi.operation.Match"
+  ]
+  // methods set by infix operations above
+
+  implements("(un)?matchedOrOperation")=[
+    "org.elixir_lang.psi.call.Named"
+    "org.elixir_lang.psi.operation.Or"
   ]
   // methods set by infix operations above
 

--- a/src/org/elixir_lang/psi/call/name/Function.java
+++ b/src/org/elixir_lang/psi/call/name/Function.java
@@ -4,6 +4,7 @@ public class Function {
     public static final String ALIAS = "alias";
     public static final String CASE = "case";
     public static final String COND = "cond";
+    public static final String CREATE = "create";
     public static final String DEF = "def";
     public static final String DEFDELEGATE = "defdelegate";
     public static final String DEFEXCEPTION = "defexception";

--- a/src/org/elixir_lang/psi/call/name/Module.java
+++ b/src/org/elixir_lang/psi/call/name/Module.java
@@ -11,6 +11,7 @@ public class Module {
 
     public static final String KERNEL = "Kernel";
     public static final String KERNEL_SPECIAL_FORMS = KERNEL + ".SpecialForms";
+    public static final String MODULE = "Module";
     public static final String ELIXIR_PREFIX = "Elixir.";
 
     /*

--- a/src/org/elixir_lang/psi/impl/ElixirPsiImplUtil.java
+++ b/src/org/elixir_lang/psi/impl/ElixirPsiImplUtil.java
@@ -2134,8 +2134,11 @@ public class ElixirPsiImplUtil {
                 }
             }
         } else if (parent instanceof Arguments ||
+                // See https://github.com/elixir-lang/elixir/blob/v1.5/lib/elixir/lib/protocol.ex#L633
+                parent instanceof AtUnqualifiedNoParenthesesCall ||
                 // See https://github.com/phoenixframework/phoenix/blob/v1.2.4/lib/phoenix/template.ex#L380-L392
                 parent instanceof ElixirAccessExpression ||
+                parent instanceof ElixirMatchedParenthesesArguments ||
                 parent instanceof ElixirTuple ||
                 parent instanceof Match ||
                 parent instanceof QualifiedAlias ||
@@ -2145,6 +2148,8 @@ public class ElixirPsiImplUtil {
             Call parentCall = (Call) parent;
 
             if (parentCall.isCalling(KERNEL, ALIAS)) {
+                enclosingMacroCall = parentCall;
+            } else if (parentCall.isCalling(org.elixir_lang.psi.call.name.Module.MODULE, CREATE, 3)) {
                 enclosingMacroCall = parentCall;
             }
         } else if (parent instanceof QuotableKeywordPair) {

--- a/src/org/elixir_lang/psi/impl/ElixirPsiImplUtil.java
+++ b/src/org/elixir_lang/psi/impl/ElixirPsiImplUtil.java
@@ -2845,19 +2845,7 @@ public class ElixirPsiImplUtil {
         String name = null;
 
         if (nameIdentifier != null) {
-            name = nameIdentifier.getText();
-
-            if (UNQUOTE.equals(name)) {
-                if (namedElement instanceof Call) {
-                    Call namedElementCall = (Call) namedElement;
-
-                    PsiElement[] primaryArguments = namedElementCall.primaryArguments();
-
-                    if (primaryArguments != null && primaryArguments.length == 1) {
-                        name += "(" + primaryArguments[0].getText() + ")";
-                    }
-                }
-            }
+            name = unquoteName(namedElement, nameIdentifier.getText());
         } else {
             if (namedElement instanceof Call) {
                 Call call = (Call) namedElement;
@@ -5856,6 +5844,27 @@ if (quoted == null) {
                 expression instanceof PsiWhiteSpace);
 
         return expression;
+    }
+
+    /**
+     * If {@code name} is {@code "unquote"} then the {@link Call#primaryArguments()} single argument is added to the
+     * name.
+     */
+    @Nullable
+    public static String unquoteName(@NotNull PsiElement named, @Nullable String name) {
+        String unquotedName = name;
+
+        if (named instanceof Call && UNQUOTE.equals(name)) {
+            Call namedElementCall = (Call) named;
+
+            PsiElement[] primaryArguments = namedElementCall.primaryArguments();
+
+            if (primaryArguments != null && primaryArguments.length == 1) {
+                unquotedName += "(" + primaryArguments[0].getText() + ")";
+            }
+        }
+
+        return unquotedName;
     }
 
     /**

--- a/src/org/elixir_lang/psi/impl/ElixirPsiImplUtil.java
+++ b/src/org/elixir_lang/psi/impl/ElixirPsiImplUtil.java
@@ -2134,6 +2134,9 @@ public class ElixirPsiImplUtil {
                 }
             }
         } else if (parent instanceof Arguments ||
+                // See https://github.com/phoenixframework/phoenix/blob/v1.2.4/lib/phoenix/template.ex#L380-L392
+                parent instanceof ElixirAccessExpression ||
+                parent instanceof ElixirTuple ||
                 parent instanceof Match ||
                 parent instanceof QualifiedAlias ||
                 parent instanceof QualifiedMultipleAliases) {

--- a/src/org/elixir_lang/psi/impl/ElixirPsiImplUtil.java
+++ b/src/org/elixir_lang/psi/impl/ElixirPsiImplUtil.java
@@ -2846,6 +2846,18 @@ public class ElixirPsiImplUtil {
 
         if (nameIdentifier != null) {
             name = nameIdentifier.getText();
+
+            if (UNQUOTE.equals(name)) {
+                if (namedElement instanceof Call) {
+                    Call namedElementCall = (Call) namedElement;
+
+                    PsiElement[] primaryArguments = namedElementCall.primaryArguments();
+
+                    if (primaryArguments != null && primaryArguments.length == 1) {
+                        name += "(" + primaryArguments[0].getText() + ")";
+                    }
+                }
+            }
         } else {
             if (namedElement instanceof Call) {
                 Call call = (Call) namedElement;

--- a/src/org/elixir_lang/psi/operation/Or.java
+++ b/src/org/elixir_lang/psi/operation/Or.java
@@ -1,0 +1,7 @@
+package org.elixir_lang.psi.operation;
+
+/**
+ * <expression> orInfixOperator <expression>
+ */
+public interface Or extends Infix {
+}

--- a/src/org/elixir_lang/structure_view/element/CallDefinitionHead.java
+++ b/src/org/elixir_lang/structure_view/element/CallDefinitionHead.java
@@ -113,6 +113,15 @@ public class CallDefinitionHead extends Element<Call> implements Presentable, Vi
             if (stripped instanceof Call) {
                 Call strippedCall = (Call) stripped;
                 name = strippedCall.functionName();
+
+                if ("unquote".equals(name)) {
+                    PsiElement[] primaryArguments = strippedCall.primaryArguments();
+
+                    if (primaryArguments != null && primaryArguments.length == 1) {
+                        name += "(" + primaryArguments[0].getText() + ")";
+                    }
+                }
+
                 arityRange = strippedCall.resolvedFinalArityRange();
                 pair = pair(name, arityRange);
             }

--- a/src/org/elixir_lang/structure_view/element/CallDefinitionHead.java
+++ b/src/org/elixir_lang/structure_view/element/CallDefinitionHead.java
@@ -14,6 +14,7 @@ import org.jetbrains.annotations.Nullable;
 
 import static com.intellij.openapi.util.Pair.pair;
 import static org.elixir_lang.psi.impl.ElixirPsiImplUtil.stripAccessExpression;
+import static org.elixir_lang.psi.impl.ElixirPsiImplUtil.unquoteName;
 import static org.elixir_lang.psi.operation.Normalized.operatorIndex;
 
 public class CallDefinitionHead extends Element<Call> implements Presentable, Visible {
@@ -112,17 +113,10 @@ public class CallDefinitionHead extends Element<Call> implements Presentable, Vi
 
             if (stripped instanceof Call) {
                 Call strippedCall = (Call) stripped;
-                name = strippedCall.functionName();
 
-                if ("unquote".equals(name)) {
-                    PsiElement[] primaryArguments = strippedCall.primaryArguments();
-
-                    if (primaryArguments != null && primaryArguments.length == 1) {
-                        name += "(" + primaryArguments[0].getText() + ")";
-                    }
-                }
-
+                name = unquoteName(strippedCall, strippedCall.functionName());
                 arityRange = strippedCall.resolvedFinalArityRange();
+
                 pair = pair(name, arityRange);
             }
         }

--- a/src/org/elixir_lang/structure_view/element/Callback.java
+++ b/src/org/elixir_lang/structure_view/element/Callback.java
@@ -2,9 +2,11 @@ package org.elixir_lang.structure_view.element;
 
 import com.intellij.ide.util.treeView.smartTree.TreeElement;
 import com.intellij.navigation.ItemPresentation;
+import com.intellij.openapi.util.Pair;
 import com.intellij.psi.ElementDescriptionLocation;
 import com.intellij.psi.PsiElement;
 import com.intellij.usageView.UsageViewTypeLocation;
+import org.apache.commons.lang.math.IntRange;
 import org.elixir_lang.navigation.item_presentation.NameArity;
 import org.elixir_lang.navigation.item_presentation.Parent;
 import org.elixir_lang.psi.*;
@@ -209,8 +211,20 @@ public class Callback extends Element<AtUnqualifiedNoParenthesesCall> implements
         Call headCall = headCall(navigationItem);
 
         if (headCall != null) {
-            name = headCall.functionName();
-            arity = headCall.resolvedFinalArity();
+            Pair<String, IntRange> nameArityRange = CallDefinitionHead.nameArityRange(headCall);
+
+            if (nameArityRange != null) {
+                name = nameArityRange.first;
+                IntRange arityRange = nameArityRange.second;
+
+                if (arityRange != null) {
+                    int maximumArity = arityRange.getMaximumInteger();
+
+                    if (arityRange.getMinimumInteger() == maximumArity) {
+                        arity = maximumArity;
+                    }
+                }
+            }
         }
 
         //noinspection ConstantConditions

--- a/src/org/elixir_lang/structure_view/element/modular/Module.java
+++ b/src/org/elixir_lang/structure_view/element/modular/Module.java
@@ -31,8 +31,10 @@ import org.jetbrains.annotations.Nullable;
 import java.util.*;
 
 import static com.intellij.openapi.util.Pair.pair;
+import static org.elixir_lang.psi.call.name.Function.CREATE;
 import static org.elixir_lang.psi.call.name.Function.DEFMODULE;
 import static org.elixir_lang.psi.call.name.Module.KERNEL;
+import static org.elixir_lang.psi.call.name.Module.MODULE;
 import static org.elixir_lang.psi.impl.ElixirPsiImplUtil.enclosingMacroCall;
 
 public class Module extends Element<Call> implements Modular {
@@ -147,7 +149,8 @@ public class Module extends Element<Call> implements Modular {
     }
 
     public static boolean is(Call call) {
-        return call.isCallingMacro(KERNEL, DEFMODULE, 2);
+        return call.isCallingMacro(KERNEL, DEFMODULE, 2) ||
+                call.isCalling(MODULE, CREATE, 3);
     }
 
     public static PsiElement nameIdentifier(Call call) {


### PR DESCRIPTION
Fixes #595

# Changelog
## Bug Fixes
* On `unquote`, include argument in name of call definition clause
*  Look outside tuple containing `quote` for `enclosingMacroCall`, which allows going to [Phoenix.Template.compile's quote's defp](https://github.com/phoenixframework/phoenix/blob/v1.2.4/lib/phoenix/template.ex#L380-L392)
* Treat `Module.create` as `Modular
* `Or` interface to unify `Matched` and `Unmatched` `Or`s.
* Look at both side of `Or` operation for nested child calls for Structure view.
* Make `unquote(ARG1)` name for `getName` and indexing




