### PR TITLE
Cache references and references multiResolve

### DIFF
--- a/src/org/elixir_lang/psi/impl/ElixirPsiImplUtil.java
+++ b/src/org/elixir_lang/psi/impl/ElixirPsiImplUtil.java
@@ -3136,6 +3136,11 @@ public class ElixirPsiImplUtil {
         );
     }
 
+    @NotNull
+    private static PsiReference computeReference(@NotNull final ElixirAtIdentifier atIdentifier) {
+        return new org.elixir_lang.reference.ModuleAttribute(atIdentifier);
+    }
+
     /**
      * <blockquote>
      *     The PSI element at the cursor (the direct tree parent of the token at the cursor position) must be either a
@@ -3148,12 +3153,14 @@ public class ElixirPsiImplUtil {
     @Contract(pure = true)
     @NotNull
     public static PsiReference getReference(@NotNull final ElixirAtIdentifier atIdentifier) {
-        // reference the parent AtUnqualifiedNoParenthesesCall
-        return new org.elixir_lang.reference.ModuleAttribute(atIdentifier);
+        return CachedValuesManager.getCachedValue(
+                atIdentifier,
+                () -> CachedValueProvider.Result.create(computeReference(atIdentifier), atIdentifier)
+        );
     }
 
     @Nullable
-    public static PsiReference getReference(@NotNull final AtNonNumericOperation atNonNumericOperation) {
+    private static PsiReference computeReference(@NotNull final AtNonNumericOperation atNonNumericOperation) {
         PsiReference reference = null;
 
         if (!isNonReferencing(atNonNumericOperation)) {
@@ -3161,6 +3168,14 @@ public class ElixirPsiImplUtil {
         }
 
         return reference;
+    }
+
+    @Nullable
+    public static PsiReference getReference(@NotNull final AtNonNumericOperation atNonNumericOperation) {
+        return CachedValuesManager.getCachedValue(
+                atNonNumericOperation,
+                () -> CachedValueProvider.Result.create(computeReference(atNonNumericOperation), atNonNumericOperation)
+        );
     }
 
     public static boolean hasDoBlockOrKeyword(@NotNull final Call call) {

--- a/src/org/elixir_lang/psi/impl/ElixirPsiImplUtil.java
+++ b/src/org/elixir_lang/psi/impl/ElixirPsiImplUtil.java
@@ -3111,14 +3111,29 @@ public class ElixirPsiImplUtil {
     }
 
     @Nullable
-    public static PsiReference getReference(@NotNull QualifiableAlias qualifiableAlias) {
-        PsiReference reference = null;
+    private static PsiPolyVariantReference computeReference(@NotNull QualifiableAlias qualifiableAlias,
+                                                            @NotNull PsiElement maxScope) {
+        PsiPolyVariantReference reference = null;
 
         if (isOutermostQualifiableAlias(qualifiableAlias)) {
-            reference = new org.elixir_lang.reference.Module(qualifiableAlias, qualifiableAlias.getContainingFile());
+            reference = new org.elixir_lang.reference.Module(qualifiableAlias, maxScope);
         }
 
         return reference;
+    }
+
+    @Nullable
+    public static PsiReference getReference(@NotNull QualifiableAlias qualifiableAlias) {
+        return getReference(qualifiableAlias, qualifiableAlias.getContainingFile());
+    }
+
+    @Nullable
+    public static PsiPolyVariantReference getReference(@NotNull QualifiableAlias qualifiableAlias,
+                                                       @NotNull PsiElement maxScope) {
+        return CachedValuesManager.getCachedValue(
+                qualifiableAlias,
+                () -> CachedValueProvider.Result.create(computeReference(qualifiableAlias, maxScope), qualifiableAlias)
+        );
     }
 
     /**
@@ -5750,7 +5765,7 @@ if (quoted == null) {
             if (!recursiveKernelImport(qualifiableAlias, maxScope)) {
                 /* need to construct reference directly as qualified aliases don't return a reference except for the
                    outermost */
