### PR TITLE
Remove background color from sigils

### DIFF
--- a/resources/colorSchemes/ElixirDarcula.xml
+++ b/resources/colorSchemes/ElixirDarcula.xml
@@ -105,7 +105,6 @@
     <option name="ELIXIR_SIGIL">
         <value>
             <option name="FOREGROUND" value="47A6B3" />
-            <option name="BACKGROUND" value="232525" />
         </value>
     </option>
     <option name="ELIXIR_SPECIFICATION">

--- a/resources/colorSchemes/ElixirDefault.xml
+++ b/resources/colorSchemes/ElixirDefault.xml
@@ -105,7 +105,6 @@
     <option name="ELIXIR_SIGIL">
         <value>
             <option name="FOREGROUND" value="996c18" />
-            <option name="BACKGROUND" value="1a3333" />
         </value>
     </option>
     <option name="ELIXIR_SPECIFICATION">


### PR DESCRIPTION
# Changelog
## Bug Fixes
* Remove background color from sigils because it stands out really badly in the Default theme where it's black on white and while it doesn't in Darcula, it's unnecessary there because it's so close to the editor background color in Darcula.