### PR TITLE
Better error for and adjustments for invalid SDK paths

### DIFF
--- a/src/org/elixir_lang/sdk/ElixirSdkType.java
+++ b/src/org/elixir_lang/sdk/ElixirSdkType.java
@@ -365,6 +365,7 @@ public class ElixirSdkType extends SdkType {
                 File nixOSRoot = new File("/nix/store/");
 
                 if (nixOSRoot.isDirectory()) {
+                    //noinspection ResultOfMethodCallIgnored
                     nixOSRoot.listFiles(
                             (dir, name) -> {
                                 Matcher matcher = NIX_PATTERN.matcher(name);


### PR DESCRIPTION
Fixes #586

# Changelog
## Enhancements
* Adjust SDK home path when `bin`, `lib,` or `src` to parent directory.
* Format `ElixirSdkType`.

## Bug Fixes
* Show expected SDK home path structure when invalid. ![screen shot 2017-08-06 at 2 28 36 pm](https://user-images.githubusercontent.com/298259/29006393-5ce71dfe-7ab4-11e7-88c9-732856f6259d.png)
* Suppress invalid warnings in `ElixirSdkType`.
