### PR TITLE
ElementDescription for ElixirVariable

### DIFF
--- a/src/org/elixir_lang/psi/ElementDescriptionProvider.java
+++ b/src/org/elixir_lang/psi/ElementDescriptionProvider.java
@@ -1,6 +1,5 @@
 package org.elixir_lang.psi;
 
-import com.ericsson.otp.erlang.OtpErlangObject;
 import com.intellij.psi.ElementDescriptionLocation;
 import com.intellij.psi.PsiElement;
 import com.intellij.usageView.UsageViewLongNameLocation;
@@ -31,6 +30,7 @@ import static org.elixir_lang.reference.module.ResolvableName.resolvableName;
  * {@link org.elixir_lang.FindUsagesProvider#getType(PsiElement)}) together together.
  */
 public class ElementDescriptionProvider implements com.intellij.psi.ElementDescriptionProvider {
+    public static final String VARIABLE_USAGE_VIEW_TYPE_LOCATION_ELEMENT_DESCRIPTION = "variable";
     /*
      *
      * Instance Methods
@@ -52,6 +52,8 @@ public class ElementDescriptionProvider implements com.intellij.psi.ElementDescr
             elementDescription = getElementDescription((ElixirIdentifier) element, location);
         } else if (element instanceof ElixirKeywordKey) {
             elementDescription = getElementDescription((ElixirKeywordKey) element, location);
+        } else if (element instanceof ElixirVariable) {
+            elementDescription = getElementDescription((ElixirVariable) element, location);
         } else if (element instanceof MaybeModuleName) {
             elementDescription = getElementDescription((MaybeModuleName) element, location);
         }
@@ -125,6 +127,20 @@ public class ElementDescriptionProvider implements com.intellij.psi.ElementDescr
             if (location == UsageViewTypeLocation.INSTANCE) {
                 elementDescription = "keyword key";
             }
+        }
+
+        return elementDescription;
+    }
+
+    @Nullable
+    private String getElementDescription(@NotNull ElixirVariable variable,
+                                         @NotNull ElementDescriptionLocation location) {
+        String elementDescription = null;
+
+        if (location == UsageViewLongNameLocation.INSTANCE || location == UsageViewShortNameLocation.INSTANCE) {
+            elementDescription = variable.getName();
+        } else if (location == UsageViewTypeLocation.INSTANCE) {
+            elementDescription = VARIABLE_USAGE_VIEW_TYPE_LOCATION_ELEMENT_DESCRIPTION;
         }
 
         return elementDescription;

--- a/src/org/elixir_lang/reference/Callable.java
+++ b/src/org/elixir_lang/reference/Callable.java
@@ -435,6 +435,8 @@ public class Callable extends PsiReferenceBase<Call> implements PsiPolyVariantRe
             isVariable = true;
         } else if (call.isCalling(Module.KERNEL, Function.VAR_BANG)) {
             isVariable = true;
+        } else if (call instanceof UnqualifiedParenthesesCall) {
+            isVariable = false;
         } else {
             PsiElement parent = call.getParent();
             isVariable = isVariable(parent);

--- a/src/org/elixir_lang/reference/Callable.java
+++ b/src/org/elixir_lang/reference/Callable.java
@@ -31,6 +31,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
+import static org.elixir_lang.psi.ElementDescriptionProvider.VARIABLE_USAGE_VIEW_TYPE_LOCATION_ELEMENT_DESCRIPTION;
 import static org.elixir_lang.psi.impl.ElixirPsiImplUtil.*;
 
 public class Callable extends PsiReferenceBase<Call> implements PsiPolyVariantReference {
@@ -353,7 +354,7 @@ public class Callable extends PsiReferenceBase<Call> implements PsiPolyVariantRe
         if (location == UsageViewLongNameLocation.INSTANCE || location == UsageViewShortNameLocation.INSTANCE) {
             elementDescription = call.getName();
         } else if (location == UsageViewTypeLocation.INSTANCE) {
-            elementDescription = "variable";
+            elementDescription = VARIABLE_USAGE_VIEW_TYPE_LOCATION_ELEMENT_DESCRIPTION;
         }
 
         return elementDescription;

--- a/tests/org/elixir_lang/reference/callable/Issue436Test.java
+++ b/tests/org/elixir_lang/reference/callable/Issue436Test.java
@@ -23,7 +23,7 @@ public class Issue436Test extends LightCodeInsightFixtureTestCase {
 
         assertInstanceOf(variable, UnqualifiedNoArgumentsCall.class);
         assertFalse("alias is marked as a parameter", isParameter(variable));
-        assertTrue("alias is not marked as a variable", isVariable(variable));
+        assertFalse("alias is marked as a variable", isVariable(variable));
     }
 
     /*


### PR DESCRIPTION
Fixes #624

# Changelog
## Bug Fixes
* `ElementDescription` for `ElixirVariable`
* Mark `UnqualifiedParenthesesCall`s as `call` instead of `variable`.