### PR TITLE
(write|read)VarInt instead of (write|read)Int

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 # https://www.jetbrains.com/intellij-repository/releases
 # https://www.jetbrains.com/intellij-repository/snapshots
 
-version = 5.1.0
+version = 6.0.0
 ideaVersion = 2017.1.5
 javaVersion = 1.8
 javaTargetVersion = 1.6

--- a/src/org/elixir_lang/beam/StubBuilder.java
+++ b/src/org/elixir_lang/beam/StubBuilder.java
@@ -11,7 +11,7 @@ import org.jetbrains.annotations.Nullable;
 
 public class StubBuilder implements BinaryFileStubBuilder {
     private static final Logger LOGGER = Logger.getInstance(StubBuilder.class);
-    private static final int STUB_VERSION = 0;
+    private static final int STUB_VERSION = 1;
 
     /**
      * @param file a .beam file

--- a/src/org/elixir_lang/beam/psi/impl/CallDefinitionStubImpl.java
+++ b/src/org/elixir_lang/beam/psi/impl/CallDefinitionStubImpl.java
@@ -1,11 +1,15 @@
 package org.elixir_lang.beam.psi.impl;
 
+import com.intellij.util.io.StringRef;
 import org.elixir_lang.beam.psi.CallDefinition;
 import org.elixir_lang.beam.psi.stubs.CallDefinitionStub;
 import org.elixir_lang.beam.psi.stubs.ModuleStub;
 import org.elixir_lang.beam.psi.stubs.ModuleStubElementTypes;
+import org.elixir_lang.psi.stub.call.Deserialized;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.Set;
 
 import static org.elixir_lang.psi.call.name.Module.KERNEL;
 
@@ -35,6 +39,30 @@ public class CallDefinitionStubImpl<T extends CallDefinition> extends StubbicBas
      */
     private final int callDefinitionClauseHeadArity;
 
+    public CallDefinitionStubImpl(@NotNull ModuleStub parentStub,
+                                  @NotNull Deserialized deserialized,
+                                  int callDefinitionClauseHeadArity) {
+        super(parentStub, ModuleStubElementTypes.CALL_DEFINITION, deserialized.name.toString());
+
+        StringRef resolvedModuleName = deserialized.resolvedModuleName;
+        assert resolvedModuleName != null;
+        assert resolvedModuleName.toString().equals(RESOLVED_MODULE_NAME);
+
+        StringRef resolvedFunctionName = deserialized.resolvedFunctionName;
+        assert resolvedFunctionName != null;
+
+        this.resolvedFunctionName = resolvedFunctionName.toString();
+
+        assert deserialized.resolvedFinalArity == RESOLVED_FINAL_ARITY;
+
+        assert deserialized.hasDoBlockOrKeyword == HAS_DO_BLOCK_OR_KEYWORD;
+
+        Set<StringRef> canonicalNameSet = deserialized.canonicalNameSet;
+        assert canonicalNameSet.size() == 1;
+        assert canonicalNameSet.iterator().next().toString().equals(this.getName());
+
+        this.callDefinitionClauseHeadArity = callDefinitionClauseHeadArity;
+    }
 
     public CallDefinitionStubImpl(@NotNull ModuleStub parentStub,
                                   @NotNull String macro,

--- a/src/org/elixir_lang/beam/psi/impl/ModuleStubImpl.java
+++ b/src/org/elixir_lang/beam/psi/impl/ModuleStubImpl.java
@@ -1,12 +1,16 @@
 package org.elixir_lang.beam.psi.impl;
 
 import com.intellij.psi.stubs.StubElement;
+import com.intellij.util.io.StringRef;
 import org.elixir_lang.beam.psi.Module;
 import org.elixir_lang.beam.psi.stubs.ModuleStub;
 import org.elixir_lang.beam.psi.stubs.ModuleStubElementTypes;
 import org.elixir_lang.psi.call.name.Function;
+import org.elixir_lang.psi.stub.call.Deserialized;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.Set;
 
 import static org.elixir_lang.psi.call.name.Function.DEFMODULE;
 import static org.elixir_lang.psi.call.name.Module.KERNEL;
@@ -15,13 +19,34 @@ import static org.elixir_lang.psi.call.name.Module.KERNEL;
  * See {@link com.intellij.psi.impl.java.stubs.impl.PsiClassStubImpl}
  */
 public class ModuleStubImpl<T extends Module> extends StubbicBase<T> implements ModuleStub<T> {
-    public static final int RESOLVED_FINAL_ARITY = 2;
-    public static final String RESOLVED_FUNCTION_NAME = DEFMODULE;
-    public static final String RESOLVED_MODULE_NAME = KERNEL;
+    private static final int RESOLVED_FINAL_ARITY = 2;
+    private static final String RESOLVED_FUNCTION_NAME = DEFMODULE;
+    private static final String RESOLVED_MODULE_NAME = KERNEL;
 
     public ModuleStubImpl(@NotNull StubElement parentStub,
                           @NotNull String name) {
         super(parentStub, ModuleStubElementTypes.MODULE, name);
+    }
+
+    public ModuleStubImpl(@NotNull StubElement parentStub,
+                          @NotNull Deserialized deserialized) {
+        super(parentStub, ModuleStubElementTypes.MODULE, deserialized.name.toString());
+
+        StringRef resolvedModuleName = deserialized.resolvedModuleName;
+        assert resolvedModuleName != null;
+        assert resolvedModuleName.getString().equals(RESOLVED_MODULE_NAME);
+
+        StringRef resolvedFunctionName = deserialized.resolvedFunctionName;
+        assert resolvedFunctionName != null;
+        assert resolvedFunctionName.toString().equals(RESOLVED_FUNCTION_NAME);
+
+        assert  deserialized.resolvedFinalArity == RESOLVED_FINAL_ARITY;
+
+        assert  deserialized.hasDoBlockOrKeyword == HAS_DO_BLOCK_OR_KEYWORD;
+
+        Set<StringRef> canonicalNameSet = deserialized.canonicalNameSet;
+        assert canonicalNameSet.size() == 1;
+        assert canonicalNameSet.iterator().next().toString().equals(this.getName());
     }
 
     /**

--- a/src/org/elixir_lang/beam/psi/stubs/ModuleElementType.java
+++ b/src/org/elixir_lang/beam/psi/stubs/ModuleElementType.java
@@ -5,13 +5,13 @@ import com.intellij.lang.LighterAST;
 import com.intellij.lang.LighterASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.stubs.*;
+import org.elixir_lang.psi.stub.call.Deserialized;
 import org.elixir_lang.psi.stub.call.Stubbic;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
 
 import static org.elixir_lang.psi.stub.type.Named.indexStubbic;
-import static org.elixir_lang.psi.stub.type.call.Stub.serializeStubbic;
 
 /**
  *
@@ -60,12 +60,12 @@ public abstract class ModuleElementType<S extends StubElement & Stubbic, P exten
      * Serializes {@code stub} as a {@link Stubbic}.
      *
      * @param stub created by {@link org.elixir_lang.beam.psi.BeamFileImpl#buildFileStub(byte[], String)}
-     * @param dataStream stream to write {@code stub} to
+     * @param stubOutputStream stream to write {@code stub} to
      * @throws IOException if {@code dataStream} cannot be written to
      */
     @Override
-    public void serialize(@NotNull S stub, @NotNull StubOutputStream dataStream) throws IOException {
-        serializeStubbic(stub, dataStream);
+    public void serialize(@NotNull S stub, @NotNull StubOutputStream stubOutputStream) throws IOException {
+        Deserialized.serialize(stubOutputStream, stub);
     }
 
     /**

--- a/src/org/elixir_lang/beam/psi/stubs/ModuleStubElementTypes.java
+++ b/src/org/elixir_lang/beam/psi/stubs/ModuleStubElementTypes.java
@@ -41,7 +41,7 @@ public interface ModuleStubElementTypes {
 
             String macro = dataStream.readName().toString();
 
-            assert dataStream.readInt() == CallDefinitionStubImpl.RESOLVED_FINAL_ARITY;
+            assert dataStream.readVarInt() == CallDefinitionStubImpl.RESOLVED_FINAL_ARITY;
             assert dataStream.readBoolean() == CallDefinitionStubImpl.HAS_DO_BLOCK_OR_KEYWORD;
 
             StringRef nameRef = dataStream.readName();
@@ -52,7 +52,7 @@ public interface ModuleStubElementTypes {
             assert canonicalNameRefSet.size() == 1;
             assert canonicalNameRefSet.iterator().next().toString().equals(name);
 
-            int callDefinitionClauseArity = dataStream.readInt();
+            int callDefinitionClauseArity = dataStream.readVarInt();
 
             return new CallDefinitionStubImpl((ModuleStub) parentStub, macro, name, callDefinitionClauseArity);
         }
@@ -60,7 +60,7 @@ public interface ModuleStubElementTypes {
         @Override
         public void serialize(@NotNull CallDefinitionStub stub, @NotNull StubOutputStream dataStream) throws IOException {
             super.serialize(stub, dataStream);
-            dataStream.writeInt(stub.callDefinitionClauseHeadArity());
+            dataStream.writeVarInt(stub.callDefinitionClauseHeadArity());
         }
     };
 
@@ -85,7 +85,7 @@ public interface ModuleStubElementTypes {
                                       @NotNull StubElement parentStub) throws IOException {
             assert dataStream.readName().toString().equals(ModuleStubImpl.RESOLVED_MODULE_NAME);
             assert dataStream.readName().toString().equals(ModuleStubImpl.RESOLVED_FUNCTION_NAME);
-            assert dataStream.readInt() == ModuleStubImpl.RESOLVED_FINAL_ARITY;
+            assert dataStream.readVarInt() == ModuleStubImpl.RESOLVED_FINAL_ARITY;
             assert dataStream.readBoolean() == ModuleStubImpl.HAS_DO_BLOCK_OR_KEYWORD;
 
             StringRef nameRef = dataStream.readName();

--- a/src/org/elixir_lang/beam/psi/stubs/ModuleStubElementTypes.java
+++ b/src/org/elixir_lang/beam/psi/stubs/ModuleStubElementTypes.java
@@ -4,7 +4,6 @@ import com.intellij.lang.ASTNode;
 import com.intellij.psi.stubs.StubElement;
 import com.intellij.psi.stubs.StubInputStream;
 import com.intellij.psi.stubs.StubOutputStream;
-import com.intellij.util.io.StringRef;
 import org.elixir_lang.beam.psi.CallDefinition;
 import org.elixir_lang.beam.psi.CallDefinitionElement;
 import org.elixir_lang.beam.psi.Module;
@@ -13,12 +12,13 @@ import org.elixir_lang.beam.psi.impl.CallDefinitionImpl;
 import org.elixir_lang.beam.psi.impl.CallDefinitionStubImpl;
 import org.elixir_lang.beam.psi.impl.ModuleImpl;
 import org.elixir_lang.beam.psi.impl.ModuleStubImpl;
+import org.elixir_lang.psi.stub.call.Deserialized;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
-import java.util.Set;
 
-import static org.elixir_lang.psi.stub.type.call.Stub.readNameSet;
+import static org.elixir_lang.psi.stub.call.Deserialized.readGuarded;
+import static org.elixir_lang.psi.stub.call.Deserialized.writeGuarded;
 
 // See com.intellij.psi.impl.java.stubs.JavaStubElementTypes
 public interface ModuleStubElementTypes {
@@ -36,31 +36,26 @@ public interface ModuleStubElementTypes {
 
         @NotNull
         @Override
-        public CallDefinitionStub deserialize(@NotNull StubInputStream dataStream, StubElement parentStub) throws IOException {
-            assert dataStream.readName().toString().equals(CallDefinitionStubImpl.RESOLVED_MODULE_NAME);
+        public CallDefinitionStub deserialize(@NotNull StubInputStream stubInputStream,
+                                              @NotNull StubElement parentStub) throws IOException {
+            Deserialized deserialized = Deserialized.deserialize(stubInputStream);
+            int callDefinitionClauseArity = deserializeCallDefinitionClauseArity(stubInputStream);
 
-            String macro = dataStream.readName().toString();
+            return new CallDefinitionStubImpl((ModuleStub) parentStub, deserialized, callDefinitionClauseArity);
+        }
 
-            assert dataStream.readVarInt() == CallDefinitionStubImpl.RESOLVED_FINAL_ARITY;
-            assert dataStream.readBoolean() == CallDefinitionStubImpl.HAS_DO_BLOCK_OR_KEYWORD;
-
-            StringRef nameRef = dataStream.readName();
-            String name = nameRef.toString();
-
-            Set<StringRef> canonicalNameRefSet = readNameSet(dataStream);
-
-            assert canonicalNameRefSet.size() == 1;
-            assert canonicalNameRefSet.iterator().next().toString().equals(name);
-
-            int callDefinitionClauseArity = dataStream.readVarInt();
-
-            return new CallDefinitionStubImpl((ModuleStub) parentStub, macro, name, callDefinitionClauseArity);
+        int deserializeCallDefinitionClauseArity(@NotNull StubInputStream stubInputStream) throws IOException {
+            return readGuarded(stubInputStream, StubInputStream::readVarInt);
         }
 
         @Override
-        public void serialize(@NotNull CallDefinitionStub stub, @NotNull StubOutputStream dataStream) throws IOException {
-            super.serialize(stub, dataStream);
-            dataStream.writeVarInt(stub.callDefinitionClauseHeadArity());
+        public void serialize(@NotNull CallDefinitionStub stub,
+                              @NotNull StubOutputStream stubOutputStream) throws IOException {
+            super.serialize(stub, stubOutputStream);
+            writeGuarded(
+                    stubOutputStream,
+                    guardedStubOutputStream -> guardedStubOutputStream.writeVarInt(stub.callDefinitionClauseHeadArity())
+            );
         }
     };
 
@@ -81,22 +76,11 @@ public interface ModuleStubElementTypes {
 
         @NotNull
         @Override
-        public ModuleStub deserialize(@NotNull StubInputStream dataStream,
+        public ModuleStub deserialize(@NotNull StubInputStream stubInputStream,
                                       @NotNull StubElement parentStub) throws IOException {
-            assert dataStream.readName().toString().equals(ModuleStubImpl.RESOLVED_MODULE_NAME);
-            assert dataStream.readName().toString().equals(ModuleStubImpl.RESOLVED_FUNCTION_NAME);
-            assert dataStream.readVarInt() == ModuleStubImpl.RESOLVED_FINAL_ARITY;
-            assert dataStream.readBoolean() == ModuleStubImpl.HAS_DO_BLOCK_OR_KEYWORD;
+            Deserialized deserialized = Deserialized.deserialize(stubInputStream);
 
-            StringRef nameRef = dataStream.readName();
-            String name = nameRef.toString();
-
-            Set<StringRef> canonicalNameRefSet = readNameSet(dataStream);
-
-            assert canonicalNameRefSet.size() == 1;
-            assert canonicalNameRefSet.iterator().next().toString().equals(name);
-
-            return new ModuleStubImpl(parentStub, name);
+            return new ModuleStubImpl(parentStub, deserialized);
         }
     };
 }

--- a/src/org/elixir_lang/psi/stub/MatchedAtUnqualifiedNoParenthesesCall.java
+++ b/src/org/elixir_lang/psi/stub/MatchedAtUnqualifiedNoParenthesesCall.java
@@ -2,36 +2,15 @@ package org.elixir_lang.psi.stub;
 
 import com.intellij.psi.stubs.IStubElementType;
 import com.intellij.psi.stubs.StubElement;
-import com.intellij.util.io.StringRef;
 import org.elixir_lang.psi.ElixirMatchedAtUnqualifiedNoParenthesesCall;
+import org.elixir_lang.psi.stub.call.Deserialized;
 import org.elixir_lang.psi.stub.call.Stub;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.Collection;
 import java.util.Set;
 
 public class MatchedAtUnqualifiedNoParenthesesCall extends Stub<ElixirMatchedAtUnqualifiedNoParenthesesCall> {
-    public MatchedAtUnqualifiedNoParenthesesCall(
-            StubElement parent,
-            @NotNull IStubElementType elementType,
-            @Nullable StringRef resolvedModuleName,
-            @Nullable StringRef resolvedFunctionName,
-            int resolvedFinalArity,
-            boolean hasDoBlockOrKeyword,
-            @NotNull StringRef name,
-            @NotNull Set<StringRef> canonicalNameSet
-    ) {
-        super(parent,
-                elementType,
-                resolvedModuleName,
-                resolvedFunctionName,
-                resolvedFinalArity,
-                hasDoBlockOrKeyword,
-                name,
-                canonicalNameSet);
-    }
-
     public MatchedAtUnqualifiedNoParenthesesCall(
             StubElement parent,
             @NotNull IStubElementType elementType,
@@ -52,5 +31,11 @@ public class MatchedAtUnqualifiedNoParenthesesCall extends Stub<ElixirMatchedAtU
                 name,
                 canonicalNameSet
         );
+    }
+
+    public MatchedAtUnqualifiedNoParenthesesCall(StubElement parentStub,
+                                                 IStubElementType elementType,
+                                                 Deserialized deserialized) {
+        super(parentStub, elementType, deserialized);
     }
 }

--- a/src/org/elixir_lang/psi/stub/MatchedDotCall.java
+++ b/src/org/elixir_lang/psi/stub/MatchedDotCall.java
@@ -2,36 +2,20 @@ package org.elixir_lang.psi.stub;
 
 import com.intellij.psi.stubs.IStubElementType;
 import com.intellij.psi.stubs.StubElement;
-import com.intellij.util.io.StringRef;
 import org.elixir_lang.psi.ElixirMatchedDotCall;
+import org.elixir_lang.psi.stub.call.Deserialized;
 import org.elixir_lang.psi.stub.call.Stub;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.Collection;
 import java.util.Set;
 
 public class MatchedDotCall extends Stub<ElixirMatchedDotCall> {
     public MatchedDotCall(
             StubElement parent,
             @NotNull IStubElementType elementType,
-            @Nullable StringRef resolvedModuleName,
-            @Nullable StringRef resolvedFunctionName,
-            int resolvedFinalArity,
-            boolean hasDoBlockOrKeyword,
-            @NotNull StringRef name,
-            @NotNull Set<StringRef> canonicalNameSet
-    ) {
-        super(
-                parent,
-                elementType,
-                resolvedModuleName,
-                resolvedFunctionName,
-                resolvedFinalArity,
-                hasDoBlockOrKeyword,
-                name,
-                canonicalNameSet
-        );
+            @NotNull Deserialized deserialized) {
+        super(parent, elementType, deserialized);
     }
 
     public MatchedDotCall(

--- a/src/org/elixir_lang/psi/stub/MatchedQualifiedNoArgumentsCall.java
+++ b/src/org/elixir_lang/psi/stub/MatchedQualifiedNoArgumentsCall.java
@@ -2,36 +2,20 @@ package org.elixir_lang.psi.stub;
 
 import com.intellij.psi.stubs.IStubElementType;
 import com.intellij.psi.stubs.StubElement;
-import com.intellij.util.io.StringRef;
 import org.elixir_lang.psi.ElixirMatchedQualifiedNoArgumentsCall;
+import org.elixir_lang.psi.stub.call.Deserialized;
 import org.elixir_lang.psi.stub.call.Stub;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.Collection;
 import java.util.Set;
 
 public class MatchedQualifiedNoArgumentsCall extends Stub<ElixirMatchedQualifiedNoArgumentsCall> {
     public MatchedQualifiedNoArgumentsCall(
             StubElement parent,
             @NotNull IStubElementType elementType,
-            @Nullable StringRef resolvedModuleName,
-            @Nullable StringRef resolvedFunctionName,
-            int resolvedFinalArity,
-            boolean hasDoBlockOrKeyword,
-            @NotNull StringRef name,
-            @NotNull Set<StringRef> canonicalNameSet
-    ) {
-        super(
-                parent,
-                elementType,
-                resolvedModuleName,
-                resolvedFunctionName,
-                resolvedFinalArity,
-                hasDoBlockOrKeyword,
-                name,
-                canonicalNameSet
-        );
+            @NotNull Deserialized deserialized) {
+        super(parent, elementType, deserialized);
     }
 
     public MatchedQualifiedNoArgumentsCall(

--- a/src/org/elixir_lang/psi/stub/MatchedQualifiedNoParenthesesCall.java
+++ b/src/org/elixir_lang/psi/stub/MatchedQualifiedNoParenthesesCall.java
@@ -2,36 +2,20 @@ package org.elixir_lang.psi.stub;
 
 import com.intellij.psi.stubs.IStubElementType;
 import com.intellij.psi.stubs.StubElement;
-import com.intellij.util.io.StringRef;
 import org.elixir_lang.psi.ElixirMatchedQualifiedNoParenthesesCall;
+import org.elixir_lang.psi.stub.call.Deserialized;
 import org.elixir_lang.psi.stub.call.Stub;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.Collection;
 import java.util.Set;
 
 public class MatchedQualifiedNoParenthesesCall extends Stub<ElixirMatchedQualifiedNoParenthesesCall> {
     public MatchedQualifiedNoParenthesesCall(
             StubElement parent,
             @NotNull IStubElementType elementType,
-            @Nullable StringRef resolvedModuleName,
-            @Nullable StringRef resolvedFunctionName,
-            int resolvedFinalArity,
-            boolean hasDoBlockOrKeyword,
-            @NotNull StringRef name,
-            @NotNull Set<StringRef> canonicalNameSet
-    ) {
-        super(
-                parent,
-                elementType,
-                resolvedModuleName,
-                resolvedFunctionName,
-                resolvedFinalArity,
-                hasDoBlockOrKeyword,
-                name,
-                canonicalNameSet
-        );
+            @NotNull Deserialized deserialized) {
+        super(parent, elementType, deserialized);
     }
 
     public MatchedQualifiedNoParenthesesCall(

--- a/src/org/elixir_lang/psi/stub/MatchedQualifiedParenthesesCall.java
+++ b/src/org/elixir_lang/psi/stub/MatchedQualifiedParenthesesCall.java
@@ -2,36 +2,20 @@ package org.elixir_lang.psi.stub;
 
 import com.intellij.psi.stubs.IStubElementType;
 import com.intellij.psi.stubs.StubElement;
-import com.intellij.util.io.StringRef;
 import org.elixir_lang.psi.ElixirMatchedQualifiedParenthesesCall;
+import org.elixir_lang.psi.stub.call.Deserialized;
 import org.elixir_lang.psi.stub.call.Stub;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.Collection;
 import java.util.Set;
 
 public class MatchedQualifiedParenthesesCall extends Stub<ElixirMatchedQualifiedParenthesesCall> {
     public MatchedQualifiedParenthesesCall(
             StubElement parent,
             @NotNull IStubElementType elementType,
-            @Nullable StringRef resolvedModuleName,
-            @Nullable StringRef resolvedFunctionName,
-            int resolvedFinalArity,
-            boolean hasDoBlockOrKeyword,
-            @NotNull StringRef name,
-            @NotNull Set<StringRef> canonicalNameSet
-    ) {
-        super(
-                parent,
-                elementType,
-                resolvedModuleName,
-                resolvedFunctionName,
-                resolvedFinalArity,
-                hasDoBlockOrKeyword,
-                name,
-                canonicalNameSet
-        );
+            @NotNull Deserialized deserialized) {
+        super(parent, elementType, deserialized);
     }
 
     public MatchedQualifiedParenthesesCall(

--- a/src/org/elixir_lang/psi/stub/MatchedUnqualifiedNoArgumentsCall.java
+++ b/src/org/elixir_lang/psi/stub/MatchedUnqualifiedNoArgumentsCall.java
@@ -2,36 +2,20 @@ package org.elixir_lang.psi.stub;
 
 import com.intellij.psi.stubs.IStubElementType;
 import com.intellij.psi.stubs.StubElement;
-import com.intellij.util.io.StringRef;
 import org.elixir_lang.psi.ElixirMatchedUnqualifiedNoArgumentsCall;
+import org.elixir_lang.psi.stub.call.Deserialized;
 import org.elixir_lang.psi.stub.call.Stub;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.Collection;
 import java.util.Set;
 
 public class MatchedUnqualifiedNoArgumentsCall extends Stub<ElixirMatchedUnqualifiedNoArgumentsCall> {
     public MatchedUnqualifiedNoArgumentsCall(
             StubElement parent,
             @NotNull IStubElementType elementType,
-            @Nullable StringRef resolvedModuleName,
-            @Nullable StringRef resolvedFunctionName,
-            int resolvedFinalArity,
-            boolean hasDoBlockOrKeyword,
-            @NotNull StringRef name,
-            @NotNull Set<StringRef> canonicalNameSet
-    ) {
-        super(
-                parent,
-                elementType,
-                resolvedModuleName,
-                resolvedFunctionName,
-                resolvedFinalArity,
-                hasDoBlockOrKeyword,
-                name,
-                canonicalNameSet
-        );
+            @NotNull Deserialized deserialized) {
+        super(parent, elementType, deserialized);
     }
 
     public MatchedUnqualifiedNoArgumentsCall(

--- a/src/org/elixir_lang/psi/stub/MatchedUnqualifiedNoParenthesesCall.java
+++ b/src/org/elixir_lang/psi/stub/MatchedUnqualifiedNoParenthesesCall.java
@@ -2,36 +2,20 @@ package org.elixir_lang.psi.stub;
 
 import com.intellij.psi.stubs.IStubElementType;
 import com.intellij.psi.stubs.StubElement;
-import com.intellij.util.io.StringRef;
 import org.elixir_lang.psi.ElixirMatchedUnqualifiedNoParenthesesCall;
+import org.elixir_lang.psi.stub.call.Deserialized;
 import org.elixir_lang.psi.stub.call.Stub;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.Collection;
 import java.util.Set;
 
 public class MatchedUnqualifiedNoParenthesesCall extends Stub<ElixirMatchedUnqualifiedNoParenthesesCall> {
     public MatchedUnqualifiedNoParenthesesCall(
             StubElement parent,
             @NotNull IStubElementType elementType,
-            @Nullable StringRef resolvedModuleName,
-            @Nullable StringRef resolvedFunctionName,
-            int resolvedFinalArity,
-            boolean hasDoBlockOrKeyword,
-            @NotNull StringRef name,
-            @NotNull Set<StringRef> canonicalNameSet
-    ) {
-        super(
-                parent,
-                elementType,
-                resolvedModuleName,
-                resolvedFunctionName,
-                resolvedFinalArity,
-                hasDoBlockOrKeyword,
-                name,
-                canonicalNameSet
-        );
+            @NotNull Deserialized deserialized) {
+        super(parent, elementType, deserialized);
     }
 
     public MatchedUnqualifiedNoParenthesesCall(

--- a/src/org/elixir_lang/psi/stub/MatchedUnqualifiedParenthesesCall.java
+++ b/src/org/elixir_lang/psi/stub/MatchedUnqualifiedParenthesesCall.java
@@ -2,36 +2,20 @@ package org.elixir_lang.psi.stub;
 
 import com.intellij.psi.stubs.IStubElementType;
 import com.intellij.psi.stubs.StubElement;
-import com.intellij.util.io.StringRef;
 import org.elixir_lang.psi.ElixirMatchedUnqualifiedParenthesesCall;
+import org.elixir_lang.psi.stub.call.Deserialized;
 import org.elixir_lang.psi.stub.call.Stub;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.Collection;
 import java.util.Set;
 
 public class MatchedUnqualifiedParenthesesCall extends Stub<ElixirMatchedUnqualifiedParenthesesCall> {
     public MatchedUnqualifiedParenthesesCall(
             StubElement parent,
             @NotNull IStubElementType elementType,
-            @Nullable StringRef resolvedModuleName,
-            @Nullable StringRef resolvedFunctionName,
-            int resolvedFinalArity,
-            boolean hasDoBlockOrKeyword,
-            @NotNull StringRef name,
-            @NotNull Set<StringRef> canonicalNameSet
-    ) {
-        super(
-                parent,
-                elementType,
-                resolvedModuleName,
-                resolvedFunctionName,
-                resolvedFinalArity,
-                hasDoBlockOrKeyword,
-                name,
-                canonicalNameSet
-        );
+            @NotNull Deserialized deserialized) {
+        super(parent, elementType, deserialized);
     }
 
     public MatchedUnqualifiedParenthesesCall(

--- a/src/org/elixir_lang/psi/stub/UnmatchedAtUnqualifiedNoParenthesesCall.java
+++ b/src/org/elixir_lang/psi/stub/UnmatchedAtUnqualifiedNoParenthesesCall.java
@@ -2,36 +2,19 @@ package org.elixir_lang.psi.stub;
 
 import com.intellij.psi.stubs.IStubElementType;
 import com.intellij.psi.stubs.StubElement;
-import com.intellij.util.io.StringRef;
 import org.elixir_lang.psi.ElixirUnmatchedAtUnqualifiedNoParenthesesCall;
+import org.elixir_lang.psi.stub.call.Deserialized;
 import org.elixir_lang.psi.stub.call.Stub;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.Collection;
 import java.util.Set;
 
 public class UnmatchedAtUnqualifiedNoParenthesesCall extends Stub<ElixirUnmatchedAtUnqualifiedNoParenthesesCall> {
-    public UnmatchedAtUnqualifiedNoParenthesesCall(
-            StubElement parent,
-            @NotNull IStubElementType elementType,
-            @Nullable StringRef resolvedModuleName,
-            @Nullable StringRef resolvedFunctionName,
-            int resolvedFinalArity,
-            boolean hasDoBlockOrKeyword,
-            @NotNull StringRef name,
-            @NotNull Set<StringRef> canonicalNameSet
-    ) {
-        super(
-                parent,
-                elementType,
-                resolvedModuleName,
-                resolvedFunctionName,
-                resolvedFinalArity,
-                hasDoBlockOrKeyword,
-                name,
-                canonicalNameSet
-        );
+    public UnmatchedAtUnqualifiedNoParenthesesCall(StubElement parentStub,
+                                                 IStubElementType elementType,
+                                                 Deserialized deserialized) {
+        super(parentStub, elementType, deserialized);
     }
 
     public UnmatchedAtUnqualifiedNoParenthesesCall(

--- a/src/org/elixir_lang/psi/stub/UnmatchedDotCall.java
+++ b/src/org/elixir_lang/psi/stub/UnmatchedDotCall.java
@@ -2,36 +2,19 @@ package org.elixir_lang.psi.stub;
 
 import com.intellij.psi.stubs.IStubElementType;
 import com.intellij.psi.stubs.StubElement;
-import com.intellij.util.io.StringRef;
 import org.elixir_lang.psi.ElixirUnmatchedDotCall;
+import org.elixir_lang.psi.stub.call.Deserialized;
 import org.elixir_lang.psi.stub.call.Stub;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.Collection;
 import java.util.Set;
 
 public class UnmatchedDotCall extends Stub<ElixirUnmatchedDotCall> {
-    public UnmatchedDotCall(
-            StubElement parent,
-            @NotNull IStubElementType elementType,
-            @Nullable StringRef resolvedModuleName,
-            @Nullable StringRef resolvedFunctionName,
-            int resolvedFinalArity,
-            boolean hasDoBlockOrKeyword,
-            @NotNull StringRef name,
-            @NotNull Set<StringRef> canonicalNameSet
-    ) {
-        super(
-                parent,
-                elementType,
-                resolvedModuleName,
-                resolvedFunctionName,
-                resolvedFinalArity,
-                hasDoBlockOrKeyword,
-                name,
-                canonicalNameSet
-        );
+    public UnmatchedDotCall(StubElement parentStub,
+                                                 IStubElementType elementType,
+                                                 Deserialized deserialized) {
+        super(parentStub, elementType, deserialized);
     }
 
     public UnmatchedDotCall(

--- a/src/org/elixir_lang/psi/stub/UnmatchedQualifiedNoArgumentsCall.java
+++ b/src/org/elixir_lang/psi/stub/UnmatchedQualifiedNoArgumentsCall.java
@@ -2,36 +2,21 @@ package org.elixir_lang.psi.stub;
 
 import com.intellij.psi.stubs.IStubElementType;
 import com.intellij.psi.stubs.StubElement;
-import com.intellij.util.io.StringRef;
 import org.elixir_lang.psi.ElixirUnmatchedQualifiedNoArgumentsCall;
+import org.elixir_lang.psi.stub.call.Deserialized;
 import org.elixir_lang.psi.stub.call.Stub;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.Collection;
 import java.util.Set;
 
 public class UnmatchedQualifiedNoArgumentsCall extends Stub<ElixirUnmatchedQualifiedNoArgumentsCall> {
     public UnmatchedQualifiedNoArgumentsCall(
             StubElement parent,
             @NotNull IStubElementType elementType,
-            @Nullable StringRef resolvedModuleName,
-            @Nullable StringRef resolvedFunctionName,
-            int resolvedFinalArity,
-            boolean hasDoBlockOrKeyword,
-            @NotNull StringRef name,
-            @NotNull Set<StringRef> canonicalNameSet
+            @NotNull Deserialized deserialized
     ) {
-        super(
-                parent,
-                elementType,
-                resolvedModuleName,
-                resolvedFunctionName,
-                resolvedFinalArity,
-                hasDoBlockOrKeyword,
-                name,
-                canonicalNameSet
-        );
+        super(parent, elementType, deserialized);
     }
 
     public UnmatchedQualifiedNoArgumentsCall(

--- a/src/org/elixir_lang/psi/stub/UnmatchedQualifiedNoParenthesesCall.java
+++ b/src/org/elixir_lang/psi/stub/UnmatchedQualifiedNoParenthesesCall.java
@@ -2,36 +2,21 @@ package org.elixir_lang.psi.stub;
 
 import com.intellij.psi.stubs.IStubElementType;
 import com.intellij.psi.stubs.StubElement;
-import com.intellij.util.io.StringRef;
 import org.elixir_lang.psi.ElixirUnmatchedQualifiedNoParenthesesCall;
+import org.elixir_lang.psi.stub.call.Deserialized;
 import org.elixir_lang.psi.stub.call.Stub;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.Collection;
 import java.util.Set;
 
 public class UnmatchedQualifiedNoParenthesesCall extends Stub<ElixirUnmatchedQualifiedNoParenthesesCall> {
     public UnmatchedQualifiedNoParenthesesCall(
             StubElement parent,
             @NotNull IStubElementType elementType,
-            @Nullable StringRef resolvedModuleName,
-            @Nullable StringRef resolvedFunctionName,
-            int resolvedFinalArity,
-            boolean hasDoBlockOrKeyword,
-            @NotNull StringRef name,
-            @NotNull Set<StringRef> canonicalNameSet
+            @NotNull Deserialized deserialized
     ) {
-        super(
-                parent,
-                elementType,
-                resolvedModuleName,
-                resolvedFunctionName,
-                resolvedFinalArity,
-                hasDoBlockOrKeyword,
-                name,
-                canonicalNameSet
-        );
+        super(parent, elementType, deserialized);
     }
 
     public UnmatchedQualifiedNoParenthesesCall(

--- a/src/org/elixir_lang/psi/stub/UnmatchedQualifiedParenthesesCall.java
+++ b/src/org/elixir_lang/psi/stub/UnmatchedQualifiedParenthesesCall.java
@@ -2,36 +2,21 @@ package org.elixir_lang.psi.stub;
 
 import com.intellij.psi.stubs.IStubElementType;
 import com.intellij.psi.stubs.StubElement;
-import com.intellij.util.io.StringRef;
 import org.elixir_lang.psi.ElixirUnmatchedQualifiedParenthesesCall;
+import org.elixir_lang.psi.stub.call.Deserialized;
 import org.elixir_lang.psi.stub.call.Stub;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.Collection;
 import java.util.Set;
 
 public class UnmatchedQualifiedParenthesesCall extends Stub<ElixirUnmatchedQualifiedParenthesesCall> {
     public UnmatchedQualifiedParenthesesCall(
             StubElement parent,
             @NotNull IStubElementType elementType,
-            @Nullable StringRef resolvedModuleName,
-            @Nullable StringRef resolvedFunctionName,
-            int resolvedFinalArity,
-            boolean hasDoBlockOrKeyword,
-            @NotNull StringRef name,
-            @NotNull Set<StringRef> canonicalNameSet
-    ) {
-        super(
-                parent,
-                elementType,
-                resolvedModuleName,
-                resolvedFunctionName,
-                resolvedFinalArity,
-                hasDoBlockOrKeyword,
-                name,
-                canonicalNameSet
-        );
+            @NotNull Deserialized deserialized
+            ) {
+        super(parent, elementType, deserialized);
     }
 
     public UnmatchedQualifiedParenthesesCall(

--- a/src/org/elixir_lang/psi/stub/UnmatchedUnqualifiedNoArgumentsCall.java
+++ b/src/org/elixir_lang/psi/stub/UnmatchedUnqualifiedNoArgumentsCall.java
@@ -2,35 +2,20 @@ package org.elixir_lang.psi.stub;
 
 import com.intellij.psi.stubs.IStubElementType;
 import com.intellij.psi.stubs.StubElement;
-import com.intellij.util.io.StringRef;
 import org.elixir_lang.psi.ElixirUnmatchedUnqualifiedNoArgumentsCall;
+import org.elixir_lang.psi.stub.call.Deserialized;
 import org.elixir_lang.psi.stub.call.Stub;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.Collection;
 import java.util.Set;
 
 public class UnmatchedUnqualifiedNoArgumentsCall extends Stub<ElixirUnmatchedUnqualifiedNoArgumentsCall> {
     public UnmatchedUnqualifiedNoArgumentsCall(
             StubElement parent,
             @NotNull IStubElementType elementType,
-            @Nullable StringRef resolvedModuleName,
-            @Nullable StringRef resolvedFunctionName,
-            int resolvedFinalArity,
-            boolean hasDoBlockOrKeyword,
-            @NotNull StringRef name,
-            @NotNull Set<StringRef> canonicalNameSet
-    ) {
-        super(
-                parent,
-                elementType,
-                resolvedModuleName,
-                resolvedFunctionName,
-                resolvedFinalArity,
-                hasDoBlockOrKeyword,
-                name,
-                canonicalNameSet);
+            @NotNull Deserialized deserialized) {
+        super(parent, elementType, deserialized);
     }
 
     public UnmatchedUnqualifiedNoArgumentsCall(

--- a/src/org/elixir_lang/psi/stub/UnmatchedUnqualifiedNoParenthesesCall.java
+++ b/src/org/elixir_lang/psi/stub/UnmatchedUnqualifiedNoParenthesesCall.java
@@ -2,36 +2,20 @@ package org.elixir_lang.psi.stub;
 
 import com.intellij.psi.stubs.IStubElementType;
 import com.intellij.psi.stubs.StubElement;
-import com.intellij.util.io.StringRef;
 import org.elixir_lang.psi.ElixirUnmatchedUnqualifiedNoParenthesesCall;
+import org.elixir_lang.psi.stub.call.Deserialized;
 import org.elixir_lang.psi.stub.call.Stub;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.Collection;
 import java.util.Set;
 
 public class UnmatchedUnqualifiedNoParenthesesCall extends Stub<ElixirUnmatchedUnqualifiedNoParenthesesCall> {
     public UnmatchedUnqualifiedNoParenthesesCall(
             StubElement parent,
             @NotNull IStubElementType elementType,
-            @Nullable StringRef resolvedModuleName,
-            @Nullable StringRef resolvedFunctionName,
-            int resolvedFinalArity,
-            boolean hasDoBlockOrKeyword,
-            @NotNull StringRef name,
-            @NotNull Set<StringRef> canonicalNameSet
-    ) {
-        super(
-                parent,
-                elementType,
-                resolvedModuleName,
-                resolvedFunctionName,
-                resolvedFinalArity,
-                hasDoBlockOrKeyword,
-                name,
-                canonicalNameSet
-        );
+            @NotNull Deserialized deserialized) {
+        super(parent, elementType, deserialized);
     }
 
     public UnmatchedUnqualifiedNoParenthesesCall(

--- a/src/org/elixir_lang/psi/stub/UnmatchedUnqualifiedParenthesesCall.java
+++ b/src/org/elixir_lang/psi/stub/UnmatchedUnqualifiedParenthesesCall.java
@@ -2,36 +2,21 @@ package org.elixir_lang.psi.stub;
 
 import com.intellij.psi.stubs.IStubElementType;
 import com.intellij.psi.stubs.StubElement;
-import com.intellij.util.io.StringRef;
 import org.elixir_lang.psi.ElixirUnmatchedUnqualifiedParenthesesCall;
+import org.elixir_lang.psi.stub.call.Deserialized;
 import org.elixir_lang.psi.stub.call.Stub;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.Collection;
 import java.util.Set;
 
 public class UnmatchedUnqualifiedParenthesesCall extends Stub<ElixirUnmatchedUnqualifiedParenthesesCall> {
     public UnmatchedUnqualifiedParenthesesCall(
             StubElement parent,
             @NotNull IStubElementType elementType,
-            @Nullable StringRef resolvedModuleName,
-            @Nullable StringRef resolvedFunctionName,
-            int resolvedFinalArity,
-            boolean hasDoBlockOrKeyword,
-            @NotNull StringRef name,
-            @NotNull Set<StringRef> canonicalNameSet
+            @NotNull Deserialized deserialized
     ) {
-        super(
-                parent,
-                elementType,
-                resolvedModuleName,
-                resolvedFunctionName,
-                resolvedFinalArity,
-                hasDoBlockOrKeyword,
-                name,
-                canonicalNameSet
-        );
+        super(parent, elementType, deserialized);
     }
 
     public UnmatchedUnqualifiedParenthesesCall(

--- a/src/org/elixir_lang/psi/stub/UnqualifiedNoParenthesesManyArgumentsCall.java
+++ b/src/org/elixir_lang/psi/stub/UnqualifiedNoParenthesesManyArgumentsCall.java
@@ -2,38 +2,15 @@ package org.elixir_lang.psi.stub;
 
 import com.intellij.psi.stubs.IStubElementType;
 import com.intellij.psi.stubs.StubElement;
-import com.intellij.util.io.StringRef;
 import org.elixir_lang.psi.ElixirUnqualifiedNoParenthesesManyArgumentsCall;
+import org.elixir_lang.psi.stub.call.Deserialized;
 import org.elixir_lang.psi.stub.call.Stub;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.Collection;
 import java.util.Set;
 
 public class UnqualifiedNoParenthesesManyArgumentsCall extends Stub<ElixirUnqualifiedNoParenthesesManyArgumentsCall> {
-    public UnqualifiedNoParenthesesManyArgumentsCall(
-            StubElement parent,
-            @NotNull IStubElementType elementType,
-            @Nullable StringRef resolvedModuleName,
-            @Nullable StringRef resolvedFunctionName,
-            int resolvedFinalArity,
-            boolean hasDoBlockOrKeyword,
-            @NotNull StringRef name,
-            @NotNull Set<StringRef> canonicalNameSet
-    ) {
-        super(
-                parent,
-                elementType,
-                resolvedModuleName,
-                resolvedFunctionName,
-                resolvedFinalArity,
-                hasDoBlockOrKeyword,
-                name,
-                canonicalNameSet
-        );
-    }
-
     public UnqualifiedNoParenthesesManyArgumentsCall(
             StubElement parent,
             @NotNull IStubElementType elementType,
@@ -54,5 +31,12 @@ public class UnqualifiedNoParenthesesManyArgumentsCall extends Stub<ElixirUnqual
                 name,
                 canonicalNameSet
         );
+    }
+
+    public UnqualifiedNoParenthesesManyArgumentsCall(
+            StubElement parent,
+            @NotNull IStubElementType elementType,
+            @NotNull Deserialized deserialized) {
+        super(parent, elementType, deserialized);
     }
 }

--- a/src/org/elixir_lang/psi/stub/call/Deserialized.java
+++ b/src/org/elixir_lang/psi/stub/call/Deserialized.java
@@ -1,0 +1,282 @@
+package org.elixir_lang.psi.stub.call;
+
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.psi.stubs.StubInputStream;
+import com.intellij.psi.stubs.StubOutputStream;
+import com.intellij.util.io.StringRef;
+import gnu.trove.THashSet;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Set;
+
+public class Deserialized {
+    private static final byte[] BEGIN;
+    private static final byte[] END;
+    /* Increase from `0` to enable guards to check for mismatches between reads and writes, such as in
+       https://github.com/KronicDeth/intellij-elixir/issues/767 */
+    private static final int GUARD_LENGTH = 0;
+    private static final Logger LOGGER = Logger.getInstance(Deserialized.class);
+
+    static {
+        int i;
+
+        BEGIN = new byte[GUARD_LENGTH];
+
+        for (i = 0; i < BEGIN.length; i++) {
+            BEGIN[i] = (byte) i;
+        }
+
+        END = new byte[BEGIN.length];
+
+        for (i = 0; i < END.length; i++) {
+            END[i] = (byte) (END.length - i);
+        }
+    }
+
+    @NotNull
+    public final Set<StringRef> canonicalNameSet;
+    public final boolean hasDoBlockOrKeyword;
+    @NotNull
+    public final StringRef name;
+    public final int resolvedFinalArity;
+    @Nullable
+    public final StringRef resolvedFunctionName;
+    @Nullable
+    public final StringRef resolvedModuleName;
+
+    public Deserialized(@Nullable StringRef resolvedModuleName,
+                        @Nullable StringRef resolvedFunctionName,
+                        int resolvedFinalArity,
+                        boolean hasDoBlockOrKeyword,
+                        @NotNull StringRef name,
+                        @NotNull Set<StringRef> canonicalNameSet) {
+        this.resolvedModuleName = resolvedModuleName;
+        this.resolvedFunctionName = resolvedFunctionName;
+        this.resolvedFinalArity = resolvedFinalArity;
+        this.hasDoBlockOrKeyword = hasDoBlockOrKeyword;
+        this.name = name;
+        this.canonicalNameSet = canonicalNameSet;
+    }
+
+    public <T extends Stubbic> Deserialized(@NotNull T stubbic) {
+        this(
+                StringRef.fromNullableString(stubbic.resolvedModuleName()),
+                StringRef.fromNullableString(stubbic.resolvedFunctionName()),
+                stubbic.resolvedFinalArity(),
+                stubbic.hasDoBlockOrKeyword(),
+                StringRef.fromNullableString(stubbic.getName()),
+                stringRefSet(stubbic.canonicalNameSet())
+        );
+    }
+
+    public static void assertGuard(@NotNull StubInputStream stubInputStream, byte[] expectedGuard) {
+        try {
+            byte[] actualGuard = new byte[expectedGuard.length];
+            //noinspection ResultOfMethodCallIgnored
+            stubInputStream.read(actualGuard);
+
+            assert Arrays.equals(actualGuard, expectedGuard) :
+                    "Expected `" + hexString(expectedGuard) + "` tag in StubInputSteam, but got `" +
+                            hexString(actualGuard) + "`";
+        } catch (IOException e) {
+            LOGGER.error(e);
+        }
+    }
+
+    public static Deserialized deserialize(@NotNull StubInputStream stubInputStream) throws IOException {
+        assertGuard(stubInputStream, BEGIN);
+
+        StringRef resolvedModuleName = deserializeResolvedModuleName(stubInputStream);
+        StringRef resolvedFunctionName = deserializeResolvedFunctionName(stubInputStream);
+        int resolvedFinalArity = deserializeResolvedFinalArity(stubInputStream);
+        boolean hasDoBlockOrKeyword = deserializeHasDoBlockOrKeyword(stubInputStream);
+        StringRef name = deserializeName(stubInputStream);
+        Set<StringRef> canonicalNameSet = deserializeCanonicalNameSet(stubInputStream);
+
+        assertGuard(stubInputStream, END);
+
+        return new Deserialized(
+                resolvedModuleName,
+                resolvedFunctionName,
+                resolvedFinalArity,
+                hasDoBlockOrKeyword,
+                name,
+                canonicalNameSet
+        );
+    }
+
+    private static Set<StringRef> deserializeCanonicalNameSet(@NotNull StubInputStream stubInputStream)
+            throws IOException {
+        return readGuarded(stubInputStream, Deserialized::readNameSet);
+    }
+
+    private static boolean deserializeHasDoBlockOrKeyword(@NotNull StubInputStream stubInputStream) throws IOException {
+        return readGuarded(stubInputStream, StubInputStream::readBoolean);
+    }
+
+    private static StringRef deserializeName(@NotNull StubInputStream stubInputStream) throws IOException {
+        return readGuardedName(stubInputStream);
+    }
+
+    private static int deserializeResolvedFinalArity(@NotNull StubInputStream stubInputStream) throws IOException {
+        return readGuarded(stubInputStream, StubInputStream::readVarInt);
+    }
+
+    private static StringRef deserializeResolvedFunctionName(@NotNull StubInputStream stubInputStream)
+            throws IOException {
+        return readGuardedName(stubInputStream);
+    }
+
+    private static StringRef deserializeResolvedModuleName(@NotNull StubInputStream stubInputStream)
+            throws IOException {
+        return readGuardedName(stubInputStream);
+    }
+
+    @NotNull
+    private static String hexString(byte[] bytes) {
+        final StringBuilder builder = new StringBuilder();
+        for (byte b : bytes) {
+            builder.append(String.format("%02x", b));
+        }
+
+        return builder.toString();
+    }
+
+    public static <T> T readGuarded(@NotNull StubInputStream stubInputStream,
+                                    @NotNull Reader<T> reader) throws IOException {
+        assertGuard(stubInputStream, BEGIN);
+        T read = reader.read(stubInputStream);
+        assertGuard(stubInputStream, END);
+
+        return read;
+    }
+
+    private static StringRef readGuardedName(@NotNull StubInputStream stubInputStream) throws IOException {
+        return readGuarded(stubInputStream, StubInputStream::readName);
+    }
+
+    private static Set<StringRef> readNameSet(@NotNull StubInputStream dataStream) throws IOException {
+        assertGuard(dataStream, BEGIN);
+
+        assertGuard(dataStream, BEGIN);
+        int nameSetSize = dataStream.readVarInt();
+        assertGuard(dataStream, END);
+
+        if (nameSetSize > 3) {
+            byte[] readAhead = new byte[BEGIN.length];
+            int bytesRead = dataStream.read(readAhead);
+            LOGGER.error("readNameSet read " + bytesRead + " of " + readAhead.length + " unexpected bytes `" + hexString(readAhead) + "`");
+        }
+        Set<StringRef> nameSet = new THashSet<>(nameSetSize);
+
+        for (int i = 0; i < nameSetSize; i++) {
+            StringRef name = dataStream.readName();
+            nameSet.add(name);
+        }
+
+        assertGuard(dataStream, END);
+
+        return nameSet;
+    }
+
+    public static <T extends Stubbic> void serialize(@NotNull StubOutputStream stubOutputStream, @NotNull T stubbic)
+            throws IOException {
+        new Deserialized(stubbic).serialize(stubOutputStream);
+    }
+
+    @NotNull
+    private static Set<StringRef> stringRefSet(@NotNull Set<String> stringSet) {
+        Set<StringRef> stringRefSet = new THashSet<>();
+
+        for (String string : stringSet) {
+            stringRefSet.add(StringRef.fromNullableString(string));
+        }
+
+        return stringRefSet;
+    }
+
+    private static void writeGuard(@NotNull StubOutputStream stubOutputStream, byte[] guard) throws IOException {
+        stubOutputStream.write(guard);
+    }
+
+    public static void writeGuarded(@NotNull StubOutputStream stubOutputStream, @NotNull Writer writer)
+            throws IOException {
+        writeGuard(stubOutputStream, BEGIN);
+        writer.write(stubOutputStream);
+        writeGuard(stubOutputStream, END);
+    }
+
+    private static void writeGuardedName(@NotNull StubOutputStream stubOutputStream, @Nullable StringRef name)
+            throws IOException {
+        writeGuarded(
+                stubOutputStream,
+                guardedStubOutputStream -> guardedStubOutputStream.writeName(StringRef.toString(name))
+        );
+    }
+
+    private void serialize(@NotNull StubOutputStream stubOutputStream) throws IOException {
+        writeGuarded(
+                stubOutputStream,
+                guardedStubOutputStream -> {
+                    serializeResolvedModuleName(guardedStubOutputStream);
+                    serializeResolvedFunctionName(guardedStubOutputStream);
+                    serializeResolvedFinalArity(guardedStubOutputStream);
+                    serializeHasDoBlockOrKeyword(guardedStubOutputStream);
+                    serializeName(guardedStubOutputStream);
+                    serializeCanonicalNameSet(guardedStubOutputStream);
+                }
+        );
+    }
+
+    private void serializeCanonicalNameSet(@NotNull StubOutputStream stubOutputStream) throws IOException {
+        writeGuarded(
+                stubOutputStream,
+                guardedOutputStream -> writeNameSet(guardedOutputStream, canonicalNameSet)
+        );
+    }
+
+    private void serializeHasDoBlockOrKeyword(@NotNull StubOutputStream stubOutputStream) throws IOException {
+        writeGuarded(
+                stubOutputStream,
+                guardedStubOutputStream -> guardedStubOutputStream.writeBoolean(hasDoBlockOrKeyword)
+        );
+    }
+
+    private void serializeName(@NotNull StubOutputStream stubOutputStream) throws IOException {
+        writeGuardedName(stubOutputStream, name);
+    }
+
+    private void serializeResolvedFinalArity(@NotNull StubOutputStream stubOutputStream) throws IOException {
+        writeGuarded(
+                stubOutputStream,
+                guardedStubOutputStream -> guardedStubOutputStream.writeVarInt(resolvedFinalArity)
+        );
+    }
+
+    private void serializeResolvedFunctionName(@NotNull StubOutputStream stubOutputStream) throws IOException {
+        writeGuardedName(stubOutputStream, resolvedFunctionName);
+    }
+
+    private void serializeResolvedModuleName(@NotNull StubOutputStream stubOutputStream) throws IOException {
+        writeGuardedName(stubOutputStream, resolvedModuleName);
+    }
+
+    private void writeNameSet(@NotNull StubOutputStream stubOutputStream, @NotNull Set<StringRef> nameSet) throws IOException {
+        writeGuarded(
+                stubOutputStream,
+                guardedStubOutputStream -> {
+                    writeGuarded(
+                            guardedStubOutputStream,
+                            sizeStubOutputStream -> sizeStubOutputStream.writeVarInt(nameSet.size())
+                    );
+
+                    for (StringRef name : nameSet) {
+                        writeGuardedName(guardedStubOutputStream, name);
+                    }
+                }
+        );
+    }
+}

--- a/src/org/elixir_lang/psi/stub/call/Reader.java
+++ b/src/org/elixir_lang/psi/stub/call/Reader.java
@@ -1,0 +1,10 @@
+package org.elixir_lang.psi.stub.call;
+
+import com.intellij.psi.stubs.StubInputStream;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.IOException;
+
+public interface Reader<T> {
+    T read(@NotNull StubInputStream stubInputStream) throws IOException;
+}

--- a/src/org/elixir_lang/psi/stub/call/Stub.java
+++ b/src/org/elixir_lang/psi/stub/call/Stub.java
@@ -10,8 +10,6 @@ import org.elixir_lang.psi.call.Call;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Set;
 
 // I normally wouldn't add the redundant StubBased prefix, but it makes generating from Elixir.bnf work
@@ -72,6 +70,21 @@ public class Stub<T extends org.elixir_lang.psi.call.StubBased> extends NamedStu
     }
 
     public Stub(StubElement parent,
+                @NotNull IStubElementType elementType,
+                @NotNull Deserialized deserialized) {
+        this(
+                parent,
+                elementType,
+                deserialized.resolvedModuleName,
+                deserialized.resolvedFunctionName,
+                deserialized.resolvedFinalArity,
+                deserialized.hasDoBlockOrKeyword,
+                deserialized.name,
+                deserialized.canonicalNameSet
+        );
+    }
+
+    private Stub(StubElement parent,
                 @NotNull IStubElementType elementType,
                 @Nullable StringRef resolvedModuleName,
                 @Nullable StringRef resolvedFunctionName,

--- a/src/org/elixir_lang/psi/stub/call/Writer.java
+++ b/src/org/elixir_lang/psi/stub/call/Writer.java
@@ -1,0 +1,9 @@
+package org.elixir_lang.psi.stub.call;
+
+import com.intellij.psi.stubs.StubOutputStream;
+
+import java.io.IOException;
+
+public interface Writer {
+    void write(StubOutputStream stubOutputStream) throws IOException;
+}

--- a/src/org/elixir_lang/psi/stub/index/AllName.java
+++ b/src/org/elixir_lang/psi/stub/index/AllName.java
@@ -7,7 +7,7 @@ import org.jetbrains.annotations.NotNull;
 
 public class AllName extends StringStubIndexExtension<NamedElement> {
     public static final StubIndexKey<String, NamedElement> KEY = StubIndexKey.createIndexKey("elixir.all.name");
-    public static final int VERSION = 2;
+    public static final int VERSION = 3;
 
     @Override
     public int getVersion() {

--- a/src/org/elixir_lang/psi/stub/type/File.java
+++ b/src/org/elixir_lang/psi/stub/type/File.java
@@ -14,7 +14,7 @@ import org.jetbrains.annotations.NotNull;
 import java.io.IOException;
 
 public class File extends IStubFileElementType<org.elixir_lang.psi.stub.File> {
-    public static final int VERSION = 2;
+    public static final int VERSION = 3;
     public static final IStubFileElementType INSTANCE = new File();
 
     public File() {

--- a/src/org/elixir_lang/psi/stub/type/MatchedAtUnqualifiedNoParenthesesCall.java
+++ b/src/org/elixir_lang/psi/stub/type/MatchedAtUnqualifiedNoParenthesesCall.java
@@ -50,7 +50,7 @@ public class MatchedAtUnqualifiedNoParenthesesCall extends Stub<org.elixir_lang.
                 this,
                 dataStream.readName(),
                 dataStream.readName(),
-                dataStream.readInt(),
+                dataStream.readVarInt(),
                 dataStream.readBoolean(),
                 dataStream.readName(),
                 readNameSet(dataStream)

--- a/src/org/elixir_lang/psi/stub/type/MatchedAtUnqualifiedNoParenthesesCall.java
+++ b/src/org/elixir_lang/psi/stub/type/MatchedAtUnqualifiedNoParenthesesCall.java
@@ -5,8 +5,10 @@ import com.intellij.psi.stubs.StubElement;
 import com.intellij.psi.stubs.StubInputStream;
 import org.elixir_lang.psi.ElixirMatchedAtUnqualifiedNoParenthesesCall;
 import org.elixir_lang.psi.impl.ElixirMatchedAtUnqualifiedNoParenthesesCallImpl;
+import org.elixir_lang.psi.stub.call.Deserialized;
 import org.elixir_lang.psi.stub.type.call.Stub;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.io.IOException;
 
@@ -44,16 +46,11 @@ public class MatchedAtUnqualifiedNoParenthesesCall extends Stub<org.elixir_lang.
 
     @NotNull
     @Override
-    public org.elixir_lang.psi.stub.MatchedAtUnqualifiedNoParenthesesCall deserialize(@NotNull StubInputStream dataStream, StubElement parentStub) throws IOException {
-        return new org.elixir_lang.psi.stub.MatchedAtUnqualifiedNoParenthesesCall(
-                parentStub,
-                this,
-                dataStream.readName(),
-                dataStream.readName(),
-                dataStream.readVarInt(),
-                dataStream.readBoolean(),
-                dataStream.readName(),
-                readNameSet(dataStream)
-        );
+    public org.elixir_lang.psi.stub.MatchedAtUnqualifiedNoParenthesesCall deserialize(
+            @NotNull StubInputStream stubInputStream,
+            @Nullable StubElement parentStub
+    ) throws IOException {
+        Deserialized deserialized = Deserialized.deserialize(stubInputStream);
+        return new org.elixir_lang.psi.stub.MatchedAtUnqualifiedNoParenthesesCall(parentStub, this, deserialized);
     }
 }

--- a/src/org/elixir_lang/psi/stub/type/MatchedDotCall.java
+++ b/src/org/elixir_lang/psi/stub/type/MatchedDotCall.java
@@ -50,7 +50,7 @@ public class MatchedDotCall extends Stub<org.elixir_lang.psi.stub.MatchedDotCall
                 this,
                 dataStream.readName(),
                 dataStream.readName(),
-                dataStream.readInt(),
+                dataStream.readVarInt(),
                 dataStream.readBoolean(),
                 dataStream.readName(),
                 readNameSet(dataStream)

--- a/src/org/elixir_lang/psi/stub/type/MatchedDotCall.java
+++ b/src/org/elixir_lang/psi/stub/type/MatchedDotCall.java
@@ -5,8 +5,10 @@ import com.intellij.psi.stubs.StubElement;
 import com.intellij.psi.stubs.StubInputStream;
 import org.elixir_lang.psi.ElixirMatchedDotCall;
 import org.elixir_lang.psi.impl.ElixirMatchedDotCallImpl;
+import org.elixir_lang.psi.stub.call.Deserialized;
 import org.elixir_lang.psi.stub.type.call.Stub;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.io.IOException;
 
@@ -28,6 +30,7 @@ public class MatchedDotCall extends Stub<org.elixir_lang.psi.stub.MatchedDotCall
         return new ElixirMatchedDotCallImpl(stub, this);
     }
 
+    @NotNull
     @Override
     public org.elixir_lang.psi.stub.MatchedDotCall createStub(@NotNull ElixirMatchedDotCall psi, StubElement parentStub) {
         return new org.elixir_lang.psi.stub.MatchedDotCall(
@@ -44,16 +47,9 @@ public class MatchedDotCall extends Stub<org.elixir_lang.psi.stub.MatchedDotCall
 
     @NotNull
     @Override
-    public org.elixir_lang.psi.stub.MatchedDotCall deserialize(@NotNull StubInputStream dataStream, StubElement parentStub) throws IOException {
-        return new org.elixir_lang.psi.stub.MatchedDotCall(
-                parentStub,
-                this,
-                dataStream.readName(),
-                dataStream.readName(),
-                dataStream.readVarInt(),
-                dataStream.readBoolean(),
-                dataStream.readName(),
-                readNameSet(dataStream)
-        );
+    public org.elixir_lang.psi.stub.MatchedDotCall deserialize(@NotNull StubInputStream dataStream,
+                                                               @Nullable StubElement parentStub) throws IOException {
+        Deserialized deserialized = Deserialized.deserialize(dataStream);
+        return new org.elixir_lang.psi.stub.MatchedDotCall(parentStub, this, deserialized);
     }
 }

--- a/src/org/elixir_lang/psi/stub/type/MatchedQualifiedNoArgumentsCall.java
+++ b/src/org/elixir_lang/psi/stub/type/MatchedQualifiedNoArgumentsCall.java
@@ -5,8 +5,10 @@ import com.intellij.psi.stubs.StubElement;
 import com.intellij.psi.stubs.StubInputStream;
 import org.elixir_lang.psi.ElixirMatchedQualifiedNoArgumentsCall;
 import org.elixir_lang.psi.impl.ElixirMatchedQualifiedNoArgumentsCallImpl;
+import org.elixir_lang.psi.stub.call.Deserialized;
 import org.elixir_lang.psi.stub.type.call.Stub;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.io.IOException;
 
@@ -44,16 +46,10 @@ public class MatchedQualifiedNoArgumentsCall extends Stub<org.elixir_lang.psi.st
 
     @NotNull
     @Override
-    public org.elixir_lang.psi.stub.MatchedQualifiedNoArgumentsCall deserialize(@NotNull StubInputStream dataStream, StubElement parentStub) throws IOException {
-        return new org.elixir_lang.psi.stub.MatchedQualifiedNoArgumentsCall(
-                parentStub,
-                this,
-                dataStream.readName(),
-                dataStream.readName(),
-                dataStream.readVarInt(),
-                dataStream.readBoolean(),
-                dataStream.readName(),
-                readNameSet(dataStream)
-        );
+    public org.elixir_lang.psi.stub.MatchedQualifiedNoArgumentsCall deserialize(@NotNull StubInputStream dataStream,
+                                                                                @Nullable StubElement parentStub)
+            throws IOException {
+        Deserialized deserialized = Deserialized.deserialize(dataStream);
+        return new org.elixir_lang.psi.stub.MatchedQualifiedNoArgumentsCall(parentStub, this, deserialized);
     }
 }

--- a/src/org/elixir_lang/psi/stub/type/MatchedQualifiedNoArgumentsCall.java
+++ b/src/org/elixir_lang/psi/stub/type/MatchedQualifiedNoArgumentsCall.java
@@ -50,7 +50,7 @@ public class MatchedQualifiedNoArgumentsCall extends Stub<org.elixir_lang.psi.st
                 this,
                 dataStream.readName(),
                 dataStream.readName(),
-                dataStream.readInt(),
+                dataStream.readVarInt(),
                 dataStream.readBoolean(),
                 dataStream.readName(),
                 readNameSet(dataStream)

--- a/src/org/elixir_lang/psi/stub/type/MatchedQualifiedNoParenthesesCall.java
+++ b/src/org/elixir_lang/psi/stub/type/MatchedQualifiedNoParenthesesCall.java
@@ -50,7 +50,7 @@ public class MatchedQualifiedNoParenthesesCall extends Stub<org.elixir_lang.psi.
                 this,
                 dataStream.readName(),
                 dataStream.readName(),
-                dataStream.readInt(),
+                dataStream.readVarInt(),
                 dataStream.readBoolean(),
                 dataStream.readName(),
                 readNameSet(dataStream)

--- a/src/org/elixir_lang/psi/stub/type/MatchedQualifiedNoParenthesesCall.java
+++ b/src/org/elixir_lang/psi/stub/type/MatchedQualifiedNoParenthesesCall.java
@@ -5,8 +5,10 @@ import com.intellij.psi.stubs.StubElement;
 import com.intellij.psi.stubs.StubInputStream;
 import org.elixir_lang.psi.ElixirMatchedQualifiedNoParenthesesCall;
 import org.elixir_lang.psi.impl.ElixirMatchedQualifiedNoParenthesesCallImpl;
+import org.elixir_lang.psi.stub.call.Deserialized;
 import org.elixir_lang.psi.stub.type.call.Stub;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.io.IOException;
 
@@ -44,16 +46,10 @@ public class MatchedQualifiedNoParenthesesCall extends Stub<org.elixir_lang.psi.
 
     @NotNull
     @Override
-    public org.elixir_lang.psi.stub.MatchedQualifiedNoParenthesesCall deserialize(@NotNull StubInputStream dataStream, StubElement parentStub) throws IOException {
-        return new org.elixir_lang.psi.stub.MatchedQualifiedNoParenthesesCall(
-                parentStub,
-                this,
-                dataStream.readName(),
-                dataStream.readName(),
-                dataStream.readVarInt(),
-                dataStream.readBoolean(),
-                dataStream.readName(),
-                readNameSet(dataStream)
-        );
+    public org.elixir_lang.psi.stub.MatchedQualifiedNoParenthesesCall deserialize(@NotNull StubInputStream dataStream,
+                                                                                  @Nullable StubElement parentStub)
+            throws IOException {
+        Deserialized deserialized = Deserialized.deserialize(dataStream);
+        return new org.elixir_lang.psi.stub.MatchedQualifiedNoParenthesesCall(parentStub, this, deserialized);
     }
 }

--- a/src/org/elixir_lang/psi/stub/type/MatchedQualifiedParenthesesCall.java
+++ b/src/org/elixir_lang/psi/stub/type/MatchedQualifiedParenthesesCall.java
@@ -5,6 +5,7 @@ import com.intellij.psi.stubs.StubElement;
 import com.intellij.psi.stubs.StubInputStream;
 import org.elixir_lang.psi.ElixirMatchedQualifiedParenthesesCall;
 import org.elixir_lang.psi.impl.ElixirMatchedQualifiedParenthesesCallImpl;
+import org.elixir_lang.psi.stub.call.Deserialized;
 import org.elixir_lang.psi.stub.type.call.Stub;
 import org.jetbrains.annotations.NotNull;
 
@@ -44,16 +45,10 @@ public class MatchedQualifiedParenthesesCall extends Stub<org.elixir_lang.psi.st
 
     @NotNull
     @Override
-    public org.elixir_lang.psi.stub.MatchedQualifiedParenthesesCall deserialize(@NotNull StubInputStream dataStream, StubElement parentStub) throws IOException {
-        return new org.elixir_lang.psi.stub.MatchedQualifiedParenthesesCall(
-                parentStub,
-                this,
-                dataStream.readName(),
-                dataStream.readName(),
-                dataStream.readVarInt(),
-                dataStream.readBoolean(),
-                dataStream.readName(),
-                readNameSet(dataStream)
-        );
+    public org.elixir_lang.psi.stub.MatchedQualifiedParenthesesCall deserialize(@NotNull StubInputStream dataStream,
+                                                                                StubElement parentStub)
+            throws IOException {
+        Deserialized deserialized = Deserialized.deserialize(dataStream);
+        return new org.elixir_lang.psi.stub.MatchedQualifiedParenthesesCall(parentStub, this, deserialized);
     }
 }

--- a/src/org/elixir_lang/psi/stub/type/MatchedQualifiedParenthesesCall.java
+++ b/src/org/elixir_lang/psi/stub/type/MatchedQualifiedParenthesesCall.java
@@ -50,7 +50,7 @@ public class MatchedQualifiedParenthesesCall extends Stub<org.elixir_lang.psi.st
                 this,
                 dataStream.readName(),
                 dataStream.readName(),
-                dataStream.readInt(),
+                dataStream.readVarInt(),
                 dataStream.readBoolean(),
                 dataStream.readName(),
                 readNameSet(dataStream)

--- a/src/org/elixir_lang/psi/stub/type/MatchedUnqualifiedNoArgumentsCall.java
+++ b/src/org/elixir_lang/psi/stub/type/MatchedUnqualifiedNoArgumentsCall.java
@@ -50,7 +50,7 @@ public class MatchedUnqualifiedNoArgumentsCall extends Stub<org.elixir_lang.psi.
                 this,
                 dataStream.readName(),
                 dataStream.readName(),
-                dataStream.readInt(),
+                dataStream.readVarInt(),
                 dataStream.readBoolean(),
                 dataStream.readName(),
                 readNameSet(dataStream)

--- a/src/org/elixir_lang/psi/stub/type/MatchedUnqualifiedNoArgumentsCall.java
+++ b/src/org/elixir_lang/psi/stub/type/MatchedUnqualifiedNoArgumentsCall.java
@@ -5,8 +5,10 @@ import com.intellij.psi.stubs.StubElement;
 import com.intellij.psi.stubs.StubInputStream;
 import org.elixir_lang.psi.ElixirMatchedUnqualifiedNoArgumentsCall;
 import org.elixir_lang.psi.impl.ElixirMatchedUnqualifiedNoArgumentsCallImpl;
+import org.elixir_lang.psi.stub.call.Deserialized;
 import org.elixir_lang.psi.stub.type.call.Stub;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.io.IOException;
 
@@ -44,16 +46,10 @@ public class MatchedUnqualifiedNoArgumentsCall extends Stub<org.elixir_lang.psi.
 
     @NotNull
     @Override
-    public org.elixir_lang.psi.stub.MatchedUnqualifiedNoArgumentsCall deserialize(@NotNull StubInputStream dataStream, StubElement parentStub) throws IOException {
-        return new org.elixir_lang.psi.stub.MatchedUnqualifiedNoArgumentsCall(
-                parentStub,
-                this,
-                dataStream.readName(),
-                dataStream.readName(),
-                dataStream.readVarInt(),
-                dataStream.readBoolean(),
-                dataStream.readName(),
-                readNameSet(dataStream)
-        );
+    public org.elixir_lang.psi.stub.MatchedUnqualifiedNoArgumentsCall deserialize(@NotNull StubInputStream dataStream,
+                                                                                  @Nullable StubElement parentStub)
+            throws IOException {
+        Deserialized deserialized = Deserialized.deserialize(dataStream);
+        return new org.elixir_lang.psi.stub.MatchedUnqualifiedNoArgumentsCall(parentStub, this, deserialized);
     }
 }

--- a/src/org/elixir_lang/psi/stub/type/MatchedUnqualifiedNoParenthesesCall.java
+++ b/src/org/elixir_lang/psi/stub/type/MatchedUnqualifiedNoParenthesesCall.java
@@ -50,7 +50,7 @@ public class MatchedUnqualifiedNoParenthesesCall extends Stub<org.elixir_lang.ps
                 this,
                 dataStream.readName(),
                 dataStream.readName(),
-                dataStream.readInt(),
+                dataStream.readVarInt(),
                 dataStream.readBoolean(),
                 dataStream.readName(),
                 readNameSet(dataStream)

--- a/src/org/elixir_lang/psi/stub/type/MatchedUnqualifiedNoParenthesesCall.java
+++ b/src/org/elixir_lang/psi/stub/type/MatchedUnqualifiedNoParenthesesCall.java
@@ -5,8 +5,10 @@ import com.intellij.psi.stubs.StubElement;
 import com.intellij.psi.stubs.StubInputStream;
 import org.elixir_lang.psi.ElixirMatchedUnqualifiedNoParenthesesCall;
 import org.elixir_lang.psi.impl.ElixirMatchedUnqualifiedNoParenthesesCallImpl;
+import org.elixir_lang.psi.stub.call.Deserialized;
 import org.elixir_lang.psi.stub.type.call.Stub;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.io.IOException;
 
@@ -44,16 +46,10 @@ public class MatchedUnqualifiedNoParenthesesCall extends Stub<org.elixir_lang.ps
 
     @NotNull
     @Override
-    public org.elixir_lang.psi.stub.MatchedUnqualifiedNoParenthesesCall deserialize(@NotNull StubInputStream dataStream, StubElement parentStub) throws IOException {
-        return new org.elixir_lang.psi.stub.MatchedUnqualifiedNoParenthesesCall(
-                parentStub,
-                this,
-                dataStream.readName(),
-                dataStream.readName(),
-                dataStream.readVarInt(),
-                dataStream.readBoolean(),
-                dataStream.readName(),
-                readNameSet(dataStream)
-        );
+    public org.elixir_lang.psi.stub.MatchedUnqualifiedNoParenthesesCall deserialize(@NotNull StubInputStream dataStream,
+                                                                                    @Nullable StubElement parentStub)
+            throws IOException {
+        Deserialized deserialized = Deserialized.deserialize(dataStream);
+        return new org.elixir_lang.psi.stub.MatchedUnqualifiedNoParenthesesCall(parentStub, this, deserialized);
     }
 }

--- a/src/org/elixir_lang/psi/stub/type/MatchedUnqualifiedParenthesesCall.java
+++ b/src/org/elixir_lang/psi/stub/type/MatchedUnqualifiedParenthesesCall.java
@@ -50,7 +50,7 @@ public class MatchedUnqualifiedParenthesesCall extends Stub<org.elixir_lang.psi.
                 this,
                 dataStream.readName(),
                 dataStream.readName(),
-                dataStream.readInt(),
+                dataStream.readVarInt(),
                 dataStream.readBoolean(),
                 dataStream.readName(),
                 readNameSet(dataStream)

--- a/src/org/elixir_lang/psi/stub/type/MatchedUnqualifiedParenthesesCall.java
+++ b/src/org/elixir_lang/psi/stub/type/MatchedUnqualifiedParenthesesCall.java
@@ -5,8 +5,10 @@ import com.intellij.psi.stubs.StubElement;
 import com.intellij.psi.stubs.StubInputStream;
 import org.elixir_lang.psi.ElixirMatchedUnqualifiedParenthesesCall;
 import org.elixir_lang.psi.impl.ElixirMatchedUnqualifiedParenthesesCallImpl;
+import org.elixir_lang.psi.stub.call.Deserialized;
 import org.elixir_lang.psi.stub.type.call.Stub;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.io.IOException;
 
@@ -44,16 +46,10 @@ public class MatchedUnqualifiedParenthesesCall extends Stub<org.elixir_lang.psi.
 
     @NotNull
     @Override
-    public org.elixir_lang.psi.stub.MatchedUnqualifiedParenthesesCall deserialize(@NotNull StubInputStream dataStream, StubElement parentStub) throws IOException {
-        return new org.elixir_lang.psi.stub.MatchedUnqualifiedParenthesesCall(
-                parentStub,
-                this,
-                dataStream.readName(),
-                dataStream.readName(),
-                dataStream.readVarInt(),
-                dataStream.readBoolean(),
-                dataStream.readName(),
-                readNameSet(dataStream)
-        );
+    public org.elixir_lang.psi.stub.MatchedUnqualifiedParenthesesCall deserialize(@NotNull StubInputStream dataStream,
+                                                                                  @Nullable StubElement parentStub)
+            throws IOException {
+        Deserialized deserialized = Deserialized.deserialize(dataStream);
+        return new org.elixir_lang.psi.stub.MatchedUnqualifiedParenthesesCall(parentStub, this, deserialized);
     }
 }

--- a/src/org/elixir_lang/psi/stub/type/UnmatchedAtUnqualifiedNoParenthesesCall.java
+++ b/src/org/elixir_lang/psi/stub/type/UnmatchedAtUnqualifiedNoParenthesesCall.java
@@ -50,7 +50,7 @@ public class UnmatchedAtUnqualifiedNoParenthesesCall extends Stub<org.elixir_lan
                 this,
                 dataStream.readName(),
                 dataStream.readName(),
-                dataStream.readInt(),
+                dataStream.readVarInt(),
                 dataStream.readBoolean(),
                 dataStream.readName(),
                 readNameSet(dataStream)

--- a/src/org/elixir_lang/psi/stub/type/UnmatchedAtUnqualifiedNoParenthesesCall.java
+++ b/src/org/elixir_lang/psi/stub/type/UnmatchedAtUnqualifiedNoParenthesesCall.java
@@ -5,8 +5,10 @@ import com.intellij.psi.stubs.StubElement;
 import com.intellij.psi.stubs.StubInputStream;
 import org.elixir_lang.psi.ElixirUnmatchedAtUnqualifiedNoParenthesesCall;
 import org.elixir_lang.psi.impl.ElixirUnmatchedAtUnqualifiedNoParenthesesCallImpl;
+import org.elixir_lang.psi.stub.call.Deserialized;
 import org.elixir_lang.psi.stub.type.call.Stub;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.io.IOException;
 
@@ -44,16 +46,11 @@ public class UnmatchedAtUnqualifiedNoParenthesesCall extends Stub<org.elixir_lan
 
     @NotNull
     @Override
-    public org.elixir_lang.psi.stub.UnmatchedAtUnqualifiedNoParenthesesCall deserialize(@NotNull StubInputStream dataStream, StubElement parentStub) throws IOException {
-        return new org.elixir_lang.psi.stub.UnmatchedAtUnqualifiedNoParenthesesCall(
-                parentStub,
-                this,
-                dataStream.readName(),
-                dataStream.readName(),
-                dataStream.readVarInt(),
-                dataStream.readBoolean(),
-                dataStream.readName(),
-                readNameSet(dataStream)
-        );
+    public org.elixir_lang.psi.stub.UnmatchedAtUnqualifiedNoParenthesesCall deserialize(
+            @NotNull StubInputStream dataStream,
+            @Nullable StubElement parentStub
+    ) throws IOException {
+        Deserialized deserialized = Deserialized.deserialize(dataStream);
+        return new org.elixir_lang.psi.stub.UnmatchedAtUnqualifiedNoParenthesesCall(parentStub, this, deserialized);
     }
 }

--- a/src/org/elixir_lang/psi/stub/type/UnmatchedDotCall.java
+++ b/src/org/elixir_lang/psi/stub/type/UnmatchedDotCall.java
@@ -5,8 +5,10 @@ import com.intellij.psi.stubs.StubElement;
 import com.intellij.psi.stubs.StubInputStream;
 import org.elixir_lang.psi.ElixirUnmatchedDotCall;
 import org.elixir_lang.psi.impl.ElixirUnmatchedDotCallImpl;
+import org.elixir_lang.psi.stub.call.Deserialized;
 import org.elixir_lang.psi.stub.type.call.Stub;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.io.IOException;
 
@@ -44,16 +46,9 @@ public class UnmatchedDotCall extends Stub<org.elixir_lang.psi.stub.UnmatchedDot
 
     @NotNull
     @Override
-    public org.elixir_lang.psi.stub.UnmatchedDotCall deserialize(@NotNull StubInputStream dataStream, StubElement parentStub) throws IOException {
-        return new org.elixir_lang.psi.stub.UnmatchedDotCall(
-                parentStub,
-                this,
-                dataStream.readName(),
-                dataStream.readName(),
-                dataStream.readVarInt(),
-                dataStream.readBoolean(),
-                dataStream.readName(),
-                readNameSet(dataStream)
-        );
+    public org.elixir_lang.psi.stub.UnmatchedDotCall deserialize(@NotNull StubInputStream dataStream,
+                                                                 @Nullable StubElement parentStub) throws IOException {
+        Deserialized deserialized = Deserialized.deserialize(dataStream);
+        return new org.elixir_lang.psi.stub.UnmatchedDotCall(parentStub, this, deserialized);
     }
 }

--- a/src/org/elixir_lang/psi/stub/type/UnmatchedDotCall.java
+++ b/src/org/elixir_lang/psi/stub/type/UnmatchedDotCall.java
@@ -50,7 +50,7 @@ public class UnmatchedDotCall extends Stub<org.elixir_lang.psi.stub.UnmatchedDot
                 this,
                 dataStream.readName(),
                 dataStream.readName(),
-                dataStream.readInt(),
+                dataStream.readVarInt(),
                 dataStream.readBoolean(),
                 dataStream.readName(),
                 readNameSet(dataStream)

--- a/src/org/elixir_lang/psi/stub/type/UnmatchedQualifiedNoArgumentsCall.java
+++ b/src/org/elixir_lang/psi/stub/type/UnmatchedQualifiedNoArgumentsCall.java
@@ -50,7 +50,7 @@ public class UnmatchedQualifiedNoArgumentsCall extends Stub<org.elixir_lang.psi.
                 this,
                 dataStream.readName(),
                 dataStream.readName(),
-                dataStream.readInt(),
+                dataStream.readVarInt(),
                 dataStream.readBoolean(),
                 dataStream.readName(),
                 readNameSet(dataStream)

--- a/src/org/elixir_lang/psi/stub/type/UnmatchedQualifiedNoArgumentsCall.java
+++ b/src/org/elixir_lang/psi/stub/type/UnmatchedQualifiedNoArgumentsCall.java
@@ -5,8 +5,10 @@ import com.intellij.psi.stubs.StubElement;
 import com.intellij.psi.stubs.StubInputStream;
 import org.elixir_lang.psi.ElixirUnmatchedQualifiedNoArgumentsCall;
 import org.elixir_lang.psi.impl.ElixirUnmatchedQualifiedNoArgumentsCallImpl;
+import org.elixir_lang.psi.stub.call.Deserialized;
 import org.elixir_lang.psi.stub.type.call.Stub;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.io.IOException;
 
@@ -44,16 +46,10 @@ public class UnmatchedQualifiedNoArgumentsCall extends Stub<org.elixir_lang.psi.
 
     @NotNull
     @Override
-    public org.elixir_lang.psi.stub.UnmatchedQualifiedNoArgumentsCall deserialize(@NotNull StubInputStream dataStream, StubElement parentStub) throws IOException {
-        return new org.elixir_lang.psi.stub.UnmatchedQualifiedNoArgumentsCall(
-                parentStub,
-                this,
-                dataStream.readName(),
-                dataStream.readName(),
-                dataStream.readVarInt(),
-                dataStream.readBoolean(),
-                dataStream.readName(),
-                readNameSet(dataStream)
-        );
+    public org.elixir_lang.psi.stub.UnmatchedQualifiedNoArgumentsCall deserialize(@NotNull StubInputStream dataStream,
+                                                                                  @Nullable StubElement parentStub)
+            throws IOException {
+        Deserialized deserialized = Deserialized.deserialize(dataStream);
+        return new org.elixir_lang.psi.stub.UnmatchedQualifiedNoArgumentsCall(parentStub, this, deserialized);
     }
 }

--- a/src/org/elixir_lang/psi/stub/type/UnmatchedQualifiedNoParenthesesCall.java
+++ b/src/org/elixir_lang/psi/stub/type/UnmatchedQualifiedNoParenthesesCall.java
@@ -5,8 +5,10 @@ import com.intellij.psi.stubs.StubElement;
 import com.intellij.psi.stubs.StubInputStream;
 import org.elixir_lang.psi.ElixirUnmatchedQualifiedNoParenthesesCall;
 import org.elixir_lang.psi.impl.ElixirUnmatchedQualifiedNoParenthesesCallImpl;
+import org.elixir_lang.psi.stub.call.Deserialized;
 import org.elixir_lang.psi.stub.type.call.Stub;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.io.IOException;
 
@@ -44,16 +46,10 @@ public class UnmatchedQualifiedNoParenthesesCall extends Stub<org.elixir_lang.ps
 
     @NotNull
     @Override
-    public org.elixir_lang.psi.stub.UnmatchedQualifiedNoParenthesesCall deserialize(@NotNull StubInputStream dataStream, StubElement parentStub) throws IOException {
-        return new org.elixir_lang.psi.stub.UnmatchedQualifiedNoParenthesesCall(
-                parentStub,
-                this,
-                dataStream.readName(),
-                dataStream.readName(),
-                dataStream.readVarInt(),
-                dataStream.readBoolean(),
-                dataStream.readName(),
-                readNameSet(dataStream)
-        );
+    public org.elixir_lang.psi.stub.UnmatchedQualifiedNoParenthesesCall deserialize(@NotNull StubInputStream dataStream,
+                                                                                    @Nullable StubElement parentStub)
+            throws IOException {
+        Deserialized deserialized = Deserialized.deserialize(dataStream);
+        return new org.elixir_lang.psi.stub.UnmatchedQualifiedNoParenthesesCall(parentStub, this, deserialized);
     }
 }

--- a/src/org/elixir_lang/psi/stub/type/UnmatchedQualifiedNoParenthesesCall.java
+++ b/src/org/elixir_lang/psi/stub/type/UnmatchedQualifiedNoParenthesesCall.java
@@ -50,7 +50,7 @@ public class UnmatchedQualifiedNoParenthesesCall extends Stub<org.elixir_lang.ps
                 this,
                 dataStream.readName(),
                 dataStream.readName(),
-                dataStream.readInt(),
+                dataStream.readVarInt(),
                 dataStream.readBoolean(),
                 dataStream.readName(),
                 readNameSet(dataStream)

--- a/src/org/elixir_lang/psi/stub/type/UnmatchedQualifiedParenthesesCall.java
+++ b/src/org/elixir_lang/psi/stub/type/UnmatchedQualifiedParenthesesCall.java
@@ -5,8 +5,10 @@ import com.intellij.psi.stubs.StubElement;
 import com.intellij.psi.stubs.StubInputStream;
 import org.elixir_lang.psi.ElixirUnmatchedQualifiedParenthesesCall;
 import org.elixir_lang.psi.impl.ElixirUnmatchedQualifiedParenthesesCallImpl;
+import org.elixir_lang.psi.stub.call.Deserialized;
 import org.elixir_lang.psi.stub.type.call.Stub;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.io.IOException;
 
@@ -44,16 +46,10 @@ public class UnmatchedQualifiedParenthesesCall extends Stub<org.elixir_lang.psi.
 
     @NotNull
     @Override
-    public org.elixir_lang.psi.stub.UnmatchedQualifiedParenthesesCall deserialize(@NotNull StubInputStream dataStream, StubElement parentStub) throws IOException {
-        return new org.elixir_lang.psi.stub.UnmatchedQualifiedParenthesesCall(
-                parentStub,
-                this,
-                dataStream.readName(),
-                dataStream.readName(),
-                dataStream.readVarInt(),
-                dataStream.readBoolean(),
-                dataStream.readName(),
-                readNameSet(dataStream)
-        );
+    public org.elixir_lang.psi.stub.UnmatchedQualifiedParenthesesCall deserialize(@NotNull StubInputStream dataStream,
+                                                                                  @Nullable StubElement parentStub)
+            throws IOException {
+        Deserialized deserialized = Deserialized.deserialize(dataStream);
+        return new org.elixir_lang.psi.stub.UnmatchedQualifiedParenthesesCall(parentStub, this, deserialized);
     }
 }

--- a/src/org/elixir_lang/psi/stub/type/UnmatchedQualifiedParenthesesCall.java
+++ b/src/org/elixir_lang/psi/stub/type/UnmatchedQualifiedParenthesesCall.java
@@ -50,7 +50,7 @@ public class UnmatchedQualifiedParenthesesCall extends Stub<org.elixir_lang.psi.
                 this,
                 dataStream.readName(),
                 dataStream.readName(),
-                dataStream.readInt(),
+                dataStream.readVarInt(),
                 dataStream.readBoolean(),
                 dataStream.readName(),
                 readNameSet(dataStream)

--- a/src/org/elixir_lang/psi/stub/type/UnmatchedUnqualifiedNoArgumentsCall.java
+++ b/src/org/elixir_lang/psi/stub/type/UnmatchedUnqualifiedNoArgumentsCall.java
@@ -5,8 +5,10 @@ import com.intellij.psi.stubs.StubElement;
 import com.intellij.psi.stubs.StubInputStream;
 import org.elixir_lang.psi.ElixirUnmatchedUnqualifiedNoArgumentsCall;
 import org.elixir_lang.psi.impl.ElixirUnmatchedUnqualifiedNoArgumentsCallImpl;
+import org.elixir_lang.psi.stub.call.Deserialized;
 import org.elixir_lang.psi.stub.type.call.Stub;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.io.IOException;
 
@@ -44,16 +46,10 @@ public class UnmatchedUnqualifiedNoArgumentsCall extends Stub<org.elixir_lang.ps
 
     @NotNull
     @Override
-    public org.elixir_lang.psi.stub.UnmatchedUnqualifiedNoArgumentsCall deserialize(@NotNull StubInputStream dataStream, StubElement parentStub) throws IOException {
-        return new org.elixir_lang.psi.stub.UnmatchedUnqualifiedNoArgumentsCall(
-                parentStub,
-                this,
-                dataStream.readName(),
-                dataStream.readName(),
-                dataStream.readVarInt(),
-                dataStream.readBoolean(),
-                dataStream.readName(),
-                readNameSet(dataStream)
-        );
+    public org.elixir_lang.psi.stub.UnmatchedUnqualifiedNoArgumentsCall deserialize(@NotNull StubInputStream dataStream,
+                                                                                    @Nullable StubElement parentStub)
+            throws IOException {
+        Deserialized deserialized = Deserialized.deserialize(dataStream);
+        return new org.elixir_lang.psi.stub.UnmatchedUnqualifiedNoArgumentsCall(parentStub, this, deserialized);
     }
 }

--- a/src/org/elixir_lang/psi/stub/type/UnmatchedUnqualifiedNoArgumentsCall.java
+++ b/src/org/elixir_lang/psi/stub/type/UnmatchedUnqualifiedNoArgumentsCall.java
@@ -50,7 +50,7 @@ public class UnmatchedUnqualifiedNoArgumentsCall extends Stub<org.elixir_lang.ps
                 this,
                 dataStream.readName(),
                 dataStream.readName(),
-                dataStream.readInt(),
+                dataStream.readVarInt(),
                 dataStream.readBoolean(),
                 dataStream.readName(),
                 readNameSet(dataStream)

--- a/src/org/elixir_lang/psi/stub/type/UnmatchedUnqualifiedNoParenthesesCall.java
+++ b/src/org/elixir_lang/psi/stub/type/UnmatchedUnqualifiedNoParenthesesCall.java
@@ -5,8 +5,10 @@ import com.intellij.psi.stubs.StubElement;
 import com.intellij.psi.stubs.StubInputStream;
 import org.elixir_lang.psi.ElixirUnmatchedUnqualifiedNoParenthesesCall;
 import org.elixir_lang.psi.impl.ElixirUnmatchedUnqualifiedNoParenthesesCallImpl;
+import org.elixir_lang.psi.stub.call.Deserialized;
 import org.elixir_lang.psi.stub.type.call.Stub;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -46,16 +48,11 @@ public class UnmatchedUnqualifiedNoParenthesesCall extends Stub<org.elixir_lang.
 
     @NotNull
     @Override
-    public org.elixir_lang.psi.stub.UnmatchedUnqualifiedNoParenthesesCall deserialize(@NotNull StubInputStream dataStream, StubElement parentStub) throws IOException {
-        return new org.elixir_lang.psi.stub.UnmatchedUnqualifiedNoParenthesesCall(
-                parentStub,
-                this,
-                dataStream.readName(),
-                dataStream.readName(),
-                dataStream.readVarInt(),
-                dataStream.readBoolean(),
-                dataStream.readName(),
-                readNameSet(dataStream)
-        );
+    public org.elixir_lang.psi.stub.UnmatchedUnqualifiedNoParenthesesCall deserialize(
+            @NotNull StubInputStream dataStream,
+            @Nullable StubElement parentStub
+    ) throws IOException {
+        Deserialized deserialized = Deserialized.deserialize(dataStream);
+        return new org.elixir_lang.psi.stub.UnmatchedUnqualifiedNoParenthesesCall(parentStub, this, deserialized);
     }
 }

--- a/src/org/elixir_lang/psi/stub/type/UnmatchedUnqualifiedNoParenthesesCall.java
+++ b/src/org/elixir_lang/psi/stub/type/UnmatchedUnqualifiedNoParenthesesCall.java
@@ -52,7 +52,7 @@ public class UnmatchedUnqualifiedNoParenthesesCall extends Stub<org.elixir_lang.
                 this,
                 dataStream.readName(),
                 dataStream.readName(),
-                dataStream.readInt(),
+                dataStream.readVarInt(),
                 dataStream.readBoolean(),
                 dataStream.readName(),
                 readNameSet(dataStream)

--- a/src/org/elixir_lang/psi/stub/type/UnmatchedUnqualifiedParenthesesCall.java
+++ b/src/org/elixir_lang/psi/stub/type/UnmatchedUnqualifiedParenthesesCall.java
@@ -2,15 +2,12 @@ package org.elixir_lang.psi.stub.type;
 
 import com.intellij.psi.stubs.StubElement;
 import com.intellij.psi.stubs.StubInputStream;
-import com.intellij.util.io.StringRef;
 import org.elixir_lang.psi.ElixirUnmatchedUnqualifiedParenthesesCall;
 import org.elixir_lang.psi.impl.ElixirUnmatchedUnqualifiedParenthesesCallImpl;
 import org.elixir_lang.psi.stub.type.call.Stub;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collection;
 
 public class UnmatchedUnqualifiedParenthesesCall extends Stub<org.elixir_lang.psi.stub.UnmatchedUnqualifiedParenthesesCall, ElixirUnmatchedUnqualifiedParenthesesCall> {
     /*
@@ -58,7 +55,7 @@ public class UnmatchedUnqualifiedParenthesesCall extends Stub<org.elixir_lang.ps
                 this,
                 dataStream.readName(),
                 dataStream.readName(),
-                dataStream.readInt(),
+                dataStream.readVarInt(),
                 dataStream.readBoolean(),
                 dataStream.readName(),
                 readNameSet(dataStream)

--- a/src/org/elixir_lang/psi/stub/type/UnmatchedUnqualifiedParenthesesCall.java
+++ b/src/org/elixir_lang/psi/stub/type/UnmatchedUnqualifiedParenthesesCall.java
@@ -4,6 +4,7 @@ import com.intellij.psi.stubs.StubElement;
 import com.intellij.psi.stubs.StubInputStream;
 import org.elixir_lang.psi.ElixirUnmatchedUnqualifiedParenthesesCall;
 import org.elixir_lang.psi.impl.ElixirUnmatchedUnqualifiedParenthesesCallImpl;
+import org.elixir_lang.psi.stub.call.Deserialized;
 import org.elixir_lang.psi.stub.type.call.Stub;
 import org.jetbrains.annotations.NotNull;
 
@@ -50,15 +51,7 @@ public class UnmatchedUnqualifiedParenthesesCall extends Stub<org.elixir_lang.ps
             @NotNull StubInputStream dataStream,
             StubElement parentStub
     ) throws IOException {
-        return new org.elixir_lang.psi.stub.UnmatchedUnqualifiedParenthesesCall(
-                parentStub,
-                this,
-                dataStream.readName(),
-                dataStream.readName(),
-                dataStream.readVarInt(),
-                dataStream.readBoolean(),
-                dataStream.readName(),
-                readNameSet(dataStream)
-        );
+        Deserialized deserialized = Deserialized.deserialize(dataStream);
+        return new org.elixir_lang.psi.stub.UnmatchedUnqualifiedParenthesesCall(parentStub, this, deserialized);
     }
 }

--- a/src/org/elixir_lang/psi/stub/type/UnqualifiedNoParenthesesManyArgumentsCall.java
+++ b/src/org/elixir_lang/psi/stub/type/UnqualifiedNoParenthesesManyArgumentsCall.java
@@ -5,8 +5,10 @@ import com.intellij.psi.stubs.StubElement;
 import com.intellij.psi.stubs.StubInputStream;
 import org.elixir_lang.psi.ElixirUnqualifiedNoParenthesesManyArgumentsCall;
 import org.elixir_lang.psi.impl.ElixirUnqualifiedNoParenthesesManyArgumentsCallImpl;
+import org.elixir_lang.psi.stub.call.Deserialized;
 import org.elixir_lang.psi.stub.type.call.Stub;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.io.IOException;
 
@@ -44,16 +46,11 @@ public class UnqualifiedNoParenthesesManyArgumentsCall extends Stub<org.elixir_l
 
     @NotNull
     @Override
-    public org.elixir_lang.psi.stub.UnqualifiedNoParenthesesManyArgumentsCall deserialize(@NotNull StubInputStream dataStream, StubElement parentStub) throws IOException {
-        return new org.elixir_lang.psi.stub.UnqualifiedNoParenthesesManyArgumentsCall(
-                parentStub,
-                this,
-                dataStream.readName(),
-                dataStream.readName(),
-                dataStream.readVarInt(),
-                dataStream.readBoolean(),
-                dataStream.readName(),
-                readNameSet(dataStream)
-        );
+    public org.elixir_lang.psi.stub.UnqualifiedNoParenthesesManyArgumentsCall deserialize(
+            @NotNull StubInputStream dataStream,
+            @Nullable StubElement parentStub
+    ) throws IOException {
+        Deserialized deserialized = Deserialized.deserialize(dataStream);
+        return new org.elixir_lang.psi.stub.UnqualifiedNoParenthesesManyArgumentsCall(parentStub, this, deserialized);
     }
 }

--- a/src/org/elixir_lang/psi/stub/type/UnqualifiedNoParenthesesManyArgumentsCall.java
+++ b/src/org/elixir_lang/psi/stub/type/UnqualifiedNoParenthesesManyArgumentsCall.java
@@ -50,7 +50,7 @@ public class UnqualifiedNoParenthesesManyArgumentsCall extends Stub<org.elixir_l
                 this,
                 dataStream.readName(),
                 dataStream.readName(),
-                dataStream.readInt(),
+                dataStream.readVarInt(),
                 dataStream.readBoolean(),
                 dataStream.readName(),
                 readNameSet(dataStream)

--- a/src/org/elixir_lang/psi/stub/type/call/Stub.java
+++ b/src/org/elixir_lang/psi/stub/type/call/Stub.java
@@ -18,7 +18,6 @@ import org.elixir_lang.structure_view.element.modular.Protocol;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
-import java.util.Collection;
 import java.util.Set;
 
 public abstract class Stub<Stub extends org.elixir_lang.psi.stub.call.Stub<Psi>,
@@ -33,7 +32,7 @@ public abstract class Stub<Stub extends org.elixir_lang.psi.stub.call.Stub<Psi>,
     }
 
     public static Set<StringRef> readNameSet(@NotNull StubInputStream dataStream) throws IOException {
-        int nameSetSize = dataStream.readInt();
+        int nameSetSize = dataStream.readVarInt();
 
         Set<StringRef> nameSet = new THashSet<>(nameSetSize);
 
@@ -48,7 +47,7 @@ public abstract class Stub<Stub extends org.elixir_lang.psi.stub.call.Stub<Psi>,
                                                             @NotNull StubOutputStream dataStream) throws IOException {
         dataStream.writeName(stub.resolvedModuleName());
         dataStream.writeName(stub.resolvedFunctionName());
-        dataStream.writeInt(stub.resolvedFinalArity());
+        dataStream.writeVarInt(stub.resolvedFinalArity());
         dataStream.writeBoolean(stub.hasDoBlockOrKeyword());
         dataStream.writeName(stub.getName());
         writeNameSet(dataStream, stub.canonicalNameSet());
@@ -59,10 +58,10 @@ public abstract class Stub<Stub extends org.elixir_lang.psi.stub.call.Stub<Psi>,
      */
 
     private static void writeNameSet(@NotNull StubOutputStream dataStream,
-                                     @NotNull Collection<String> nameCollection) throws IOException {
-        dataStream.writeInt(nameCollection.size());
+                                     @NotNull Set<String> nameSet) throws IOException {
+        dataStream.writeVarInt(nameSet.size());
 
-        for (String name : nameCollection) {
+        for (String name : nameSet) {
             dataStream.writeName(name);
         }
     }

--- a/src/org/elixir_lang/psi/stub/type/call/Stub.java
+++ b/src/org/elixir_lang/psi/stub/type/call/Stub.java
@@ -1,13 +1,10 @@
 package org.elixir_lang.psi.stub.type.call;
 
 import com.intellij.lang.ASTNode;
-import com.intellij.psi.stubs.StubInputStream;
 import com.intellij.psi.stubs.StubOutputStream;
-import com.intellij.util.io.StringRef;
-import gnu.trove.THashSet;
 import org.elixir_lang.psi.call.Call;
 import org.elixir_lang.psi.call.StubBased;
-import org.elixir_lang.psi.stub.call.Stubbic;
+import org.elixir_lang.psi.stub.call.Deserialized;
 import org.elixir_lang.structure_view.element.CallDefinitionClause;
 import org.elixir_lang.structure_view.element.CallDefinitionHead;
 import org.elixir_lang.structure_view.element.CallDefinitionSpecification;
@@ -18,81 +15,20 @@ import org.elixir_lang.structure_view.element.modular.Protocol;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
-import java.util.Set;
 
 public abstract class Stub<Stub extends org.elixir_lang.psi.stub.call.Stub<Psi>,
         Psi extends org.elixir_lang.psi.call.StubBased> extends org.elixir_lang.psi.stub.type.Named<Stub, Psi> {
-
     /*
      * Static Methods
-     */
-
-    public static boolean isModular(Call call) {
-        return Implementation.is(call) || Module.is(call) || Protocol.is(call);
-    }
-
-    public static Set<StringRef> readNameSet(@NotNull StubInputStream dataStream) throws IOException {
-        int nameSetSize = dataStream.readVarInt();
-
-        Set<StringRef> nameSet = new THashSet<>(nameSetSize);
-
-        for (int i = 0; i < nameSetSize; i++) {
-            nameSet.add(dataStream.readName());
-        }
-
-        return nameSet;
-    }
-
-    public static <T extends Stubbic> void serializeStubbic(@NotNull T stub,
-                                                            @NotNull StubOutputStream dataStream) throws IOException {
-        dataStream.writeName(stub.resolvedModuleName());
-        dataStream.writeName(stub.resolvedFunctionName());
-        dataStream.writeVarInt(stub.resolvedFinalArity());
-        dataStream.writeBoolean(stub.hasDoBlockOrKeyword());
-        dataStream.writeName(stub.getName());
-        writeNameSet(dataStream, stub.canonicalNameSet());
-    }
-
-    /*
-     * Private Static Methods
-     */
-
-    private static void writeNameSet(@NotNull StubOutputStream dataStream,
-                                     @NotNull Set<String> nameSet) throws IOException {
-        dataStream.writeVarInt(nameSet.size());
-
-        for (String name : nameSet) {
-            dataStream.writeName(name);
-        }
-    }
-
-    /*
-     * Constructors
      */
 
     public Stub(@NotNull String debugName) {
         super(debugName);
     }
 
-    /*
-     * Instance Methods
-     */
-
-    @Override
-    public void serialize(@NotNull Stub stub, @NotNull StubOutputStream dataStream) throws IOException {
-        serializeStubbic(stub, dataStream);
+    public static boolean isModular(Call call) {
+        return Implementation.is(call) || Module.is(call) || Protocol.is(call);
     }
-
-    @Override
-    public boolean shouldCreateStub(ASTNode node) {
-        Call call = (Call) node.getPsi();
-
-        return isNameable(call) && hasNameOrCanonicalNames(call);
-    }
-
-    /*
-     * Private Instance Methods
-     */
 
     private boolean hasCanonicalNames(Call call) {
         boolean hasCanonicalNames = false;
@@ -127,8 +63,19 @@ public abstract class Stub<Stub extends org.elixir_lang.psi.stub.call.Stub<Psi>,
                 Callback.is(call);
     }
 
-
     private boolean isNameable(Call call) {
         return isEnclosableByModular(call) || isDelegationCallDefinitionHead(call) || isModular(call);
+    }
+
+    @Override
+    public void serialize(@NotNull Stub stub, @NotNull StubOutputStream stubOutputStream) throws IOException {
+        Deserialized.serialize(stubOutputStream, stub);
+    }
+
+    @Override
+    public boolean shouldCreateStub(ASTNode node) {
+        Call call = (Call) node.getPsi();
+
+        return isNameable(call) && hasNameOrCanonicalNames(call);
     }
 }


### PR DESCRIPTION
Fixes #767 

# Changelog
## Bug Fixes
* The lower-level `Data(Output|IntputStream` `(write|read)Int` don't work correctly with sizes, so use the JetBrains `(write|read)VarInt` ones instead.