### PR TITLE
Erlang SDK

### DIFF
--- a/jps-shared/src/org/elixir_lang/jps/model/JpsErlangSdkType.java
+++ b/jps-shared/src/org/elixir_lang/jps/model/JpsErlangSdkType.java
@@ -1,0 +1,35 @@
+package org.elixir_lang.jps.model;
+
+import com.intellij.openapi.util.SystemInfo;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.jps.model.JpsDummyElement;
+import org.jetbrains.jps.model.JpsElementFactory;
+import org.jetbrains.jps.model.JpsElementTypeWithDefaultProperties;
+import org.jetbrains.jps.model.library.sdk.JpsSdkType;
+
+import java.io.File;
+
+public class JpsErlangSdkType extends JpsSdkType<JpsDummyElement> implements JpsElementTypeWithDefaultProperties<JpsDummyElement> {
+    private static final String BYTECODE_INTERPRETER = "erl";
+
+    @NotNull
+    public static File getByteCodeInterpreterExecutable(@NotNull String sdkHome) {
+        return getSdkExecutable(sdkHome, BYTECODE_INTERPRETER);
+    }
+
+    @NotNull
+    private static File getSdkExecutable(@NotNull String sdkHome, @NotNull String command) {
+        return new File(new File(sdkHome, "bin"), getExecutableFileName(command));
+    }
+
+    @NotNull
+    public static String getExecutableFileName(@NotNull String executableName) {
+        return SystemInfo.isWindows ? executableName + ".exe" : executableName;
+    }
+
+    @NotNull
+    @Override
+    public JpsDummyElement createDefaultProperties() {
+        return JpsElementFactory.getInstance().createDummyElement();
+    }
+}

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -18,7 +18,8 @@
     <errorHandler implementation="org.elixir_lang.errorreport.Submitter"/>
 
     <!-- Elixir Module Structure -->
-    <sdkType implementation="org.elixir_lang.sdk.ElixirSdkType"/>
+    <sdkType implementation="org.elixir_lang.sdk.elixir.Type"/>
+    <sdkType implementation="org.elixir_lang.sdk.erlang.Type"/>
 
     <moduleConfigurationEditorProvider implementation="org.elixir_lang.module.DefaultModuleEditorsProvider" order="first"/>
 

--- a/src/org/elixir_lang/exunit/ElixirModules.java
+++ b/src/org/elixir_lang/exunit/ElixirModules.java
@@ -1,7 +1,7 @@
 package org.elixir_lang.exunit;
 
 import org.elixir_lang.jps.builder.ParametersList;
