### PR TITLE
 Use SmallIDE setting for SDK path for elixir path

### DIFF
--- a/src/org/elixir_lang/mix/runner/MixRunningStateUtil.java
+++ b/src/org/elixir_lang/mix/runner/MixRunningStateUtil.java
@@ -22,6 +22,7 @@ import org.elixir_lang.jps.builder.ParametersList;
 import org.elixir_lang.jps.model.JpsElixirSdkType;
 import org.elixir_lang.jps.model.JpsErlangSdkType;
 import org.elixir_lang.mix.settings.MixSettings;
+import org.elixir_lang.sdk.elixir.ForSmallIdes;
 import org.elixir_lang.sdk.elixir.Type;
 import org.elixir_lang.utils.ElixirExternalToolsNotificationListener;
 import org.jetbrains.annotations.NotNull;
@@ -31,6 +32,7 @@ import java.io.File;
 import java.nio.file.Paths;
 
 import static org.apache.commons.lang.StringUtils.isBlank;
+import static org.elixir_lang.sdk.ProcessOutput.isSmallIde;
 import static org.elixir_lang.sdk.elixir.Type.addDocumentationPaths;
 import static org.elixir_lang.sdk.elixir.Type.addSourcePaths;
 import static org.elixir_lang.sdk.elixir.Type.putDefaultErlangSdk;
@@ -304,6 +306,17 @@ public class MixRunningStateUtil {
                         commandLine.addParameter("-extra");
                     }
                 }
+            } else if (isSmallIde()) {
+                String sdkHome = ForSmallIdes.getSdkHome(project);
+                String elixir;
+
+                if (sdkHome != null) {
+                    elixir = JpsElixirSdkType.getScriptInterpreterExecutable(sdkHome).toString();
+                } else {
+                    elixir = JpsElixirSdkType.getExecutableFileName("elixir");
+                }
+
+                commandLine.setExePath(elixir);
             }
         } else {
             String elixir = JpsElixirSdkType.getExecutableFileName("elixir");

--- a/src/org/elixir_lang/mix/runner/MixRunningStateUtil.java
+++ b/src/org/elixir_lang/mix/runner/MixRunningStateUtil.java
@@ -243,7 +243,9 @@ public class MixRunningStateUtil {
                         new Notification(
                                 "Mix run configuration",
                                 "Mix settings",
-                                "Mix executable path is " + (isEmpty ? "empty" : "not specified correctly") + "<br><a href='configure'>Configure</a></br>",
+                                "Mix executable path, elixir executable path, or erl executable path is " +
+                                        (isEmpty ? "empty" : "not specified correctly") +
+                                        "<br><a href='configure'>Configure</a></br>",
                                 NotificationType.ERROR,
                                 new ElixirExternalToolsNotificationListener(project)
                         )


### PR DESCRIPTION
Fixes #853

# Test Report
Tested with Rubymine on C-S-D/alembic running `mix test`.

# Changlelog
## Bug Fixes
* Change error to say mix, elixir, or erlang path is not set instead of just mix path.
* Rewrite of `MixRunningStateUtil#setElixir` to support calling `erl` directly in IntelliJ IDEA added a check that sdk type was the Elixir SDK Type, but there was no `else` clauses to handle that there IS an SDK, but its NOT Elixir, which is the common case on all Small IDEs (like Rubymine).  To fill this gap, if the SDK is not Elixir and a Small IDE is detected, then the SDK Home from Preferences > Other Settings > Elixir External Tools > Elixir SDK > Path will be used to get the absolute path to the `elixir` (or `elixir.bat` executable and set it in the `GeneralCommandLine`.

  