### PR TITLE
Check if program parameters is blank before splitting into mix args

### DIFF
--- a/src/org/elixir_lang/mix/runner/MixRunConfigurationBase.java
+++ b/src/org/elixir_lang/mix/runner/MixRunConfigurationBase.java
@@ -102,12 +102,21 @@ public abstract class MixRunConfigurationBase extends ModuleBasedConfiguration<E
   @NotNull
   public List<String> getMixArgs() {
     String programParameters = getProgramParameters();
+    List<String> mixArgs = null;
 
     if (programParameters != null) {
-      return Arrays.asList(programParameters.split("\\s+"));
-    } else {
-      return new ArrayList<>(0);
+      String trimmedProgramParameters = programParameters.trim();
+
+      if (trimmedProgramParameters.length() > 0) {
+        mixArgs = Arrays.asList(programParameters.split("\\s+"));
+      }
     }
+
+    if (mixArgs == null) {
+      mixArgs = new ArrayList<>();
+    }
+
+    return mixArgs;
   }
 
   @NotNull

--- a/src/org/elixir_lang/mix/runner/MixRunConfigurationBase.java
+++ b/src/org/elixir_lang/mix/runner/MixRunConfigurationBase.java
@@ -18,6 +18,7 @@ import com.intellij.psi.search.GlobalSearchScope;
 import com.intellij.util.containers.hash.LinkedHashMap;
 import com.intellij.util.xmlb.SerializationFilter;
 import com.intellij.util.xmlb.XmlSerializer;
+import org.elixir_lang.jps.builder.ParametersList;
 import org.elixir_lang.runconfig.ElixirModuleBasedConfiguration;
 import org.jdom.Attribute;
 import org.jdom.Element;
@@ -100,23 +101,15 @@ public abstract class MixRunConfigurationBase extends ModuleBasedConfiguration<E
   }
 
   @NotNull
