### PR TITLE
Wrap runWriteAction in Type in invokeAndWait

### DIFF
--- a/src/org/elixir_lang/sdk/elixir/Type.java
+++ b/src/org/elixir_lang/sdk/elixir/Type.java
@@ -42,6 +42,7 @@ import java.util.*;
 import java.util.function.Function;
 import java.util.regex.Pattern;
 
+import static com.intellij.openapi.application.ModalityState.NON_MODAL;
 import static org.elixir_lang.sdk.HomePath.*;
 import static org.elixir_lang.sdk.ProcessOutput.STANDARD_TIMEOUT;
 import static org.elixir_lang.sdk.ProcessOutput.transformStdoutLine;
@@ -284,7 +285,12 @@ public class Type extends org.elixir_lang.sdk.erlang_dependent.Type {
         final Sdk erlangSdk;
 
         if (projectJdkImpl.getVersionString() != null) {
-            ApplicationManager.getApplication().runWriteAction(() -> projectJdkTable.addJdk(projectJdkImpl));
+            ApplicationManager.getApplication().invokeAndWait(
+                    () -> ApplicationManager.getApplication().runWriteAction(() ->
+                            projectJdkTable.addJdk(projectJdkImpl)
+                    ),
+                    NON_MODAL
+            );
 
             erlangSdk = projectJdkImpl;
         } else {
@@ -336,7 +342,10 @@ public class Type extends org.elixir_lang.sdk.erlang_dependent.Type {
 
         SdkModificator sdkModificator = elixirSdk.getSdkModificator();
         Sdk defaultErlangSdk = configureInternalErlangSdk(elixirSdk, sdkModificator);
-        ApplicationManager.getApplication().runWriteAction(sdkModificator::commitChanges);
+        ApplicationManager.getApplication().invokeAndWait(
+                () -> ApplicationManager.getApplication().runWriteAction(sdkModificator::commitChanges),
+                NON_MODAL
+        );
 
         return defaultErlangSdk;
     }


### PR DESCRIPTION
Fixes #864 

# Test Report
Tested by setting up C-S-D/alembic SDK under 6.0.0, then updated to
master with changes: no errors occurred and credo issues were annotated.

# Changelog
## Bug Fixes
* `Application#runWriteAction` MUST be run from EventDispatch thread.  This is true when run from a Run Configuration runner, but when the Credo annotator runs `runWriteAction`, it's not in an EventDispatch thread, so followed [IntelliJ Platform SDK DevGuide - General Threading Rules](https://www.jetbrains.org/intellij/sdk/docs/basics/architectural_overview/general_threading_rules.html) and wrapped the `runWriteAction` in `Application#invokeAndWait`.

