### PR TITLE
When setting up paths for Elixir SDK, setup and copy Erlang SDK paths

### DIFF
--- a/src/org/elixir_lang/sdk/HomePath.java
+++ b/src/org/elixir_lang/sdk/HomePath.java
@@ -7,6 +7,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -30,11 +31,11 @@ public class HomePath {
     public static void eachEbinPath(@NotNull String homePath, @NotNull Consumer<Path> ebinPathConsumer) {
         Path lib = Paths.get(homePath, "lib");
 
-        try {
-            Files.newDirectoryStream(lib).forEach(
+        try (DirectoryStream<Path> libDirectoryStream = Files.newDirectoryStream(lib)) {
+            libDirectoryStream.forEach(
                     app -> {
-                        try {
-                            Files.newDirectoryStream(app, "ebin").forEach(ebinPathConsumer);
+                        try (DirectoryStream<Path> ebinDirectoryStream = Files.newDirectoryStream(app, "ebin")) {
+                            ebinDirectoryStream.forEach(ebinPathConsumer);
                         } catch (IOException ioException) {
                             LOGGER.error(ioException);
                         }

--- a/src/org/elixir_lang/sdk/elixir/Type.java
+++ b/src/org/elixir_lang/sdk/elixir/Type.java
@@ -20,7 +20,6 @@ import com.intellij.openapi.vfs.VfsUtil;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.openapi.vfs.VirtualFileManager;
 import com.intellij.psi.PsiElement;
-import com.intellij.util.Function;
 import gnu.trove.THashSet;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang.ArrayUtils;
@@ -40,6 +39,7 @@ import java.io.File;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.*;
+import java.util.function.Function;
 import java.util.regex.Pattern;
 
 import static org.elixir_lang.sdk.HomePath.*;
@@ -55,7 +55,6 @@ public class Type extends org.elixir_lang.sdk.erlang_dependent.Type {
     private static final Set<String> SDK_HOME_CHILD_BASE_NAME_SET = new THashSet<>(Arrays.asList("bin", "lib", "src"));
     private static final String WINDOWS_32BIT_DEFAULT_HOME_PATH = "C:\\Program Files\\Elixir";
     private static final String WINDOWS_64BIT_DEFAULT_HOME_PATH = "C:\\Program Files (x86)\\Elixir";
-    private static final Function<File, File> ID = file -> file;
     private final Map<String, Release> mySdkHomeToReleaseCache =
             ApplicationManager.getApplication().isUnitTestMode() ? new HashMap<>() : new WeakHashMap<>();
 
@@ -566,8 +565,8 @@ public class Type extends org.elixir_lang.sdk.erlang_dependent.Type {
         );
 
         if (SystemInfo.isMac) {
-            mergeHomebrew(homePathByVersion, "elixir", ID);
-            mergeNixStore(homePathByVersion, NIX_PATTERN, ID);
+            mergeHomebrew(homePathByVersion, "elixir", java.util.function.Function.identity());
+            mergeNixStore(homePathByVersion, NIX_PATTERN, Function.identity());
         } else {
             String sdkPath;
 
@@ -582,7 +581,7 @@ public class Type extends org.elixir_lang.sdk.erlang_dependent.Type {
             } else if (SystemInfo.isLinux) {
                 homePathByVersion.put(UNKNOWN_VERSION, LINUX_DEFAULT_HOME_PATH);
 
-                mergeNixStore(homePathByVersion, NIX_PATTERN, ID);
+                mergeNixStore(homePathByVersion, NIX_PATTERN, Function.identity());
             }
         }
 

--- a/src/org/elixir_lang/sdk/erlang/Type.java
+++ b/src/org/elixir_lang/sdk/erlang/Type.java
@@ -11,7 +11,6 @@ import com.intellij.openapi.roots.JavadocOrderRootType;
 import com.intellij.openapi.roots.OrderRootType;
 import com.intellij.openapi.util.SystemInfo;
 import com.intellij.openapi.util.Version;
-import com.intellij.util.Function;
 import com.intellij.util.containers.WeakHashMap;
 import org.elixir_lang.jps.model.JpsErlangSdkType;
 import org.elixir_lang.sdk.HomePath;
@@ -22,6 +21,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.io.File;
 import java.util.*;
+import java.util.function.Function;
 import java.util.regex.Pattern;
 
 import static org.elixir_lang.sdk.HomePath.*;
@@ -123,6 +123,7 @@ public class Type extends SdkType {
             } else if (SystemInfo.isLinux) {
                 putIfDirectory(homePathByVersion, UNKNOWN_VERSION, LINUX_DEFAULT_HOME_PATH);
 
+                mergeTravisCIKerl(homePathByVersion, Function.identity());
                 mergeNixStore(homePathByVersion, NIX_PATTERN, VERSION_PATH_TO_HOME_PATH);
             }
         }

--- a/src/org/elixir_lang/sdk/erlang/Type.java
+++ b/src/org/elixir_lang/sdk/erlang/Type.java
@@ -118,20 +118,26 @@ public class Type extends SdkType {
             mergeHomebrew(homePathByVersion, "erlang", VERSION_PATH_TO_HOME_PATH);
             mergeNixStore(homePathByVersion, NIX_PATTERN, VERSION_PATH_TO_HOME_PATH);
         } else {
-            String sdkPath;
-
             if (SystemInfo.isWindows) {
-                sdkPath = WINDOWS_DEFAULT_HOME_PATH;
-
-                homePathByVersion.put(UNKNOWN_VERSION, sdkPath);
+                putIfDirectory(homePathByVersion, UNKNOWN_VERSION, WINDOWS_DEFAULT_HOME_PATH);
             } else if (SystemInfo.isLinux) {
-                homePathByVersion.put(UNKNOWN_VERSION, LINUX_DEFAULT_HOME_PATH);
+                putIfDirectory(homePathByVersion, UNKNOWN_VERSION, LINUX_DEFAULT_HOME_PATH);
 
                 mergeNixStore(homePathByVersion, NIX_PATTERN, VERSION_PATH_TO_HOME_PATH);
             }
         }
 
         return homePathByVersion;
+    }
+
+    private static void putIfDirectory(@NotNull Map<Version, String> homePathByVersion,
+                                       @NotNull Version version,
+                                       @NotNull String homePath) {
+        File homeFile = new File(homePath);
+
+        if (homeFile.isDirectory()) {
+            homePathByVersion.put(version, homePath);
+        }
     }
 
     @Override

--- a/src/org/elixir_lang/sdk/erlang_dependent/SdkModificatorRootTypeConsumer.java
+++ b/src/org/elixir_lang/sdk/erlang_dependent/SdkModificatorRootTypeConsumer.java
@@ -1,0 +1,13 @@
+package org.elixir_lang.sdk.erlang_dependent;
+
+import com.intellij.openapi.projectRoots.SdkModificator;
+import com.intellij.openapi.roots.OrderRootType;
+import com.intellij.openapi.vfs.VirtualFile;
+import org.jetbrains.annotations.NotNull;
+
+public  interface SdkModificatorRootTypeConsumer {
+    void consume(@NotNull SdkModificator sdkModificator,
+                 @NotNull VirtualFile[] configuredRoots,
+                 @NotNull VirtualFile expandedInternalRoot,
+                 @NotNull OrderRootType type);
+}

--- a/tests/org/elixir_lang/parser_definition/ParsingTestCase.java
+++ b/tests/org/elixir_lang/parser_definition/ParsingTestCase.java
@@ -298,6 +298,7 @@ public abstract class ParsingTestCase extends com.intellij.testFramework.Parsing
                 com.intellij.openapi.projectRoots.SdkType.class
         );
         registerExtension(com.intellij.openapi.projectRoots.SdkType.EP_NAME, new Type());
+        registerExtension(com.intellij.openapi.projectRoots.SdkType.EP_NAME, new org.elixir_lang.sdk.erlang.Type());
 
         Sdk sdk = Type.createMockSdk(sdkHome, elixirSdkRelease());
         projectJdkTable.addJdk(sdk);


### PR DESCRIPTION
Fixes #847

# Changelog
## Bug Fixes
* `AdditionalDataConfigurable` only copied the the Internal Erlang SDK Code Paths when the selection in the `ComboBox` was changed, which meant if the there was only one Erlang SDK or the user never changed the selection, the Code Paths were never copied.  To get the Code Paths copied when the Elixir SDK is first created and `setupSdkPaths` interface method is called
  1. All paths are set directly on the Elixir SDK as before
  2. The default Erlang SDK, which should be the one that was last created, is configured in SdkAdditionalaData
  3. The Code paths from the Erlang SDK are copied to the Elixir SDK
      1. If the the Erlang SDK is from intellij-elixir and does not have `ebin` directories for its Class Paths, then the Class Paths is expanded to Code Paths.