-import org.elixir_lang.sdk.ElixirSdkRelease;
+import org.elixir_lang.sdk.elixir.Release;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -26,11 +26,11 @@ public class ElixirModules {
     }
 
     private static void addFormatterPath(@NotNull List<String> relativeSourcePathList,
-                                         @Nullable ElixirSdkRelease elixirSdkRelease) {
+                                         @Nullable Release elixirSdkRelease) {
 
         String versionDirectory = "1.4.0";
 
-        if (elixirSdkRelease != null && elixirSdkRelease.compareTo(ElixirSdkRelease.V_1_4) < 0) {
+        if (elixirSdkRelease != null && elixirSdkRelease.compareTo(Release.V_1_4) < 0) {
             versionDirectory = "1.1.0";
         }
 
@@ -40,17 +40,17 @@ public class ElixirModules {
     }
 
     @NotNull
-    private static List<File> copy(@Nullable ElixirSdkRelease elixirSdkRelease, boolean useCustomMixTask) throws IOException {
+    private static List<File> copy(@Nullable Release elixirSdkRelease, boolean useCustomMixTask) throws IOException {
         return org.elixir_lang.ElixirModules.copy(BASE_PATH, relativeSourcePathList(elixirSdkRelease, useCustomMixTask));
     }
 
     @NotNull
-    public static ParametersList parametersList(@Nullable ElixirSdkRelease elixirSdkRelease, boolean useCustomMixTask) throws IOException {
+    public static ParametersList parametersList(@Nullable Release elixirSdkRelease,
+                                                boolean useCustomMixTask) throws IOException {
         return org.elixir_lang.ElixirModules.parametersList(copy(elixirSdkRelease, useCustomMixTask));
     }
 
-    private static List<String> relativeSourcePathList(@Nullable ElixirSdkRelease elixirSdkRelease,
-                                                       boolean useCustomMixTask) {
+    private static List<String> relativeSourcePathList(@Nullable Release elixirSdkRelease, boolean useCustomMixTask) {
         List<String> relativeSourcePathList = new ArrayList<>();
         relativeSourcePathList.add(FORMATTING_FILE_NAME);
 

--- a/src/org/elixir_lang/inspection/SetupSDKNotificationProvider.java
+++ b/src/org/elixir_lang/inspection/SetupSDKNotificationProvider.java
@@ -21,9 +21,9 @@ import com.intellij.ui.EditorNotificationPanel;
 import com.intellij.ui.EditorNotifications;
 import org.elixir_lang.ElixirFileType;
 import org.elixir_lang.ElixirLanguage;
-import org.elixir_lang.sdk.ElixirSdkRelease;
-import org.elixir_lang.sdk.ElixirSdkType;
-import org.elixir_lang.sdk.ElixirSystemUtil;
+import org.elixir_lang.sdk.ProcessOutput;
+import org.elixir_lang.sdk.elixir.Release;
+import org.elixir_lang.sdk.elixir.Type;
 import org.elixir_lang.settings.ElixirExternalToolsConfigurable;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -62,7 +62,7 @@ public class SetupSDKNotificationProvider extends EditorNotifications.Provider<E
     PsiFile psiFile = PsiManager.getInstance(myProject).findFile(file);
     if(psiFile == null || psiFile.getLanguage() != ElixirLanguage.INSTANCE) return null;
 
-    ElixirSdkRelease sdkRelease = ElixirSdkType.getRelease(psiFile);
+    Release sdkRelease = Type.getRelease(psiFile);
     if(sdkRelease != null) return null;
 
     return createPanel(myProject, psiFile);
@@ -78,7 +78,7 @@ public class SetupSDKNotificationProvider extends EditorNotifications.Provider<E
     panel.createActionLabel(ProjectBundle.message("project.sdk.setup"), new Runnable() {
       @Override
       public void run() {
-        if(ElixirSystemUtil.isSmallIde()){
+        if(ProcessOutput.isSmallIde()){
           ShowSettingsUtil.getInstance().showSettingsDialog(project, ElixirExternalToolsConfigurable.ELIXIR_RELATED_TOOLS);
           return;
         }

--- a/src/org/elixir_lang/mix/importWizard/MixProjectImportBuilder.java
+++ b/src/org/elixir_lang/mix/importWizard/MixProjectImportBuilder.java
@@ -32,7 +32,7 @@ import org.elixir_lang.configuration.ElixirCompilerSettings;
 import org.elixir_lang.icons.ElixirIcons;
 import org.elixir_lang.mix.settings.MixSettings;
 import org.elixir_lang.module.ElixirModuleType;
-import org.elixir_lang.sdk.ElixirSdkType;
+import org.elixir_lang.sdk.elixir.Type;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -71,7 +71,7 @@ public class MixProjectImportBuilder extends ProjectImportBuilder<ImportedOtpApp
 
   @Override
   public boolean isSuitableSdkType(SdkTypeId sdkType) {
-    return sdkType == ElixirSdkType.getInstance();
+    return sdkType == Type.getInstance();
   }
 
   @Override
@@ -292,17 +292,16 @@ public class MixProjectImportBuilder extends ProjectImportBuilder<ImportedOtpApp
   private static Sdk fixProjectSdk(@NotNull Project project){
     final ProjectRootManagerEx projectRootMgr = ProjectRootManagerEx.getInstanceEx(project);
     Sdk selectedSdk = projectRootMgr.getProjectSdk();
-    if(selectedSdk == null || selectedSdk.getSdkType() != ElixirSdkType.getInstance()){
-      final Sdk moreSuitableSdk = ProjectJdkTable.getInstance().findMostRecentSdkOfType(ElixirSdkType.getInstance());
-      ApplicationManager.getApplication().runWriteAction(new Runnable() {
-        @Override
-        public void run() {
-          projectRootMgr.setProjectSdk(moreSuitableSdk);
-        }
-      });
-      return moreSuitableSdk;
+    Sdk fixedProjectSdk;
+
+    if (selectedSdk == null || selectedSdk.getSdkType() != Type.getInstance()){
+      fixedProjectSdk = ProjectJdkTable.getInstance().findMostRecentSdkOfType(Type.getInstance());
+      ApplicationManager.getApplication().runWriteAction(() -> projectRootMgr.setProjectSdk(fixedProjectSdk));
+    } else {
+      fixedProjectSdk = selectedSdk;
     }
-    return selectedSdk;
+
+    return fixedProjectSdk;
   }
 
   private static void addSourceDirToContent(@NotNull ContentEntry content,

--- a/src/org/elixir_lang/mix/importWizard/MixProjectImportProvider.java
+++ b/src/org/elixir_lang/mix/importWizard/MixProjectImportProvider.java
@@ -5,7 +5,7 @@ import com.intellij.ide.util.projectWizard.ProjectJdkForModuleStep;
 import com.intellij.ide.util.projectWizard.WizardContext;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.projectImport.ProjectImportProvider;
-import org.elixir_lang.sdk.ElixirSdkType;
+import org.elixir_lang.sdk.elixir.Type;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -22,7 +22,7 @@ public class MixProjectImportProvider extends ProjectImportProvider {
     return new ModuleWizardStep[]{
         new MixProjectRootStep(context),
         new SelectImportedOtpAppsStep(context),
-        new ProjectJdkForModuleStep(context, ElixirSdkType.getInstance())
+        new ProjectJdkForModuleStep(context, Type.getInstance())
     };
   }
 

--- a/src/org/elixir_lang/mix/importWizard/MixProjectRootStep.java
+++ b/src/org/elixir_lang/mix/importWizard/MixProjectRootStep.java
@@ -23,7 +23,7 @@ import com.intellij.projectImport.ProjectImportBuilder;
 import com.intellij.projectImport.ProjectImportWizardStep;
 import org.elixir_lang.jps.model.JpsElixirSdkType;
 import org.elixir_lang.mix.settings.MixConfigurationForm;
-import org.elixir_lang.sdk.ElixirSdkType;
+import org.elixir_lang.sdk.elixir.Type;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -113,7 +113,7 @@ public class MixProjectRootStep extends ProjectImportWizardStep {
         String sdkPath;
 
         if (project != null) {
-            sdkPath = ElixirSdkType.getSdkPath(project);
+            sdkPath = Type.getSdkPath(project);
         } else {
             sdkPath = null;
         }

--- a/src/org/elixir_lang/mix/runner/MixRunConfigurationEditorForm.java
+++ b/src/org/elixir_lang/mix/runner/MixRunConfigurationEditorForm.java
@@ -6,12 +6,10 @@ import com.intellij.openapi.module.Module;
 import com.intellij.openapi.options.ConfigurationException;
 import com.intellij.openapi.options.SettingsEditor;
 import org.elixir_lang.module.ElixirModuleType;
-import org.elixir_lang.sdk.ElixirSystemUtil;
+import org.elixir_lang.sdk.ProcessOutput;
 import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 
 /**
  * Created by zyuyou on 15/7/8.
@@ -26,15 +24,12 @@ public final class MixRunConfigurationEditorForm extends SettingsEditor<MixRunCo
   private CommonProgramParametersPanel commonProgramParametersPanel;
 
   public MixRunConfigurationEditorForm(){
-    myRunInModuleCheckBox.addActionListener(new ActionListener() {
-      @Override
-      public void actionPerformed(ActionEvent e) {
-        myModulesComboBox.setEnabled(myRunInModuleCheckBox.isSelected());
-      }
-    });
+    myRunInModuleCheckBox.addActionListener(e -> myModulesComboBox.setEnabled(myRunInModuleCheckBox.isSelected()));
 
-    myModulesComboBox.setVisible(!ElixirSystemUtil.isSmallIde());
-    myRunInModuleCheckBox.setVisible(!ElixirSystemUtil.isSmallIde());
+    boolean richIde = !ProcessOutput.isSmallIde();
+
+    myModulesComboBox.setVisible(richIde);
+    myRunInModuleCheckBox.setVisible(richIde);
   }
 
   @Override
@@ -45,7 +40,7 @@ public final class MixRunConfigurationEditorForm extends SettingsEditor<MixRunCo
   public void reset(@NotNull MixRunConfigurationBase configuration) {
       mySkipDependenciesCheckBox.setSelected(configuration.isSkipDependencies());
       Module module = null;
-      if(!ElixirSystemUtil.isSmallIde()){
+      if(!ProcessOutput.isSmallIde()){
         myModulesComboBox.fillModules(configuration.getProject(), ElixirModuleType.getInstance());
         module = configuration.getConfigurationModule().getModule();
       }

--- a/src/org/elixir_lang/mix/runner/MixRunningStateUtil.java
+++ b/src/org/elixir_lang/mix/runner/MixRunningStateUtil.java
@@ -30,6 +30,8 @@ import java.io.File;
 import java.nio.file.Paths;
 
 import static org.apache.commons.lang.StringUtils.isBlank;
+import static org.elixir_lang.sdk.elixir.Type.addDocumentationPaths;
+import static org.elixir_lang.sdk.elixir.Type.addSourcePaths;
 import static org.elixir_lang.sdk.elixir.Type.putDefaultErlangSdk;
 
 /**
@@ -110,7 +112,7 @@ public class MixRunningStateUtil {
 
             if (classPathPath.equals(oldSourcePathPath)) {
                 sdkModificator.removeRoot(classPath, OrderRootType.SOURCES);
-                org.elixir_lang.sdk.elixir.Type.addSourcePaths(sdkModificator);
+                addSourcePaths(sdkModificator);
                 modified = true;
             }
         }
@@ -128,7 +130,7 @@ public class MixRunningStateUtil {
                 VirtualFile elixirLangDotOrgDocsUrlVirtualFile =
                         VirtualFileManager.getInstance().findFileByUrl(elixirLangDotOrgDocsUrl);
                 sdkModificator.removeRoot(elixirLangDotOrgDocsUrlVirtualFile, documentationRootType);
-                org.elixir_lang.sdk.elixir.Type.addDocumentationPaths(sdkModificator);
+                addDocumentationPaths(sdkModificator);
                 modified = true;
             }
         }

--- a/src/org/elixir_lang/mix/runner/MixRunningStateUtil.java
+++ b/src/org/elixir_lang/mix/runner/MixRunningStateUtil.java
@@ -9,21 +9,22 @@ import com.intellij.notification.Notifications;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.projectRoots.Sdk;
+import com.intellij.openapi.projectRoots.SdkTypeId;
 import com.intellij.openapi.roots.ModuleRootManager;
+import com.intellij.openapi.roots.OrderRootType;
+import com.intellij.openapi.roots.ProjectRootManager;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.util.ObjectUtils;
 import org.elixir_lang.jps.builder.ParametersList;
 import org.elixir_lang.jps.model.JpsElixirSdkType;
+import org.elixir_lang.jps.model.JpsErlangSdkType;
 import org.elixir_lang.mix.settings.MixSettings;
-import org.elixir_lang.sdk.ElixirSdkType;
+import org.elixir_lang.sdk.elixir.Type;
 import org.elixir_lang.utils.ElixirExternalToolsNotificationListener;
 import org.jetbrains.annotations.NotNull;
 
-import java.io.IOException;
-import java.nio.file.DirectoryStream;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
+import java.io.File;
 
 import static org.apache.commons.lang.StringUtils.isBlank;
 
@@ -34,19 +35,9 @@ public class MixRunningStateUtil {
     private static final Logger LOGGER = Logger.getInstance(MixRunningStateUtil.class);
     private static final String SKIP_DEPENDENCIES_PARAMETER = "--no-deps-check";
 
-    private static void addEbinPaths(@NotNull GeneralCommandLine commandLine, @NotNull String sdkPath) {
-        try (DirectoryStream<Path> libStream = Files.newDirectoryStream(Paths.get(sdkPath, "lib"))) {
-            libStream.forEach(
-                    path -> {
-                        try (DirectoryStream<Path> pathStream = Files.newDirectoryStream(path, "*")) {
-                            pathStream.forEach(ebinPath -> commandLine.addParameters("-pa", ebinPath.toString()));
-                        } catch (IOException ioException) {
-                            LOGGER.error(ioException);
-                        }
-                    }
-            );
-        } catch (IOException ioException) {
-            LOGGER.error(ioException);
+    private static void prependCodePaths(@NotNull GeneralCommandLine commandLine, @NotNull Sdk sdk) {
+        for (VirtualFile virtualFile : sdk.getRootProvider().getFiles(OrderRootType.CLASSES)) {
+            commandLine.addParameters("-pa", virtualFile.getCanonicalPath());
         }
     }
 
@@ -149,22 +140,52 @@ public class MixRunningStateUtil {
     private static void setElixir(@NotNull GeneralCommandLine commandLine,
                                   @NotNull Project project,
                                   @NotNull ParametersList parametersList) {
-        String sdkPath = ElixirSdkType.getSdkPath(project);
-        String elixirPath = elixirPath(sdkPath);
+        Sdk sdk = ProjectRootManager.getInstance(project).getProjectSdk();
 
-    /* replace elixir.bat with direct call to erl.exe, to work around quoting problem
-       See https://github.com/KronicDeth/intellij-elixir/issues/603 */
-        if (elixirPath.endsWith(".bat") && sdkPath != null) {
-            // See https://github.com/elixir-lang/elixir/blob/v1.5.1/bin/elixir.bat#L111
-            commandLine.setExePath("erl.exe");
-            // See https://github.com/elixir-lang/elixir/blob/v1.5.1/bin/elixir.bat#L96-L102
-            addEbinPaths(commandLine, sdkPath);
-            // See https://github.com/elixir-lang/elixir/blob/v1.5.1/bin/elixir.bat#L106
-            commandLine.addParameters("-noshell", "-s", "elixir", "start_cli");
-            // See https://github.com/elixir-lang/elixir/blob/v1.5.1/bin/elixir.bat#L111
-            commandLine.addParameter("-extra");
+        if (sdk != null) {
+            SdkTypeId sdkType = sdk.getSdkType();
+
+            if (sdkType == Type.getInstance()) {
+                org.elixir_lang.sdk.erlang_dependent.SdkAdditionalData sdkAdditionalData =
+                        (org.elixir_lang.sdk.erlang_dependent.SdkAdditionalData) sdk.getSdkAdditionalData();
+
+                if (sdkAdditionalData != null) {
+                    Sdk erlangSdk = sdkAdditionalData.getErlangSdk();
+
+                    if (erlangSdk != null) {
+                        String erlangHomePath = erlangSdk.getHomePath();
+
+                        if (erlangHomePath != null) {
+                            File erlFile = JpsErlangSdkType.getByteCodeInterpreterExecutable(erlangHomePath);
+
+                            if (erlFile.exists() && erlFile.canExecute()) {
+                                // See https://github.com/elixir-lang/elixir/blob/v1.5.1/bin/elixir.bat#L111
+                                commandLine.setExePath(erlFile.getAbsolutePath());
+                                // See https://github.com/elixir-lang/elixir/blob/v1.5.1/bin/elixir.bat#L96-L102
+                                prependCodePaths(commandLine, sdk);
+                                // See https://github.com/elixir-lang/elixir/blob/v1.5.1/bin/elixir.bat#L106
+                                commandLine.addParameters("-noshell", "-s", "elixir", "start_cli");
+                                // See https://github.com/elixir-lang/elixir/blob/v1.5.1/bin/elixir.bat#L111
+                                commandLine.addParameter("-extra");
+                            }
+                        }
+                    } else {
+                        String erl = JpsErlangSdkType.getExecutableFileName("erl");
+
+                        // See https://github.com/elixir-lang/elixir/blob/v1.5.1/bin/elixir.bat#L111
+                        commandLine.setExePath(erl);
+                        // See https://github.com/elixir-lang/elixir/blob/v1.5.1/bin/elixir.bat#L96-L102
+                        prependCodePaths(commandLine, sdk);
+                        // See https://github.com/elixir-lang/elixir/blob/v1.5.1/bin/elixir.bat#L106
+                        commandLine.addParameters("-noshell", "-s", "elixir", "start_cli");
+                        // See https://github.com/elixir-lang/elixir/blob/v1.5.1/bin/elixir.bat#L111
+                        commandLine.addParameter("-extra");
+                    }
+                }
+            }
         } else {
-            commandLine.setExePath(elixirPath);
+            String elixir = JpsElixirSdkType.getExecutableFileName("elixir");
+            commandLine.setExePath(elixir);
         }
 
         commandLine.addParameters(parametersList.getList());

--- a/src/org/elixir_lang/mix/runner/MixRunningStateUtil.java
+++ b/src/org/elixir_lang/mix/runner/MixRunningStateUtil.java
@@ -27,6 +27,7 @@ import org.jetbrains.annotations.NotNull;
 import java.io.File;
 
 import static org.apache.commons.lang.StringUtils.isBlank;
+import static org.elixir_lang.sdk.elixir.Type.putDefaultErlangSdk;
 
 /**
  * https://github.com/ignatov/intellij-erlang/blob/master/src/org/intellij/erlang/rebar/runner/RebarRunningStateUtil.java
@@ -151,6 +152,10 @@ public class MixRunningStateUtil {
 
                 if (sdkAdditionalData != null) {
                     Sdk erlangSdk = sdkAdditionalData.getErlangSdk();
+
+                    if (erlangSdk == null) {
+                        erlangSdk = putDefaultErlangSdk(sdk);
+                    }
 
                     if (erlangSdk != null) {
                         String erlangHomePath = erlangSdk.getHomePath();

--- a/src/org/elixir_lang/mix/runner/exunit/MixExUnitRunConfigurationProducer.java
+++ b/src/org/elixir_lang/mix/runner/exunit/MixExUnitRunConfigurationProducer.java
@@ -16,7 +16,7 @@ import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.*;
 import org.elixir_lang.psi.ElixirFile;
-import org.elixir_lang.sdk.ElixirSdkType;
+import org.elixir_lang.sdk.elixir.Type;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -72,7 +72,7 @@ public class MixExUnitRunConfigurationProducer extends RunConfigurationProducer<
         sdkTypeId = sdk.getSdkType();
       }
 
-      if ((sdkTypeId == null || sdkTypeId.equals(ElixirSdkType.getInstance())) &&
+      if ((sdkTypeId == null || sdkTypeId.equals(Type.getInstance())) &&
               ProjectRootsUtil.isInTestSource(psiDirectory.getVirtualFile(),  psiDirectory.getProject())) {
         String basePath = psiElement.getProject().getBasePath();
         String workingDirectory = workingDirectory(psiElement, basePath);

--- a/src/org/elixir_lang/mix/runner/exunit/MixExUnitRunningState.java
+++ b/src/org/elixir_lang/mix/runner/exunit/MixExUnitRunningState.java
@@ -21,7 +21,7 @@ import org.elixir_lang.jps.builder.ParametersList;
 import org.elixir_lang.mix.runner.MixRunningState;
 import org.elixir_lang.mix.runner.MixTestConsoleProperties;
 import org.elixir_lang.mix.settings.MixSettings;
-import org.elixir_lang.sdk.ElixirSdkType;
+import org.elixir_lang.sdk.elixir.Type;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -53,7 +53,7 @@ final class MixExUnitRunningState extends MixRunningState {
 
     @NotNull
     private static ParametersList elixirParametersList(@Nullable Sdk sdk, boolean useCustomMixTask) throws IOException {
-        return ElixirModules.parametersList(ElixirSdkType.getRelease(sdk), useCustomMixTask);
+        return ElixirModules.parametersList(Type.getRelease(sdk), useCustomMixTask);
     }
 
     /**

--- a/src/org/elixir_lang/mix/settings/MixConfigurationForm.java
+++ b/src/org/elixir_lang/mix/settings/MixConfigurationForm.java
@@ -1,7 +1,6 @@
 package org.elixir_lang.mix.settings;
 
 import com.intellij.execution.ExecutionException;
-import com.intellij.execution.process.ProcessOutput;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.diagnostic.Logger;
@@ -18,8 +17,8 @@ import com.intellij.util.containers.ContainerUtil;
 import com.intellij.util.download.DownloadableFileDescription;
 import com.intellij.util.download.DownloadableFileService;
 import com.intellij.util.download.FileDownloader;
-import org.elixir_lang.sdk.ElixirSdkRelease;
-import org.elixir_lang.sdk.ElixirSystemUtil;
+import org.elixir_lang.sdk.ProcessOutput;
+import org.elixir_lang.sdk.elixir.Release;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -29,7 +28,7 @@ import java.awt.*;
 import java.io.File;
 import java.util.List;
 
-import static org.elixir_lang.sdk.ElixirSystemUtil.transformStdoutLine;
+import static org.elixir_lang.sdk.ProcessOutput.transformStdoutLine;
 
 /**
  * Created by zyuyou on 2015/5/26.
@@ -122,12 +121,12 @@ public class MixConfigurationForm {
     File exeFile = mix.getAbsoluteFile();
     String exePath = exeFile.getPath();
     String workDir = exeFile.getParent();
-    ProcessOutput output = null;
+    com.intellij.execution.process.ProcessOutput output = null;
     boolean valid = false;
 
     for (String[] arguments : MIX_ARGUMENTS_ARRAY) {
       try {
-        output = ElixirSystemUtil.getProcessOutput(3000, workDir, exePath, arguments);
+        output = ProcessOutput.getProcessOutput(3000, workDir, exePath, arguments);
       } catch (ExecutionException executionException) {
         LOGGER.warn(executionException);
       }
@@ -141,10 +140,10 @@ public class MixConfigurationForm {
 
           // Support for the --formatter option may be added in a 1.3.x release, but I'm being conservative for now
           // and assuming it won't be released until 1.4
-          ElixirSdkRelease elixirSdkRelease = ElixirSdkRelease.fromString(versionString);
+          Release elixirSdkRelease = Release.fromString(versionString);
 
           if (elixirSdkRelease != null) {
-            supportsFormatterOptionCheckBox.setSelected(elixirSdkRelease.compareTo(ElixirSdkRelease.V_1_4) >= 0);
+            supportsFormatterOptionCheckBox.setSelected(elixirSdkRelease.compareTo(Release.V_1_4) >= 0);
           }
 
           valid = true;

--- a/src/org/elixir_lang/module/ElixirModuleBuilder.java
+++ b/src/org/elixir_lang/module/ElixirModuleBuilder.java
@@ -10,7 +10,7 @@ import com.intellij.openapi.roots.ModifiableRootModel;
 import com.intellij.openapi.util.Condition;
 import com.intellij.openapi.util.Pair;
 import org.elixir_lang.icons.ElixirIcons;
-import org.elixir_lang.sdk.ElixirSdkType;
+import org.elixir_lang.sdk.elixir.Type;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -35,7 +35,7 @@ public class ElixirModuleBuilder extends JavaModuleBuilder implements ModuleBuil
 
   @Override
   public boolean isSuitableSdkType(SdkTypeId sdkType) {
-    return sdkType == ElixirSdkType.getInstance();
+    return sdkType == Type.getInstance();
   }
 
   @Override

--- a/src/org/elixir_lang/module/ElixirModuleType.java
+++ b/src/org/elixir_lang/module/ElixirModuleType.java
@@ -7,7 +7,7 @@ import com.intellij.openapi.module.ModuleType;
 import com.intellij.openapi.module.ModuleTypeManager;
 import com.intellij.openapi.roots.ui.configuration.ModulesProvider;
 import org.elixir_lang.icons.ElixirIcons;
-import org.elixir_lang.sdk.ElixirSdkType;
+import org.elixir_lang.sdk.elixir.Type;
 import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
@@ -60,7 +60,7 @@ public class ElixirModuleType extends ModuleType<ElixirModuleBuilder>{
                                               @NotNull final ElixirModuleBuilder moduleBuilder,
                                               @NotNull ModulesProvider modulesProvider) {
     return new ModuleWizardStep[]{
-        new ProjectJdkForModuleStep(wizardContext, ElixirSdkType.getInstance()){
+        new ProjectJdkForModuleStep(wizardContext, Type.getInstance()){
           public void updateDataModel(){
             super.updateDataModel();
             moduleBuilder.setModuleJdk(getJdk());

--- a/src/org/elixir_lang/module/ElixirModuleType.java
+++ b/src/org/elixir_lang/module/ElixirModuleType.java
@@ -16,7 +16,7 @@ import javax.swing.*;
  * Created by zyuyou on 2015/5/26.
  */
 public class ElixirModuleType extends ModuleType<ElixirModuleBuilder>{
-  public static final String MODULE_TYPE_ID = "ELIXIR_MODULE";
+  private static final String MODULE_TYPE_ID = "ELIXIR_MODULE";
 
   public ElixirModuleType() {
     super(MODULE_TYPE_ID);
@@ -44,7 +44,7 @@ public class ElixirModuleType extends ModuleType<ElixirModuleBuilder>{
     return "Elixir modules are used for developing <b>Elixir</b> applications.";
   }
 
-  @Override
+//  @Override
   public Icon getBigIcon() {
     return ElixirIcons.FILE;
   }

--- a/src/org/elixir_lang/module/ElixirProjectStructureDetector.java
+++ b/src/org/elixir_lang/module/ElixirProjectStructureDetector.java
@@ -10,7 +10,7 @@ import com.intellij.ide.util.projectWizard.importSources.ProjectFromSourcesBuild
 import com.intellij.ide.util.projectWizard.importSources.ProjectStructureDetector;
 import com.intellij.openapi.util.io.FileUtil;
 import com.intellij.util.containers.ContainerUtil;
-import org.elixir_lang.sdk.ElixirSdkType;
+import org.elixir_lang.sdk.elixir.Type;
 import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
@@ -65,7 +65,7 @@ public class ElixirProjectStructureDetector extends ProjectStructureDetector {
 
   @Override
   public List<ModuleWizardStep> createWizardSteps(ProjectFromSourcesBuilder builder, ProjectDescriptor projectDescriptor, Icon stepIcon) {
-    ProjectJdkForModuleStep projectJdkForModuleStep = new ProjectJdkForModuleStep(builder.getContext(), ElixirSdkType.getInstance());
+    ProjectJdkForModuleStep projectJdkForModuleStep = new ProjectJdkForModuleStep(builder.getContext(), Type.getInstance());
     return Collections.<ModuleWizardStep>singletonList(projectJdkForModuleStep);
   }
 

--- a/src/org/elixir_lang/psi/impl/ElixirPsiImplUtil.java
+++ b/src/org/elixir_lang/psi/impl/ElixirPsiImplUtil.java
@@ -45,7 +45,7 @@ import org.elixir_lang.psi.qualification.Qualified;
 import org.elixir_lang.psi.qualification.Unqualified;
 import org.elixir_lang.psi.stub.call.Stub;
 import org.elixir_lang.reference.Callable;
-import org.elixir_lang.sdk.ElixirSdkRelease;
+import org.elixir_lang.sdk.elixir.Release;
 import org.elixir_lang.structure_view.element.CallDefinitionClause;
 import org.elixir_lang.structure_view.element.CallDefinitionSpecification;
 import org.elixir_lang.structure_view.element.Callback;
@@ -70,7 +70,7 @@ import static org.elixir_lang.psi.call.name.Module.*;
 import static org.elixir_lang.psi.stub.type.call.Stub.isModular;
 import static org.elixir_lang.reference.Callable.*;
 import static org.elixir_lang.reference.ModuleAttribute.isNonReferencing;
-import static org.elixir_lang.sdk.ElixirSdkType.getNonNullRelease;
+import static org.elixir_lang.sdk.elixir.Type.getNonNullRelease;
 import static org.elixir_lang.structure_view.element.CallDefinitionClause.enclosingModularMacroCall;
 import static org.elixir_lang.structure_view.element.modular.Implementation.forNameCollection;
 
@@ -4880,10 +4880,10 @@ if (quoted == null) {
     @Contract(pure = true)
     @NotNull
     private static String quoteBinaryFunctionIdentifier(@NotNull final InterpolatedCharList interpolatedCharList) {
-        ElixirSdkRelease release = getNonNullRelease(interpolatedCharList);
+        Release release = getNonNullRelease(interpolatedCharList);
         String functionIdentifier = "to_charlist";
 
-        if (release.compareTo(ElixirSdkRelease.V_1_3) < 0) {
+        if (release.compareTo(Release.V_1_3) < 0) {
             functionIdentifier = "to_char_list";
         }
 
@@ -5732,10 +5732,10 @@ if (quoted == null) {
         }
 
         Body body = line.getBody();
-        ElixirSdkRelease release = getNonNullRelease(line);
+        Release release = getNonNullRelease(line);
         ASTNode[] childNodes = childNodes(body);
 
-        if (release.compareTo(ElixirSdkRelease.V_1_3) < 0 &&
+        if (release.compareTo(Release.V_1_3) < 0 &&
                 childNodes.length >= 1 &&
                 childNodes[childNodes.length - 1].getElementType().equals(ElixirTypes.ESCAPED_EOL)) {
             heredocDescendantNodes.addAll(Arrays.asList(childNodes).subList(0, childNodes.length - 1));
@@ -5835,9 +5835,9 @@ if (quoted == null) {
                                               @NotNull @SuppressWarnings("unused") ASTNode child) {
         List<Integer> codePointList = ensureCodePointList(maybeCodePointList);
 
-        ElixirSdkRelease release = getNonNullRelease(parent);
+        Release release = getNonNullRelease(parent);
 
-        if (release.compareTo(ElixirSdkRelease.V_1_3) >= 0) {
+        if (release.compareTo(Release.V_1_3) >= 0) {
             if (parent instanceof LiteralSigilHeredoc) {
                 codePointList = addStringCodePoints(codePointList, "\\");
             } else if (parent instanceof LiteralSigilLine) {

--- a/src/org/elixir_lang/sdk/HomePath.java
+++ b/src/org/elixir_lang/sdk/HomePath.java
@@ -1,0 +1,113 @@
+package org.elixir_lang.sdk;
+
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.util.Version;
+import com.intellij.util.Function;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.function.Consumer;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class HomePath {
+    public static final String LINUX_DEFAULT_HOME_PATH = "/usr/local/lib";
+    public static final Version UNKNOWN_VERSION = new Version(0, 0, 0);
+    private static final File HOMEBREW_ROOT = new File("/usr/local/Cellar");
+    private static final File NIX_STORE = new File("/nix/store/");
+    private static final Logger LOGGER = Logger.getInstance(HomePath.class);
+
+    private HomePath() {
+    }
+
+    public static void eachEbinPath(@NotNull String homePath, @NotNull Consumer<Path> ebinPathConsumer) {
+        Path lib = Paths.get(homePath, "lib");
+
+        try {
+            Files.newDirectoryStream(lib).forEach(
+                    app -> {
+                        try {
+                            Files.newDirectoryStream(app, "ebin").forEach(ebinPathConsumer);
+                        } catch (IOException ioException) {
+                            LOGGER.error(ioException);
+                        }
+                    }
+            );
+        } catch (IOException ioException) {
+            LOGGER.error(ioException);
+        }
+    }
+
+    @NotNull
+    public static Pattern nixPattern(@NotNull String name) {
+        return Pattern.compile(".+-" + name + "-(\\d+)\\.(\\d+)\\.(\\d+)");
+    }
+
+    public static void mergeHomebrew(@NotNull Map<Version, String> homePathByVersion,
+                                     @NotNull String name,
+                                     @NotNull Function<File, File> versionPathToHomePath) {
+        if (HOMEBREW_ROOT.isDirectory()) {
+            File nameDirectory = new File(HOMEBREW_ROOT, name);
+
+            if (nameDirectory.isDirectory()) {
+                File[] files = nameDirectory.listFiles();
+
+                if (files != null) {
+                    for (File child : files) {
+                        if (child.isDirectory()) {
+                            String versionString = child.getName();
+                            Version version = Version.parseVersion(versionString);
+                            File homePath = versionPathToHomePath.fun(child);
+                            homePathByVersion.put(version, homePath.getAbsolutePath());
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    public static void mergeNixStore(@NotNull Map<Version, String> homePathByVersion,
+                                     @NotNull Pattern nixPattern,
+                                     @NotNull Function<File, File> versionPathToHomePath) {
+        if (NIX_STORE.isDirectory()) {
+            //noinspection ResultOfMethodCallIgnored
+            NIX_STORE.listFiles(
+                    (dir, name) -> {
+                        Matcher matcher = nixPattern.matcher(name);
+                        boolean accept = false;
+
+                        if (matcher.matches()) {
+                            int major = Integer.parseInt(matcher.group(1));
+                            int minor = Integer.parseInt(matcher.group(2));
+                            int bugfix = Integer.parseInt(matcher.group(3));
+
+                            Version version = new Version(major, minor, bugfix);
+                            File homePath = versionPathToHomePath.fun(new File(dir, name));
+
+                            homePathByVersion.put(version, homePath.getAbsolutePath());
+                            accept = true;
+                        }
+                        return accept;
+                    }
+            );
+        }
+    }
+
+    @Contract(pure = true)
+    @NotNull
+    public static Map<Version, String> homePathByVersion() {
+        return new TreeMap<>(
+                (version1, version2) -> {
+                    // compare version2 to version1 to produce descending instead of ascending order.
+                    return version2.compareTo(version1);
+                }
+        );
+    }
+}

--- a/src/org/elixir_lang/sdk/ProcessOutput.java
+++ b/src/org/elixir_lang/sdk/ProcessOutput.java
@@ -3,7 +3,6 @@ package org.elixir_lang.sdk;
 import com.intellij.execution.ExecutionException;
 import com.intellij.execution.configurations.GeneralCommandLine;
 import com.intellij.execution.process.CapturingProcessHandler;
-import com.intellij.execution.process.ProcessOutput;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.util.Function;
 import com.intellij.util.PlatformUtils;
@@ -18,16 +17,16 @@ import java.util.List;
  * Created by zyuyou on 2015/5/27.
  *
  */
-public class ElixirSystemUtil {
+public class ProcessOutput {
   /*
    * CONSTANTS
    */
 
-  public static final Logger LOGGER = Logger.getInstance(ElixirSystemUtil.class);
+  private static final Logger LOGGER = Logger.getInstance(ProcessOutput.class);
   public static final int STANDARD_TIMEOUT = 10 * 1000;
 
   @Nullable
-  public static <T> T transformStdoutLine(@NotNull ProcessOutput output, @NotNull Function<String, T> lineTransformer) {
+  public static <T> T transformStdoutLine(@NotNull com.intellij.execution.process.ProcessOutput output, @NotNull Function<String, T> lineTransformer) {
     List<String> lines;
 
     if (output.getExitCode() != 0 || output.isTimeout() || output.isCancelled()) {
@@ -58,7 +57,7 @@ public class ElixirSystemUtil {
     T transformed = null;
 
     try {
-      ProcessOutput output = getProcessOutput(timeout, workDir, exePath, arguments);
+      com.intellij.execution.process.ProcessOutput output = getProcessOutput(timeout, workDir, exePath, arguments);
 
       transformed = transformStdoutLine(output, lineTransformer);
     } catch (ExecutionException executionException) {
@@ -69,12 +68,12 @@ public class ElixirSystemUtil {
   }
 
   @NotNull
-  public static ProcessOutput getProcessOutput(int timeout,
-                                               @Nullable String workDir,
-                                               @NotNull String exePath,
-                                               @NotNull String... arguments) throws ExecutionException{
+  public static com.intellij.execution.process.ProcessOutput getProcessOutput(int timeout,
+                                                                              @Nullable String workDir,
+                                                                              @NotNull String exePath,
+                                                                              @NotNull String... arguments) throws ExecutionException{
     if(workDir == null || !new File(workDir).isDirectory() || !new File(exePath).canExecute()){
-      return new ProcessOutput();
+      return new com.intellij.execution.process.ProcessOutput();
     }
 
     GeneralCommandLine cmd = new GeneralCommandLine();
@@ -86,12 +85,12 @@ public class ElixirSystemUtil {
   }
 
   @NotNull
-  public static ProcessOutput execute(@NotNull GeneralCommandLine cmd) throws ExecutionException {
+  public static com.intellij.execution.process.ProcessOutput execute(@NotNull GeneralCommandLine cmd) throws ExecutionException {
     return execute(cmd, STANDARD_TIMEOUT);
   }
 
   @NotNull
-  public static ProcessOutput execute(@NotNull GeneralCommandLine cmd, int timeout) throws ExecutionException {
+  public static com.intellij.execution.process.ProcessOutput execute(@NotNull GeneralCommandLine cmd, int timeout) throws ExecutionException {
     CapturingProcessHandler processHandler = new CapturingProcessHandler(cmd.createProcess());
     return timeout < 0 ? processHandler.runProcess() : processHandler.runProcess(timeout);
   }

--- a/src/org/elixir_lang/sdk/Type.java
+++ b/src/org/elixir_lang/sdk/Type.java
@@ -1,0 +1,29 @@
+package org.elixir_lang.sdk;
+
+import com.intellij.openapi.projectRoots.SdkModificator;
+import com.intellij.openapi.roots.OrderRootType;
+import com.intellij.openapi.vfs.LocalFileSystem;
+import com.intellij.openapi.vfs.VirtualFile;
+import org.jetbrains.annotations.NotNull;
+
+import static org.elixir_lang.sdk.HomePath.eachEbinPath;
+
+public class Type {
+    private Type() {
+    }
+
+    public static void addCodePaths(@NotNull SdkModificator sdkModificator) {
+        eachEbinPath(
+                sdkModificator.getHomePath(),
+                ebin -> {
+                    VirtualFile virtualFile = LocalFileSystem
+                            .getInstance()
+                            .findFileByIoFile(ebin.toFile());
+
+                    if (virtualFile != null) {
+                        sdkModificator.addRoot(virtualFile, OrderRootType.CLASSES);
+                    }
+                }
+        );
+    }
+}

--- a/src/org/elixir_lang/sdk/elixir/ForSmallIdes.java
+++ b/src/org/elixir_lang/sdk/elixir/ForSmallIdes.java
@@ -20,9 +20,6 @@ import org.jetbrains.annotations.Nullable;
 public abstract class ForSmallIdes {
   private static final String LIBRARY_NAME = "Elixir SDK";
 
-  public ForSmallIdes() {
-  }
-
   public static void setUpOrUpdateSdk(@NotNull final Project project, @NotNull final String path){
     ApplicationManager.getApplication().runWriteAction(new Runnable() {
       @Override

--- a/src/org/elixir_lang/sdk/elixir/ForSmallIdes.java
+++ b/src/org/elixir_lang/sdk/elixir/ForSmallIdes.java
@@ -1,4 +1,4 @@
-package org.elixir_lang.sdk;
+package org.elixir_lang.sdk.elixir;
 
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.module.Module;
@@ -17,10 +17,10 @@ import org.jetbrains.annotations.Nullable;
 /**
  * Created by zyuyou on 15/7/16.
  */
-public abstract class ElixirSdkForSmallIdes {
+public abstract class ForSmallIdes {
   private static final String LIBRARY_NAME = "Elixir SDK";
 
-  public ElixirSdkForSmallIdes() {
+  public ForSmallIdes() {
   }
 
   public static void setUpOrUpdateSdk(@NotNull final Project project, @NotNull final String path){

--- a/src/org/elixir_lang/sdk/elixir/Release.java
+++ b/src/org/elixir_lang/sdk/elixir/Release.java
@@ -1,4 +1,4 @@
-package org.elixir_lang.sdk;
+package org.elixir_lang.sdk.elixir;
 
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
@@ -7,16 +7,16 @@ import org.jetbrains.annotations.Nullable;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-public final class ElixirSdkRelease implements Comparable<ElixirSdkRelease> {
+public final class Release implements Comparable<Release> {
   /*
    * CONSTANTS
    */
 
-  public static final ElixirSdkRelease V_1_0_4 = new ElixirSdkRelease("1", "0", "4", null, null);
-  public static final ElixirSdkRelease V_1_2 = new ElixirSdkRelease("1", "2", null, null, null);
-  public static final ElixirSdkRelease V_1_3 = new ElixirSdkRelease("1", "3", null, null, null);
-  public static final ElixirSdkRelease V_1_4 = new ElixirSdkRelease("1", "4", null, null, null);
-  public static final ElixirSdkRelease LATEST = V_1_4;
+  public static final Release V_1_0_4 = new Release("1", "0", "4", null, null);
+  public static final Release V_1_2 = new Release("1", "2", null, null, null);
+  public static final Release V_1_3 = new Release("1", "3", null, null, null);
+  public static final Release V_1_4 = new Release("1", "4", null, null, null);
+  public static final Release LATEST = V_1_4;
 
   private static final Pattern VERSION_PATTERN = Pattern.compile(
           // @version_regex from Version in elixir itself
@@ -34,9 +34,9 @@ public final class ElixirSdkRelease implements Comparable<ElixirSdkRelease> {
    */
 
   @Nullable
-  public static ElixirSdkRelease fromString(@Nullable String versionString){
+  public static Release fromString(@Nullable String versionString){
     Matcher m = versionString != null ? VERSION_PATTERN.matcher(versionString) : null;
-    return m != null && m.matches() ? new ElixirSdkRelease(m.group(1), m.group(2), m.group(3), m.group(4), m.group(5)) : null;
+    return m != null && m.matches() ? new Release(m.group(1), m.group(2), m.group(3), m.group(4), m.group(5)) : null;
   }
 
   /*
@@ -119,11 +119,11 @@ public final class ElixirSdkRelease implements Comparable<ElixirSdkRelease> {
    * Constructors
    */
 
-  public ElixirSdkRelease(@NotNull String major,
-                          @Nullable String minor,
-                          @Nullable String patch,
-                          @Nullable String pre,
-                          @Nullable String build) {
+  public Release(@NotNull String major,
+                 @Nullable String minor,
+                 @Nullable String patch,
+                 @Nullable String pre,
+                 @Nullable String build) {
     this.major = major;
     this.minor = minor;
     this.patch = patch;
@@ -140,7 +140,7 @@ public final class ElixirSdkRelease implements Comparable<ElixirSdkRelease> {
    */
 
   @Override
-  public int compareTo(@NotNull ElixirSdkRelease other) {
+  public int compareTo(@NotNull Release other) {
     int comparison = compareMaybeFormattedDecimals(major, other.major);
 
     if (comparison == 0) {

--- a/src/org/elixir_lang/sdk/elixir/Type.java
+++ b/src/org/elixir_lang/sdk/elixir/Type.java
@@ -48,7 +48,7 @@ import static org.elixir_lang.sdk.Type.addCodePaths;
 public class Type extends org.elixir_lang.sdk.erlang_dependent.Type {
     private static final String LINUX_DEFAULT_HOME_PATH = HomePath.LINUX_DEFAULT_HOME_PATH + "/elixir";
     private static final Logger LOG = Logger.getInstance(Type.class);
-    private static final Pattern NIX_PATTERN = HomePath.nixPattern("elixir");
+    private static final Pattern NIX_PATTERN = nixPattern("elixir");
     private static final Set<String> SDK_HOME_CHILD_BASE_NAME_SET = new THashSet<>(Arrays.asList("bin", "lib", "src"));
     private static final String WINDOWS_32BIT_DEFAULT_HOME_PATH = "C:\\Program Files\\Elixir";
     private static final String WINDOWS_64BIT_DEFAULT_HOME_PATH = "C:\\Program Files (x86)\\Elixir";

--- a/src/org/elixir_lang/sdk/elixir/Type.java
+++ b/src/org/elixir_lang/sdk/elixir/Type.java
@@ -1,4 +1,4 @@
-package org.elixir_lang.sdk;
+package org.elixir_lang.sdk.elixir;
 
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.diagnostic.Logger;
@@ -9,19 +9,26 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.project.ProjectBundle;
 import com.intellij.openapi.projectRoots.*;
 import com.intellij.openapi.projectRoots.impl.ProjectJdkImpl;
-import com.intellij.openapi.roots.*;
+import com.intellij.openapi.roots.JavadocOrderRootType;
+import com.intellij.openapi.roots.ModuleRootManager;
+import com.intellij.openapi.roots.ProjectFileIndex;
+import com.intellij.openapi.roots.ProjectRootManager;
+import com.intellij.openapi.util.InvalidDataException;
 import com.intellij.openapi.util.SystemInfo;
 import com.intellij.openapi.util.Version;
+import com.intellij.openapi.util.WriteExternalException;
 import com.intellij.openapi.util.text.StringUtil;
-import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.openapi.vfs.VirtualFileManager;
 import com.intellij.psi.PsiElement;
+import com.intellij.util.Function;
 import gnu.trove.THashSet;
 import org.apache.commons.io.FilenameUtils;
 import org.elixir_lang.icons.ElixirIcons;
 import org.elixir_lang.jps.model.JpsElixirModelSerializerExtension;
 import org.elixir_lang.jps.model.JpsElixirSdkType;
+import org.elixir_lang.sdk.HomePath;
+import org.elixir_lang.sdk.ProcessOutput;
 import org.jdom.Element;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -29,48 +36,96 @@ import org.jetbrains.annotations.TestOnly;
 
 import javax.swing.*;
 import java.io.File;
+import java.nio.file.Path;
 import java.util.*;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import static org.elixir_lang.sdk.ElixirSystemUtil.STANDARD_TIMEOUT;
-import static org.elixir_lang.sdk.ElixirSystemUtil.transformStdoutLine;
+import static org.elixir_lang.sdk.HomePath.*;
+import static org.elixir_lang.sdk.ProcessOutput.STANDARD_TIMEOUT;
+import static org.elixir_lang.sdk.ProcessOutput.transformStdoutLine;
+import static org.elixir_lang.sdk.Type.addCodePaths;
 
-public class ElixirSdkType extends SdkType {
-    public static final Version UNKNOWN_VERSION = new Version(0, 0, 0);
-    private static final File HOMEBREW_ROOT = new File("/usr/local/Cellar/elixir");
-    private static final String LINUX_DEFAULT_HOME_PATH = "/usr/local/lib/elixir";
-    private static final Logger LOG = Logger.getInstance(ElixirSdkType.class);
-    private static final Pattern NIX_PATTERN = Pattern.compile(".+-elixir-(\\d+)\\.(\\d+)\\.(\\d+)");
-    private static final File NIX_STORE = new File("/nix/store/");
+public class Type extends org.elixir_lang.sdk.erlang_dependent.Type {
+    private static final String LINUX_DEFAULT_HOME_PATH = HomePath.LINUX_DEFAULT_HOME_PATH + "/elixir";
+    private static final Logger LOG = Logger.getInstance(Type.class);
+    private static final Pattern NIX_PATTERN = HomePath.nixPattern("elixir");
     private static final Set<String> SDK_HOME_CHILD_BASE_NAME_SET = new THashSet<>(Arrays.asList("bin", "lib", "src"));
     private static final String WINDOWS_32BIT_DEFAULT_HOME_PATH = "C:\\Program Files\\Elixir";
     private static final String WINDOWS_64BIT_DEFAULT_HOME_PATH = "C:\\Program Files (x86)\\Elixir";
-    private final Map<String, ElixirSdkRelease> mySdkHomeToReleaseCache =
+    private static final Function<File, File> ID = file -> file;
+    private final Map<String, Release> mySdkHomeToReleaseCache =
             ApplicationManager.getApplication().isUnitTestMode() ? new HashMap<>() : new WeakHashMap<>();
 
-    public ElixirSdkType() {
+    public Type() {
         super(JpsElixirModelSerializerExtension.ELIXIR_SDK_TYPE_ID);
+    }
+
+    @Nullable
+    private static String releaseVersion(@NotNull SdkModificator sdkModificator) {
+        String versionString = sdkModificator.getVersionString();
+        final String releaseVersion;
+
+        if (versionString != null) {
+            Release release = Release.fromString(versionString);
+
+            if (release != null) {
+                releaseVersion = release.version();
+            } else {
+                releaseVersion = null;
+            }
+        } else {
+            releaseVersion = null;
+        }
+
+        return releaseVersion;
+    }
+
+    private static void addDocumentationPath(@NotNull SdkModificator sdkModificator,
+                                             @Nullable String releaseVersion,
+                                             @NotNull String appName) {
+        StringBuilder hexdocUrlBuilder =
+                new StringBuilder("https://hexdoc.pm/").append(appName);
+
+        if (releaseVersion != null) {
+            hexdocUrlBuilder.append('/').append(releaseVersion);
+        }
+
+        VirtualFile hexdocUrlVirtualFile =
+                VirtualFileManager.getInstance().findFileByUrl(hexdocUrlBuilder.toString());
+
+        if (hexdocUrlVirtualFile != null) {
+            sdkModificator.addRoot(hexdocUrlVirtualFile, JavadocOrderRootType.getInstance());
+        }
+    }
+
+    private static void addDocumentationPath(@NotNull SdkModificator sdkModificator,
+                                             @Nullable String releaseVersion,
+                                             @NotNull Path ebinPath) {
+        String appName = ebinPath.getParent().getFileName().toString();
+
+        addDocumentationPath(sdkModificator, releaseVersion, appName);
+    }
+
+    private static void addDocumentationPaths(@NotNull SdkModificator sdkModificator) {
+        String releaseVersion = releaseVersion(sdkModificator);
+
+        eachEbinPath(
+                sdkModificator.getHomePath(),
+                ebin -> addDocumentationPath(sdkModificator, releaseVersion, ebin)
+        );
     }
 
     private static void configureSdkPaths(@NotNull Sdk sdk) {
         SdkModificator sdkModificator = sdk.getSdkModificator();
-        setupLocalSdkPaths(sdkModificator);
-        String externalDocUrl = getDefaultDocumentationUrl(getRelease(sdk));
-        if (externalDocUrl != null) {
-            VirtualFile fileByUrl = VirtualFileManager.getInstance().findFileByUrl(externalDocUrl);
-
-            if (fileByUrl != null) {
-                sdkModificator.addRoot(fileByUrl, JavadocOrderRootType.getInstance());
-            }
-        }
+        addCodePaths(sdkModificator);
+        addDocumentationPaths(sdkModificator);
 
         sdkModificator.commitChanges();
     }
 
     @TestOnly
     @NotNull
-    public static Sdk createMockSdk(@NotNull String sdkHome, @NotNull ElixirSdkRelease version) {
+    public static Sdk createMockSdk(@NotNull String sdkHome, @NotNull Release version) {
         getInstance().mySdkHomeToReleaseCache.put(getVersionCacheKey(sdkHome), version);  // we'll not try to detect sdk version in tests environment
         Sdk sdk = new ProjectJdkImpl(getDefaultSdkName(sdkHome, version), getInstance());
         SdkModificator sdkModificator = sdk.getSdkModificator();
@@ -82,37 +137,37 @@ public class ElixirSdkType extends SdkType {
     }
 
     @Nullable
-    private static String getDefaultDocumentationUrl(@Nullable ElixirSdkRelease version) {
+    private static String getDefaultDocumentationUrl(@Nullable Release version) {
         return version == null ? null : "http://elixir-lang.org/docs/stable/elixir/";
     }
 
     @NotNull
-    private static String getDefaultSdkName(@NotNull String sdkHome, @Nullable ElixirSdkRelease release) {
+    private static String getDefaultSdkName(@NotNull String sdkHome, @Nullable Release release) {
         return release != null ? release.toString() : "Unknown Elixir version at " + sdkHome;
     }
 
     @NotNull
-    public static ElixirSdkType getInstance() {
-        return SdkType.findInstance(ElixirSdkType.class);
+    public static Type getInstance() {
+        return SdkType.findInstance(Type.class);
     }
 
     @NotNull
-    public static ElixirSdkRelease getNonNullRelease(@NotNull PsiElement element) {
-        ElixirSdkRelease nonNullRelease = getRelease(element);
+    public static Release getNonNullRelease(@NotNull PsiElement element) {
+        Release nonNullRelease = getRelease(element);
 
         if (nonNullRelease == null) {
-            nonNullRelease = ElixirSdkRelease.LATEST;
+            nonNullRelease = Release.LATEST;
         }
 
         return nonNullRelease;
     }
 
     @Nullable
-    public static ElixirSdkRelease getRelease(@NotNull PsiElement element) {
-        ElixirSdkRelease release = null;
+    public static Release getRelease(@NotNull PsiElement element) {
+        Release release = null;
         Project project = element.getProject();
 
-        if (ElixirSystemUtil.isSmallIde()) {
+        if (ProcessOutput.isSmallIde()) {
             release = getReleaseForSmallIde(project);
         } else {
       /* ModuleUtilCore.findModuleForPsiElement can fail with NullPointerException if the
@@ -143,10 +198,10 @@ public class ElixirSdkType extends SdkType {
     }
 
     @Nullable
-    private static ElixirSdkRelease getRelease(@NotNull Project project) {
-        ElixirSdkRelease release;
+    private static Release getRelease(@NotNull Project project) {
+        Release release;
 
-        if (ElixirSystemUtil.isSmallIde()) {
+        if (ProcessOutput.isSmallIde()) {
             release = getReleaseForSmallIde(project);
         } else {
             ProjectRootManager projectRootManager = ProjectRootManager.getInstance(project);
@@ -162,16 +217,16 @@ public class ElixirSdkType extends SdkType {
     }
 
     @Nullable
-    public static ElixirSdkRelease getRelease(@Nullable Sdk sdk) {
+    public static Release getRelease(@Nullable Sdk sdk) {
         if (sdk != null && sdk.getSdkType() == getInstance()) {
-            ElixirSdkRelease fromVersionString = ElixirSdkRelease.fromString(sdk.getVersionString());
+            Release fromVersionString = Release.fromString(sdk.getVersionString());
             return fromVersionString != null ? fromVersionString : getInstance().detectSdkVersion(StringUtil.notNullize(sdk.getHomePath()));
         }
         return null;
     }
 
     @Nullable
-    private static ElixirSdkRelease getReleaseForSmallIde(@NotNull Project project) {
+    private static Release getReleaseForSmallIde(@NotNull Project project) {
         String sdkPath = getSdkPath(project);
         return StringUtil.isEmpty(sdkPath) ? null : getInstance().detectSdkVersion(sdkPath);
     }
@@ -179,8 +234,8 @@ public class ElixirSdkType extends SdkType {
     @Nullable
     public static String getSdkPath(@NotNull final Project project) {
         // todo small ide
-        if (ElixirSystemUtil.isSmallIde()) {
-            return ElixirSdkForSmallIdes.getSdkHome(project);
+        if (ProcessOutput.isSmallIde()) {
+            return ForSmallIdes.getSdkHome(project);
         }
 
         Sdk sdk = ProjectRootManager.getInstance(project).getProjectSdk();
@@ -193,83 +248,8 @@ public class ElixirSdkType extends SdkType {
     }
 
     @Nullable
-    private static String getVersionString(@Nullable ElixirSdkRelease version) {
+    private static String getVersionString(@Nullable Release version) {
         return version != null ? version.toString() : null;
-    }
-
-    private static boolean isStandardLibraryDir(@NotNull File dir) {
-        return dir.isDirectory();
-    }
-
-    private static void mergeHomebrew(Map<Version, String> homePathByVersion) {
-        if (HOMEBREW_ROOT.isDirectory()) {
-            File[] files = HOMEBREW_ROOT.listFiles();
-            if (files != null) {
-                for (File child : files) {
-                    if (child.isDirectory()) {
-                        String versionString = child.getName();
-                        Version version = Version.parseVersion(versionString);
-                        homePathByVersion.put(version, child.getAbsolutePath());
-                    }
-                }
-            }
-        }
-    }
-
-    private static void mergeNixStore(Map<Version, String> homePathByVersion) {
-        if (NIX_STORE.isDirectory()) {
-            //noinspection ResultOfMethodCallIgnored
-            NIX_STORE.listFiles(
-                    (dir, name) -> {
-                        Matcher matcher = NIX_PATTERN.matcher(name);
-                        boolean accept = false;
-
-                        if (matcher.matches()) {
-                            int major = Integer.parseInt(matcher.group(1));
-                            int minor = Integer.parseInt(matcher.group(2));
-                            int bugfix = Integer.parseInt(matcher.group(3));
-
-                            Version version = new Version(major, minor, bugfix);
-
-                            homePathByVersion.put(version, new File(dir, name).getAbsolutePath());
-                            accept = true;
-                        }
-                        return accept;
-                    }
-            );
-        }
-    }
-
-    private static void setupLocalSdkPaths(@NotNull SdkModificator sdkModificator) {
-        String sdkHome = sdkModificator.getHomePath();
-
-        {
-            File stdLibDir = new File(new File(sdkHome), "lib");
-            if (tryToProcessAsStandardLibraryDir(sdkModificator, stdLibDir)) {
-                return;
-            }
-        }
-
-        assert !ApplicationManager.getApplication().isUnitTestMode() : "Failed to setup a mock SDK";
-
-        File stdLibDir = new File("/usr/lib/erlang");
-        tryToProcessAsStandardLibraryDir(sdkModificator, stdLibDir);
-    }
-
-    /**
-     * set the sdk libs
-     * todo: differentiating `Elixir.*.beam` files and `*.ex` files.
-     */
-    private static boolean tryToProcessAsStandardLibraryDir(@NotNull SdkModificator sdkModificator, @NotNull File stdLibDir) {
-        if (!isStandardLibraryDir(stdLibDir)) {
-            return false;
-        }
-        VirtualFile dir = LocalFileSystem.getInstance().findFileByIoFile(stdLibDir);
-        if (dir != null) {
-            sdkModificator.addRoot(dir, OrderRootType.SOURCES);
-            sdkModificator.addRoot(dir, OrderRootType.CLASSES);
-        }
-        return true;
     }
 
     /**
@@ -298,14 +278,8 @@ public class ElixirSdkType extends SdkType {
     }
 
     @Nullable
-    @Override
-    public AdditionalDataConfigurable createAdditionalDataConfigurable(@NotNull SdkModel sdkModel, @NotNull SdkModificator sdkModificator) {
-        return null;
-    }
-
-    @Nullable
-    private ElixirSdkRelease detectSdkVersion(@NotNull String sdkHome) {
-        ElixirSdkRelease cachedRelease = mySdkHomeToReleaseCache.get(getVersionCacheKey(sdkHome));
+    private Release detectSdkVersion(@NotNull String sdkHome) {
+        Release cachedRelease = mySdkHomeToReleaseCache.get(getVersionCacheKey(sdkHome));
         if (cachedRelease != null) {
             return cachedRelease;
         }
@@ -317,13 +291,13 @@ public class ElixirSdkType extends SdkType {
             return null;
         }
 
-        ElixirSdkRelease release = transformStdoutLine(
-                ElixirSdkRelease::fromString,
+        Release release = transformStdoutLine(
+                Release::fromString,
                 STANDARD_TIMEOUT,
                 sdkHome,
                 elixir.getAbsolutePath(),
                 "-e",
-                "IO.puts System.build_info[:version]"
+                "System.version() |> IO.puts()"
         );
 
         if (release != null) {
@@ -393,8 +367,8 @@ public class ElixirSdkType extends SdkType {
         );
 
         if (SystemInfo.isMac) {
-            mergeHomebrew(homePathByVersion);
-            mergeNixStore(homePathByVersion);
+            mergeHomebrew(homePathByVersion, "elixir", ID);
+            mergeNixStore(homePathByVersion, NIX_PATTERN, ID);
         } else {
             String sdkPath;
 
@@ -409,7 +383,7 @@ public class ElixirSdkType extends SdkType {
             } else if (SystemInfo.isLinux) {
                 homePathByVersion.put(UNKNOWN_VERSION, LINUX_DEFAULT_HOME_PATH);
 
-                mergeNixStore(homePathByVersion);
+                mergeNixStore(homePathByVersion, NIX_PATTERN, ID);
             }
         }
 
@@ -461,10 +435,6 @@ public class ElixirSdkType extends SdkType {
     }
 
     @Override
-    public void saveAdditionalData(@NotNull SdkAdditionalData additionalData, @NotNull Element additional) {
-    }
-
-    @Override
     public void setupSdkPaths(@NotNull Sdk sdk) {
         configureSdkPaths(sdk);
     }
@@ -504,5 +474,36 @@ public class ElixirSdkType extends SdkType {
                 throw invalidSdkHomeException(virtualFile);
             }
         }
+    }
+
+    @Nullable
+    @Override
+    public com.intellij.openapi.projectRoots.AdditionalDataConfigurable createAdditionalDataConfigurable(
+            @NotNull SdkModel sdkModel,
+            @NotNull SdkModificator sdkModificator
+    ) {
+        return new org.elixir_lang.sdk.erlang_dependent.AdditionalDataConfigurable(sdkModel);
+    }
+
+    public void saveAdditionalData(@NotNull SdkAdditionalData additionalData, @NotNull Element additional) {
+        if (additionalData instanceof org.elixir_lang.sdk.erlang_dependent.SdkAdditionalData) {
+            try {
+                ((org.elixir_lang.sdk.erlang_dependent.SdkAdditionalData) additionalData).writeExternal(additional);
+            } catch (WriteExternalException e) {
+                LOG.error(e);
+            }
+        }
+    }
+
+    public SdkAdditionalData loadAdditionalData(@NotNull Sdk elixirSdk, Element additional) {
+        org.elixir_lang.sdk.erlang_dependent.SdkAdditionalData sdkAdditionalData = new org.elixir_lang.sdk.erlang_dependent.SdkAdditionalData(elixirSdk);
+
+        try {
+            sdkAdditionalData.readExternal(additional);
+        } catch (InvalidDataException e) {
+            LOG.error(e);
+        }
+
+        return sdkAdditionalData;
     }
 }

--- a/src/org/elixir_lang/sdk/erlang/Release.java
+++ b/src/org/elixir_lang/sdk/erlang/Release.java
@@ -1,0 +1,42 @@
+package org.elixir_lang.sdk.erlang;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class Release {
+    private static final Pattern VERSION_PATTERN = Pattern.compile("Erlang/OTP (\\S+) \\[erts-(\\S+)\\]");
+
+    @NotNull
+    final String otpRelease;
+    @NotNull
+    private final String ertsVersion;
+
+    Release(@NotNull String otpRelease, @NotNull String ertsVersion) {
+        this.otpRelease = otpRelease;
+        this.ertsVersion = ertsVersion;
+    }
+
+    @Nullable
+    static Release fromString(@Nullable String versionString) {
+        Release release = null;
+
+        if (versionString != null) {
+            Matcher matcher = VERSION_PATTERN.matcher(versionString);
+
+            if (matcher.matches()) {
+                release = new Release(matcher.group(1), matcher.group(2));
+            }
+        }
+
+        return release;
+    }
+
+    @NotNull
+    @Override
+    public String toString() {
+        return "Erlang/OTP " + otpRelease + " [erts-" + ertsVersion + "]";
+    }
+}

--- a/src/org/elixir_lang/sdk/erlang/Type.java
+++ b/src/org/elixir_lang/sdk/erlang/Type.java
@@ -1,0 +1,274 @@
+package org.elixir_lang.sdk.erlang;
+
+import com.intellij.execution.ExecutionException;
+import com.intellij.execution.process.ProcessOutput;
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.projectRoots.Sdk;
+import com.intellij.openapi.projectRoots.SdkModel;
+import com.intellij.openapi.projectRoots.SdkModificator;
+import com.intellij.openapi.projectRoots.SdkType;
+import com.intellij.openapi.roots.JavadocOrderRootType;
+import com.intellij.openapi.roots.OrderRootType;
+import com.intellij.openapi.util.SystemInfo;
+import com.intellij.openapi.util.Version;
+import com.intellij.util.Function;
+import com.intellij.util.containers.WeakHashMap;
+import org.elixir_lang.jps.model.JpsErlangSdkType;
+import org.elixir_lang.sdk.HomePath;
+import org.elixir_lang.sdk.erlang_dependent.AdditionalDataConfigurable;
+import org.jdom.Element;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.io.File;
+import java.util.*;
+import java.util.regex.Pattern;
+
+import static org.elixir_lang.sdk.HomePath.*;
+import static org.elixir_lang.sdk.Type.addCodePaths;
+
+/**
+ * An Erlang SdkType for use when `intellij-erlang` is not installed
+ */
+public class Type extends SdkType {
+    private static final String OTP_RELEASE_PREFIX_LINE = Type.class.getCanonicalName() + " OTP_RELEASE:";
+    private static final String ERTS_VERSION_PREFIX_LINE = Type.class.getCanonicalName() + " ERTS_VERSION:";
+    private static final String PRINT_VERSION_INFO_EXPRESSION =
+            "io:format(\"~n~s~n~s~n~s~n~s~n\",[" +
+                    "\"" + OTP_RELEASE_PREFIX_LINE + "\"," +
+                    "erlang:system_info(otp_release)," +
+                    "\"" + ERTS_VERSION_PREFIX_LINE + "\"," +
+                    "erlang:system_info(version)" +
+                    "]),erlang:halt().";
+    private static final String WINDOWS_DEFAULT_HOME_PATH = "C:\\Program Files\\erl9.0";
+    private static final Pattern NIX_PATTERN = HomePath.nixPattern("erlang");
+    private static final String LINUX_DEFAULT_HOME_PATH = HomePath.LINUX_DEFAULT_HOME_PATH + "/erlang";
+    private static final Function<File, File> VERSION_PATH_TO_HOME_PATH =
+            versionPath -> new File(versionPath, "lib/erlang");
+    private static final Logger LOGGER = Logger.getInstance(Type.class);
+    private final Map<String, Release> releaseBySdkHome = new WeakHashMap<>();
+
+
+    public Type() {
+        // Don't use "Erlang SDK" as we want it to be different from the name in intellij-erlang
+        super("Erlang SDK for Elixir SDK");
+    }
+
+    @NotNull
+    private static String getDefaultSdkName(@NotNull String sdkHome, @Nullable Release version) {
+        StringBuilder defaultSdkNameBuilder = new StringBuilder("Erlang for Elixir ");
+
+        if (version != null) {
+            defaultSdkNameBuilder.append(version.otpRelease);
+        } else {
+            defaultSdkNameBuilder.append(" at ").append(sdkHome);
+        }
+
+        return defaultSdkNameBuilder.toString();
+    }
+
+    @Nullable
+    private static String getVersionCacheKey(@Nullable String sdkHome) {
+        String versionCacheKey = null;
+
+        if (sdkHome != null) {
+            versionCacheKey = new File(sdkHome).getAbsolutePath();
+        }
+
+        return versionCacheKey;
+    }
+
+    @Nullable
+    private static Release parseSdkVersion(@NotNull List<String> printVersionInfoOutput) {
+        String otpRelease = null;
+        String ertsVersion = null;
+
+        ListIterator<String> iterator = printVersionInfoOutput.listIterator();
+
+        while (iterator.hasNext()) {
+            String line = iterator.next();
+
+            if (OTP_RELEASE_PREFIX_LINE.equals(line) && iterator.hasNext()) {
+                otpRelease = iterator.next();
+            } else if (ERTS_VERSION_PREFIX_LINE.equals(line) && iterator.hasNext()) {
+                ertsVersion = iterator.next();
+            }
+        }
+
+        Release release;
+
+        if (otpRelease != null && ertsVersion != null) {
+            release = new Release(otpRelease, ertsVersion);
+        } else {
+            release = null;
+        }
+
+        return release;
+    }
+
+    @Override
+    public boolean isRootTypeApplicable(@NotNull OrderRootType type) {
+        return type == OrderRootType.CLASSES ||
+                type == OrderRootType.SOURCES ||
+                type == JavadocOrderRootType.getInstance();
+    }
+
+    @Override
+    public void setupSdkPaths(@NotNull Sdk sdk) {
+        SdkModificator sdkModificator = sdk.getSdkModificator();
+        addCodePaths(sdkModificator);
+
+        sdkModificator.commitChanges();
+    }
+
+    /**
+     * Returns a recommended starting path for a file chooser (where SDKs of this type are usually may be found),
+     * or {@code null} if not applicable/no SDKs found.
+     * <p/>
+     * E.g. for Python SDK on Unix the method may return either {@code "/usr/bin"} or {@code "/usr/bin/python"}
+     * (if there is only one Python interpreter installed on a host).
+     */
+    @Nullable
+    @Override
+    public String suggestHomePath() {
+        Iterator<String> iterator = suggestHomePaths().iterator();
+        String suggestedHomePath = null;
+
+        if (iterator.hasNext()) {
+            suggestedHomePath = iterator.next();
+        }
+
+        return suggestedHomePath;
+    }
+
+    @NotNull
+    @Override
+    public Collection<String> suggestHomePaths() {
+        return homePathByVersion().values();
+    }
+
+    /**
+     * Map of home paths to versions in descending version order so that newer versions are favored.
+     *
+     * @return Map
+     */
+    private Map<Version, String> homePathByVersion() {
+        Map<Version, String> homePathByVersion = HomePath.homePathByVersion();
+
+        if (SystemInfo.isMac) {
+            mergeHomebrew(homePathByVersion, "erlang", VERSION_PATH_TO_HOME_PATH);
+            mergeNixStore(homePathByVersion, NIX_PATTERN, VERSION_PATH_TO_HOME_PATH);
+        } else {
+            String sdkPath;
+
+            if (SystemInfo.isWindows) {
+                sdkPath = WINDOWS_DEFAULT_HOME_PATH;
+
+                homePathByVersion.put(UNKNOWN_VERSION, sdkPath);
+            } else if (SystemInfo.isLinux) {
+                homePathByVersion.put(UNKNOWN_VERSION, LINUX_DEFAULT_HOME_PATH);
+
+                mergeNixStore(homePathByVersion, NIX_PATTERN, VERSION_PATH_TO_HOME_PATH);
+            }
+        }
+
+        return homePathByVersion;
+    }
+
+    @Override
+    public boolean isValidSdkHome(String path) {
+        File erl = JpsErlangSdkType.getByteCodeInterpreterExecutable(path);
+
+        return erl.canExecute();
+    }
+
+    @Override
+    public String suggestSdkName(String currentSdkName, String sdkHome) {
+        return getDefaultSdkName(sdkHome, detectSdkVersion(sdkHome));
+    }
+
+    @Nullable
+    @Override
+    public String getVersionString(@NotNull String sdkHome) {
+        Release release = detectSdkVersion(sdkHome);
+        String versionString;
+
+        if (release != null) {
+            versionString = release.otpRelease;
+        } else {
+            versionString = null;
+        }
+
+        return versionString;
+    }
+
+    @Nullable
+    @Override
+    public AdditionalDataConfigurable createAdditionalDataConfigurable(@NotNull SdkModel sdkModel,
+                                                                       @NotNull SdkModificator sdkModificator) {
+        return null;
+    }
+
+    @NotNull
+    @Override
+    public String getPresentableName() {
+        return getName();
+    }
+
+    @Override
+    public void saveAdditionalData(@NotNull com.intellij.openapi.projectRoots.SdkAdditionalData additionalData,
+                                   @NotNull Element additional) {
+    }
+
+    @Nullable
+    private Release detectSdkVersion(@NotNull String sdkHome) {
+        Release release = null;
+
+        Release cachedRelease = releaseBySdkHome.get(getVersionCacheKey(sdkHome));
+
+        if (cachedRelease != null) {
+            release = cachedRelease;
+        } else {
+            File erl = JpsErlangSdkType.getByteCodeInterpreterExecutable(sdkHome);
+
+            if (!erl.canExecute()) {
+                StringBuilder messageBuilder = new StringBuilder("Can't detect Erlang version: ").append(erl.getPath());
+
+                if (erl.exists()) {
+                    messageBuilder.append(" is not executable.");
+                } else {
+                    messageBuilder.append(" is missing.");
+                }
+
+                LOGGER.warn(messageBuilder.toString());
+            } else {
+                try {
+                    ProcessOutput output = org.elixir_lang.sdk.ProcessOutput.getProcessOutput(
+                            10 * 1000,
+                            sdkHome,
+                            erl.getAbsolutePath(),
+                            "-noshell",
+                            "-eval",
+                            PRINT_VERSION_INFO_EXPRESSION
+                    );
+
+                    if (!(output.getExitCode() != 0 || output.isCancelled() || output.isTimeout())) {
+                        release = parseSdkVersion(output.getStdoutLines());
+                    }
+
+                    if (release != null) {
+                        releaseBySdkHome.put(getVersionCacheKey(sdkHome), release);
+                    } else {
+                        LOGGER.warn("Failed to detect Erlang version.\n" +
+                                "StdOut: " + output.getStdout() + "\n" +
+                                "StdErr: " + output.getStderr());
+                    }
+                } catch (ExecutionException e) {
+                    LOGGER.warn(e);
+                }
+            }
+        }
+
+        return release;
+    }
+}

--- a/src/org/elixir_lang/sdk/erlang/Type.java
+++ b/src/org/elixir_lang/sdk/erlang/Type.java
@@ -218,6 +218,7 @@ public class Type extends SdkType {
     @Override
     public void saveAdditionalData(@NotNull com.intellij.openapi.projectRoots.SdkAdditionalData additionalData,
                                    @NotNull Element additional) {
+        // Intentionally left blank
     }
 
     @Nullable

--- a/src/org/elixir_lang/sdk/erlang/Type.java
+++ b/src/org/elixir_lang/sdk/erlang/Type.java
@@ -41,7 +41,7 @@ public class Type extends SdkType {
                     "erlang:system_info(version)" +
                     "]),erlang:halt().";
     private static final String WINDOWS_DEFAULT_HOME_PATH = "C:\\Program Files\\erl9.0";
-    private static final Pattern NIX_PATTERN = HomePath.nixPattern("erlang");
+    private static final Pattern NIX_PATTERN = nixPattern("erlang");
     private static final String LINUX_DEFAULT_HOME_PATH = HomePath.LINUX_DEFAULT_HOME_PATH + "/erlang";
     private static final Function<File, File> VERSION_PATH_TO_HOME_PATH =
             versionPath -> new File(versionPath, "lib/erlang");

--- a/src/org/elixir_lang/sdk/erlang/Type.java
+++ b/src/org/elixir_lang/sdk/erlang/Type.java
@@ -106,6 +106,34 @@ public class Type extends SdkType {
         return release;
     }
 
+    /**
+     * Map of home paths to versions in descending version order so that newer versions are favored.
+     *
+     * @return Map
+     */
+    public static Map<Version, String> homePathByVersion() {
+        Map<Version, String> homePathByVersion = HomePath.homePathByVersion();
+
+        if (SystemInfo.isMac) {
+            mergeHomebrew(homePathByVersion, "erlang", VERSION_PATH_TO_HOME_PATH);
+            mergeNixStore(homePathByVersion, NIX_PATTERN, VERSION_PATH_TO_HOME_PATH);
+        } else {
+            String sdkPath;
+
+            if (SystemInfo.isWindows) {
+                sdkPath = WINDOWS_DEFAULT_HOME_PATH;
+
+                homePathByVersion.put(UNKNOWN_VERSION, sdkPath);
+            } else if (SystemInfo.isLinux) {
+                homePathByVersion.put(UNKNOWN_VERSION, LINUX_DEFAULT_HOME_PATH);
+
+                mergeNixStore(homePathByVersion, NIX_PATTERN, VERSION_PATH_TO_HOME_PATH);
+            }
+        }
+
+        return homePathByVersion;
+    }
+
     @Override
     public boolean isRootTypeApplicable(@NotNull OrderRootType type) {
         return type == OrderRootType.CLASSES ||
@@ -145,34 +173,6 @@ public class Type extends SdkType {
     @Override
     public Collection<String> suggestHomePaths() {
         return homePathByVersion().values();
-    }
-
-    /**
-     * Map of home paths to versions in descending version order so that newer versions are favored.
-     *
-     * @return Map
-     */
-    private Map<Version, String> homePathByVersion() {
-        Map<Version, String> homePathByVersion = HomePath.homePathByVersion();
-
-        if (SystemInfo.isMac) {
-            mergeHomebrew(homePathByVersion, "erlang", VERSION_PATH_TO_HOME_PATH);
-            mergeNixStore(homePathByVersion, NIX_PATTERN, VERSION_PATH_TO_HOME_PATH);
-        } else {
-            String sdkPath;
-
-            if (SystemInfo.isWindows) {
-                sdkPath = WINDOWS_DEFAULT_HOME_PATH;
-
-                homePathByVersion.put(UNKNOWN_VERSION, sdkPath);
-            } else if (SystemInfo.isLinux) {
-                homePathByVersion.put(UNKNOWN_VERSION, LINUX_DEFAULT_HOME_PATH);
-
-                mergeNixStore(homePathByVersion, NIX_PATTERN, VERSION_PATH_TO_HOME_PATH);
-            }
-        }
-
-        return homePathByVersion;
     }
 
     @Override

--- a/src/org/elixir_lang/sdk/erlang_dependent/AdditionalDataConfigurable.java
+++ b/src/org/elixir_lang/sdk/erlang_dependent/AdditionalDataConfigurable.java
@@ -1,0 +1,211 @@
+package org.elixir_lang.sdk.erlang_dependent;
+
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.options.ConfigurationException;
+import com.intellij.openapi.projectRoots.Sdk;
+import com.intellij.openapi.projectRoots.SdkModel;
+import com.intellij.openapi.projectRoots.SdkModificator;
+import com.intellij.openapi.projectRoots.impl.ProjectJdkImpl;
+import com.intellij.openapi.ui.ComboBox;
+import com.intellij.openapi.util.Comparing;
+import com.intellij.ui.ListCellRendererWrapper;
+import com.intellij.util.ui.JBUI;
+import org.elixir_lang.sdk.elixir.Type;
+import org.jetbrains.annotations.NotNull;
+
+import javax.swing.*;
+import java.awt.*;
+import java.awt.event.ItemEvent;
+
+import static org.elixir_lang.sdk.erlang_dependent.Type.staticIsValidDependency;
+
+public class AdditionalDataConfigurable implements com.intellij.openapi.projectRoots.AdditionalDataConfigurable {
+    private final JLabel internalErlangSdkLabel = new JLabel("Internal Erlang SDK:");
+    private final DefaultComboBoxModel<Sdk> internalErlangSdksComboBoxModel = new DefaultComboBoxModel<>();
+    private final ComboBox internalErlangSdksComboBox = new ComboBox(internalErlangSdksComboBoxModel);
+    private final SdkModel sdkModel;
+    private final SdkModel.Listener sdkModelListener;
+    private Sdk elixirSdk;
+    private boolean modified;
+
+    public AdditionalDataConfigurable(@NotNull SdkModel sdkModel) {
+        this.sdkModel = sdkModel;
+        sdkModelListener = new SdkModel.Listener() {
+            public void sdkAdded(Sdk sdk) {
+                if (staticIsValidDependency(sdk)) {
+                    addErlangSdk(sdk);
+                }
+            }
+
+            public void beforeSdkRemove(Sdk sdk) {
+                if (staticIsValidDependency(sdk)) {
+                    removeErlangSdk(sdk);
+                }
+            }
+
+            public void sdkChanged(Sdk sdk, String previousName) {
+                if (staticIsValidDependency(sdk)) {
+                    updateErlangSdkList(sdk, previousName);
+                }
+            }
+
+            public void sdkHomeSelected(final Sdk sdk, final String newSdkHome) {
+                if (staticIsValidDependency(sdk)) {
+                    internalErlangSdkUpdate(sdk);
+                }
+            }
+        };
+        this.sdkModel.addListener(sdkModelListener);
+    }
+
+    private void updateJdkList() {
+        internalErlangSdksComboBoxModel.removeAllElements();
+
+        for (Sdk sdk : sdkModel.getSdks()) {
+            if (staticIsValidDependency(sdk)) {
+                internalErlangSdksComboBoxModel.addElement(sdk);
+            }
+        }
+    }
+
+    public void setSdk(Sdk sdk) {
+        elixirSdk = sdk;
+    }
+
+    public JComponent createComponent() {
+        JPanel wholePanel = new JPanel(new GridBagLayout());
+
+        wholePanel.add(
+                internalErlangSdkLabel,
+                new GridBagConstraints(
+                        0,
+                        GridBagConstraints.RELATIVE,
+                        1,
+                        1,
+                        0,
+                        1,
+                        GridBagConstraints.WEST,
+                        GridBagConstraints.NONE,
+                        JBUI.emptyInsets(),
+                        0,
+                        0
+                )
+        );
+        wholePanel.add(
+                internalErlangSdksComboBox,
+                new GridBagConstraints(
+                        1,
+                        GridBagConstraints.RELATIVE,
+                        1,
+                        1,
+                        1,
+                        1,
+                        GridBagConstraints.EAST,
+                        GridBagConstraints.HORIZONTAL,
+                        JBUI.insets(0, 30, 0, 0),
+                        0,
+                        0
+                )
+        );
+        internalErlangSdksComboBox.setRenderer(
+                new ListCellRendererWrapper() {
+                    @Override
+                    public void customize(JList list, Object value, int index, boolean selected, boolean hasFocus) {
+                        if (value instanceof Sdk) {
+                            setText(((Sdk) value).getName());
+                        }
+                    }
+                }
+        );
+        internalErlangSdksComboBox.addItemListener(itemEvent -> {
+            if (itemEvent.getStateChange() == ItemEvent.SELECTED) {
+                modified = true;
+            }
+        });
+
+        modified = true;
+
+        return wholePanel;
+    }
+
+    private void internalErlangSdkUpdate(final Sdk sdk) {
+        final Sdk erlangSdk = ((SdkAdditionalData) sdk.getSdkAdditionalData()).getErlangSdk();
+
+        if (internalErlangSdksComboBoxModel.getIndexOf(erlangSdk) == -1) {
+            internalErlangSdksComboBoxModel.addElement(erlangSdk);
+        } else {
+            internalErlangSdksComboBoxModel.setSelectedItem(erlangSdk);
+        }
+    }
+
+    public boolean isModified() {
+        return modified;
+    }
+
+    public void apply() throws ConfigurationException {
+        SdkAdditionalData sdkAdditionData = new SdkAdditionalData(
+                (Sdk) internalErlangSdksComboBox.getSelectedItem(),
+                elixirSdk
+        );
+        final SdkModificator modificator = elixirSdk.getSdkModificator();
+        modificator.setSdkAdditionalData(sdkAdditionData);
+        ApplicationManager.getApplication().runWriteAction(() -> modificator.commitChanges());
+        ((ProjectJdkImpl) elixirSdk).resetVersionString();
+        modified = false;
+    }
+
+    public void reset() {
+        updateJdkList();
+
+        if (elixirSdk != null && elixirSdk.getSdkAdditionalData() instanceof SdkAdditionalData) {
+            final SdkAdditionalData sdkAdditionalData = (SdkAdditionalData) elixirSdk.getSdkAdditionalData();
+            final Sdk erlangSdk = sdkAdditionalData.getErlangSdk();
+
+            if (erlangSdk != null) {
+                for (int i = 0; i < internalErlangSdksComboBoxModel.getSize(); i++) {
+                    if (Comparing.strEqual(
+                            internalErlangSdksComboBoxModel.getElementAt(i).getName(),
+                            erlangSdk.getName()
+                    )) {
+                        internalErlangSdksComboBox.setSelectedIndex(i);
+                        break;
+                    }
+                }
+            }
+
+            modified = false;
+        }
+    }
+
+    public void disposeUIResources() {
+        sdkModel.removeListener(sdkModelListener);
+    }
+
+    private void addErlangSdk(final Sdk sdk) {
+        internalErlangSdksComboBoxModel.addElement(sdk);
+    }
+
+    private void removeErlangSdk(final Sdk sdk) {
+        if (internalErlangSdksComboBoxModel.getSelectedItem().equals(sdk)) {
+            modified = true;
+        }
+
+        internalErlangSdksComboBoxModel.removeElement(sdk);
+    }
+
+    private void updateErlangSdkList(Sdk sdk, String previousName) {
+        final Sdk[] sdks = sdkModel.getSdks();
+
+        for (Sdk currentSdk : sdks) {
+            if (currentSdk.getSdkType() instanceof Type) {
+                final SdkAdditionalData sdkAdditionalData = (SdkAdditionalData) currentSdk.getSdkAdditionalData();
+                final Sdk erlangSdk = sdkAdditionalData.getErlangSdk();
+
+                if (erlangSdk != null && Comparing.equal(erlangSdk.getName(), previousName)) {
+                    sdkAdditionalData.setErlangSdk(sdk);
+                }
+            }
+        }
+        updateJdkList();
+    }
+}

--- a/src/org/elixir_lang/sdk/erlang_dependent/SdkAdditionalData.java
+++ b/src/org/elixir_lang/sdk/erlang_dependent/SdkAdditionalData.java
@@ -1,0 +1,94 @@
+package org.elixir_lang.sdk.erlang_dependent;
+
+import com.intellij.openapi.options.ConfigurationException;
+import com.intellij.openapi.projectRoots.ProjectJdkTable;
+import com.intellij.openapi.projectRoots.Sdk;
+import com.intellij.openapi.projectRoots.SdkModel;
+import com.intellij.openapi.projectRoots.ValidatableSdkAdditionalData;
+import com.intellij.openapi.util.DefaultJDOMExternalizer;
+import com.intellij.openapi.util.InvalidDataException;
+import com.intellij.openapi.util.WriteExternalException;
+import org.elixir_lang.sdk.elixir.Type;
+import org.jdom.Element;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class SdkAdditionalData implements ValidatableSdkAdditionalData {
+    @NotNull
+    private final Sdk elixirSdk;
+    @Nullable
+    private Sdk erlangSdk;
+    @Nullable
+    private String erlangSdkName;
+    private static final String ERLANG_SDK_NAME = "erlang-sdk-name";
+
+    public SdkAdditionalData(@Nullable Sdk erlangSdk, @NotNull Sdk elixirSdk) {
+        this.erlangSdk = erlangSdk;
+        this.elixirSdk = elixirSdk;
+    }
+
+    // readExternal
+    public SdkAdditionalData(@NotNull Sdk elixirSdk) {
+        this.elixirSdk = elixirSdk;
+    }
+
+
+    /**
+     * Checks if the ERLANG_SDK_NAME properties are configured correctly, and throws an exception
+     * if they are not.
+     *
+     * @param sdkModel the model containing all configured SDKs.
+     * @throws ConfigurationException if the ERLANG_SDK_NAME is not configured correctly.
+     * @since 5.0.1
+     */
+    @Override
+    public void checkValid(SdkModel sdkModel) throws ConfigurationException {
+        if (getErlangSdk() == null) {
+            throw new ConfigurationException("Please configure the Erlang ERLANG_SDK_NAME");
+        }
+    }
+
+    @Override
+    public Object clone() throws CloneNotSupportedException {
+        return new SdkAdditionalData(erlangSdk, elixirSdk);
+    }
+
+    public void readExternal(Element element) throws InvalidDataException {
+        DefaultJDOMExternalizer.readExternal(this, element);
+        erlangSdkName = element.getAttributeValue(ERLANG_SDK_NAME);
+    }
+
+    public void writeExternal(Element element) throws WriteExternalException {
+        DefaultJDOMExternalizer.writeExternal(this, element);
+        final Sdk sdk = getErlangSdk();
+
+        if (sdk != null) {
+            element.setAttribute(ERLANG_SDK_NAME, sdk.getName());
+        }
+    }
+
+    @Nullable
+    public Sdk getErlangSdk() {
+        final ProjectJdkTable jdkTable = ProjectJdkTable.getInstance();
+
+        if (erlangSdk == null) {
+            if (erlangSdkName != null) {
+                erlangSdk = jdkTable.findJdk(erlangSdkName);
+                erlangSdkName = null;
+            } else {
+                for (Sdk jdk : jdkTable.getAllJdks()) {
+                    if (Type.staticIsValidDependency(jdk)) {
+                        erlangSdk = jdk;
+                        break;
+                    }
+                }
+            }
+        }
+
+        return erlangSdk;
+    }
+
+    public void setErlangSdk(@Nullable Sdk erlangSdk) {
+        this.erlangSdk = erlangSdk;
+    }
+}

--- a/src/org/elixir_lang/sdk/erlang_dependent/Type.java
+++ b/src/org/elixir_lang/sdk/erlang_dependent/Type.java
@@ -71,6 +71,6 @@ public abstract class Type extends DependentSdkType {
 
     @Override
     public void saveAdditionalData(@NotNull SdkAdditionalData additionalData, @NotNull Element additional) {
+        // intentionally left blank
     }
-
 }

--- a/src/org/elixir_lang/sdk/erlang_dependent/Type.java
+++ b/src/org/elixir_lang/sdk/erlang_dependent/Type.java
@@ -1,0 +1,76 @@
+package org.elixir_lang.sdk.erlang_dependent;
+
+import com.intellij.openapi.projectRoots.*;
+import com.intellij.openapi.projectRoots.SdkAdditionalData;
+import com.intellij.openapi.projectRoots.impl.DependentSdkType;
+import com.intellij.openapi.roots.JavadocOrderRootType;
+import com.intellij.openapi.roots.OrderRootType;
+import org.jdom.Element;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * An SDK that depends on an Erlang SDK, either
+ * * org.intellij.erlang.sdk.ErlangSdkType when intellij-erlang IS installed
+ * * org.elixir_lang.sdk.erlang.Type when intellij-erlang IS NOT installed
+ */
+public abstract class Type extends DependentSdkType {
+    private static final String ERLANG_SDK_TYPE_CANONICAL_NAME = "org.intellij.erlang.sdk.ErlangSdkType";
+    private static final String ERLANG_SDK_FOR_ELIXIR_SDK_TYPE_CANONICAL_NAME = org.elixir_lang.sdk.erlang.Type.class.getCanonicalName();
+
+    protected Type(@NotNull String name) {
+        super(name);
+    }
+
+    public static boolean staticIsValidDependency(Sdk sdk) {
+        String sdkTypeCanonicalName = sdk.getSdkType().getClass().getCanonicalName();
+
+        return sdkTypeCanonicalName.equals(ERLANG_SDK_TYPE_CANONICAL_NAME) ||
+                sdkTypeCanonicalName.equals(ERLANG_SDK_FOR_ELIXIR_SDK_TYPE_CANONICAL_NAME);
+    }
+
+    @Override
+    protected boolean isValidDependency(Sdk sdk) {
+        return staticIsValidDependency(sdk);
+    }
+
+    @Override
+    public String getUnsatisfiedDependencyMessage() {
+        return "You need to configure an Erlang SDK (from intellij-erlang) or " +
+                "Erlang SDK for Elixir SDK (from intellij-elixir) first";
+    }
+
+    @Override
+    protected SdkType getDependencyType() {
+        Class<? extends SdkType> sdkTypeClass;
+
+        try {
+            sdkTypeClass = (Class<? extends SdkType>) Class.forName(ERLANG_SDK_TYPE_CANONICAL_NAME);
+        } catch (ClassNotFoundException e) {
+            sdkTypeClass = org.elixir_lang.sdk.erlang.Type.class;
+        }
+
+        return SdkType.findInstance(sdkTypeClass);
+    }
+
+    @Nullable
+    @Override
+    public com.intellij.openapi.projectRoots.AdditionalDataConfigurable createAdditionalDataConfigurable(
+            @NotNull SdkModel sdkModel,
+            @NotNull SdkModificator sdkModificator
+    ) {
+        return null;
+    }
+
+    @Override
+    public boolean isRootTypeApplicable(@NotNull OrderRootType type) {
+        return type == OrderRootType.CLASSES ||
+                type == OrderRootType.SOURCES ||
+                type == JavadocOrderRootType.getInstance();
+    }
+
+    @Override
+    public void saveAdditionalData(@NotNull SdkAdditionalData additionalData, @NotNull Element additional) {
+    }
+
+}

--- a/src/org/elixir_lang/settings/ElixirExternalToolsConfigurable.java
+++ b/src/org/elixir_lang/settings/ElixirExternalToolsConfigurable.java
@@ -11,9 +11,9 @@ import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.ui.TitledSeparator;
 import org.elixir_lang.mix.settings.MixConfigurationForm;
 import org.elixir_lang.mix.settings.MixSettings;
-import org.elixir_lang.sdk.ElixirSdkForSmallIdes;
-import org.elixir_lang.sdk.ElixirSdkType;
-import org.elixir_lang.sdk.ElixirSystemUtil;
+import org.elixir_lang.sdk.elixir.ForSmallIdes;
+import org.elixir_lang.sdk.elixir.Type;
+import org.elixir_lang.sdk.ProcessOutput;
 import org.jetbrains.annotations.Nls;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -56,7 +56,7 @@ public class ElixirExternalToolsConfigurable implements SearchableConfigurable, 
       }
     }
 
-    if(!ElixirSystemUtil.isSmallIde()){
+    if(!ProcessOutput.isSmallIde()){
       mySdkPathLabel.setVisible(false);
       mySdkPathSelector.setVisible(false);
       mySdkTitledSeparator.setVisible(false);
@@ -101,15 +101,15 @@ public class ElixirExternalToolsConfigurable implements SearchableConfigurable, 
     myMixSettings.setMixPath(myMixConfigurationForm.getPath());
     myMixSettings.setSupportsFormatterOption(myMixConfigurationForm.getSupportsFormatterOption());
 
-    if(ElixirSystemUtil.isSmallIde()){
-      ElixirSdkForSmallIdes.setUpOrUpdateSdk(myProject, mySdkPathSelector.getText());
+    if(ProcessOutput.isSmallIde()){
+      ForSmallIdes.setUpOrUpdateSdk(myProject, mySdkPathSelector.getText());
     }
   }
 
   @Override
   public boolean isModified() {
     return !myMixSettings.getMixPath().equals(myMixConfigurationForm.getPath())
-        || !StringUtil.notNullize(ElixirSdkType.getSdkPath(myProject)).equals(mySdkPathSelector.getText());
+        || !StringUtil.notNullize(Type.getSdkPath(myProject)).equals(mySdkPathSelector.getText());
 
   }
 
@@ -121,6 +121,6 @@ public class ElixirExternalToolsConfigurable implements SearchableConfigurable, 
   public void reset() {
     myMixConfigurationForm.setPath(myMixSettings.getMixPath());
 
-    mySdkPathSelector.setText(StringUtil.notNullize(ElixirSdkType.getSdkPath(myProject)));
+    mySdkPathSelector.setText(StringUtil.notNullize(Type.getSdkPath(myProject)));
   }
 }

--- a/tests/org/elixir_lang/mix/importWizard/MixProjectImportBuilderTest.java
+++ b/tests/org/elixir_lang/mix/importWizard/MixProjectImportBuilderTest.java
@@ -15,8 +15,8 @@ import com.intellij.openapi.roots.impl.ModuleRootManagerImpl;
 import com.intellij.openapi.util.JDOMUtil;
 import com.intellij.openapi.util.io.FileUtil;
 import org.elixir_lang.configuration.ElixirCompilerSettings;
-import org.elixir_lang.sdk.ElixirSdkRelease;
-import org.elixir_lang.sdk.ElixirSdkType;
+import org.elixir_lang.sdk.elixir.Release;
+import org.elixir_lang.sdk.elixir.Type;
 import org.jdom.Document;
 import org.jdom.Element;
 import org.jetbrains.annotations.NotNull;
@@ -50,7 +50,7 @@ public class MixProjectImportBuilderTest extends ProjectWizardTestCase{
   }
 
   private static void createMockSdk(){
-    final Sdk mockSdk = ElixirSdkType.createMockSdk(MOCK_SDK_DIR, ElixirSdkRelease.V_1_0_4);
+    final Sdk mockSdk = Type.createMockSdk(MOCK_SDK_DIR, Release.V_1_0_4);
     ApplicationManager.getApplication().runWriteAction(() -> ProjectJdkTable.getInstance().addJdk(mockSdk));
   }
 

--- a/tests/org/elixir_lang/parser_definition/CharTokenParsingTestCase.java
+++ b/tests/org/elixir_lang/parser_definition/CharTokenParsingTestCase.java
@@ -1,6 +1,6 @@
 package org.elixir_lang.parser_definition;
 
-import org.elixir_lang.sdk.ElixirSdkRelease;
+import org.elixir_lang.sdk.elixir.Release;
 
 import static org.elixir_lang.test.ElixirVersion.elixirSdkRelease;
 
@@ -41,7 +41,7 @@ public class CharTokenParsingTestCase extends ParsingTestCase {
      */
 
     public void testOpenHexadecimalEscapeSequence() {
-        if (elixirSdkRelease().compareTo(ElixirSdkRelease.V_1_3) < 0) {
+        if (elixirSdkRelease().compareTo(Release.V_1_3) < 0) {
             assertParsedAndQuotedCorrectly();
         } else {
             assertParsedAndQuotedAroundError();
@@ -49,7 +49,7 @@ public class CharTokenParsingTestCase extends ParsingTestCase {
     }
 
     public void testEnclosedHexadecimalEscapeSequence() {
-        if (elixirSdkRelease().compareTo(ElixirSdkRelease.V_1_3) < 0) {
+        if (elixirSdkRelease().compareTo(Release.V_1_3) < 0) {
             assertParsedAndQuotedCorrectly();
         } else {
             assertParsedAndQuotedAroundError();

--- a/tests/org/elixir_lang/parser_definition/ElixirLangElixirParsingTestCase.java
+++ b/tests/org/elixir_lang/parser_definition/ElixirLangElixirParsingTestCase.java
@@ -4,7 +4,7 @@ import com.intellij.openapi.util.io.FileUtil;
 import com.intellij.openapi.util.io.FileUtilRt;
 import com.intellij.openapi.vfs.CharsetToolkit;
 import org.elixir_lang.intellij_elixir.Quoter;
-import org.elixir_lang.sdk.ElixirSdkRelease;
+import org.elixir_lang.sdk.elixir.Release;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.File;
@@ -354,10 +354,10 @@ public class ElixirLangElixirParsingTestCase extends ParsingTestCase {
     }
 
     public void testParallelCompilerBat() {
-        if (elixirSdkRelease().compareTo(ElixirSdkRelease.V_1_3) < 0) {
+        if (elixirSdkRelease().compareTo(Release.V_1_3) < 0) {
             assertParsed("lib/elixir/test/elixir/fixtures/parallel_compiler/bat.ex", Parse.ERROR);
         } else {
-            assertTrue(elixirSdkRelease().compareTo(ElixirSdkRelease.V_1_3) >= 0);
+            assertTrue(elixirSdkRelease().compareTo(Release.V_1_3) >= 0);
         }
     }
 
@@ -538,10 +538,10 @@ public class ElixirLangElixirParsingTestCase extends ParsingTestCase {
     }
 
     public void testMixArchive() {
-        if (elixirSdkRelease().compareTo(ElixirSdkRelease.V_1_3) < 0) {
+        if (elixirSdkRelease().compareTo(Release.V_1_3) < 0) {
             assertParsed("lib/mix/lib/mix/archive.ex", Parse.CORRECT);
         } else {
-            assertTrue(elixirSdkRelease().compareTo(ElixirSdkRelease.V_1_3) >= 0);
+            assertTrue(elixirSdkRelease().compareTo(Release.V_1_3) >= 0);
         }
     }
 
@@ -718,10 +718,10 @@ public class ElixirLangElixirParsingTestCase extends ParsingTestCase {
     }
 
     public void testMixTasksDepsCheck() {
-        if (elixirSdkRelease().compareTo(ElixirSdkRelease.V_1_3) < 0) {
+        if (elixirSdkRelease().compareTo(Release.V_1_3) < 0) {
             assertParsed("lib/mix/lib/mix/tasks/deps.check.ex", Parse.CORRECT);
         } else {
-            assertTrue(elixirSdkRelease().compareTo(ElixirSdkRelease.V_1_3) >= 0);
+            assertTrue(elixirSdkRelease().compareTo(Release.V_1_3) >= 0);
         }
     }
 
@@ -841,10 +841,10 @@ public class ElixirLangElixirParsingTestCase extends ParsingTestCase {
     }
 
     public void testNoMixfileLibC() {
-        if (elixirSdkRelease().compareTo(ElixirSdkRelease.V_1_3) < 0) {
+        if (elixirSdkRelease().compareTo(Release.V_1_3) < 0) {
             assertParsed("lib/mix/test/fixtures/no_mixfile/lib/c.ex", Parse.CORRECT);
         } else {
-            assertTrue(elixirSdkRelease().compareTo(ElixirSdkRelease.V_1_3) >= 0);
+            assertTrue(elixirSdkRelease().compareTo(Release.V_1_3) >= 0);
         }
     }
 

--- a/tests/org/elixir_lang/parser_definition/MatchedArrowOperationParsingTestCase.java
+++ b/tests/org/elixir_lang/parser_definition/MatchedArrowOperationParsingTestCase.java
@@ -1,6 +1,6 @@
 package org.elixir_lang.parser_definition;
 
-import org.elixir_lang.sdk.ElixirSdkRelease;
+import org.elixir_lang.sdk.elixir.Release;
 
 import static org.elixir_lang.test.ElixirVersion.elixirSdkRelease;
 
@@ -23,7 +23,7 @@ public class MatchedArrowOperationParsingTestCase extends ParsingTestCase {
     }
 
     public void testMatchedInOperation() {
-        if (!isTravis() && elixirSdkRelease().compareTo(ElixirSdkRelease.V_1_2) > 0) {
+        if (!isTravis() && elixirSdkRelease().compareTo(Release.V_1_2) > 0) {
             assertParsedAndQuotedCorrectly();
         }
     }

--- a/tests/org/elixir_lang/parser_definition/MatchedQualifiedMultipleAliasesParsingTestCase.java
+++ b/tests/org/elixir_lang/parser_definition/MatchedQualifiedMultipleAliasesParsingTestCase.java
@@ -1,6 +1,6 @@
 package org.elixir_lang.parser_definition;
 
-import org.elixir_lang.sdk.ElixirSdkRelease;
+import org.elixir_lang.sdk.elixir.Release;
 
 /**
  * atom is invalid to the right of `.`, so unlike in {@link MatchedDotOperationParsingTestcase}, this tests only when
@@ -205,7 +205,7 @@ public class MatchedQualifiedMultipleAliasesParsingTestCase extends ParsingTestC
     }
 
     private void assertParsedAndQuotedCorrectlyInOneThree() {
-        if (elixirSdkRelease().compareTo(ElixirSdkRelease.V_1_2) >= 0) {
+        if (elixirSdkRelease().compareTo(Release.V_1_2) >= 0) {
             assertParsedAndQuotedCorrectly();
         } else {
             assertParsedAndQuotedAroundError();
@@ -216,9 +216,9 @@ public class MatchedQualifiedMultipleAliasesParsingTestCase extends ParsingTestC
      * Private Instance Methods
      */
 
-    private ElixirSdkRelease elixirSdkRelease() {
+    private Release elixirSdkRelease() {
         String elixirVersion = elixirVersion();
-        ElixirSdkRelease elixirSdkRelease = ElixirSdkRelease.fromString((elixirVersion));
+        Release elixirSdkRelease = Release.fromString((elixirVersion));
 
         assertNotNull(
                 "ELIXIR_VERSION (" + elixirVersion  + ") could not be parsed into an ElixirSdkRelease",

--- a/tests/org/elixir_lang/parser_definition/MatchedThreeOperationParsingTestCase.java
+++ b/tests/org/elixir_lang/parser_definition/MatchedThreeOperationParsingTestCase.java
@@ -1,6 +1,6 @@
 package org.elixir_lang.parser_definition;
 
-import org.elixir_lang.sdk.ElixirSdkRelease;
+import org.elixir_lang.sdk.elixir.Release;
 
 import static org.elixir_lang.test.ElixirVersion.elixirSdkRelease;
 
@@ -23,7 +23,7 @@ public class MatchedThreeOperationParsingTestCase extends ParsingTestCase {
     }
 
     public void testMatchedInOperation() {
-        if (!isTravis() && elixirSdkRelease().compareTo(ElixirSdkRelease.V_1_2) > 0) {
+        if (!isTravis() && elixirSdkRelease().compareTo(Release.V_1_2) > 0) {
             assertParsedAndQuotedCorrectly();
         }
     }

--- a/tests/org/elixir_lang/parser_definition/ParsingTestCase.java
+++ b/tests/org/elixir_lang/parser_definition/ParsingTestCase.java
@@ -24,7 +24,7 @@ import org.elixir_lang.ElixirLanguage;
 import org.elixir_lang.ElixirParserDefinition;
 import org.elixir_lang.intellij_elixir.Quoter;
 import org.elixir_lang.psi.impl.ElixirPsiImplUtil;
-import org.elixir_lang.sdk.ElixirSdkType;
+import org.elixir_lang.sdk.elixir.Type;
 import org.jetbrains.annotations.NotNull;
 import org.picocontainer.MutablePicoContainer;
 
@@ -249,13 +249,13 @@ public abstract class ParsingTestCase extends com.intellij.testFramework.Parsing
     }
 
     @NotNull
-    protected ElixirSdkType registerElixirSdkType() {
+    protected Type registerElixirSdkType() {
         registerExtensionPoint(
                 com.intellij.openapi.projectRoots.SdkType.EP_NAME,
                 com.intellij.openapi.projectRoots.SdkType.class
         );
-        registerExtension(com.intellij.openapi.projectRoots.SdkType.EP_NAME, new ElixirSdkType());
-        ElixirSdkType elixirSdkType = ElixirSdkType.getInstance();
+        registerExtension(com.intellij.openapi.projectRoots.SdkType.EP_NAME, new Type());
+        Type elixirSdkType = Type.getInstance();
 
         assertNotNull(elixirSdkType);
 
@@ -297,9 +297,9 @@ public abstract class ParsingTestCase extends com.intellij.testFramework.Parsing
                 com.intellij.openapi.projectRoots.SdkType.EP_NAME,
                 com.intellij.openapi.projectRoots.SdkType.class
         );
-        registerExtension(com.intellij.openapi.projectRoots.SdkType.EP_NAME, new ElixirSdkType());
+        registerExtension(com.intellij.openapi.projectRoots.SdkType.EP_NAME, new Type());
 
-        Sdk sdk = ElixirSdkType.createMockSdk(sdkHome, elixirSdkRelease());
+        Sdk sdk = Type.createMockSdk(sdkHome, elixirSdkRelease());
         projectJdkTable.addJdk(sdk);
 
         ExtensionsArea area = Extensions.getArea(myProject);

--- a/tests/org/elixir_lang/sdk/ProcessOutputTest.java
+++ b/tests/org/elixir_lang/sdk/ProcessOutputTest.java
@@ -3,7 +3,7 @@ package org.elixir_lang.sdk;
 import com.intellij.execution.ExecutionException;
 import junit.framework.TestCase;
 
-public class ElixirSystemUtilTest extends TestCase {
+public class ProcessOutputTest extends TestCase {
     /*
      * Tests
      */
@@ -11,7 +11,7 @@ public class ElixirSystemUtilTest extends TestCase {
     public void testIssue521() throws ExecutionException {
         assertEquals(
                 -1,
-                ElixirSystemUtil
+                ProcessOutput
                         .getProcessOutput(
                                 1,
                                 null,

--- a/tests/org/elixir_lang/test/ElixirVersion.java
+++ b/tests/org/elixir_lang/test/ElixirVersion.java
@@ -1,13 +1,13 @@
 package org.elixir_lang.test;
 
-import org.elixir_lang.sdk.ElixirSdkRelease;
+import org.elixir_lang.sdk.elixir.Release;
 
 import static junit.framework.TestCase.assertNotNull;
 
 public class ElixirVersion {
-    public static ElixirSdkRelease elixirSdkRelease() {
+    public static Release elixirSdkRelease() {
         String elixirVersion = elixirVersion();
-        ElixirSdkRelease elixirSdkRelease = ElixirSdkRelease.fromString((elixirVersion));
+        Release elixirSdkRelease = Release.fromString((elixirVersion));
 
         assertNotNull(
                 "ELIXIR_VERSION (" + elixirVersion  + ") could not be parsed into an ElixirSdkRelease",
@@ -17,7 +17,7 @@ public class ElixirVersion {
         return elixirSdkRelease;
     }
 
-    public static String elixirVersion() {
+    private static String elixirVersion() {
         String elixirVersion = System.getenv("ELIXIR_VERSION");
 
         assertNotNull("ELIXIR_VERSION is not set", elixirVersion);


### PR DESCRIPTION
Resolved #701

# Changelog
## Enhancements
* Elixir SDK will now have an Internal Erlang SDK, which can be supplied one of two ways:
  1. If `intellij-erlang` is installed: its Erlang SDK can be used
  2. Otherwise: the Erlang SDK for Elixir SDK from this plugin can be used

  Either Internal Erlang SDK's home path is used to locate the `erl` (or `erl.exe` on Windows) executable and it is used to run Elixir; bypassing the `elixir` (or `elixir.bat` on Windows) script.  Instead, as was done in #789, the ebin directories for the Elixir SDK are passed as `-pa` options to `erl`.

  The Elixir SDK's configuration becomes more important: the classpath entries are now the list of `ebin` directories to pass to `erl` using `-pa` instead of scanning for ebins in the homepath, so additional code paths can be added to the Classpaths configuration and they will be used when running `mix` and `mix test`.  The classpaths will be initialized to the ebin directories under the home path.

  * To support migrating from earlier version of the plugin, an SDK will be updated when it is used for Mix ExUnit Run Configurations
    * The default Internal Erlang SDK will be set, which uses the latest version of Erlang that can be found on the system.  When `intellij-erlang` is installed, `intellij-elixir`'s Erlang version suggestion is still used because `intellij-elixir` favors the latest version while `intellij-erlang` favors the first found, which is usually the oldest version.
    * Update roots (class path, source paths, documentation paths):
      * Class path of `HOMEPATH/lib` is replaced with `HOMEPATH/lib/APP/ebin`.
      * Source path of `HOMEPATH/lib` is replaced with `HOMEPATH/lib/APP/lib` IF it exists (so only for source SDKs)
      * Documentation of `http://elixir-lang.org/docs/stable/elixir/` will be replaced with `https://hexdoc.pm/APP/VERSION` for every `APP` in `HOMEPATH/lib`.