### PR TITLE
Apply stabChildrenIndent rules to DO childAttributes

### DIFF
--- a/src/org/elixir_lang/formatter/Block.java
+++ b/src/org/elixir_lang/formatter/Block.java
@@ -28,6 +28,7 @@ import java.util.List;
 import static com.intellij.formatting.ChildAttributes.DELEGATE_TO_PREV_CHILD;
 import static org.apache.commons.lang.StringUtils.isWhitespace;
 import static org.elixir_lang.psi.ElixirTypes.*;
+import static org.elixir_lang.psi.ElixirTypes.DO;
 import static org.elixir_lang.psi.ElixirTypes.FN;
 import static org.elixir_lang.psi.ElixirTypes.MULTIPLE_ALIASES;
 import static org.elixir_lang.psi.call.name.Function.IMPORT;
@@ -2227,6 +2228,17 @@ public class Block extends AbstractBlock implements BlockEx {
 
         if (newChildIndex > 0) {
            childAttributes = DELEGATE_TO_PREV_CHILD;
+        } else if (myNode.getElementType() == DO) {
+            boolean indentRelativeToDirectParent =
+                    codeStyleSettings(myNode).ALIGN_UNMATCHED_CALL_DO_BLOCKS ==
+                            CodeStyleSettings.UnmatchedCallDoBlockAlignment.CALL.value;
+            Indent indent = Indent.getNormalIndent(indentRelativeToDirectParent);
+            childAttributes = new ChildAttributes(
+                    indent,
+                    /* all children share the same alignment as expressions inside a doBlock above the stab are assumed
+                       to be aligned on the left-side */
+                    Alignment.createAlignment()
+            );
         } else {
            childAttributes = super.getChildAttributes(newChildIndex);
         }


### PR DESCRIPTION
Fixes #793

# Changelog
## Bug Fixes
* When `do ... end` template is inserted, it did not have a previous child whose attributes to use, so it used the default, which left the cursor unindented.  To get the cursor indented by default, When the `ElementType` is `DO`, apply the `stabChildrenIndent` rules: indent normal and determine
whether to indent relative to direct parent using code style setting.