### PR TITLE
Delegate `ChildAttributes` to previous child when available

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,20 +27,25 @@ allprojects {
 
   apply plugin: 'org.jetbrains.intellij'
   intellij {
+    def intellij_erlang_version
+
     if (ideaVersion.startsWith("2017.1.")) {
-      plugins = ['org.jetbrains.erlang:0.9.939']
+      intellij_erlang_version = "0.9.939"
     } else if (ideaVersion.startsWith("2016.3.")) {
-      plugins = ['org.jetbrains.erlang:0.9.912']
+      intellij_erlang_version = "0.9.912"
     } else if (ideaVersion.startsWith("2016.2.")) {
-      plugins = ['org.jetbrains.erlang:0.8.913']
+      intellij_erlang_version = "0.8.913"
     } else if (ideaVersion.startsWith("2016.1.")) {
-      plugins = ['org.jetbrains.erlang:0.7.876']
+      intellij_erlang_version = "0.7.876"
     } else if (ideaVersion.startsWith("15.0.")) {
-      plugins = ['org.jetbrains.erlang:0.6.873']
+      intellij_erlang_version = "0.6.873"
     } else {
       throw new IllegalArgumentException("ideaVersion is not a recognized MAJOR.MINOR for IntelliJ Erlang compatibility")
     }
 
+    plugins = ["org.jetbrains.erlang:${intellij_erlang_version}",
+               // always have IdeaVIM installed in sandbox
+               "IdeaVIM:0.48"]
     pluginName 'intellij-elixir'
     version ideaVersion
     downloadSources Boolean.valueOf(sources)

--- a/src/org/elixir_lang/formatter/Block.java
+++ b/src/org/elixir_lang/formatter/Block.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import static com.intellij.formatting.ChildAttributes.DELEGATE_TO_PREV_CHILD;
 import static org.apache.commons.lang.StringUtils.isWhitespace;
 import static org.elixir_lang.psi.ElixirTypes.*;
 import static org.elixir_lang.psi.ElixirTypes.FN;
@@ -2217,6 +2218,20 @@ public class Block extends AbstractBlock implements BlockEx {
     @Override
     public Indent getIndent() {
         return indent;
+    }
+
+    @NotNull
+    @Override
+    public ChildAttributes getChildAttributes(int newChildIndex) {
+        ChildAttributes childAttributes;
+
+        if (newChildIndex > 0) {
+           childAttributes = DELEGATE_TO_PREV_CHILD;
+        } else {
+           childAttributes = super.getChildAttributes(newChildIndex);
+        }
+
+        return childAttributes;
     }
 
     /**


### PR DESCRIPTION
Fixes #779

# Changelog
## Enhancements
* Always install `IdeaVIM` in the gradle sandbox because it got annoying having to reinstall it when the sandbox reset.

## Bug Fixes
* Delegate `ChildAttributes` to previous child when available: `Block.getChildAttributes` is used when Enter is pressed to determine the indentation and alignment.  Using the default implementation, newlines in stabs look overly indented, but there is a constant, `DELEGATE_TO_PREV_CHILD` that can be used to just use the last child's indent as long as there is one, which appears to work well for stabs (do block bodies, etc).