### PR TITLE
Look above List for enclosing modular macro

### DIFF
--- a/src/org/elixir_lang/psi/impl/ElixirPsiImplUtil.java
+++ b/src/org/elixir_lang/psi/impl/ElixirPsiImplUtil.java
@@ -2144,6 +2144,8 @@ public class ElixirPsiImplUtil {
                 // See https://github.com/absinthe-graphql/absinthe/blob/v1.3.0/lib/absinthe/schema/notation/writer.ex#L24-L44
                 parent instanceof ElixirList ||
                 parent instanceof ElixirMatchedParenthesesArguments ||
+                // See https://github.com/absinthe-graphql/absinthe/blob/v1.3.0/lib/absinthe/schema/notation/writer.ex#L96
+                parent instanceof ElixirNoParenthesesManyStrictNoParenthesesExpression ||
                 parent instanceof ElixirTuple ||
                 parent instanceof Match ||
                 parent instanceof QualifiedAlias ||

--- a/src/org/elixir_lang/psi/impl/ElixirPsiImplUtil.java
+++ b/src/org/elixir_lang/psi/impl/ElixirPsiImplUtil.java
@@ -2141,6 +2141,8 @@ public class ElixirPsiImplUtil {
                 parent instanceof AtUnqualifiedNoParenthesesCall ||
                 // See https://github.com/phoenixframework/phoenix/blob/v1.2.4/lib/phoenix/template.ex#L380-L392
                 parent instanceof ElixirAccessExpression ||
+                // See https://github.com/absinthe-graphql/absinthe/blob/v1.3.0/lib/absinthe/schema/notation/writer.ex#L24-L44
+                parent instanceof ElixirList ||
                 parent instanceof ElixirMatchedParenthesesArguments ||
                 parent instanceof ElixirTuple ||
                 parent instanceof Match ||

--- a/testData/org/elixir_lang/navigation/goto_symbol_contributor/issue_705__before_compile__.ex
+++ b/testData/org/elixir_lang/navigation/goto_symbol_contributor/issue_705__before_compile__.ex
@@ -1,0 +1,33 @@
+defmodule Absinthe.Schema.Notation.Writer do
+  defmacro __before_compile__(env) do
+    info = build_info(env)
+
+    errors        = Macro.escape info.errors
+    exports       = Macro.escape info.exports
+    type_map      = Macro.escape info.type_map
+    implementors  = Macro.escape info.implementors
+    directive_map = Macro.escape info.directive_map
+
+    [
+      quote do
+        def __absinthe_types__, do: unquote(type_map)
+      end,
+      info.type_functions,
+      quote do
+        def __absinthe_type__(_), do: nil
+      end,
+      quote do
+        def __absinthe_<caret>directives__, do: unquote(directive_map)
+      end,
+      info.directive_functions,
+      quote do
+        def __absinthe_directive__(_), do: nil
+      end,
+      quote do
+        def __absinthe_errors__, do: unquote(errors)
+        def __absinthe_interface_implementors__, do: unquote(implementors)
+        def __absinthe_exports__, do: unquote(exports)
+      end,
+    ]
+  end
+end

--- a/testData/org/elixir_lang/navigation/goto_symbol_contributor/issue_705_type_functions.ex
+++ b/testData/org/elixir_lang/navigation/goto_symbol_contributor/issue_705_type_functions.ex
@@ -1,0 +1,29 @@
+defmodule Absinthe.Schema.Notation.Writer do
+  defp type_functions(definition) do
+    ast = build(:type, definition)
+    identifier = definition.identifier
+    name = definition.attrs[:name]
+
+    result = [
+      quote do: def __absinthe<caret>_type__(unquote(name)), do: __absinthe_type__(unquote(identifier))
+    ]
+
+    if definition.builder == Absinthe.Type.Object do
+      [
+        quote do
+          def __absinthe_type__(unquote(identifier)) do
+            unquote(ast)
+          end
+        end,
+        result
+      ]
+    else
+      [
+        quote do
+          def __absinthe_type__(unquote(identifier)), do: unquote(ast)
+        end,
+        result
+      ]
+    end
+  end
+end

--- a/tests/org/elixir_lang/navigation/GotoSymbolContributorTest.java
+++ b/tests/org/elixir_lang/navigation/GotoSymbolContributorTest.java
@@ -3,17 +3,15 @@ package org.elixir_lang.navigation;
 import com.intellij.navigation.ChooseByNameContributor;
 import com.intellij.navigation.ChooseByNameRegistry;
 import com.intellij.navigation.NavigationItem;
+import com.intellij.psi.PsiElement;
 import com.intellij.testFramework.fixtures.LightPlatformCodeInsightFixtureTestCase;
+import org.elixir_lang.psi.call.Call;
 import org.elixir_lang.structure_view.element.CallDefinition;
 import org.elixir_lang.structure_view.element.CallDefinitionClause;
+import org.elixir_lang.structure_view.element.modular.Modular;
 
 public class GotoSymbolContributorTest extends LightPlatformCodeInsightFixtureTestCase {
-    /*
-     * Tests
-     */
-
-    public void testIssue472() {
-        myFixture.configureByFile("issue_472.ex");
+    private static GotoSymbolContributor gotoSymbolContributor() {
         ChooseByNameContributor[] symbolModelContributors = ChooseByNameRegistry
                 .getInstance()
                 .getSymbolModelContributors();
@@ -28,6 +26,21 @@ public class GotoSymbolContributorTest extends LightPlatformCodeInsightFixtureTe
 
         assertNotNull(gotoSymbolContributor);
 
+        return gotoSymbolContributor;
+    }
+
+    @Override
+    protected String getTestDataPath() {
+        return "testData/org/elixir_lang/navigation/goto_symbol_contributor";
+    }
+
+    /*
+     * Tests
+     */
+
+    public void testIssue472() {
+        myFixture.configureByFile("issue_472.ex");
+        GotoSymbolContributor gotoSymbolContributor = gotoSymbolContributor();
         NavigationItem[] itemsByName = gotoSymbolContributor.getItemsByName(
                 "decode_auth_type",
                 "decode_a",
@@ -46,12 +59,30 @@ public class GotoSymbolContributorTest extends LightPlatformCodeInsightFixtureTe
         assertEquals("decode_auth_type", callDefinitionClause.getName());
     }
 
-    /*
-     * Protected Instance Methods
-     */
+    public void testIssue705BeforeCompile() {
+        myFixture.configureByFile("issue_705__before_compile__.ex");
+        PsiElement elementAtCaret = myFixture.getFile().findElementAt(myFixture.getCaretOffset());
 
-    @Override
-    protected String getTestDataPath() {
-        return "testData/org/elixir_lang/navigation/goto_symbol_contributor";
+        Call call = (Call) elementAtCaret.getParent().getParent().getParent().getParent();
+
+        Call enclosingModularMacroCall = CallDefinitionClause.enclosingModularMacroCall(call);
+        assertNotNull(enclosingModularMacroCall);
+
+        Modular modular = CallDefinitionClause.enclosingModular(call);
+        assertNotNull(modular);
     }
+
+    public void testIssue705TypeFunctions() {
+        myFixture.configureByFile("issue_705_type_functions.ex");
+        PsiElement elementAtCaret = myFixture.getFile().findElementAt(myFixture.getCaretOffset());
+
+        Call call = (Call) elementAtCaret.getParent().getParent().getParent();
+
+        Call enclosingModularMacroCall = CallDefinitionClause.enclosingModularMacroCall(call);
+        assertNotNull(enclosingModularMacroCall);
+
+        Modular modular = CallDefinitionClause.enclosingModular(call);
+        assertNotNull(modular);
+    }
+
 }


### PR DESCRIPTION
Fixes #705 

# Changelog
## Enhancements
* Show `quote`s in list in macros in Structure View

## Bug Fixes
* Look above `List` for enclosing modular macro.
* Look above `ElixirNoParenthesesManyStrictNoParenthesesExpression` for enclosing modular macro.

