### PR TITLE
Check if at end of file before checking for call opener

### DIFF
--- a/src/org/elixir_lang/code_insight/completion/insert_handler/CallDefinitionClause.java
+++ b/src/org/elixir_lang/code_insight/completion/insert_handler/CallDefinitionClause.java
@@ -3,6 +3,7 @@ package org.elixir_lang.code_insight.completion.insert_handler;
 import com.intellij.codeInsight.completion.InsertHandler;
 import com.intellij.codeInsight.completion.InsertionContext;
 import com.intellij.codeInsight.lookup.LookupElement;
+import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.util.TextRange;
 import org.jetbrains.annotations.NotNull;
 
@@ -22,12 +23,22 @@ public class CallDefinitionClause implements InsertHandler<LookupElement> {
     public void handleInsert(@NotNull InsertionContext context,
                              @NotNull LookupElement item) {
         int tailOffset = context.getTailOffset();
-        String currentTail = context.getDocument().getText(
-                new TextRange(tailOffset, tailOffset + 1)
-        );
-        char firstChar = currentTail.charAt(0);
+        Document document = context.getDocument();
+        int documentTextLength = document.getTextLength();
+        boolean insertParentheses;
 
-        if (firstChar != ' ' && firstChar != '(' && firstChar != '[') {
+        if (documentTextLength > tailOffset) {
+            String currentTail = document.getText(
+                    new TextRange(tailOffset, tailOffset + 1)
+            );
+            char firstChar = currentTail.charAt(0);
+
+            insertParentheses = firstChar != ' ' && firstChar != '(' && firstChar != '[';
+        } else {
+            insertParentheses = true;
+        }
+
+        if (insertParentheses) {
             context.getDocument().insertString(tailOffset, "()");
             // + 1 to put between the `(`  and `)`
             context.getEditor().getCaretModel().moveToOffset(tailOffset + 1);


### PR DESCRIPTION
Fixes #713

# Changelog
## Bug Fixes
* `CallDefinitionClause` `InsertHandler` always assumed there was a character after the insert location, but when inserting at the very end of the file, there isn't, which caused an `IndexOutOfBoundsException`.  Only check if the following character is not a space, `(`, or `[` when the document is longer than the tail offset to prevent the `IndexOutOfBoundsException`.  If the insertion is at the end of the file, then the `()` will always be inserted.