-  public List<String> getMixArgs() {
+  public ParametersList mixParametersList() {
     String programParameters = getProgramParameters();
-    List<String> mixArgs = null;
+    ParametersList parametersList = new ParametersList();
 
     if (programParameters != null) {
-      String trimmedProgramParameters = programParameters.trim();
-
-      if (trimmedProgramParameters.length() > 0) {
-        mixArgs = Arrays.asList(programParameters.split("\\s+"));
-      }
+      parametersList.addAll(ParametersList.parse(programParameters));
     }
 
-    if (mixArgs == null) {
-      mixArgs = new ArrayList<>();
-    }
-
-    return mixArgs;
+    return parametersList;
   }
 
   @NotNull

--- a/src/org/elixir_lang/mix/runner/MixRunningState.java
+++ b/src/org/elixir_lang/mix/runner/MixRunningState.java
@@ -14,11 +14,9 @@ import com.intellij.execution.runners.ExecutionEnvironment;
 import com.intellij.execution.runners.ProgramRunner;
 import com.intellij.execution.ui.ConsoleView;
 import org.elixir_lang.console.ElixirConsoleUtil;
+import org.elixir_lang.jps.builder.ParametersList;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-
-import java.util.ArrayList;
-import java.util.List;
 
 import static org.elixir_lang.mix.runner.MixRunningStateUtil.runMix;
 
@@ -53,7 +51,7 @@ public class MixRunningState extends CommandLineState {
   @Override
   protected ProcessHandler startProcess() throws ExecutionException {
     GeneralCommandLine commandLine = MixRunningStateUtil.commandLine(
-      myConfiguration, setupElixirParams(myConfiguration), myConfiguration.getMixArgs()
+      myConfiguration, setupElixirParametersList(myConfiguration), myConfiguration.mixParametersList()
     );
     return runMix(myConfiguration.getProject(), commandLine);
   }
@@ -65,7 +63,7 @@ public class MixRunningState extends CommandLineState {
   }
 
   @NotNull
-  public List<String> setupElixirParams(@Nullable RunConfiguration runConfiguration) throws ExecutionException {
-    return new ArrayList<>();
+  public ParametersList setupElixirParametersList(@Nullable RunConfiguration runConfiguration) throws ExecutionException {
+    return new ParametersList();
   }
 }

--- a/src/org/elixir_lang/mix/runner/MixRunningStateUtil.java
+++ b/src/org/elixir_lang/mix/runner/MixRunningStateUtil.java
@@ -2,7 +2,6 @@ package org.elixir_lang.mix.runner;
 
 import com.intellij.execution.ExecutionException;
 import com.intellij.execution.configurations.GeneralCommandLine;
-import com.intellij.execution.configurations.ParametersList;
 import com.intellij.execution.process.OSProcessHandler;
 import com.intellij.notification.Notification;
 import com.intellij.notification.NotificationType;
@@ -17,7 +16,7 @@ import org.elixir_lang.mix.settings.MixSettings;
 import org.elixir_lang.sdk.ElixirSdkType;
 import org.elixir_lang.utils.ElixirExternalToolsNotificationListener;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.elixir_lang.jps.builder.ParametersList;
 
 import java.util.List;
 
@@ -76,7 +75,7 @@ public class MixRunningStateUtil {
   public static GeneralCommandLine addNewSkipDependencies(@NotNull GeneralCommandLine commandLine,
                                                           @NotNull MixRunConfigurationBase configuration) {
     if (configuration.isSkipDependencies()) {
-      ParametersList parametersList = commandLine.getParametersList();
+      com.intellij.execution.configurations.ParametersList parametersList = commandLine.getParametersList();
 
       if (!parametersList.hasParameter(SKIP_DEPENDENCIES_PARAMETER)) {
         parametersList.add(SKIP_DEPENDENCIES_PARAMETER);
@@ -161,15 +160,17 @@ public class MixRunningStateUtil {
   }
 
   public static GeneralCommandLine commandLine(@NotNull MixRunConfigurationBase configuration,
-                                               @NotNull List<String> elixirParams,
-                                               @NotNull List<String> mixParams) {
+                                               @NotNull ParametersList elixirParametersList,
+                                               @NotNull ParametersList mixParametersList) {
 
     GeneralCommandLine commandLine = getBaseMixCommandLine(configuration);
 
     Project project = configuration.getProject();
     String mixPath = mixPath(project);
 
-    if (mixPath.endsWith(".bat") && elixirParams.isEmpty()) {
+    List<String> elixirParameterList = elixirParametersList.getList();
+
+    if (mixPath.endsWith(".bat") && elixirParameterList.isEmpty()) {
       commandLine.setExePath(mixPath);
     } else {
       mixPath = stripEnd(mixPath, ".bat");
@@ -177,11 +178,11 @@ public class MixRunningStateUtil {
       String elixirPath = elixirPath(sdkPath);
 
       commandLine.setExePath(elixirPath);
-      commandLine.addParameters(elixirParams);
+      commandLine.addParameters(elixirParameterList);
       commandLine.addParameter(mixPath);
     }
 
-    commandLine.addParameters(mixParams);
+    commandLine.addParameters(mixParametersList.getList());
 
     return addNewSkipDependencies(commandLine, configuration);
   }

--- a/src/org/elixir_lang/mix/runner/exunit/MixExUnitRunConfiguration.java
+++ b/src/org/elixir_lang/mix/runner/exunit/MixExUnitRunConfiguration.java
@@ -7,13 +7,10 @@ import com.intellij.execution.configurations.RunProfileState;
 import com.intellij.execution.runners.ExecutionEnvironment;
 import com.intellij.openapi.options.SettingsEditor;
 import com.intellij.openapi.project.Project;
+import org.elixir_lang.jps.builder.ParametersList;
 import org.elixir_lang.mix.runner.MixRunConfigurationBase;
 import org.elixir_lang.mix.settings.MixSettings;
 import org.jetbrains.annotations.NotNull;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
 
 public final class MixExUnitRunConfiguration extends MixRunConfigurationBase {
   MixExUnitRunConfiguration(@NotNull String name, @NotNull Project project){
@@ -34,15 +31,17 @@ public final class MixExUnitRunConfiguration extends MixRunConfigurationBase {
   }
 
   @NotNull
-  public List<String> getMixArgs() {
-    List<String> params = super.getMixArgs();
+  public ParametersList mixParametersList() {
+    ParametersList superParametersList = super.mixParametersList();
+    ParametersList parametersList = new ParametersList();
+
     MixSettings mixSettings = MixSettings.getInstance(getProject());
-
     String task = mixSettings.getSupportsFormatterOption() ? "test" : "test_with_formatter";
+    parametersList.add(task);
 
-    ArrayList<String> mixArgs = new ArrayList<>();
-    mixArgs.addAll(Arrays.asList(task, "--formatter", "TeamCityExUnitFormatter"));
-    mixArgs.addAll(params);
-    return mixArgs;
+    parametersList.addAll("--formatter", "TeamCityExUnitFormatter");
+    parametersList.addAll(superParametersList.getParameters());
+
+    return parametersList;
   }
 }

--- a/src/org/elixir_lang/mix/runner/exunit/MixExUnitRunningState.java
+++ b/src/org/elixir_lang/mix/runner/exunit/MixExUnitRunningState.java
@@ -16,6 +16,7 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.io.FileUtil;
 import org.elixir_lang.console.ElixirConsoleUtil;
 import org.elixir_lang.exunit.ElixirModules;
+import org.elixir_lang.jps.builder.ParametersList;
 import org.elixir_lang.mix.runner.MixRunningState;
 import org.elixir_lang.mix.runner.MixTestConsoleProperties;
 import org.elixir_lang.mix.settings.MixSettings;
@@ -143,18 +144,19 @@ final class MixExUnitRunningState extends MixRunningState {
   }
 
   @NotNull
-  private static List<String> elixirParams(@NotNull Collection<File> elixirModuleFileCollection) {
-    ArrayList<String> elixirParams = new ArrayList<>();
+  private static ParametersList elixirParametersList(@NotNull Collection<File> elixirModuleFileCollection) {
+    ParametersList parametersList = new ParametersList();
+
     for (File elixirModuleFile : elixirModuleFileCollection) {
-      elixirParams.add("-r");
-      elixirParams.add(String.valueOf(elixirModuleFile));
+      parametersList.add("-r");
+      parametersList.add(String.valueOf(elixirModuleFile));
     }
 
-    return elixirParams;
+    return parametersList;
   }
 
   @NotNull
-  public List<String> setupElixirParams(@Nullable RunConfiguration runConfiguration) throws ExecutionException {
+  public ParametersList setupElixirParametersList(@Nullable RunConfiguration runConfiguration) throws ExecutionException {
     List<File> elixirModuleFileList = new ArrayList<>();
 
     try {
@@ -179,6 +181,6 @@ final class MixExUnitRunningState extends MixRunningState {
       throw new ExecutionException(e);
     }
 
-    return elixirParams(elixirModuleFileList);
+    return elixirParametersList(elixirModuleFileList);
   }
 }


### PR DESCRIPTION
Fixes #709

# Changelog
## Enhancements
* Use `ParameterLists` to support Path Variables in program parameters.

## Bug Fixes
* Check if program parameters is blank before splitting into mix args.
* Use `ParametersList` to properly parse quote program parameters.