### PR TITLE
Adding a space to import window text

### DIFF
--- a/src/org/elixir_lang/mix/importWizard/MixProjectRootStep.form
+++ b/src/org/elixir_lang/mix/importWizard/MixProjectRootStep.form
@@ -35,7 +35,7 @@
         </constraints>
         <properties>
           <selected value="true"/>
-          <text value="&amp;Fetch dependencies with mix(requires valid mix path)"/>
+          <text value="&amp;Fetch dependencies with mix (requires valid mix path)"/>
         </properties>
       </component>
       <nested-form id="13435" form-file="org/elixir_lang/mix/settings/MixConfigurationForm.form" binding="myMixConfigurationForm">


### PR DESCRIPTION
I just saw this when setting up a new module and thought this might be the simplest PR known to man