### PR TITLE
Mark DecimalFloat as error in types

### DIFF
--- a/testData/org/elixir_lang/annotator/module_attribute/issue_632.ex
+++ b/testData/org/elixir_lang/annotator/module_attribute/issue_632.ex
@@ -1,0 +1,2 @@
+@type unity <error descr="Float literals are not allowed in types: use float() instead">1.0</error>
+@type percentage_change -100.0..<error descr="Floats aren't allowed in Ranges">100.0</error>

--- a/tests/org/elixir_lang/annotator/ModuleAttributeTest.java
+++ b/tests/org/elixir_lang/annotator/ModuleAttributeTest.java
@@ -54,6 +54,11 @@ public class ModuleAttributeTest extends LightCodeInsightFixtureTestCase {
         myFixture.checkHighlighting(false, false, true);
     }
 
+    public void testIssue632() {
+        myFixture.configureByFile("issue_632.ex");
+        myFixture.checkHighlighting(false, false, true);
+    }
+
     public void testMatch() {
         myFixture.configureByFile("match.ex");
         myFixture.checkHighlighting(false, false, true);


### PR DESCRIPTION
Fixes #632

# Changelog
## Bug Fixes
* Mark `ElixirDecimalFloat` as error in types.
  * If in a Range: "Floats aren't allowed in Ranges"
  * Otherwise: "Float literals are not allowed in types.  Use float() instead".