-                PsiPolyVariantReference reference = new org.elixir_lang.reference.Module(qualifiableAlias, maxScope);
+                PsiPolyVariantReference reference = getReference(qualifiableAlias, maxScope);
                 modular = aliasToModular(qualifiableAlias, reference);
             }
         }

--- a/src/org/elixir_lang/reference/resolver/CallDefinitionClause.java
+++ b/src/org/elixir_lang/reference/resolver/CallDefinitionClause.java
@@ -1,0 +1,95 @@
+package org.elixir_lang.reference.resolver;
+
+import com.intellij.openapi.util.Pair;
+import com.intellij.psi.PsiElementResolveResult;
+import com.intellij.psi.ResolveResult;
+import com.intellij.psi.impl.source.resolve.ResolveCache;
+import org.apache.commons.lang.math.IntRange;
+import org.elixir_lang.psi.call.Call;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.elixir_lang.psi.impl.ElixirPsiImplUtil.macroChildCalls;
+import static org.elixir_lang.structure_view.element.CallDefinitionClause.enclosingModularMacroCall;
+import static org.elixir_lang.structure_view.element.CallDefinitionSpecification.typeNameArity;
+
+public class CallDefinitionClause implements ResolveCache.PolyVariantResolver<org.elixir_lang.reference.CallDefinitionClause> {
+    public static final CallDefinitionClause INSTANCE = new CallDefinitionClause();
+
+    @NotNull
+    private static List<ResolveResult> add(@Nullable List<ResolveResult> resolveResultList,
+                                           @NotNull Call call,
+                                           boolean validResult) {
+        @NotNull List<ResolveResult> nonNullResolveResultList;
+
+        if (resolveResultList != null) {
+            nonNullResolveResultList = resolveResultList;
+        } else {
+            nonNullResolveResultList = new ArrayList<>();
+        }
+
+        nonNullResolveResultList.add(new PsiElementResolveResult(call, validResult));
+
+        return nonNullResolveResultList;
+    }
+
+    @NotNull
+    @Override
+    public ResolveResult[] resolve(@NotNull org.elixir_lang.reference.CallDefinitionClause callDefinitionClause,
+                                   boolean incompleteCode) {
+        Call enclosingModularMacroCall = enclosingModularMacroCall(callDefinitionClause.moduleAttribute);
+        List<ResolveResult> resolveResultList = null;
+
+        if (enclosingModularMacroCall != null) {
+            Call[] siblings = macroChildCalls(enclosingModularMacroCall);
+
+            if (siblings != null && siblings.length > 0) {
+                Pair<String, Integer> nameArity = typeNameArity(callDefinitionClause.getElement());
+                String name = nameArity.first;
+                int arity = nameArity.second;
+
+                for (Call call : siblings) {
+                    if (org.elixir_lang.structure_view.element.CallDefinitionClause.is(call)) {
+                        Pair<String, IntRange> callNameArityRange =
+                                org.elixir_lang.structure_view.element.CallDefinitionClause.nameArityRange(call);
+
+                        if (callNameArityRange != null) {
+                            String callName = callNameArityRange.first;
+
+                            if (callName.equals(name)) {
+                                IntRange callArityRange = callNameArityRange.second;
+
+                                if (callArityRange.containsInteger(arity)) {
+                                    resolveResultList = add(resolveResultList, call, true);
+                                } else if (arity < callArityRange.getMaximumInteger()) {
+                                    resolveResultList = add(resolveResultList, call, false);
+                                }
+                            } else if (incompleteCode && callName.startsWith(name)) {
+                                IntRange callArityRange = callNameArityRange.second;
+
+                                if (callArityRange.containsInteger(arity)) {
+                                    resolveResultList = add(resolveResultList, call, false);
+                                } else if (arity < callArityRange.getMaximumInteger()) {
+                                    resolveResultList = add(resolveResultList, call, false);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        ResolveResult[] resolveResults;
+
+        if (resolveResultList != null) {
+            resolveResults = resolveResultList.toArray(new ResolveResult[resolveResultList.size()]);
+        } else {
+            resolveResults = ResolveResult.EMPTY_ARRAY;
+        }
+
+        return resolveResults;
+    }
+}

--- a/src/org/elixir_lang/reference/resolver/Callable.java
+++ b/src/org/elixir_lang/reference/resolver/Callable.java
@@ -1,0 +1,86 @@
+package org.elixir_lang.reference.resolver;
+
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiElementResolveResult;
+import com.intellij.psi.ResolveResult;
+import com.intellij.psi.impl.source.resolve.ResolveCache;
+import org.elixir_lang.psi.Modular;
+import org.elixir_lang.psi.UnqualifiedNoArgumentsCall;
+import org.elixir_lang.psi.call.Call;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.elixir_lang.psi.impl.ElixirPsiImplUtil.qualifiedToModular;
+
+public class Callable implements ResolveCache.PolyVariantResolver<org.elixir_lang.reference.Callable> {
+    public static final Callable INSTANCE = new Callable();
+
+    @NotNull
+    @Override
+    public ResolveResult[] resolve(@NotNull org.elixir_lang.reference.Callable callable, boolean incompleteCode) {
+        final List<ResolveResult> resolveResultList = new ArrayList<ResolveResult>();
+        Call element = callable.getElement();
+        int resolvedFinalArity = element.resolvedFinalArity();
+
+        if (element instanceof org.elixir_lang.psi.call.qualification.Qualified) {
+            Call modular = qualifiedToModular((org.elixir_lang.psi.call.qualification.Qualified) element);
+
+            /* If modular cannot be found then it means that either the qualifier has a typo or its part of
+               .beam-only Module.  Since .beam-only Modules aren't resolvable at this time, assume typo and mark all
+                ResolveResults with `validResult` `false.  Finally, it could also be a variable. */
+            if (modular != null) {
+                Modular.forEachCallDefinitionClauseNameIdentifier(
+                        modular,
+                        element.functionName(),
+                        resolvedFinalArity,
+                        new com.intellij.util.Function<PsiElement, Boolean>() {
+                            @Override
+                            public Boolean fun(PsiElement nameIdentifier) {
+                                resolveResultList.add(new PsiElementResolveResult(nameIdentifier, true));
+
+                                return true;
+                            }
+                        }
+                );
+            }
+        } else {
+            /* DO NOT use `getName()` as it will return the NameIdentifier's text, which for `defmodule` is the Alias,
+               not `defmodule` */
+            String name = element.functionName();
+
+            if (name != null) {
+                // UnqualifiedNorArgumentsCall prevents `foo()` from being treated as a variable.
+                // resolvedFinalArity prevents `|> foo` from being counted as 0-arity
+                if (element instanceof UnqualifiedNoArgumentsCall && resolvedFinalArity == 0) {
+                    List<ResolveResult> variableResolveList =
+                            org.elixir_lang.psi.scope.variable.MultiResolve.resolveResultList(
+                                    name,
+                                    incompleteCode,
+                                    element
+                            );
+
+                    if (variableResolveList != null) {
+                        resolveResultList.addAll(variableResolveList);
+                    }
+                }
+
+                List<ResolveResult> callDefinitionClauseResolveResultList =
+                        org.elixir_lang.psi.scope.call_definition_clause.MultiResolve.resolveResultList(
+                                name,
+                                resolvedFinalArity,
+                                incompleteCode,
+                                element
+                        );
+
+                if (callDefinitionClauseResolveResultList != null) {
+                    resolveResultList.addAll(callDefinitionClauseResolveResultList);
+                }
+            }
+
+        }
+
+        return resolveResultList.toArray(new ResolveResult[resolveResultList.size()]);
+    }
+}

--- a/src/org/elixir_lang/reference/resolver/Module.java
+++ b/src/org/elixir_lang/reference/resolver/Module.java
@@ -62,5 +62,4 @@ public class Module implements ResolveCache.PolyVariantResolver<org.elixir_lang.
 
         return resolveResults;
     }
-
 }

--- a/src/org/elixir_lang/reference/resolver/Module.java
+++ b/src/org/elixir_lang/reference/resolver/Module.java
@@ -1,0 +1,66 @@
+package org.elixir_lang.reference.resolver;
+
+import com.intellij.openapi.project.Project;
+import com.intellij.psi.PsiElementResolveResult;
+import com.intellij.psi.ResolveResult;
+import com.intellij.psi.impl.source.resolve.ResolveCache;
+import org.elixir_lang.psi.QualifiableAlias;
+import org.elixir_lang.psi.scope.module.MultiResolve;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.elixir_lang.reference.Module.forEachNavigationElement;
+import static org.elixir_lang.reference.module.ResolvableName.resolvableName;
+
+public class Module implements ResolveCache.PolyVariantResolver<org.elixir_lang.reference.Module> {
+    public static final Module INSTANCE = new Module();
+
+    private List<ResolveResult> multiResolveProject(@NotNull Project project,
+                                                    @NotNull String name) {
+        List<ResolveResult> results = new ArrayList<>();
+
+        forEachNavigationElement(
+                project,
+                name,
+                navigationElement -> {
+                    results.add(new PsiElementResolveResult(navigationElement));
+
+                    return true;
+                }
+        );
+
+        return results;
+    }
+
+    @NotNull
+    @Override
+    public ResolveResult[] resolve(@NotNull org.elixir_lang.reference.Module module, boolean incompleteCode) {
+        List<ResolveResult> resolveResultList = null;
+        QualifiableAlias element = module.getElement();
+        final String name = resolvableName(element);
+
+        if (name != null) {
+            resolveResultList = MultiResolve.resolveResultList(name, incompleteCode, element, module.maxScope);
+
+            if (resolveResultList == null || resolveResultList.isEmpty()) {
+                resolveResultList = multiResolveProject(
+                        element.getProject(),
+                        name
+                );
+            }
+        }
+
+        ResolveResult[] resolveResults;
+
+        if (resolveResultList == null) {
+            resolveResults = ResolveResult.EMPTY_ARRAY;
+        } else {
+            resolveResults = resolveResultList.toArray(new ResolveResult[resolveResultList.size()]);
+        }
+
+        return resolveResults;
+    }
+
+}

--- a/src/org/elixir_lang/reference/resolver/ModuleAttribute.java
+++ b/src/org/elixir_lang/reference/resolver/ModuleAttribute.java
@@ -1,0 +1,132 @@
+package org.elixir_lang.reference.resolver;
+
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiElementResolveResult;
+import com.intellij.psi.ResolveResult;
+import com.intellij.psi.impl.source.resolve.ResolveCache;
+import com.intellij.util.containers.ContainerUtil;
+import org.elixir_lang.psi.AtNonNumericOperation;
+import org.elixir_lang.psi.AtUnqualifiedNoParenthesesCall;
+import org.elixir_lang.psi.ElixirAtIdentifier;
+import org.elixir_lang.psi.impl.ElixirPsiImplUtil;
+import org.elixir_lang.psi.scope.module_attribute.implemetation.For;
+import org.elixir_lang.psi.scope.module_attribute.implemetation.Protocol;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.elixir_lang.psi.scope.MultiResolve.HAS_VALID_RESULT_CONDITION;
+import static org.elixir_lang.reference.ModuleAttribute.isNonReferencing;
+
+public class ModuleAttribute implements ResolveCache.PolyVariantResolver<org.elixir_lang.reference.ModuleAttribute> {
+    public static final ModuleAttribute INSTANCE = new ModuleAttribute();
+
+    @NotNull
+    private static List<ResolveResult> multiResolveSibling(
+            @NotNull org.elixir_lang.reference.ModuleAttribute moduleAttribute,
+            @Nullable PsiElement lastSibling,
+            boolean incompleteCode
+    ) {
+        List<ResolveResult> resultList = new ArrayList<>();
+
+        for (PsiElement sibling = lastSibling; sibling != null; sibling = sibling.getPrevSibling()) {
+            if (sibling instanceof AtUnqualifiedNoParenthesesCall) {
+                AtUnqualifiedNoParenthesesCall atUnqualifiedNoParenthesesCall =
+                        (AtUnqualifiedNoParenthesesCall) sibling;
+                String moduleAttributeName = ElixirPsiImplUtil.moduleAttributeName(atUnqualifiedNoParenthesesCall);
+                String value = moduleAttribute.getValue();
+
+                if (moduleAttributeName.equals(value)) {
+                    resultList.add(new PsiElementResolveResult(atUnqualifiedNoParenthesesCall));
+                } else if (incompleteCode && moduleAttributeName.startsWith(value)) {
+                    resultList.add(new PsiElementResolveResult(atUnqualifiedNoParenthesesCall, false));
+                }
+            }
+        }
+
+        return resultList;
+    }
+
+    @NotNull
+    private static List<ResolveResult> multiResolveUpFromElement(
+            @NotNull org.elixir_lang.reference.ModuleAttribute moduleAttribute,
+            @NotNull final PsiElement element,
+            boolean incompleteCode
+    ) {
+        List<ResolveResult> resultList = new ArrayList<>();
+        PsiElement lastSibling = element;
+
+        while (lastSibling != null) {
+            resultList.addAll(multiResolveSibling(moduleAttribute, lastSibling, incompleteCode));
+
+            lastSibling = lastSibling.getParent();
+        }
+
+        return resultList;
+    }
+
+    @Nullable
+    private static Boolean validResult(@NotNull org.elixir_lang.reference.ModuleAttribute moduleAttribute,
+                                       @NotNull String moduleAttributeName,
+                                       boolean incompleteCode) {
+        Boolean validResult = null;
+        String value = moduleAttribute.getValue();
+
+        if (value.equals(moduleAttributeName)) {
+            validResult = true;
+        } else if (incompleteCode && moduleAttributeName.startsWith(value)) {
+            validResult = false;
+        }
+
+        return validResult;
+    }
+
+    @NotNull
+    @Override
+    public ResolveResult[] resolve(@NotNull org.elixir_lang.reference.ModuleAttribute moduleAttribute, boolean incompleteCode) {
+        List<ResolveResult> resultList = new ArrayList<>();
+        boolean isNonReferencing = false;
+        PsiElement element = moduleAttribute.getElement();
+
+        if (element instanceof AtNonNumericOperation) {
+            isNonReferencing = isNonReferencing((AtNonNumericOperation) element);
+        } else if (element instanceof ElixirAtIdentifier) {
+            isNonReferencing = isNonReferencing((ElixirAtIdentifier) element);
+        }
+
+        if (!isNonReferencing) {
+            Boolean validResult;
+
+            validResult = validResult(moduleAttribute, "@protocol", incompleteCode);
+
+            if (validResult != null) {
+                List<ResolveResult> resolveResultList = Protocol.resolveResultList(validResult, element);
+
+                if (resolveResultList != null) {
+                    resultList.addAll(resolveResultList);
+                }
+            }
+
+            if (incompleteCode || !ContainerUtil.exists(resultList, HAS_VALID_RESULT_CONDITION)) {
+                validResult = validResult(moduleAttribute, "@for", incompleteCode);
+
+                if (validResult != null) {
+                    List<ResolveResult> resolveResultList = For.resolveResultList(validResult, element);
+
+                    if (resolveResultList != null) {
+                        resultList.addAll(resolveResultList);
+                    }
+                }
+
+                if (incompleteCode || !ContainerUtil.exists(resultList, HAS_VALID_RESULT_CONDITION)) {
+                    resultList.addAll(multiResolveUpFromElement(moduleAttribute, element, incompleteCode));
+                }
+            }
+        }
+
+        return resultList.toArray(new ResolveResult[resultList.size()]);
+    }
+
+}


### PR DESCRIPTION
Resolves #766

# Changelog
## Enhancements
* References will be cached until the file containing the PSI element changes, so that results from `Callable#multiResolve`, `CallDefinitionClause#multiResolve`, `Module#multiResolve`, and `ModuleAttribute#multiResolve`, which are all the extant references, can be cached and invalidated correctly.