### PR TITLE
Require debugger modules instead of using path prepend to compiled .beams

### DIFF
--- a/src/org/elixir_lang/ElixirModules.java
+++ b/src/org/elixir_lang/ElixirModules.java
@@ -1,0 +1,81 @@
+package org.elixir_lang;
+
+import com.intellij.openapi.util.io.FileUtil;
+import com.intellij.util.ResourceUtil;
+import com.intellij.util.io.URLUtil;
+import org.elixir_lang.jps.builder.ParametersList;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.*;
+import java.net.URL;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+
+public class ElixirModules {
+    private ElixirModules() {
+    }
+
+    @NotNull
+    public static ParametersList add(@NotNull ParametersList parametersList, @NotNull List<File> fileList) {
+        for (File file : fileList) {
+            parametersList.add("-r", file.getPath());
+        }
+
+        return parametersList;
+    }
+
+    @NotNull
+    private static List<File> copy(@NotNull String basePath,
+                                   @NotNull List<String> relativePathList,
+                                   @NotNull String destinationDirectoryPath) throws IOException {
+        List<File> destinationFileList = new ArrayList<>(relativePathList.size());
+
+        for (String relativePath : relativePathList) {
+            destinationFileList.add(copy(basePath, relativePath, destinationDirectoryPath));
+        }
+
+        return destinationFileList;
+    }
+
+    @NotNull
+    private static File copy(@NotNull String basePath,
+                             @NotNull String relativePath,
+                             @NotNull String destinationDirectoryPath) throws IOException {
+        URL moduleUrl = ResourceUtil.getResource(ElixirModules.class, basePath, relativePath);
+
+        if (moduleUrl == null) {
+            throw new IOException(
+                    "Failed to locate Elixir module (under base path `" + basePath + "` on relative path `" +
+                            relativePath + "`"
+            );
+        }
+
+        return copy(moduleUrl, Paths.get(destinationDirectoryPath, basePath, relativePath).toFile());
+    }
+
+    @NotNull
+    private static File copy(@NotNull URL moduleURL, File destination) throws IOException {
+        try (BufferedInputStream inputStream = new BufferedInputStream(URLUtil.openStream(moduleURL))) {
+            //noinspection ResultOfMethodCallIgnored
+            destination.getParentFile().mkdirs();
+
+            try (BufferedOutputStream outputStream = new BufferedOutputStream(new FileOutputStream(destination))) {
+                FileUtil.copy(inputStream, outputStream);
+            }
+        }
+
+        return destination;
+    }
+
+    @NotNull
+    public static List<File> copy(@NotNull String basePath, @NotNull List<String> relativePathList) throws IOException {
+        File temporaryDirectory = FileUtil.createTempDirectory("intellij_elixir", null);
+        return copy(basePath, relativePathList, temporaryDirectory.getPath());
+    }
+
+    @NotNull
+    public static ParametersList parametersList(@NotNull List<File> fileList) {
+        return add(new ParametersList(), fileList);
+    }
+}

--- a/src/org/elixir_lang/debugger/ElixirModules.java
+++ b/src/org/elixir_lang/debugger/ElixirModules.java
@@ -1,0 +1,32 @@
+package org.elixir_lang.debugger;
+
+import org.elixir_lang.jps.builder.ParametersList;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+
+public class ElixirModules {
+    private static final String BASE_PATH = "/debugger";
+    private static final String INTELLIJ_ELIXIR_DEBUG_SERVER = "lib/debug_server.ex";
+    private static final String MIX_TASKS_INTELLIJ_ELIXIR_DEBUG_TASK = "lib/debug_task.ex";
+    private static final List<String> RELATIVE_SOURCE_PATH_LIST = Arrays.asList(
+            INTELLIJ_ELIXIR_DEBUG_SERVER,
+            MIX_TASKS_INTELLIJ_ELIXIR_DEBUG_TASK
+    );
+
+    private ElixirModules() {
+    }
+
+    @NotNull
+    public static ParametersList add(@NotNull ParametersList parametersList) throws IOException {
+        return org.elixir_lang.ElixirModules.add(parametersList, copy());
+    }
+
+    @NotNull
+    private static List<File> copy() throws IOException {
+        return org.elixir_lang.ElixirModules.copy(BASE_PATH, RELATIVE_SOURCE_PATH_LIST);
+    }
+}

