### PR TITLE
Autocomplete Erlang SDK module names and functions in those modules.

### DIFF
--- a/gen/org/elixir_lang/psi/ElixirAlias.java
+++ b/gen/org/elixir_lang/psi/ElixirAlias.java
@@ -3,6 +3,7 @@ package org.elixir_lang.psi;
 
 import com.ericsson.otp.erlang.OtpErlangObject;
 import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiPolyVariantReference;
 import com.intellij.psi.PsiReference;
 import com.intellij.psi.ResolveState;
 import com.intellij.psi.scope.PsiScopeProcessor;
@@ -22,6 +23,9 @@ public interface ElixirAlias extends NamedElement, QualifiableAlias, Quotable {
 
   @Nullable
   PsiReference getReference();
+
+  @Nullable
+  PsiPolyVariantReference getReference(PsiElement maxScope);
 
   boolean isModuleName();
 

--- a/gen/org/elixir_lang/psi/ElixirAtom.java
+++ b/gen/org/elixir_lang/psi/ElixirAtom.java
@@ -3,6 +3,7 @@ package org.elixir_lang.psi;
 
 import com.ericsson.otp.erlang.OtpErlangObject;
 import com.intellij.psi.NavigatablePsiElement;
+import com.intellij.psi.PsiReference;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -13,6 +14,9 @@ public interface ElixirAtom extends NavigatablePsiElement, Quotable {
 
   @Nullable
   ElixirStringLine getStringLine();
+
+  @Nullable
+  PsiReference getReference();
 
   @NotNull
   OtpErlangObject quote();

--- a/gen/org/elixir_lang/psi/ElixirMatchedQualifiedAlias.java
+++ b/gen/org/elixir_lang/psi/ElixirMatchedQualifiedAlias.java
@@ -3,6 +3,7 @@ package org.elixir_lang.psi;
 
 import com.ericsson.otp.erlang.OtpErlangObject;
 import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiPolyVariantReference;
 import com.intellij.psi.PsiReference;
 import com.intellij.psi.ResolveState;
 import com.intellij.psi.scope.PsiScopeProcessor;
@@ -31,6 +32,9 @@ public interface ElixirMatchedQualifiedAlias extends ElixirMatchedExpression, Na
 
   @Nullable
   PsiReference getReference();
+
+  @Nullable
+  PsiPolyVariantReference getReference(PsiElement maxScope);
 
   boolean isModuleName();
 

--- a/gen/org/elixir_lang/psi/ElixirUnmatchedQualifiedAlias.java
+++ b/gen/org/elixir_lang/psi/ElixirUnmatchedQualifiedAlias.java
@@ -3,6 +3,7 @@ package org.elixir_lang.psi;
 
 import com.ericsson.otp.erlang.OtpErlangObject;
 import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiPolyVariantReference;
 import com.intellij.psi.PsiReference;
 import com.intellij.psi.ResolveState;
 import com.intellij.psi.scope.PsiScopeProcessor;
@@ -31,6 +32,9 @@ public interface ElixirUnmatchedQualifiedAlias extends ElixirUnmatchedExpression
 
   @Nullable
   PsiReference getReference();
+
+  @Nullable
+  PsiPolyVariantReference getReference(PsiElement maxScope);
 
   boolean isModuleName();
 

--- a/gen/org/elixir_lang/psi/impl/ElixirAliasImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirAliasImpl.java
@@ -4,10 +4,7 @@ package org.elixir_lang.psi.impl;
 import com.ericsson.otp.erlang.OtpErlangObject;
 import com.intellij.extapi.psi.ASTWrapperPsiElement;
 import com.intellij.lang.ASTNode;
-import com.intellij.psi.PsiElement;
-import com.intellij.psi.PsiElementVisitor;
-import com.intellij.psi.PsiReference;
-import com.intellij.psi.ResolveState;
+import com.intellij.psi.*;
 import com.intellij.psi.scope.PsiScopeProcessor;
 import org.elixir_lang.psi.ElixirAlias;
 import org.elixir_lang.psi.ElixirVisitor;
@@ -47,6 +44,11 @@ public class ElixirAliasImpl extends ASTWrapperPsiElement implements ElixirAlias
   @Nullable
   public PsiReference getReference() {
     return ElixirPsiImplUtil.getReference(this);
+  }
+
+  @Nullable
+  public PsiPolyVariantReference getReference(PsiElement maxScope) {
+    return ElixirPsiImplUtil.getReference(this, maxScope);
   }
 
   public boolean isModuleName() {

--- a/gen/org/elixir_lang/psi/impl/ElixirAtomImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirAtomImpl.java
@@ -5,6 +5,7 @@ import com.ericsson.otp.erlang.OtpErlangObject;
 import com.intellij.extapi.psi.ASTWrapperPsiElement;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElementVisitor;
+import com.intellij.psi.PsiReference;
 import com.intellij.psi.util.PsiTreeUtil;
 import org.elixir_lang.psi.ElixirAtom;
 import org.elixir_lang.psi.ElixirCharListLine;
@@ -38,6 +39,11 @@ public class ElixirAtomImpl extends ASTWrapperPsiElement implements ElixirAtom {
   @Nullable
   public ElixirStringLine getStringLine() {
     return PsiTreeUtil.getChildOfType(this, ElixirStringLine.class);
+  }
+
+  @Nullable
+  public PsiReference getReference() {
+    return ElixirPsiImplUtil.getReference(this);
   }
 
   @NotNull

--- a/gen/org/elixir_lang/psi/impl/ElixirMatchedQualifiedAliasImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMatchedQualifiedAliasImpl.java
@@ -3,10 +3,7 @@ package org.elixir_lang.psi.impl;
 
 import com.ericsson.otp.erlang.OtpErlangObject;
 import com.intellij.lang.ASTNode;
-import com.intellij.psi.PsiElement;
-import com.intellij.psi.PsiElementVisitor;
-import com.intellij.psi.PsiReference;
-import com.intellij.psi.ResolveState;
+import com.intellij.psi.*;
 import com.intellij.psi.scope.PsiScopeProcessor;
 import com.intellij.psi.util.PsiTreeUtil;
 import org.elixir_lang.psi.*;
@@ -64,6 +61,11 @@ public class ElixirMatchedQualifiedAliasImpl extends ElixirMatchedExpressionImpl
   @Nullable
   public PsiReference getReference() {
     return ElixirPsiImplUtil.getReference(this);
+  }
+
+  @Nullable
+  public PsiPolyVariantReference getReference(PsiElement maxScope) {
+    return ElixirPsiImplUtil.getReference(this, maxScope);
   }
 
   public boolean isModuleName() {

--- a/gen/org/elixir_lang/psi/impl/ElixirUnmatchedQualifiedAliasImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnmatchedQualifiedAliasImpl.java
@@ -3,10 +3,7 @@ package org.elixir_lang.psi.impl;
 
 import com.ericsson.otp.erlang.OtpErlangObject;
 import com.intellij.lang.ASTNode;
-import com.intellij.psi.PsiElement;
-import com.intellij.psi.PsiElementVisitor;
-import com.intellij.psi.PsiReference;
-import com.intellij.psi.ResolveState;
+import com.intellij.psi.*;
 import com.intellij.psi.scope.PsiScopeProcessor;
 import com.intellij.psi.util.PsiTreeUtil;
 import org.elixir_lang.psi.*;
@@ -64,6 +61,11 @@ public class ElixirUnmatchedQualifiedAliasImpl extends ElixirUnmatchedExpression
   @Nullable
   public PsiReference getReference() {
     return ElixirPsiImplUtil.getReference(this);
+  }
+
+  @Nullable
+  public PsiPolyVariantReference getReference(PsiElement maxScope) {
+    return ElixirPsiImplUtil.getReference(this, maxScope);
   }
 
   public boolean isModuleName() {

--- a/src/org/elixir_lang/Elixir.bnf
+++ b/src/org/elixir_lang/Elixir.bnf
@@ -2772,7 +2772,10 @@ atom ::= COLON (ATOM_FRAGMENT | quote)
              "com.intellij.psi.NavigatablePsiElement"
              "org.elixir_lang.psi.Quotable"
            ]
-           methods = [quote]
+           methods = [
+             getReference
+             quote
+           ]
          }
 
 private infixComma ::= COMMA EOL*

--- a/src/org/elixir_lang/Reference.java
+++ b/src/org/elixir_lang/Reference.java
@@ -1,0 +1,93 @@
+package org.elixir_lang;
+
+import com.intellij.openapi.project.DumbService;
+import com.intellij.openapi.project.Project;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.search.GlobalSearchScope;
+import com.intellij.psi.stubs.StubIndex;
+import com.intellij.util.Function;
+import org.elixir_lang.psi.NamedElement;
+import org.elixir_lang.psi.stub.index.AllName;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.stream.Stream;
+
+public class Reference {
+    @NotNull
+    public static Collection<String> indexedNameCollection(@NotNull Project project) {
+        return StubIndex.getInstance().getAllKeys(AllName.KEY, project);
+    }
+
+    @NotNull
+    public static Stream<String> indexedNameStream(@NotNull Project project) {
+        return indexedNameCollection(project).stream();
+    }
+
+    /**
+     * Iterates over each navigation element for the PsiElements with {@code name} in {@code project}.
+     *
+     * @param project  Whose index to search for {@code name}
+     * @param name     Name to search for in {@code project} StubIndex
+     * @param function return {@code false} to stop iteration early
+     * @return {@code true} if all calls to {@code function} returned {@code true}
+     */
+    public static boolean forEachNavigationElement(@NotNull Project project,
+                                                   @NotNull String name,
+                                                   @NotNull Function<PsiElement, Boolean> function) {
+        Collection<NamedElement> namedElementCollection = namedElementCollection(project, name);
+
+        return forEachNavigationElement(namedElementCollection, function);
+    }
+
+    /**
+     * Iterates over each navigation element for the PsiElements in {@code psiElementCollection}.
+     *
+     * @param psiElementCollection Collection of PsiElements that aren't guaranteed to be navigation elements, such as
+     *                             the binary elements in {@code .beam} files.
+     * @param function             Return {@code false} to stop processing and abandon enumeration early
+     * @return {@code true} if all calls to {@code function} returned {@code true}
+     */
+    private static boolean forEachNavigationElement(@NotNull Collection<? extends PsiElement> psiElementCollection,
+                                                    @NotNull Function<PsiElement, Boolean> function) {
+        boolean keepProcessing = true;
+
+        for (PsiElement psiElement : psiElementCollection) {
+            /* The psiElement may be a ModuleImpl from a .beam.  Using #getNaviationElement() ensures a source
+               (either true source or decompiled) is used. */
+            keepProcessing = function.fun(psiElement.getNavigationElement());
+
+            if (!keepProcessing) {
+                break;
+            }
+        }
+
+        return keepProcessing;
+    }
+
+    public static Collection<NamedElement> namedElementCollection(@NotNull Project project, @NotNull String name) {
+        return namedElementCollection(project, GlobalSearchScope.allScope(project), name);
+    }
+
+    public static Collection<NamedElement> namedElementCollection(@NotNull Project project,
+                                                                  @NotNull GlobalSearchScope scope,
+                                                                  @NotNull String name) {
+        Collection<NamedElement> namedElementCollection;
+
+        if (DumbService.isDumb(project)) {
+            namedElementCollection = Collections.emptyList();
+        } else {
+            namedElementCollection = StubIndex.getElements(
+                    AllName.KEY,
+                    name,
+                    project,
+                    scope,
+                    NamedElement.class
+            );
+        }
+
+        return namedElementCollection;
+
+    }
+}

--- a/src/org/elixir_lang/code_insight/completion/provider/CallDefinitionClause.java
+++ b/src/org/elixir_lang/code_insight/completion/provider/CallDefinitionClause.java
@@ -8,8 +8,11 @@ import com.intellij.openapi.util.Pair;
 import com.intellij.psi.PsiElement;
 import com.intellij.util.ProcessingContext;
 import org.apache.commons.lang.math.IntRange;
+import org.elixir_lang.psi.ElixirEndOfExpression;
+import org.elixir_lang.psi.ElixirTypes;
 import org.elixir_lang.psi.call.Call;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -20,10 +23,6 @@ import static org.elixir_lang.psi.impl.ElixirPsiImplUtil.maybeModularNameToModul
 import static org.elixir_lang.structure_view.element.CallDefinitionClause.nameArityRange;
 
 public class CallDefinitionClause extends CompletionProvider<CompletionParameters> {
-    /*
-     * Private Instance Methods
-     */
-
     @NotNull
     private static Iterable<LookupElement> callDefinitionClauseLookupElements(@NotNull Call scope) {
         Call[] childCalls = macroChildCalls(scope);
@@ -61,19 +60,13 @@ public class CallDefinitionClause extends CompletionProvider<CompletionParameter
         return lookupElementList;
     }
 
-    /*
-     * Protected Instance Methods
-     */
-
-    @Override
-    protected void addCompletions(@NotNull CompletionParameters parameters,
-                                  ProcessingContext context,
-                                  @NotNull CompletionResultSet resultSet) {
+    @Nullable
+    private static PsiElement maybeModularName(@NotNull CompletionParameters parameters) {
         PsiElement originalPosition = parameters.getOriginalPosition();
-        PsiElement originalParent;
+        PsiElement maybeModularName = null;
 
         if (originalPosition != null) {
-            originalParent = originalPosition.getParent();
+            PsiElement originalParent = originalPosition.getParent();
 
             if (originalParent != null) {
                 PsiElement grandParent = originalParent.getParent();
@@ -81,20 +74,43 @@ public class CallDefinitionClause extends CompletionProvider<CompletionParameter
                 if (grandParent instanceof org.elixir_lang.psi.qualification.Qualified) {
                     org.elixir_lang.psi.qualification.Qualified qualifiedGrandParent =
                             (org.elixir_lang.psi.qualification.Qualified) grandParent;
-                    PsiElement qualifier = qualifiedGrandParent.qualifier();
+                    maybeModularName = qualifiedGrandParent.qualifier();
+                } else if (originalParent instanceof ElixirEndOfExpression) {
+                    final int originalParentOffset = originalParent.getTextOffset();
 
-                    Call modular = maybeModularNameToModular(qualifier, qualifier.getContainingFile());
+                    if (originalParentOffset > 0) {
+                        final PsiElement previousElement =
+                                parameters.getOriginalFile().findElementAt(originalParentOffset - 1);
 
-                    if (modular != null) {
-                        if (resultSet.getPrefixMatcher().getPrefix().endsWith(".")) {
-                            resultSet = resultSet.withPrefixMatcher("");
+                        if (previousElement != null &&
+                                previousElement.getNode().getElementType() == ElixirTypes.DOT_OPERATOR) {
+                            maybeModularName = previousElement.getPrevSibling();
                         }
-
-                        resultSet.addAllElements(
-                                callDefinitionClauseLookupElements(modular)
-                        );
                     }
                 }
+            }
+        }
+
+        return maybeModularName;
+    }
+
+    @Override
+    protected void addCompletions(@NotNull CompletionParameters parameters,
+                                  ProcessingContext context,
+                                  @NotNull CompletionResultSet resultSet) {
+        PsiElement maybeModularName = maybeModularName(parameters);
+
+        if (maybeModularName != null) {
+            Call modular = maybeModularNameToModular(maybeModularName, maybeModularName.getContainingFile());
+
+            if (modular != null) {
+                if (resultSet.getPrefixMatcher().getPrefix().endsWith(".")) {
+                    resultSet = resultSet.withPrefixMatcher("");
+                }
+
+                resultSet.addAllElements(
+                        callDefinitionClauseLookupElements(modular)
+                );
             }
         }
     }

--- a/src/org/elixir_lang/code_insight/completion/provider/CallDefinitionClause.java
+++ b/src/org/elixir_lang/code_insight/completion/provider/CallDefinitionClause.java
@@ -9,7 +9,6 @@ import com.intellij.psi.PsiElement;
 import com.intellij.util.ProcessingContext;
 import org.apache.commons.lang.math.IntRange;
 import org.elixir_lang.psi.call.Call;
-import org.elixir_lang.psi.impl.ElixirPsiImplUtil;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
@@ -17,6 +16,7 @@ import java.util.Collections;
 import java.util.List;
 
 import static org.elixir_lang.psi.impl.ElixirPsiImplUtil.macroChildCalls;
+import static org.elixir_lang.psi.impl.ElixirPsiImplUtil.maybeModularNameToModular;
 import static org.elixir_lang.structure_view.element.CallDefinitionClause.nameArityRange;
 
 public class CallDefinitionClause extends CompletionProvider<CompletionParameters> {
@@ -79,10 +79,11 @@ public class CallDefinitionClause extends CompletionProvider<CompletionParameter
                 PsiElement grandParent = originalParent.getParent();
 
                 if (grandParent instanceof org.elixir_lang.psi.qualification.Qualified) {
-                    org.elixir_lang.psi.qualification.Qualified qualifiedGrandParent = (org.elixir_lang.psi.qualification.Qualified) grandParent;
+                    org.elixir_lang.psi.qualification.Qualified qualifiedGrandParent =
+                            (org.elixir_lang.psi.qualification.Qualified) grandParent;
                     PsiElement qualifier = qualifiedGrandParent.qualifier();
 
-                    Call modular = ElixirPsiImplUtil.maybeAliasToModular(qualifier, qualifier.getContainingFile());
+                    Call modular = maybeModularNameToModular(qualifier, qualifier.getContainingFile());
 
                     if (modular != null) {
                         if (resultSet.getPrefixMatcher().getPrefix().endsWith(".")) {

--- a/src/org/elixir_lang/psi/Import.java
+++ b/src/org/elixir_lang/psi/Import.java
@@ -271,7 +271,7 @@ public class Import {
         Call modular = null;
 
         if (finalArguments != null && finalArguments.length >= 1) {
-            modular = maybeAliasToModular(finalArguments[0], importCall.getParent());
+            modular = maybeModularNameToModular(finalArguments[0], importCall.getParent());
         }
 
         return modular;

--- a/src/org/elixir_lang/psi/impl/ElixirPsiImplUtil.java
+++ b/src/org/elixir_lang/psi/impl/ElixirPsiImplUtil.java
@@ -5650,7 +5650,7 @@ if (quoted == null) {
      * Private static methods
      */
 
-    private static ASTNode[] childNodes(PsiElement parentElement) {
+    public static ASTNode[] childNodes(PsiElement parentElement) {
         ASTNode parentNode = parentElement.getNode();
         return parentNode.getChildren(null);
     }
@@ -5801,7 +5801,7 @@ if (quoted == null) {
     }
 
     @NotNull
-    private static List<Integer> addChildTextCodePoints(@Nullable List<Integer> codePointList, @NotNull ASTNode child) {
+    public static List<Integer> addChildTextCodePoints(@Nullable List<Integer> codePointList, @NotNull ASTNode child) {
         return addStringCodePoints(codePointList, child.getText());
     }
 

--- a/src/org/elixir_lang/psi/impl/ElixirPsiImplUtil.java
+++ b/src/org/elixir_lang/psi/impl/ElixirPsiImplUtil.java
@@ -5731,7 +5731,7 @@ if (quoted == null) {
     @Contract(pure = true)
     @Nullable
     public static Call qualifiedToModular(@NotNull final org.elixir_lang.psi.call.qualification.Qualified qualified) {
-        return maybeAliasToModular(qualified.qualifier(), qualified.getContainingFile());
+        return maybeModularNameToModular(qualified.qualifier(), qualified.getContainingFile());
     }
 
     @NotNull
@@ -5890,13 +5890,28 @@ if (quoted == null) {
      */
     @Contract(pure = true)
     @Nullable
-    public static Call maybeAliasToModular(@NotNull final PsiElement maybeAlias, @NotNull PsiElement maxScope) {
-        PsiElement maybeQualifiableAlias = stripAccessExpression(maybeAlias);
+    public static Call maybeModularNameToModular(@NotNull final PsiElement maybeModularName, @NotNull PsiElement maxScope) {
+        PsiElement strippedMaybeModuleName = stripAccessExpression(maybeModularName);
 
         Call modular = null;
 
-        if (maybeQualifiableAlias instanceof QualifiableAlias) {
-            QualifiableAlias qualifiableAlias = (QualifiableAlias) maybeQualifiableAlias;
+        if (strippedMaybeModuleName instanceof ElixirAtom) {
+            ElixirAtom atom = (ElixirAtom) strippedMaybeModuleName;
+            PsiReference reference = atom.getReference();
+
+            if (reference != null) {
+                final PsiElement resolved = reference.resolve();
+
+                if (resolved != null && resolved instanceof Call) {
+                    Call call = (Call) resolved;
+
+                    if (isModular(call)) {
+                        modular = call;
+                    }
+                }
+            }
+        } else if (strippedMaybeModuleName instanceof QualifiableAlias) {
+            QualifiableAlias qualifiableAlias = (QualifiableAlias) strippedMaybeModuleName;
 
             if (!recursiveKernelImport(qualifiableAlias, maxScope)) {
                 /* need to construct reference directly as qualified aliases don't return a reference except for the

--- a/src/org/elixir_lang/psi/impl/ElixirPsiImplUtil.java
+++ b/src/org/elixir_lang/psi/impl/ElixirPsiImplUtil.java
@@ -3231,6 +3231,19 @@ public class ElixirPsiImplUtil {
     }
 
     @Nullable
+    public static PsiReference getReference(@NotNull ElixirAtom atom) {
+        return CachedValuesManager.getCachedValue(
+                atom,
+                () -> CachedValueProvider.Result.create(computeReference(atom), atom)
+        );
+    }
+
+    @NotNull
+    private static PsiReference computeReference(@NotNull ElixirAtom atom) {
+        return new org.elixir_lang.reference.Atom(atom);
+    }
+
+    @Nullable
     public static PsiReference getReference(@NotNull QualifiableAlias qualifiableAlias) {
         return getReference(qualifiableAlias, qualifiableAlias.getContainingFile());
     }

--- a/src/org/elixir_lang/psi/scope/Atom.java
+++ b/src/org/elixir_lang/psi/scope/Atom.java
@@ -1,0 +1,30 @@
+package org.elixir_lang.psi.scope;
+
+import com.intellij.openapi.util.Key;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.ResolveState;
+import com.intellij.psi.scope.PsiScopeProcessor;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class Atom implements PsiScopeProcessor {
+    /**
+     * @param element candidate element.
+     * @param state   current state of resolver.
+     * @return false to stop processing.
+     */
+    @Override
+    public boolean execute(@NotNull PsiElement element, @NotNull ResolveState state) {
+        return false;
+    }
+
+    @Nullable
+    @Override
+    public <T> T getHint(@NotNull Key<T> hintKey) {
+        return null;
+    }
+
+    @Override
+    public void handleEvent(@NotNull Event event, @Nullable Object associated) {
+    }
+}

--- a/src/org/elixir_lang/psi/scope/CallDefinitionClause.java
+++ b/src/org/elixir_lang/psi/scope/CallDefinitionClause.java
@@ -129,7 +129,7 @@ public abstract class CallDefinitionClause implements PsiScopeProcessor {
     private boolean implicitImports(@NotNull PsiElement element, @NotNull ResolveState state) {
         Project project = element.getProject();
 
-        boolean keepProcessing = org.elixir_lang.reference.Module.forEachNavigationElement(
+        boolean keepProcessing = org.elixir_lang.Reference.forEachNavigationElement(
                 project,
                 KERNEL,
                 new Function<PsiElement, Boolean>() {
@@ -159,7 +159,7 @@ public abstract class CallDefinitionClause implements PsiScopeProcessor {
         // the implicit `import Kernel.SpecialForms`
         if (keepProcessing) {
             ResolveState modularCanonicalNameState = state.put(MODULAR_CANONICAL_NAME, KERNEL_SPECIAL_FORMS);
-            keepProcessing = org.elixir_lang.reference.Module.forEachNavigationElement(
+            keepProcessing = org.elixir_lang.Reference.forEachNavigationElement(
                     project,
                     KERNEL_SPECIAL_FORMS,
                     new Function<PsiElement, Boolean>() {

--- a/src/org/elixir_lang/psi/scope/atom/Variants.java
+++ b/src/org/elixir_lang/psi/scope/atom/Variants.java
@@ -1,0 +1,81 @@
+package org.elixir_lang.psi.scope.atom;
+
+import com.intellij.codeInsight.lookup.LookupElement;
+import com.intellij.codeInsight.lookup.LookupElementBuilder;
+import com.intellij.openapi.project.Project;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.search.GlobalSearchScope;
+import com.intellij.psi.stubs.StubIndex;
+import com.intellij.util.containers.ContainerUtil;
+import org.elixir_lang.psi.NamedElement;
+import org.elixir_lang.psi.scope.Atom;
+import org.elixir_lang.psi.stub.index.AllName;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+public class Variants extends Atom {
+    @NotNull
+    public static List<LookupElement> lookupElementList(@NotNull PsiElement entrance) {
+        return new Variants().projectLookupElementStream(entrance);
+    }
+
+    private List<LookupElement> projectLookupElementStream(@NotNull PsiElement entrance) {
+        Project project = entrance.getProject();
+        /* getAllKeys is not the actual keys in the actual project.  They need to be checked.
+           See https://intellij-support.jetbrains.com/hc/en-us/community/posts/207930789-StubIndex-persisting-between-test-runs-leading-to-incorrect-completions */
+        Collection<String> indexedNameCollection = StubIndex.getInstance().getAllKeys(AllName.KEY, project);
+        GlobalSearchScope scope = GlobalSearchScope.allScope(project);
+
+        Collection<String> atomNameCollection = atomNameCollection(indexedNameCollection);
+        String prefix = prefix(entrance);
+        Collection<String> prefixedNameCollection = prefixedNameCollection(atomNameCollection, prefix);
+        List<LookupElement> lookupElementList = new ArrayList<>();
+
+        for (String atomName : prefixedNameCollection) {
+            Collection<NamedElement> atomNamedElementCollection = StubIndex.getElements(
+                    AllName.KEY,
+                    atomName,
+                    project,
+                    scope,
+                    NamedElement.class
+            );
+
+            for (NamedElement atomNamedElement : atomNamedElementCollection) {
+                PsiElement navigationElement = atomNamedElement.getNavigationElement();
+                lookupElementList.add(
+                        LookupElementBuilder.createWithSmartPointer(atomName, navigationElement)
+                );
+            }
+        }
+
+        return lookupElementList;
+    }
+
+    @Contract(pure = true)
+    @NotNull
+    private Collection<String> prefixedNameCollection(Collection<String> atomNameCollection, String prefix) {
+        return ContainerUtil.filter(atomNameCollection, atomName -> atomName.startsWith(prefix));
+    }
+
+    @Contract(pure = true)
+    @NotNull
+    private static String prefix(PsiElement atom) {
+        return atom.getText().replace("IntellijIdeaRulezzz", "");
+    }
+
+    @Contract(pure = true)
+    @NotNull
+    private static Collection<String> atomNameCollection(@NotNull Collection<String> indexedNameCollection) {
+        return ContainerUtil.filter(indexedNameCollection, Variants::isAtomName);
+    }
+
+    @Contract(value = "null -> false", pure = true)
+    private static boolean isAtomName(@Nullable String indexedName) {
+        return indexedName != null && indexedName.startsWith(":");
+    }
+}

--- a/src/org/elixir_lang/psi/scope/module/Variants.java
+++ b/src/org/elixir_lang/psi/scope/module/Variants.java
@@ -26,6 +26,7 @@ import java.util.List;
 import static com.intellij.psi.util.PsiTreeUtil.treeWalkUp;
 import static org.elixir_lang.Module.concat;
 import static org.elixir_lang.Module.split;
+import static org.elixir_lang.Reference.indexedNameCollection;
 import static org.elixir_lang.psi.impl.ElixirPsiImplUtil.ENTRANCE;
 
 public class Variants extends Module {
@@ -230,9 +231,7 @@ public class Variants extends Module {
         if (unaliasedName != null) {
             Project project = match.getProject();
 
-            Collection<String> indexedNameCollection = StubIndex
-                    .getInstance()
-                    .getAllKeys(AllName.KEY, project);
+            Collection<String> indexedNameCollection = indexedNameCollection(project);
             List<String> unaliasedNestedNames = ContainerUtil.findAll(
                     indexedNameCollection,
                     new org.elixir_lang.Module.IsNestedUnder(unaliasedName)

--- a/src/org/elixir_lang/reference/Atom.java
+++ b/src/org/elixir_lang/reference/Atom.java
@@ -1,0 +1,49 @@
+package org.elixir_lang.reference;
+
+import com.intellij.codeInsight.lookup.LookupElement;
+import com.intellij.openapi.util.TextRange;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiPolyVariantReference;
+import com.intellij.psi.PsiReferenceBase;
+import com.intellij.psi.ResolveResult;
+import org.elixir_lang.psi.ElixirAtom;
+import org.elixir_lang.psi.scope.atom.Variants;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+
+public class Atom extends PsiReferenceBase<ElixirAtom> implements PsiPolyVariantReference {
+    public Atom(ElixirAtom atom) {
+        super(atom, TextRange.create(0, atom.getTextLength()));
+    }
+
+    @NotNull
+    @Override
+    public Object[] getVariants() {
+        List<LookupElement> lookupElementList = Variants.lookupElementList(myElement);
+
+        return lookupElementList.toArray(new Object[lookupElementList.size()]);
+    }
+
+    /**
+     * Returns the results of resolving the reference.
+     *
+     * @param incompleteCode if true, the code in the context of which the reference is
+     *                       being resolved is considered incomplete, and the method may return additional
+     *                       invalid results.
+     * @return the array of results for resolving the reference.
+     */
+    @NotNull
+    @Override
+    public ResolveResult[] multiResolve(boolean incompleteCode) {
+        return new ResolveResult[0];
+    }
+
+    @Nullable
+    @Override
+    public PsiElement resolve() {
+        ResolveResult[] resolveResults = multiResolve(false);
+        return resolveResults.length == 1 ? resolveResults[0].getElement() : null;
+    }
+}

--- a/src/org/elixir_lang/reference/Atom.java
+++ b/src/org/elixir_lang/reference/Atom.java
@@ -6,6 +6,7 @@ import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiPolyVariantReference;
 import com.intellij.psi.PsiReferenceBase;
 import com.intellij.psi.ResolveResult;
+import com.intellij.psi.impl.source.resolve.ResolveCache;
 import org.elixir_lang.psi.ElixirAtom;
 import org.elixir_lang.psi.scope.atom.Variants;
 import org.jetbrains.annotations.NotNull;
@@ -37,7 +38,9 @@ public class Atom extends PsiReferenceBase<ElixirAtom> implements PsiPolyVariant
     @NotNull
     @Override
     public ResolveResult[] multiResolve(boolean incompleteCode) {
-        return new ResolveResult[0];
+        return ResolveCache
+                .getInstance(this.myElement.getProject())
+                .resolveWithCaching(this, org.elixir_lang.reference.resolver.Atom.INSTANCE, false, incompleteCode);
     }
 
     @Nullable

--- a/src/org/elixir_lang/reference/Module.java
+++ b/src/org/elixir_lang/reference/Module.java
@@ -1,116 +1,34 @@
 package org.elixir_lang.reference;
 
 import com.intellij.codeInsight.lookup.LookupElement;
-import com.intellij.openapi.project.DumbService;
-import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.TextRange;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiPolyVariantReference;
 import com.intellij.psi.PsiReferenceBase;
 import com.intellij.psi.ResolveResult;
 import com.intellij.psi.impl.source.resolve.ResolveCache;
-import com.intellij.psi.search.GlobalSearchScope;
-import com.intellij.psi.stubs.StubIndex;
-import com.intellij.util.Function;
-import org.elixir_lang.psi.NamedElement;
 import org.elixir_lang.psi.QualifiableAlias;
 import org.elixir_lang.psi.scope.module.Variants;
-import org.elixir_lang.psi.stub.index.AllName;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 
 public class Module extends PsiReferenceBase<QualifiableAlias> implements PsiPolyVariantReference {
     /*
-     *
-     * Static Methods
-     *
-     */
-
-    /*
-     * Public Static Methods
+     * Fields
      */
 
     @NotNull
     public final PsiElement maxScope;
 
     /*
-     * Private Static Methods
+     * Constructors
      */
 
     public Module(@NotNull QualifiableAlias qualifiableAlias, @NotNull PsiElement maxScope) {
         super(qualifiableAlias, TextRange.create(0, qualifiableAlias.getTextLength()));
         this.maxScope = maxScope;
-    }
-
-    /**
-     * Iterates over each navigation element for the PsiElements with {@code name} in {@code project}.
-     *
-     * @param project Whose index to search for {@code name}
-     * @param name Name to search for in {@code project} StubIndex
-     * @param function return {@code false} to stop iteration early
-     * @return {@code true} if all calls to {@code function} returned {@code true}
-     */
-    public static boolean forEachNavigationElement(@NotNull Project project,
-                                                   @NotNull String name,
-                                                   @NotNull Function<PsiElement, Boolean> function) {
-        Collection<NamedElement> namedElementCollection = namedElementCollection(project, name);
-
-        return forEachNavigationElement(namedElementCollection, function);
-    }
-
-    /*
-     * Fields
-     */
-
-    /**
-     * Iterates over each navigation element for the PsiElements in {@code psiElementCollection}.
-     *
-     * @param psiElementCollection Collection of PsiElements that aren't guaranteed to be navigation elements, such as
-     *                             the binary elements in {@code .beam} files.
-     * @param function Return {@code false} to stop processing and abandon enumeration early
-     * @return {@code true} if all calls to {@code function} returned {@code true}
-     */
-    private static boolean forEachNavigationElement(@NotNull Collection<? extends PsiElement> psiElementCollection,
-                                                    @NotNull Function<PsiElement, Boolean> function) {
-        boolean keepProcessing = true;
-
-        for (PsiElement psiElement : psiElementCollection) {
-            /* The psiElement may be a ModuleImpl from a .beam.  Using #getNaviationElement() ensures a source
-               (either true source or decompiled) is used. */
-            keepProcessing = function.fun(psiElement.getNavigationElement());
-
-            if (!keepProcessing) {
-                break;
-            }
-        }
-
-        return keepProcessing;
-    }
-
-    /*
-     * Constructors
-     */
-
-    private static Collection<NamedElement> namedElementCollection(@NotNull Project project, @NotNull String name) {
-        Collection<NamedElement> namedElementCollection;
-
-        if (DumbService.isDumb(project)) {
-            namedElementCollection = Collections.emptyList();
-        } else {
-            namedElementCollection = StubIndex.getElements(
-                    AllName.KEY,
-                    name,
-                    project,
-                    GlobalSearchScope.allScope(project),
-                    NamedElement.class
-            );
-        }
-
-        return namedElementCollection;
     }
 
     /*

--- a/src/org/elixir_lang/reference/resolver/Atom.java
+++ b/src/org/elixir_lang/reference/resolver/Atom.java
@@ -1,0 +1,22 @@
+package org.elixir_lang.reference.resolver;
+
+import com.intellij.psi.ResolveResult;
+import com.intellij.psi.impl.source.resolve.ResolveCache;
+import org.elixir_lang.psi.ElixirAtom;
+import org.elixir_lang.reference.resolver.atom.Resolvable;
+import org.jetbrains.annotations.NotNull;
+
+import static org.elixir_lang.reference.resolver.atom.Resolvable.resolvable;
+
+public class Atom implements ResolveCache.PolyVariantResolver<org.elixir_lang.reference.Atom>{
+    public static final Atom INSTANCE = new Atom();
+
+    @NotNull
+    @Override
+    public ResolveResult[] resolve(@NotNull org.elixir_lang.reference.Atom atom, boolean incompleteCode) {
+        ElixirAtom element = atom.getElement();
+        Resolvable resolvable = resolvable(element);
+
+        return resolvable.resolve(element.getProject());
+    }
+}

--- a/src/org/elixir_lang/reference/resolver/Module.java
+++ b/src/org/elixir_lang/reference/resolver/Module.java
@@ -11,7 +11,7 @@ import org.jetbrains.annotations.NotNull;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.elixir_lang.reference.Module.forEachNavigationElement;
+import static org.elixir_lang.Reference.forEachNavigationElement;
 import static org.elixir_lang.reference.module.ResolvableName.resolvableName;
 
 public class Module implements ResolveCache.PolyVariantResolver<org.elixir_lang.reference.Module> {

--- a/src/org/elixir_lang/reference/resolver/atom/Resolvable.java
+++ b/src/org/elixir_lang/reference/resolver/atom/Resolvable.java
@@ -1,0 +1,149 @@
+package org.elixir_lang.reference.resolver.atom;
+
+import com.intellij.lang.ASTNode;
+import com.intellij.openapi.project.Project;
+import com.intellij.psi.ResolveResult;
+import com.intellij.psi.tree.IElementType;
+import org.apache.commons.lang.NotImplementedException;
+import org.elixir_lang.psi.*;
+import org.elixir_lang.reference.resolver.atom.resolvable.Exact;
+import org.elixir_lang.reference.resolver.atom.resolvable.Pattern;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.LinkedList;
+import java.util.List;
+
+import static org.elixir_lang.psi.impl.ElixirPsiImplUtil.addChildTextCodePoints;
+import static org.elixir_lang.psi.impl.ElixirPsiImplUtil.childNodes;
+
+/**
+ * How to resolve an {@link ElixirAtom}.
+ * <p>
+ * If the {ElixirAtom} is a normal, unquoted atom, it can be resolved exactly, but if it's quoted and contains
+ * interpolation, then it cannot be resolved exactly.
+ */
+public abstract class Resolvable {
+    @NotNull
+    public static Resolvable resolvable(@NotNull ElixirAtom atom) {
+        ElixirCharListLine charListLine = atom.getCharListLine();
+        Resolvable resolvable;
+
+        if (charListLine != null) {
+            resolvable = resolvable(charListLine);
+        } else {
+            ElixirStringLine stringLine = atom.getStringLine();
+
+            if (stringLine != null) {
+                resolvable = resolvable(stringLine);
+            } else {
+                ASTNode atomNode = atom.getNode();
+                ASTNode atomFragmentNode = atomNode.getLastChildNode();
+
+                assert atomFragmentNode.getElementType() == ElixirTypes.ATOM_FRAGMENT;
+
+                resolvable = new Exact(":" + atomFragmentNode.getText());
+            }
+        }
+
+        return resolvable;
+    }
+
+    @NotNull
+    private static <I extends Bodied & Parent> Resolvable resolvable(@NotNull I parentBodied) {
+        Body body = parentBodied.getBody();
+
+        return resolvable(parentBodied, childNodes(body));
+    }
+
+    @NotNull
+    private static Resolvable resolvable(@NotNull Parent parent, @NotNull ASTNode[] children) {
+        Resolvable resolvable;
+
+        if (children.length == 0) {
+            resolvable = new Exact(":\"\"");
+        } else {
+            List<String> regexList = new LinkedList<>();
+            List<Integer> codePointList = null;
+
+            for (ASTNode child : children) {
+                IElementType elementType = child.getElementType();
+
+                if (elementType == parent.getFragmentType()) {
+                    codePointList = parent.addFragmentCodePoints(codePointList, child);
+                } else if (elementType == ElixirTypes.ESCAPED_CHARACTER) {
+                    codePointList = parent.addEscapedCharacterCodePoints(codePointList, child);
+                } else if (elementType == ElixirTypes.ESCAPED_EOL) {
+                    codePointList = parent.addEscapedEOL(codePointList, child);
+                } else if (elementType == ElixirTypes.HEXADECIMAL_ESCAPE_PREFIX) {
+                    codePointList = addChildTextCodePoints(codePointList, child);
+                } else if (elementType == ElixirTypes.INTERPOLATION) {
+                    if (codePointList != null) {
+                        regexList.add(codePointListToString(codePointList));
+                        codePointList = null;
+                    }
+
+                    regexList.add(interpolation());
+                } else if (elementType == ElixirTypes.QUOTE_HEXADECIMAL_ESCAPE_SEQUENCE ||
+                        elementType == ElixirTypes.SIGIL_HEXADECIMAL_ESCAPE_SEQUENCE) {
+                    codePointList = parent.addHexadecimalEscapeSequenceCodePoints(codePointList, child);
+                } else {
+                    throw new NotImplementedException("Can't convert to Resolvable " + child);
+                }
+            }
+
+            if (codePointList != null && regexList.isEmpty()) {
+                resolvable = resolvableLiteral(codePointList);
+            } else {
+                if (codePointList != null) {
+                    regexList.add(codePointListToRegex(codePointList));
+                }
+
+                resolvable = new Pattern(join(regexList));
+            }
+        }
+
+        return resolvable;
+    }
+
+    @NotNull
+    private static String join(List<String> regexList) {
+        return String.join("", regexList);
+    }
+
+    @Contract(pure = true)
+    @NotNull
+    private static String interpolation() {
+        return ".*";
+    }
+
+    @NotNull
+    private static String codePointListToRegex(@NotNull List<Integer> codePointList) {
+        String string = codePointListToString(codePointList);
+        return java.util.regex.Pattern.quote(string);
+    }
+
+    @NotNull
+    private static String codePointListToString(@NotNull List<Integer> codePointList) {
+        StringBuilder stringAccumulator = new StringBuilder();
+
+        for (int codePoint : codePointList) {
+            stringAccumulator.appendCodePoint(codePoint);
+        }
+
+        return stringAccumulator.toString();
+    }
+
+    @NotNull
+    private static Resolvable resolvableLiteral(List<Integer> codePointList) {
+        StringBuilder stringAccumulator = new StringBuilder();
+
+        for (int codePoint : codePointList) {
+            stringAccumulator.appendCodePoint(codePoint);
+        }
+
+        return new Exact(":" + stringAccumulator.toString());
+    }
+
+    public abstract ResolveResult[] resolve(@NotNull Project project);
+}

--- a/src/org/elixir_lang/reference/resolver/atom/resolvable/Exact.java
+++ b/src/org/elixir_lang/reference/resolver/atom/resolvable/Exact.java
@@ -1,0 +1,38 @@
+package org.elixir_lang.reference.resolver.atom.resolvable;
+
+import com.intellij.openapi.project.Project;
+import com.intellij.psi.PsiElementResolveResult;
+import com.intellij.psi.ResolveResult;
+import org.elixir_lang.reference.resolver.atom.Resolvable;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.elixir_lang.Reference.forEachNavigationElement;
+
+public class Exact extends Resolvable {
+    @NotNull
+    private final String name;
+
+    public Exact(@NotNull String name) {
+        this.name = name;
+    }
+
+    @Override
+    public ResolveResult[] resolve(@NotNull Project project) {
+        List<ResolveResult> resolveResultList = new ArrayList<>();
+
+        forEachNavigationElement(
+                project,
+                name,
+                navigationElement -> {
+                    resolveResultList.add(new PsiElementResolveResult(navigationElement));
+
+                    return true;
+                }
+        );
+
+        return resolveResultList.toArray(new ResolveResult[resolveResultList.size()]);
+    }
+}

--- a/src/org/elixir_lang/reference/resolver/atom/resolvable/Pattern.java
+++ b/src/org/elixir_lang/reference/resolver/atom/resolvable/Pattern.java
@@ -1,0 +1,46 @@
+package org.elixir_lang.reference.resolver.atom.resolvable;
+
+import com.intellij.openapi.project.Project;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiElementResolveResult;
+import com.intellij.psi.ResolveResult;
+import com.intellij.psi.search.GlobalSearchScope;
+import org.elixir_lang.reference.resolver.atom.Resolvable;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.function.Predicate;
+
+import static org.elixir_lang.Reference.indexedNameStream;
+import static org.elixir_lang.Reference.namedElementCollection;
+
+public class Pattern extends Resolvable {
+    @NotNull
+    private final Predicate<String> predicate;
+
+    public Pattern(@NotNull String regex) {
+        this(java.util.regex.Pattern.compile(":" + regex));
+    }
+
+    public Pattern(@NotNull java.util.regex.Pattern pattern) {
+        this(pattern.asPredicate());
+    }
+
+    public Pattern(@NotNull Predicate<String> predicate) {
+        this.predicate = predicate;
+    }
+
+    @Override
+    public ResolveResult[] resolve(@NotNull Project project) {
+        GlobalSearchScope scope = GlobalSearchScope.allScope(project);
+        return indexedNameStream(project)
+                .filter(predicate)
+                .flatMap(name ->
+                        namedElementCollection(project, scope, name)
+                                .stream()
+                                .map(PsiElement::getNavigationElement)
+                                .map(navigationElement ->
+                                        (ResolveResult) new PsiElementResolveResult(navigationElement, false)
+                                )
+                ).toArray(ResolveResult[]::new);
+    }
+}

--- a/src/org/elixir_lang/sdk/elixir/Type.java
+++ b/src/org/elixir_lang/sdk/elixir/Type.java
@@ -589,7 +589,7 @@ public class Type extends org.elixir_lang.sdk.erlang_dependent.Type {
             @NotNull SdkModel sdkModel,
             @NotNull SdkModificator sdkModificator
     ) {
-        return new org.elixir_lang.sdk.erlang_dependent.AdditionalDataConfigurable(sdkModel);
+        return new org.elixir_lang.sdk.erlang_dependent.AdditionalDataConfigurable(sdkModel, sdkModificator);
     }
 
     public void saveAdditionalData(@NotNull SdkAdditionalData additionalData, @NotNull Element additional) {


### PR DESCRIPTION
Resolves #829

# Changelog
## Enhancements
* All `ebin` paths in the Internal Erlang SDK will be copied to the Elixir SDK, so that they are indexed, which makes the Internal Erlang SDK modules show up in Symbol search.
* Erlang SDK modules can be completed and then functions in those modules can be completed after typing `.`.
  * Atoms have References.
    * Indexed atoms (from decompiled Erlang `.beams` from the Internal Erlang SDK) will be used for completing atoms as soon the atom is parseable: either after the first letter `:` or inside the quotes when making a quoted atom.
    * Atoms will resolve to modules if the atom is a module name.  If the atom is quoted and contains interpolation, it will treat each interpolation as `.*` and look for regex matches to this derived potential atom name.
* Completions for functions after `.` will now work at the end of file.  Previously, completions only worked in the middle of a file, where the `.` could parse the next work an existing call, now if that parse doesn't work and the only thing after is a new line, it will still complete.