### PR TITLE
Include path in error messages from buildFileStub

### DIFF
--- a/src/org/elixir_lang/beam/StubBuilder.java
+++ b/src/org/elixir_lang/beam/StubBuilder.java
@@ -27,7 +27,7 @@ public class StubBuilder implements BinaryFileStubBuilder {
     public Stub buildStubTree(FileContent fileContent) {
         byte[] content = fileContent.getContent();
 
-        PsiFileStub<?> stub = BeamFileImpl.buildFileStub(content);
+        PsiFileStub<?> stub = BeamFileImpl.buildFileStub(content, fileContent.getFile().getPath());
 
         if (stub == null) {
             LOGGER.info("No stub built for file " + fileContent);

--- a/src/org/elixir_lang/beam/psi/BeamFileImpl.java
+++ b/src/org/elixir_lang/beam/psi/BeamFileImpl.java
@@ -10,7 +10,6 @@ import com.intellij.openapi.fileEditor.FileDocumentManager;
 import com.intellij.openapi.fileTypes.FileType;
 import com.intellij.openapi.progress.ProgressManager;
 import com.intellij.openapi.util.Key;
-import com.intellij.openapi.util.Pair;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.*;
 import com.intellij.psi.impl.source.PsiFileImpl;
@@ -31,7 +30,6 @@ import org.elixir_lang.beam.Beam;
 import org.elixir_lang.beam.MacroNameArity;
 import org.elixir_lang.beam.chunk.Atoms;
 import org.elixir_lang.beam.chunk.Exports;
-import org.elixir_lang.beam.chunk.exports.Export;
 import org.elixir_lang.beam.psi.impl.ModuleElementImpl;
 import org.elixir_lang.beam.psi.impl.ModuleImpl;
 import org.elixir_lang.beam.psi.impl.ModuleStubImpl;
@@ -48,7 +46,6 @@ import org.jetbrains.annotations.Nullable;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.SortedMap;
 import java.util.SortedSet;
 
 import static com.intellij.reference.SoftReference.dereference;
@@ -84,7 +81,7 @@ public class BeamFileImpl extends ModuleElementImpl implements ModuleOwner, PsiC
         this.isForDecompiling = isForDecompiling;
     }
 
-    public static PsiFileStub<?> buildFileStub(byte[] bytes) {
+    public static PsiFileStub<?> buildFileStub(@NotNull byte[] bytes, @NotNull String path) {
         ElixirFileStubImpl stub = new ElixirFileStubImpl();
 
         Beam beam = null;
@@ -92,9 +89,9 @@ public class BeamFileImpl extends ModuleElementImpl implements ModuleOwner, PsiC
         try {
             beam = Beam.from(bytes);
         } catch (IOException e) {
-            LOGGER.error(e);
+            LOGGER.error("IOException during BeamFileImpl.buildFileStub(bytes, " + path + ")",  e);
         } catch (OtpErlangDecodeException e) {
-            LOGGER.error(e);
+            LOGGER.error("OtpErlangDecodeException during BeamFileImpl.buildFileStub(bytes, " + path + ")", e);
         }
 
         ModuleStub moduleStub = buildModuleStub(stub, beam);

--- a/src/org/elixir_lang/beam/psi/stubs/ModuleElementType.java
+++ b/src/org/elixir_lang/beam/psi/stubs/ModuleElementType.java
@@ -17,7 +17,7 @@ import static org.elixir_lang.psi.stub.type.call.Stub.serializeStubbic;
  *
  * @param <S> The stub element that {@link #serialize(StubElement, StubOutputStream)} and
  *   {@link #indexStub(StubElement, IndexSink)} should accept.  These stubs should be created by
- *   {@link org.elixir_lang.beam.psi.BeamFileImpl#buildFileStub(byte[])}.
+ *   {@link org.elixir_lang.beam.psi.BeamFileImpl#buildFileStub(byte[], String)}.
  * @param <P> The PSI element that should be returned by {@link #createPsi(StubElement)} in subclasses
  */
 public abstract class ModuleElementType<S extends StubElement & Stubbic, P extends PsiElement>
@@ -25,7 +25,7 @@ public abstract class ModuleElementType<S extends StubElement & Stubbic, P exten
     /**
      * @throws IllegalArgumentException stubs should never be created from {@link LighterAST} and
      *   {@link LighterASTNode}:  Stubs should be created by
-     *   {@link org.elixir_lang.beam.psi.BeamFileImpl#buildFileStub(byte[])}.
+     *   {@link org.elixir_lang.beam.psi.BeamFileImpl#buildFileStub(byte[], String)}.
      */
     @Override
     public S createStub(LighterAST tree, LighterASTNode node, StubElement parentStub) {
@@ -59,7 +59,7 @@ public abstract class ModuleElementType<S extends StubElement & Stubbic, P exten
     /**
      * Serializes {@code stub} as a {@link Stubbic}.
      *
-     * @param stub created by {@link org.elixir_lang.beam.psi.BeamFileImpl#buildFileStub(byte[])}
+     * @param stub created by {@link org.elixir_lang.beam.psi.BeamFileImpl#buildFileStub(byte[], String)}
      * @param dataStream stream to write {@code stub} to
      * @throws IOException if {@code dataStream} cannot be written to
      */
@@ -71,7 +71,7 @@ public abstract class ModuleElementType<S extends StubElement & Stubbic, P exten
     /**
      * Indexes {@code stub} as a {@link Stubbic}.
      *
-     * @param stub created by {@link org.elixir_lang.beam.psi.BeamFileImpl#buildFileStub(byte[])}
+     * @param stub created by {@link org.elixir_lang.beam.psi.BeamFileImpl#buildFileStub(byte[], String)}
      * @param sink stub index
      */
     @Override


### PR DESCRIPTION
Fixes #671 

# Changelog
## Bug Fixes
* Include path in error messages from `buildFileStub`