### PR TITLE
isParameter and isVariable for AtUnqualifiedBracketOperation 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,5 +22,7 @@ src/org/elixir_lang/ElixirFlexLexer.java~
 .gradle
 /build
 jps-builder/build
+jps-builder/out
 jps-shared/build
+jps-shared/out
 libs/

--- a/src/org/elixir_lang/annonator/Parameter.java
+++ b/src/org/elixir_lang/annonator/Parameter.java
@@ -173,16 +173,17 @@ public class Parameter {
             parameterizedParameter = putParameterized(parameter, (ElixirAnonymousFunction) parent);
         } else if (parent instanceof InMatch) {
             parameterizedParameter = putParameterized(parameter, (InMatch) parent);
-        } else if (parent instanceof BracketOperation ||
-                    parent instanceof ElixirBlockItem ||
-                    parent instanceof ElixirDoBlock ||
-                    parent instanceof ElixirInterpolation ||
-                    parent instanceof ElixirMapUpdateArguments ||
-                    parent instanceof ElixirMultipleAliases ||
-                    parent instanceof ElixirQuoteStringBody ||
-                    parent instanceof PsiFile ||
-                    parent instanceof QualifiedAlias ||
-                    parent instanceof QualifiedMultipleAliases) {
+        } else if (parent instanceof AtUnqualifiedBracketOperation ||
+                parent instanceof BracketOperation ||
+                parent instanceof ElixirBlockItem ||
+                parent instanceof ElixirDoBlock ||
+                parent instanceof ElixirInterpolation ||
+                parent instanceof ElixirMapUpdateArguments ||
+                parent instanceof ElixirMultipleAliases ||
+                parent instanceof ElixirQuoteStringBody ||
+                parent instanceof PsiFile ||
+                parent instanceof QualifiedAlias ||
+                parent instanceof QualifiedMultipleAliases) {
             parameterizedParameter = new Parameter(parameter.entrance);
         } else {
             error("Don't know how to check if parameter", parent);

--- a/src/org/elixir_lang/reference/Callable.java
+++ b/src/org/elixir_lang/reference/Callable.java
@@ -314,7 +314,8 @@ public class Callable extends PsiReferenceBase<Call> implements PsiPolyVariantRe
             // MUST be after any operations because operations also implement Call
             isVariable = isVariable((Call) ancestor);
         } else {
-            if (!(ancestor instanceof AtNonNumericOperation ||
+            if (!(ancestor instanceof AtUnqualifiedBracketOperation ||
+                    ancestor instanceof AtNonNumericOperation ||
                     ancestor instanceof BracketOperation ||
                     ancestor instanceof PsiFile ||
                     ancestor instanceof QualifiedMultipleAliases)) {

--- a/testData/org/elixir_lang/reference/callable/issue_659/is.ex
+++ b/testData/org/elixir_lang/reference/callable/issue_659/is.ex
@@ -1,0 +1,4 @@
+defmodule One do
+  @two %{}
+  @two[three<caret>]
+end

--- a/tests/org/elixir_lang/reference/callable/Issue659Test.java
+++ b/tests/org/elixir_lang/reference/callable/Issue659Test.java
@@ -1,0 +1,41 @@
+package org.elixir_lang.reference.callable;
+
+import com.intellij.psi.PsiElement;
+import com.intellij.testFramework.fixtures.LightCodeInsightFixtureTestCase;
+import org.elixir_lang.psi.call.Call;
+
+import static org.elixir_lang.reference.Callable.isParameter;
+import static org.elixir_lang.reference.Callable.isVariable;
+
+public class Issue659Test extends LightCodeInsightFixtureTestCase {
+    /*
+     * Tests
+     */
+
+    public void testIs() {
+        myFixture.configureByFiles("is.ex");
+        PsiElement callable = myFixture
+                .getFile()
+                .findElementAt(myFixture.getCaretOffset())
+                .getPrevSibling();
+
+        assertInstanceOf(callable, Call.class);
+        assertFalse(
+                "unresolvable no argument call in at bracket operation is incorrectly marked as a parameter",
+                isParameter(callable)
+        );
+        assertFalse(
+                "unresolvable no argument call in at bracket operation is incorrectly marked as a variable",
+                isVariable(callable)
+        );
+    }
+
+    /*
+     * Protected Instance Methods
+     */
+
+    @Override
+    protected String getTestDataPath() {
+        return "testData/org/elixir_lang/reference/callable/issue_659";
+    }
+}


### PR DESCRIPTION
Fixes #659

# Changelog
## Enhancements
* Regression test for #659.

## Bug Fixes
* Ignore `jps-*/out` directories.
* Look at parent for `isParameter` for `AtUnqualifiedBracketOperation`.
* Treat `AtUnqualifiedBracketOperation` the same as `UnqualifiedBracketOperation` for `isVariable`.