### PR TITLE
Move Quoter in test directory

### DIFF
--- a/tests/org/elixir_lang/intellij_elixir/Quoter.java
+++ b/tests/org/elixir_lang/intellij_elixir/Quoter.java
@@ -24,14 +24,6 @@ public class Quoter {
     private static final String REMOTE_NAME = "Elixir.IntellijElixir.Quoter";
     private static final int TIMEOUT_IN_MILLISECONDS = 1000;
 
-    @Contract("null -> fail")
-    private static void assertMessageReceived(OtpErlangObject message) {
-        assertNotNull(
-                "did not receive message from " + REMOTE_NAME + "@" + IntellijElixir.REMOTE_NODE + ".  Make sure it is running",
-                message
-        );
-    }
-
     public static void assertError(PsiFile file) {
         final String text = file.getText();
 
@@ -43,8 +35,7 @@ public class Quoter {
             String statusString = status.atomValue();
 
             assertEquals(statusString, "error");
-        }
-        catch (IOException | OtpErlangDecodeException | OtpErlangExit e) {
+        } catch (IOException | OtpErlangDecodeException | OtpErlangExit e) {
             throw new RuntimeException(e);
         }
     }
@@ -55,12 +46,19 @@ public class Quoter {
 
         try {
             Quoter.quote(text);
-        }
-        catch (IOException | OtpErlangDecodeException | OtpErlangExit e) {
+        } catch (IOException | OtpErlangDecodeException | OtpErlangExit e) {
             exception = e;
         }
 
         assertThat(exception, instanceOf(OtpErlangExit.class));
+    }
+
+    @Contract("null -> fail")
+    private static void assertMessageReceived(OtpErlangObject message) {
+        assertNotNull(
+                "did not receive message from " + REMOTE_NAME + "@" + IntellijElixir.REMOTE_NODE + ".  Make sure it is running",
+                message
+        );
     }
 
     public static void assertQuotedCorrectly(PsiFile file) {
@@ -89,20 +87,19 @@ public class Quoter {
                 String token = ElixirPsiImplUtil.javaString(tokenBinary);
 
                 throw new AssertionError(
-                        "intellij_elixir returned \"" + message + "\" on line " + line + " due to " + token  +
+                        "intellij_elixir returned \"" + message + "\" on line " + line + " due to " + token +
                                 ", use assertQuotesAroundError if error is expect in Elixir natively, " +
                                 "but not in intellij-elixir plugin"
                 );
             }
-        }
-        catch (IOException | OtpErlangDecodeException | OtpErlangExit e) {
+        } catch (IOException | OtpErlangDecodeException | OtpErlangExit e) {
             throw new RuntimeException(e);
         }
     }
 
     private static void assertQuotedCorrectly(@NotNull OtpErlangObject expectedQuoted,
                                               @NotNull OtpErlangObject actualQuoted) {
-        if(!expectedQuoted.equals(actualQuoted)) {
+        if (!expectedQuoted.equals(actualQuoted)) {
             throw new ComparisonFailure(null, toString(expectedQuoted), toString(actualQuoted));
         }
     }
@@ -148,7 +145,7 @@ public class Quoter {
 
         stringBuilder.append("[");
 
-        for (int i = 0; i< quoted.arity(); i++) {
+        for (int i = 0; i < quoted.arity(); i++) {
             if (i > 0) {
                 stringBuilder.append(",");
             }

--- a/tests/org/elixir_lang/intellij_elixir/Quoter.java
+++ b/tests/org/elixir_lang/intellij_elixir/Quoter.java
@@ -10,7 +10,6 @@ import org.jetbrains.annotations.NotNull;
 import org.junit.ComparisonFailure;
 
 import java.io.IOException;
-import java.nio.charset.Charset;
 
 import static org.apache.commons.lang.CharUtils.isAsciiPrintable;
 import static org.hamcrest.CoreMatchers.instanceOf;
@@ -20,14 +19,13 @@ import static org.junit.Assert.*;
  * Created by luke.imhoff on 12/31/14.
  */
 public class Quoter {
-    public static final OtpErlangAtom CODE_KEY = new OtpErlangAtom("code");
-    public static final OtpErlangAtom QUOTED_KEY = new OtpErlangAtom("quoted");
     /* remote name is Elixir.IntellijElixir.Quoter because all aliases in Elixir look like atoms prefixed with
        with Elixir. from erlang's perspective. */
-    public static final String REMOTE_NAME = "Elixir.IntellijElixir.Quoter";
-    public static final int TIMEOUT_IN_MILLISECONDS = 1000;
+    private static final String REMOTE_NAME = "Elixir.IntellijElixir.Quoter";
+    private static final int TIMEOUT_IN_MILLISECONDS = 1000;
 
-    public static void assertMessageReceived(OtpErlangObject message) {
+    @Contract("null -> fail")
+    private static void assertMessageReceived(OtpErlangObject message) {
         assertNotNull(
                 "did not receive message from " + REMOTE_NAME + "@" + IntellijElixir.REMOTE_NODE + ".  Make sure it is running",
                 message
@@ -46,11 +44,7 @@ public class Quoter {
 
             assertEquals(statusString, "error");
         }
-        catch (IOException e) {
-            throw new RuntimeException(e);
-        } catch (OtpErlangDecodeException e) {
-            throw new RuntimeException(e);
-        } catch (OtpErlangExit e) {
+        catch (IOException | OtpErlangDecodeException | OtpErlangExit e) {
             throw new RuntimeException(e);
         }
     }
@@ -62,12 +56,8 @@ public class Quoter {
         try {
             Quoter.quote(text);
         }
-        catch (IOException ioExeption) {
-            exception = ioExeption;
-        } catch (OtpErlangDecodeException otpErlangDecodeException) {
-            exception = otpErlangDecodeException;
-        } catch (OtpErlangExit otpErlangExit) {
-            exception = otpErlangExit;
+        catch (IOException | OtpErlangDecodeException | OtpErlangExit e) {
+            exception = e;
         }
 
         assertThat(exception, instanceOf(OtpErlangExit.class));
@@ -105,29 +95,16 @@ public class Quoter {
                 );
             }
         }
-        catch (IOException e) {
-            throw new RuntimeException(e);
-        } catch (OtpErlangDecodeException e) {
-            throw new RuntimeException(e);
-        } catch (OtpErlangExit e) {
+        catch (IOException | OtpErlangDecodeException | OtpErlangExit e) {
             throw new RuntimeException(e);
         }
     }
 
-    public static void assertQuotedCorrectly(@NotNull OtpErlangObject expectedQuoted,
-                                             @NotNull OtpErlangObject actualQuoted) {
+    private static void assertQuotedCorrectly(@NotNull OtpErlangObject expectedQuoted,
+                                              @NotNull OtpErlangObject actualQuoted) {
         if(!expectedQuoted.equals(actualQuoted)) {
             throw new ComparisonFailure(null, toString(expectedQuoted), toString(actualQuoted));
         }
-    }
-
-    @Contract(pure = true)
-    @NotNull
-    public static String code(@NotNull OtpErlangMap quotedMessageMap) {
-        OtpErlangBinary actualElixirString = (OtpErlangBinary) quotedMessageMap.get(CODE_KEY);
-        byte[] actualBytes = actualElixirString.binaryValue();
-
-        return new String(actualBytes, Charset.forName("UTF-8"));
     }
 
     public static OtpErlangTuple quote(@NotNull String code) throws IOException, OtpErlangExit, OtpErlangDecodeException {
@@ -146,7 +123,7 @@ public class Quoter {
     }
 
     @NotNull
-    public static String toString(@NotNull OtpErlangBitstr quoted) {
+    private static String toString(@NotNull OtpErlangBitstr quoted) {
         StringBuilder stringBuilder = new StringBuilder();
         stringBuilder.append('"');
 
@@ -166,7 +143,7 @@ public class Quoter {
     }
 
     @NotNull
-    public static String toString(@NotNull OtpErlangList quoted) {
+    private static String toString(@NotNull OtpErlangList quoted) {
         StringBuilder stringBuilder = new StringBuilder();
 
         stringBuilder.append("[");
@@ -185,7 +162,7 @@ public class Quoter {
     }
 
     @NotNull
-    public static String toString(@NotNull OtpErlangObject quoted) {
+    private static String toString(@NotNull OtpErlangObject quoted) {
         String string;
 
         if (quoted instanceof OtpErlangBoolean ||
@@ -216,7 +193,7 @@ public class Quoter {
     }
 
     @NotNull
-    public static String toString(@NotNull OtpErlangTuple quoted) {
+    private static String toString(@NotNull OtpErlangTuple quoted) {
         StringBuilder stringBuilder = new StringBuilder();
 
         stringBuilder.append("{");


### PR DESCRIPTION
Fixes #714

# Changelog
## Bug Fixes
* Move `Quoter` into `test` directory, so it and its dependency on `JUnit` is only used for test compilation and runtime and not the shipped runtime.
* Fix `Quoter` warnings and format.