### PR TITLE
Skip `processDeclarationsInPreviousSibling` when `lastParent` is `ElixirFile`

### DIFF
--- a/src/org/elixir_lang/psi/impl/ElixirPsiImplUtil.java
+++ b/src/org/elixir_lang/psi/impl/ElixirPsiImplUtil.java
@@ -1736,7 +1736,7 @@ public class ElixirPsiImplUtil {
 
                 previousSibling = previousSibling.getPrevSibling();
             }
-        } else {
+        } else if (!(lastParent instanceof ElixirFile)) {
             error(
                     PsiElement.class,
                     "Scope is not lastParent's parent\nlastParent:\n" + lastParent.getText(),

--- a/testData/org/elixir_lang/reference/callable/issue_692/unresolved_at_top_of_file.ex
+++ b/testData/org/elixir_lang/reference/callable/issue_692/unresolved_at_top_of_file.ex
@@ -1,0 +1,1 @@
+left=ri<caret>ght

--- a/tests/org/elixir_lang/reference/callable/Issue692Test.java
+++ b/tests/org/elixir_lang/reference/callable/Issue692Test.java
@@ -1,0 +1,54 @@
+package org.elixir_lang.reference.callable;
+
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiReference;
+import com.intellij.psi.impl.source.tree.LeafPsiElement;
+import com.intellij.testFramework.fixtures.LightCodeInsightFixtureTestCase;
+import org.elixir_lang.psi.ElixirIdentifier;
+import org.elixir_lang.psi.call.Call;
+
+public class Issue692Test extends LightCodeInsightFixtureTestCase {
+    /*
+     * Tests
+     */
+
+    public void testUnresolvedAtTopOfFile() {
+        myFixture.configureByFiles("unresolved_at_top_of_file.ex");
+        PsiElement elementAtCaret = myFixture
+                .getFile()
+                .findElementAt(myFixture.getCaretOffset());
+
+        assertNotNull(elementAtCaret);
+        assertInstanceOf(elementAtCaret, LeafPsiElement.class);
+
+        PsiElement parent = elementAtCaret.getParent();
+
+        assertNotNull(parent);
+        assertInstanceOf(parent, ElixirIdentifier.class);
+
+        PsiElement grandParent = parent.getParent();
+
+        assertNotNull(grandParent);
+        assertInstanceOf(grandParent, Call.class);
+
+        Call grandParentCall = (Call) grandParent;
+
+        PsiReference reference = grandParentCall.getReference();
+
+        assertNotNull(reference);
+
+        PsiElement resolved = reference.resolve();
+
+        assertNotNull(resolved);
+        assertTrue(resolved.isEquivalentTo(grandParent));
+    }
+
+    /*
+     * Protected Instance Methods
+     */
+
+    @Override
+    protected String getTestDataPath() {
+        return "testData/org/elixir_lang/reference/callable/issue_692";
+    }
+}


### PR DESCRIPTION
Fixes #692

# Changelog
## Enhancements
* Regression test for #692 

## Bug Fixes
* Skip `processDeclarationsInPreviousSibling` when `lastParent` is `ElixirFile`

