### PR TITLE
Add missing breaks to case statement in `processDeclarations(Match, ...)`

### DIFF
--- a/src/org/elixir_lang/psi/impl/ElixirPsiImplUtil.java
+++ b/src/org/elixir_lang/psi/impl/ElixirPsiImplUtil.java
@@ -1660,12 +1660,15 @@ public class ElixirPsiImplUtil {
                 case LEFT:
                     checkLeft  = true;
                     checkRight = false;
+                    break;
                 case OPERATOR:
                     checkLeft  = true;
                     checkRight = true;
+                    break;
                 case RIGHT:
                     checkLeft  = false;
                     checkRight = true;
+                    break;
             }
         } else if (PsiTreeUtil.isAncestor(match, lastParent, false)) {
             checkLeft  = true;

--- a/testData/org/elixir_lang/reference/callable/issue_687/repeated_map_value_in_match.ex
+++ b/testData/org/elixir_lang/reference/callable/issue_687/repeated_map_value_in_match.ex
@@ -1,0 +1,20 @@
+defmodule One do
+  def two(
+        three,
+        %{
+          four: five,
+          six: seven
+        }
+      ) do
+    %{
+      ^five => %Eight{
+        nine_id: nine_id
+      },
+      ^seven => %Nine{
+        id: nine<caret>_id
+      }
+    } = three
+
+    nine_id
+  end
+end

--- a/tests/org/elixir_lang/reference/callable/Issue687Test.java
+++ b/tests/org/elixir_lang/reference/callable/Issue687Test.java
@@ -1,0 +1,59 @@
+package org.elixir_lang.reference.callable;
+
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiReference;
+import com.intellij.psi.impl.source.tree.LeafPsiElement;
+import com.intellij.testFramework.fixtures.LightCodeInsightFixtureTestCase;
+import org.elixir_lang.psi.ElixirIdentifier;
+import org.elixir_lang.psi.UnqualifiedNoArgumentsCall;
+import org.elixir_lang.psi.call.Call;
+
+public class Issue687Test extends LightCodeInsightFixtureTestCase {
+    /*
+     * Tests
+     */
+
+    public void testRepeatedMapValueInMatch() {
+        myFixture.configureByFiles("repeated_map_value_in_match.ex");
+        PsiElement elementAtCaret = myFixture
+                .getFile()
+                .findElementAt(myFixture.getCaretOffset());
+
+        assertNotNull(elementAtCaret);
+        assertInstanceOf(elementAtCaret, LeafPsiElement.class);
+
+        PsiElement parent = elementAtCaret.getParent();
+
+        assertNotNull(parent);
+        assertInstanceOf(parent, ElixirIdentifier.class);
+
+        PsiElement grandParent = parent.getParent();
+
+        assertNotNull(grandParent);
+        assertInstanceOf(grandParent, Call.class);
+
+        Call grandParentCall = (Call) grandParent;
+
+        PsiReference reference = grandParentCall.getReference();
+
+        assertNotNull(reference);
+
+        PsiElement resolved = reference.resolve();
+
+        assertNotNull(resolved);
+
+        assertInstanceOf(resolved, UnqualifiedNoArgumentsCall.class);
+        assertEquals(resolved.getText(), "nine_id");
+
+        assertEquals(resolved.getParent().getParent().getText(), "nine_id: nine_id");
+    }
+
+    /*
+     * Protected Instance Methods
+     */
+
+    @Override
+    protected String getTestDataPath() {
+        return "testData/org/elixir_lang/reference/callable/issue_687";
+    }
+}


### PR DESCRIPTION
Fixes #687

# Changelog
## Enhancements
* Regression test for #687 

## Bug Fixes
* Add missing `break`s to `case` statement in `processDeclarations(Match, ...)` that caused the logic of whether to check left, right, or both operand based on the whether the treeWalkUp came from always fell through to the `RIGHT` case, so it was only, always checking the right operand of the match and never the left operand.