--- a/src/org/elixir_lang/mix/runner/MixRunningState.java
+++ b/src/org/elixir_lang/mix/runner/MixRunningState.java
@@ -51,7 +51,7 @@ public class MixRunningState extends CommandLineState {
   @Override
   protected ProcessHandler startProcess() throws ExecutionException {
     GeneralCommandLine commandLine = MixRunningStateUtil.commandLine(
-      myConfiguration, setupElixirParametersList(myConfiguration), myConfiguration.mixParametersList()
+      myConfiguration, elixirParametersList(myConfiguration), myConfiguration.mixParametersList()
     );
     return runMix(myConfiguration.getProject(), commandLine);
   }
@@ -63,7 +63,7 @@ public class MixRunningState extends CommandLineState {
   }
 
   @NotNull
-  public ParametersList setupElixirParametersList(@Nullable RunConfiguration runConfiguration) throws ExecutionException {
+  public ParametersList elixirParametersList(@Nullable RunConfiguration runConfiguration) throws ExecutionException {
     return new ParametersList();
   }
 }

--- a/src/org/elixir_lang/mix/runner/MixRunningState.java
+++ b/src/org/elixir_lang/mix/runner/MixRunningState.java
@@ -21,49 +21,48 @@ import org.jetbrains.annotations.Nullable;
 import static org.elixir_lang.mix.runner.MixRunningStateUtil.runMix;
 
 /**
- * Created by zyuyou on 15/7/8.
  * https://github.com/ignatov/intellij-erlang/blob/master/src/org/intellij/erlang/rebar/runner/RebarRunningState.java
  */
 public class MixRunningState extends CommandLineState {
-  protected final MixRunConfigurationBase myConfiguration;
+    protected final MixRunConfigurationBase myConfiguration;
 
-  public MixRunningState(@NotNull ExecutionEnvironment environment, MixRunConfigurationBase configuration) {
-    super(environment);
-    myConfiguration = configuration;
-  }
+    public MixRunningState(@NotNull ExecutionEnvironment environment, MixRunConfigurationBase configuration) {
+        super(environment);
+        myConfiguration = configuration;
+    }
 
-  @NotNull
-  @Override
-  public ExecutionResult execute(@NotNull Executor executor, @NotNull ProgramRunner runner) throws ExecutionException {
-    TextConsoleBuilder consoleBuilder = new TextConsoleBuilderImpl(myConfiguration.getProject()) {
-      @Override
-      public ConsoleView getConsole() {
-        ConsoleView consoleView = super.getConsole();
-        ElixirConsoleUtil.attachFilters(myConfiguration.getProject(), consoleView);
-        return consoleView;
-      }
-    };
-    setConsoleBuilder(consoleBuilder);
-    return super.execute(executor, runner);
-  }
+    @NotNull
+    public ConsoleView createConsoleView(Executor executor) {
+        TextConsoleBuilder consoleBuilder = TextConsoleBuilderFactory.getInstance().createBuilder(myConfiguration.getProject());
+        return consoleBuilder.getConsole();
+    }
 
-  @NotNull
-  @Override
-  protected ProcessHandler startProcess() throws ExecutionException {
-    GeneralCommandLine commandLine = MixRunningStateUtil.commandLine(
-      myConfiguration, elixirParametersList(myConfiguration), myConfiguration.mixParametersList()
-    );
-    return runMix(myConfiguration.getProject(), commandLine);
-  }
+    @NotNull
+    public ParametersList elixirParametersList(@Nullable RunConfiguration runConfiguration) throws ExecutionException {
+        return new ParametersList();
+    }
 
-  @NotNull
-  public ConsoleView createConsoleView(Executor executor) {
-    TextConsoleBuilder consoleBuilder = TextConsoleBuilderFactory.getInstance().createBuilder(myConfiguration.getProject());
-    return consoleBuilder.getConsole();
-  }
+    @NotNull
+    @Override
+    public ExecutionResult execute(@NotNull Executor executor, @NotNull ProgramRunner runner) throws ExecutionException {
+        TextConsoleBuilder consoleBuilder = new TextConsoleBuilderImpl(myConfiguration.getProject()) {
+            @Override
+            public ConsoleView getConsole() {
+                ConsoleView consoleView = super.getConsole();
+                ElixirConsoleUtil.attachFilters(myConfiguration.getProject(), consoleView);
+                return consoleView;
+            }
+        };
+        setConsoleBuilder(consoleBuilder);
+        return super.execute(executor, runner);
+    }
 
-  @NotNull
-  public ParametersList elixirParametersList(@Nullable RunConfiguration runConfiguration) throws ExecutionException {
-    return new ParametersList();
-  }
+    @NotNull
+    @Override
+    protected ProcessHandler startProcess() throws ExecutionException {
+        GeneralCommandLine commandLine = MixRunningStateUtil.commandLine(
+                myConfiguration, elixirParametersList(myConfiguration), myConfiguration.mixParametersList()
+        );
+        return runMix(myConfiguration.getProject(), commandLine);
+    }
 }

--- a/src/org/elixir_lang/mix/runner/exunit/MixExUnitRunningState.java
+++ b/src/org/elixir_lang/mix/runner/exunit/MixExUnitRunningState.java
@@ -30,139 +30,139 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
 final class MixExUnitRunningState extends MixRunningState {
-  private static final Logger LOGGER = com.intellij.openapi.diagnostic.Logger.getInstance(MixExUnitRunningState.class);
+    private static final Logger LOGGER = com.intellij.openapi.diagnostic.Logger.getInstance(MixExUnitRunningState.class);
 
-  private final String TEST_FRAMEWORK_NAME = "ExUnit";
+    private final String TEST_FRAMEWORK_NAME = "ExUnit";
 
-  MixExUnitRunningState(@NotNull ExecutionEnvironment environment, MixExUnitRunConfiguration configuration) {
-    super(environment, configuration);
-  }
+    MixExUnitRunningState(@NotNull ExecutionEnvironment environment, MixExUnitRunConfiguration configuration) {
+        super(environment, configuration);
+    }
 
-  @NotNull
-  @Override
-  public ExecutionResult execute(@NotNull Executor executor, @NotNull ProgramRunner runner) throws ExecutionException {
-    ProcessHandler processHandler = startProcess();
+    @NotNull
+    private static ParametersList elixirParametersList(@Nullable Project project) throws IOException {
+        Sdk sdk = null;
+        boolean useCustomMixTask = false;
 
-    TestConsoleProperties properties = new MixTestConsoleProperties(myConfiguration, TEST_FRAMEWORK_NAME, executor);
-    ConsoleView console = createAndAttachConsole(TEST_FRAMEWORK_NAME, processHandler, properties);
-    ElixirConsoleUtil.attachFilters(myConfiguration.getProject(), console);
-    return new DefaultExecutionResult(console, processHandler, createActions(console, processHandler));
-  }
+        if (project != null) {
+            sdk = ProjectRootManager.getInstance(project).getProjectSdk();
+            useCustomMixTask = !MixSettings.getInstance(project).getSupportsFormatterOption();
+        }
 
-  @NotNull
-  public ConsoleView createConsoleView(Executor executor) {
-    TestConsoleProperties properties = new MixTestConsoleProperties(myConfiguration, TEST_FRAMEWORK_NAME, executor);
+        return elixirParametersList(sdk, useCustomMixTask);
+    }
 
-    return createConsole(TEST_FRAMEWORK_NAME, properties);
-  }
+    @NotNull
+    private static ParametersList elixirParametersList(@Nullable Sdk sdk, boolean useCustomMixTask) throws IOException {
+        return ElixirModules.parametersList(ElixirSdkType.getRelease(sdk), useCustomMixTask);
+    }
 
-  /**
-   * Unifies the interface for {@code SMTestRunnerConnectionUtil.createConsole} between 141 and later releases
-   */
-  private ConsoleView createConsole(@NotNull String name , @NotNull  TestConsoleProperties testConsoleProperties) {
+    /**
+     * Unifies the interface for {@code SMTestRunnerConnectionUtil.createAndAttachConsole} between 141 and later releases
+     */
+    private ConsoleView createAndAttachConsole(@NotNull String testFrameworkName,
+                                               @NotNull ProcessHandler processHandler,
+                                               @NotNull TestConsoleProperties consoleProperties) throws ExecutionException {
+        Class<SMTestRunnerConnectionUtil> klass = SMTestRunnerConnectionUtil.class;
         ConsoleView consoleView = null;
 
-    try {
-      Method createConsole2 = SMTestRunnerConnectionUtil.class.getMethod(
-              "createConsole",
-              String.class,
-              TestConsoleProperties.class
-      );
+        try {
+            Method createAndAttachConsole = klass.getMethod("createAndAttachConsole", String.class, ProcessHandler.class, TestConsoleProperties.class);
 
-      try {
-        // first argument is `null` because it's a static method
-        consoleView = (ConsoleView) createConsole2.invoke(null, name, testConsoleProperties);
-      } catch (IllegalAccessException | InvocationTargetException e) {
-        LOGGER.error(e);
-      }
-    } catch (NoSuchMethodException e) {
-      try {
-        Method createConsole3 = SMTestRunnerConnectionUtil.class.getMethod(
-                "createConsole",
-                String.class,
-                TestConsoleProperties.class,
-                ExecutionEnvironment.class
-        );
+            try {
+                consoleView = (ConsoleView) createAndAttachConsole.invoke(null, testFrameworkName, processHandler, consoleProperties);
+            } catch (IllegalAccessException | InvocationTargetException e) {
+                LOGGER.error(e);
+            }
+        } catch (NoSuchMethodException noSuchCreateAndAttachConsole3Method) {
+            try {
+                Method createAndAttachConsole = klass.getMethod("createAndAttachConsole", String.class, ProcessHandler.class, TestConsoleProperties.class, ExecutionEnvironment.class);
+
+                try {
+                    consoleView = (ConsoleView) createAndAttachConsole.invoke(null, testFrameworkName, processHandler, consoleProperties, getEnvironment());
+                } catch (IllegalAccessException | InvocationTargetException e) {
+                    LOGGER.error(e);
+                }
+            } catch (NoSuchMethodException noSuchCreateAndAttachConsole4Method) {
+                noSuchCreateAndAttachConsole4Method.printStackTrace();
+            }
+        }
+
+        return consoleView;
+    }
+
+    /**
+     * Unifies the interface for {@code SMTestRunnerConnectionUtil.createConsole} between 141 and later releases
+     */
+    private ConsoleView createConsole(@NotNull String name, @NotNull TestConsoleProperties testConsoleProperties) {
+        ConsoleView consoleView = null;
 
         try {
-          // first argument is `null` because it's a static method
-          consoleView = (ConsoleView) createConsole3.invoke(null, name, testConsoleProperties, null);
-        } catch (IllegalAccessException | InvocationTargetException e1) {
-          LOGGER.error(e1);
+            Method createConsole2 = SMTestRunnerConnectionUtil.class.getMethod(
+                    "createConsole",
+                    String.class,
+                    TestConsoleProperties.class
+            );
+
+            try {
+                // first argument is `null` because it's a static method
+                consoleView = (ConsoleView) createConsole2.invoke(null, name, testConsoleProperties);
+            } catch (IllegalAccessException | InvocationTargetException e) {
+                LOGGER.error(e);
+            }
+        } catch (NoSuchMethodException e) {
+            try {
+                Method createConsole3 = SMTestRunnerConnectionUtil.class.getMethod(
+                        "createConsole",
+                        String.class,
+                        TestConsoleProperties.class,
+                        ExecutionEnvironment.class
+                );
+
+                try {
+                    // first argument is `null` because it's a static method
+                    consoleView = (ConsoleView) createConsole3.invoke(null, name, testConsoleProperties, null);
+                } catch (IllegalAccessException | InvocationTargetException e1) {
+                    LOGGER.error(e1);
+                }
+            } catch (NoSuchMethodException e1) {
+                LOGGER.error(e1);
+            }
         }
-      } catch (NoSuchMethodException e1) {
-        LOGGER.error(e1);
-      }
+
+        //noinspection ConstantConditions
+        return consoleView;
     }
 
-    //noinspection ConstantConditions
-    return consoleView;
-  }
+    @NotNull
+    public ConsoleView createConsoleView(Executor executor) {
+        TestConsoleProperties properties = new MixTestConsoleProperties(myConfiguration, TEST_FRAMEWORK_NAME, executor);
 
-  /**
-   * Unifies the interface for {@code SMTestRunnerConnectionUtil.createAndAttachConsole} between 141 and later releases
-   */
-  private ConsoleView createAndAttachConsole(@NotNull String testFrameworkName,
-                                             @NotNull ProcessHandler processHandler,
-                                             @NotNull TestConsoleProperties consoleProperties) throws ExecutionException {
-    Class<SMTestRunnerConnectionUtil> klass = SMTestRunnerConnectionUtil.class;
-    ConsoleView consoleView = null;
+        return createConsole(TEST_FRAMEWORK_NAME, properties);
+    }
 
-    try {
-      Method createAndAttachConsole = klass.getMethod("createAndAttachConsole", String.class, ProcessHandler.class, TestConsoleProperties.class);
+    @NotNull
+    public ParametersList elixirParametersList(@Nullable RunConfiguration runConfiguration) throws ExecutionException {
+        Project project = null;
 
-      try {
-        consoleView = (ConsoleView) createAndAttachConsole.invoke(null, testFrameworkName, processHandler, consoleProperties);
-      } catch (IllegalAccessException | InvocationTargetException e) {
-        LOGGER.error(e);
-      }
-    } catch (NoSuchMethodException noSuchCreateAndAttachConsole3Method) {
-      try {
-        Method createAndAttachConsole = klass.getMethod("createAndAttachConsole", String.class, ProcessHandler.class, TestConsoleProperties.class, ExecutionEnvironment.class);
+        if (runConfiguration != null) {
+            project = runConfiguration.getProject();
+        }
 
         try {
-          consoleView = (ConsoleView) createAndAttachConsole.invoke(null, testFrameworkName, processHandler, consoleProperties, getEnvironment());
-        } catch (IllegalAccessException | InvocationTargetException e) {
-          LOGGER.error(e);
+            return elixirParametersList(project);
+        } catch (IOException ioException) {
+            throw new ExecutionException(ioException);
         }
-      } catch (NoSuchMethodException noSuchCreateAndAttachConsole4Method) {
-        noSuchCreateAndAttachConsole4Method.printStackTrace();
-      }
     }
 
-    return consoleView;
-  }
+    @NotNull
+    @Override
+    public ExecutionResult execute(@NotNull Executor executor, @NotNull ProgramRunner runner) throws ExecutionException {
+        ProcessHandler processHandler = startProcess();
 
-  @NotNull
-  private static ParametersList elixirParametersList(@Nullable Project project) throws IOException {
-    Sdk sdk = null;
-    boolean useCustomMixTask = false;
-
-    if (project != null) {
-      sdk = ProjectRootManager.getInstance(project).getProjectSdk();
-      useCustomMixTask = !MixSettings.getInstance(project).getSupportsFormatterOption();
+        TestConsoleProperties properties = new MixTestConsoleProperties(myConfiguration, TEST_FRAMEWORK_NAME, executor);
+        ConsoleView console = createAndAttachConsole(TEST_FRAMEWORK_NAME, processHandler, properties);
+        ElixirConsoleUtil.attachFilters(myConfiguration.getProject(), console);
+        return new DefaultExecutionResult(console, processHandler, createActions(console, processHandler));
     }
-
-    return elixirParametersList(sdk, useCustomMixTask);
-  }
-
-  @NotNull
-  private static ParametersList elixirParametersList(@Nullable Sdk sdk, boolean useCustomMixTask) throws IOException {
-    return ElixirModules.parametersList(ElixirSdkType.getRelease(sdk), useCustomMixTask);
-  }
-
-  @NotNull
-  public ParametersList elixirParametersList(@Nullable RunConfiguration runConfiguration) throws ExecutionException {
-    Project project = null;
-
-    if (runConfiguration != null) {
-      project = runConfiguration.getProject();
-    }
-
-    try {
-      return elixirParametersList(project);
-    } catch (IOException ioException) {
-      throw new ExecutionException(ioException);
-    }
-  }
 }


### PR DESCRIPTION
Fixes #739

# Changelog
## Enhancements
* Since the process of requiring resource files is the same, `org.elixir_lang.ElixirModules` has static methods for copying resources out to a temporary directory and adding the `-r <temporary_path>` for one or more resource files to a new or existing ParametersList.  These are now shared for the Mix ExUnit and Debugger code paths.
* Format class
  * `ElixirXDebugProcess`
  * `MixExUnitRunningState`
  * `MIxRunningState`

## Bug Fixes
* The compiled `.beam` files were removed in 58e7d4a, which was before v5.1.0, but not all users had problems with using the debugger.  #739 [persisted](https://github.com/KronicDeth/intellij-elixir/issues/739#issuecomment-322032123) (as reporte by @erikreedstrom) when 6.0.0 was released; I retried reproducing on a clean VM and I got it.  I'm not sure why it worked for some people in prior releases since the `.beam` don't exist that were being copied, but now the debugger uses the same system of copying `.ex` files and requiring them with `-r` instead of copying `.beam` and using `-pa` to add the `ebin` directory.  Fix was verified local under macOS and in Windows VM that reproduced #739.