### PR TITLE
Always check if result is right operand of match

### DIFF
--- a/src/org/elixir_lang/psi/scope/Variable.java
+++ b/src/org/elixir_lang/psi/scope/Variable.java
@@ -29,12 +29,6 @@ import static org.elixir_lang.psi.operation.infix.Normalized.rightOperand;
 
 public abstract class Variable implements PsiScopeProcessor {
     /*
-     * CONSTANTS
-     */
-
-    public static Key<Boolean> MAYBE_MACRO = new Key<Boolean>("MAYBE_MACRO");
-
-    /*
      *
      * Instance Methods
      *
@@ -340,13 +334,12 @@ public abstract class Variable implements PsiScopeProcessor {
                 if (match instanceof UnqualifiedNoArgumentsCall && resolvedFinalArity == 0) {
                     keepProcessing = executeOnVariable((PsiNamedElement) match, state);
                 } else if (maybeMacro(match, state)) {
-                    ResolveState maybeMacroState = state.put(MAYBE_MACRO, true);
                     /* macros uses in stab signatures see
                        @see https://github.com/elixir-lang/elixir/blob/0c9e72c8d7be3ee502c43762e0ccbbf244198aeb/lib/elixir/lib/stream/reducers.ex#L7 */
                     PsiElement[] finalArguments = finalArguments(match);
 
                     if (finalArguments != null) {
-                        keepProcessing = execute(finalArguments, maybeMacroState);
+                        keepProcessing = execute(finalArguments, state);
                     }
                 }
             }

--- a/testData/org/elixir_lang/reference/callable/issue_354/logger_logstash_backend.ex
+++ b/testData/org/elixir_lang/reference/callable/issue_354/logger_logstash_backend.ex
@@ -1,0 +1,26 @@
+defmodule LoggerLogstashBackend.TCPTest do
+  def setup_backend(context = %{backend: true}) do
+    # don't include in function head so that backend true will always match even if forgot to populate :port
+    %{line: line, port: port} = context
+
+    backend = {LoggerLogstashBackend, String.to_atom("#{inspect __MODULE__}:#{line}")}
+
+    Logger.add_backend backend
+    Logger.configure_backend backend, [
+      host: "127.0.0.1",
+      port: port,
+      level: :info,
+      type: "some_app",
+      metadata: [
+        some_metadata: "go here"
+      ],
+      protocol: :tcp
+    ]
+
+    on_exit fn ->
+      Logger.remove_backend backend
+    end
+
+    con<caret>text
+  end
+end

--- a/tests/org/elixir_lang/reference/callable/Issue354Test.java
+++ b/tests/org/elixir_lang/reference/callable/Issue354Test.java
@@ -1,0 +1,83 @@
+package org.elixir_lang.reference.callable;
+
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiReference;
+import com.intellij.psi.impl.source.tree.LeafPsiElement;
+import com.intellij.testFramework.fixtures.LightCodeInsightFixtureTestCase;
+import org.elixir_lang.psi.ElixirIdentifier;
+import org.elixir_lang.psi.call.Call;
+import org.elixir_lang.psi.operation.Match;
+import org.elixir_lang.structure_view.element.CallDefinitionClause;
+
+public class Issue354Test extends LightCodeInsightFixtureTestCase {
+    /*
+     * Tests
+     */
+
+    public void testLoggerLogstashBackend() {
+        myFixture.configureByFile("logger_logstash_backend.ex");
+        PsiElement elementAtCaret = myFixture.getFile().findElementAt(myFixture.getCaretOffset());
+
+        assertNotNull(elementAtCaret);
+        assertInstanceOf(elementAtCaret, LeafPsiElement.class);
+
+        PsiElement parent = elementAtCaret.getParent();
+
+        assertNotNull(parent);
+        assertInstanceOf(parent, ElixirIdentifier.class);
+
+        PsiElement grandParent = parent.getParent();
+
+        assertNotNull(grandParent);
+        assertInstanceOf(grandParent, Call.class);
+
+        Call grandParentCall = (Call) grandParent;
+        PsiReference reference = grandParentCall.getReference();
+
+        assertNotNull(reference);
+
+        PsiElement resolved = reference.resolve();
+
+        assertNotNull(resolved);
+        assertInstanceOf(resolved, Call.class);
+
+        PsiElement resolvedParent = resolved.getParent();
+
+        assertNotNull(resolvedParent);
+        assertInstanceOf(resolvedParent, Match.class);
+
+        PsiElement resolvedGrandParent = resolvedParent.getParent();
+
+        assertNotNull(resolvedGrandParent);
+
+        PsiElement resolvedGreatGrandParent = resolvedGrandParent.getParent();
+
+        assertNotNull(resolvedGreatGrandParent);
+
+        PsiElement resolvedGreatGreatGrandParent = resolvedGreatGrandParent.getParent();
+
+        assertNotNull(resolvedGreatGreatGrandParent);
+
+        PsiElement resolvedGreatGreatGreatGrandParent = resolvedGreatGreatGrandParent.getParent();
+
+        assertNotNull(resolvedGreatGreatGreatGrandParent);
+
+        PsiElement resolvedGreatGreatGreatGreatGrandParent = resolvedGreatGreatGreatGrandParent.getParent();
+
+        assertNotNull(resolvedGreatGreatGreatGreatGrandParent);
+        assertInstanceOf(resolvedGreatGreatGreatGreatGrandParent, Call.class);
+
+        Call resolvedGreatGreatGreatGreatGrandParentCall = (Call) resolvedGreatGreatGreatGreatGrandParent;
+
+        assertTrue(CallDefinitionClause.is(resolvedGreatGreatGreatGreatGrandParentCall));
+    }
+
+    /*
+     * Protected Instance Methods
+     */
+
+    @Override
+    protected String getTestDataPath() {
+        return "testData/org/elixir_lang/reference/callable/issue_354";
+    }
+}


### PR DESCRIPTION
Fixes #354 

# Changelog
## Enhancements
* Regression test for #354 

## Bug Fixes
* Always check if resolution result is right operand of match.