### PR TITLE
Ignore call definition clauses after `when` when typing type specificiation

### DIFF
--- a/src/org/elixir_lang/annonator/ModuleAttribute.java
+++ b/src/org/elixir_lang/annonator/ModuleAttribute.java
@@ -816,6 +816,10 @@ public class ModuleAttribute implements Annotator, DumbAware {
                     annotationHolder,
                     typeTextAttributesKey
             );
+        } else if (psiElement instanceof UnqualifiedNoParenthesesCall) {
+            highlightTypesAndSpecificationTypeParameterDeclarations(
+                    (UnqualifiedNoParenthesesCall) psiElement
+            );
         } else {
             error("Cannot highlight types and specification type parameter declarations", psiElement);
         }
@@ -848,6 +852,14 @@ public class ModuleAttribute implements Annotator, DumbAware {
                     annotationHolder,
                     ElixirSyntaxHighlighter.TYPE_PARAMETER
             );
+        }
+    }
+
+    private void highlightTypesAndSpecificationTypeParameterDeclarations(
+            UnqualifiedNoParenthesesCall unqualifiedNoParenthesesCall) {
+        if (!CallDefinitionClause.is(unqualifiedNoParenthesesCall)) {
+            error(
+                    "Cannot highlight types and specification type parameter declarations in UnqualifiedNoParenthesesCall that is not a call definition clause", unqualifiedNoParenthesesCall);
         }
     }
 

--- a/src/org/elixir_lang/annonator/ModuleAttribute.java
+++ b/src/org/elixir_lang/annonator/ModuleAttribute.java
@@ -17,6 +17,7 @@ import org.elixir_lang.errorreport.Logger;
 import org.elixir_lang.psi.*;
 import org.elixir_lang.psi.call.Call;
 import org.elixir_lang.psi.operation.*;
+import org.elixir_lang.structure_view.element.CallDefinitionClause;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Collections;
@@ -1396,6 +1397,8 @@ public class ModuleAttribute implements Annotator, DumbAware {
             parameterNameSet = specificationTypeParameterNameSet((ElixirNoParenthesesKeywordPair) psiElement);
         } else if (psiElement instanceof UnqualifiedNoArgumentsCall) {
             parameterNameSet = specificationTypeParameterNameSet((UnqualifiedNoArgumentsCall) psiElement);
+        } else if (psiElement instanceof UnqualifiedNoParenthesesCall) {
+            parameterNameSet = specificationTypeParameterNameSet((UnqualifiedNoParenthesesCall) psiElement);
         } else {
             error("Cannot extract specification type parameter name set", psiElement);
             parameterNameSet = Collections.emptySet();
@@ -1429,6 +1432,21 @@ public class ModuleAttribute implements Annotator, DumbAware {
         }
 
         return nameSet;
+    }
+
+    @NotNull
+    private Set<String> specificationTypeParameterNameSet(
+            @NotNull UnqualifiedNoParenthesesCall unqualifiedNoParenthesesCall
+    ) {
+        if (!CallDefinitionClause.is(unqualifiedNoParenthesesCall)) {
+            error(
+                    "Cannot extract specification type parameter name set from " +
+                            "unqualifiedNoParenthesesCall that is a not a call definition clause",
+                    unqualifiedNoParenthesesCall
+            );
+        }
+
+        return Collections.emptySet();
     }
 
     /**

--- a/testData/org/elixir_lang/annotator/module_attribute/issue_699.ex
+++ b/testData/org/elixir_lang/annotator/module_attribute/issue_699.ex
@@ -1,0 +1,4 @@
+defmodule One do
+  @spec area(length, width) :: integer when
+  def area(length \\ 1, width \\ 1) when is_number(length) and is_number(width)
+end

--- a/tests/org/elixir_lang/annotator/ModuleAttributeTest.java
+++ b/tests/org/elixir_lang/annotator/ModuleAttributeTest.java
@@ -64,6 +64,11 @@ public class ModuleAttributeTest extends LightCodeInsightFixtureTestCase {
         myFixture.checkHighlighting(false, false, true);
     }
 
+    public void testIssue699() {
+        myFixture.configureByFile("issue_699.ex");
+        myFixture.checkHighlighting(false, false, true);
+    }
+
     public void testMatch() {
         myFixture.configureByFile("match.ex");
         myFixture.checkHighlighting(false, false, true);


### PR DESCRIPTION
Fixes #699

# Changelog
## Enhancements
* Regression test for #699 

## Bug Fixes
* Ignore call definition clauses after `when` in type specifications as it is a common occurrence when typing a specification above a pre-existing call definition clause.