### PR TITLE
Call withCharSet(Charsets.UTF_8) on all GeneralCommandLines

### DIFF
--- a/src/org/elixir_lang/annotator/Credo.java
+++ b/src/org/elixir_lang/annotator/Credo.java
@@ -1,5 +1,6 @@
 package org.elixir_lang.annotator;
 
+import com.google.common.base.Charsets;
 import com.google.common.base.Joiner;
 import com.intellij.diagnostic.LogMessageEx;
 import com.intellij.execution.ExecutionException;
@@ -140,7 +141,7 @@ public class Credo extends ExternalAnnotator<PsiFile, List<Credo.Issue>> {
 
     @NotNull
     private static GeneralCommandLine generalCommandLine(@NotNull Project project, @NotNull ParametersList mixParametersList) {
-        GeneralCommandLine workingDirectoryGeneralCommandLine = new GeneralCommandLine();
+        GeneralCommandLine workingDirectoryGeneralCommandLine = new GeneralCommandLine().withCharset(Charsets.UTF_8);
 
         String workingDirectory = workingDirectory(project);
         workingDirectoryGeneralCommandLine.withWorkDirectory(workingDirectory);

--- a/src/org/elixir_lang/mix/importWizard/MixProjectRootStep.java
+++ b/src/org/elixir_lang/mix/importWizard/MixProjectRootStep.java
@@ -1,5 +1,6 @@
 package org.elixir_lang.mix.importWizard;
 
+import com.google.common.base.Charsets;
 import com.intellij.execution.ExecutionException;
 import com.intellij.execution.Platform;
 import com.intellij.execution.configurations.GeneralCommandLine;
@@ -83,10 +84,10 @@ public class MixProjectRootStep extends ProjectImportWizardStep {
         GeneralCommandLine generalCommandLine = null;
 
         if (SystemInfo.isWindows) {
-            generalCommandLine = new GeneralCommandLine("where");
+            generalCommandLine = new GeneralCommandLine("where").withCharset(Charsets.UTF_8);
             generalCommandLine.addParameter("mix.bat");
         } else if (SystemInfo.isMac || SystemInfo.isLinux || SystemInfo.isUnix) {
-            generalCommandLine = new GeneralCommandLine("which");
+            generalCommandLine = new GeneralCommandLine("which").withCharset(Charsets.UTF_8);
             generalCommandLine.addParameter("mix");
         }
 
@@ -146,7 +147,7 @@ public class MixProjectRootStep extends ProjectImportWizardStep {
                     public void run(@NotNull final ProgressIndicator indicator) {
                         indicator.setIndeterminate(true);
 
-                        GeneralCommandLine commandLine = new GeneralCommandLine();
+                        GeneralCommandLine commandLine = new GeneralCommandLine().withCharset(Charsets.UTF_8);
                         commandLine.withWorkDirectory(workingDirectory);
                         commandLine.setExePath(elixirPath);
                         commandLine.addParameter(mixPath);

--- a/src/org/elixir_lang/mix/runner/MixRunningStateUtil.java
+++ b/src/org/elixir_lang/mix/runner/MixRunningStateUtil.java
@@ -1,5 +1,6 @@
 package org.elixir_lang.mix.runner;
 
+import com.google.common.base.Charsets;
 import com.intellij.execution.ExecutionException;
 import com.intellij.execution.configurations.GeneralCommandLine;
 import com.intellij.execution.process.ColoredProcessHandler;
@@ -189,7 +190,8 @@ public class MixRunningStateUtil {
 
     @NotNull
     private static GeneralCommandLine getBaseMixCommandLine(@NotNull MixRunConfigurationBase configuration) {
-        GeneralCommandLine commandLine = withEnvironment(new GeneralCommandLine(), configuration);
+        GeneralCommandLine commandLine =
+                withEnvironment(new GeneralCommandLine().withCharset(Charsets.UTF_8), configuration);
 
         return withWorkDirectory(commandLine, configuration);
     }

--- a/src/org/elixir_lang/sdk/ProcessOutput.java
+++ b/src/org/elixir_lang/sdk/ProcessOutput.java
@@ -1,5 +1,6 @@
 package org.elixir_lang.sdk;
 
+import com.google.common.base.Charsets;
 import com.intellij.execution.ExecutionException;
 import com.intellij.execution.configurations.GeneralCommandLine;
 import com.intellij.execution.process.CapturingProcessHandler;
@@ -76,7 +77,7 @@ public class ProcessOutput {
       return new com.intellij.execution.process.ProcessOutput();
     }
 
-    GeneralCommandLine cmd = new GeneralCommandLine();
+    GeneralCommandLine cmd = new GeneralCommandLine().withCharset(Charsets.UTF_8);
     cmd.withWorkDirectory(workDir);
     cmd.setExePath(exePath);
     cmd.addParameters(arguments);

--- a/src/org/elixir_lang/utils/ExtProcessUtil.java
+++ b/src/org/elixir_lang/utils/ExtProcessUtil.java
@@ -16,6 +16,7 @@
 
 package org.elixir_lang.utils;
 
+import com.google.common.base.Charsets;
 import com.intellij.execution.ExecutionException;
 import com.intellij.execution.configurations.GeneralCommandLine;
 import com.intellij.openapi.util.text.StringUtil;
@@ -34,7 +35,7 @@ public final class ExtProcessUtil {
   @NotNull
   public static ExtProcessOutput execAndGetFirstLine(long timeout, @NotNull String... command) {
     try {
-      final Process cmdRunner = new GeneralCommandLine(command).createProcess();
+      final Process cmdRunner = new GeneralCommandLine(command).withCharset(Charsets.UTF_8).createProcess();
       ExecutorService singleTreadExecutor = Executors.newSingleThreadExecutor();
       try {
         Future<ExtProcessOutput> cmdRunnerFuture = singleTreadExecutor.submit(new Callable<ExtProcessOutput>() {


### PR DESCRIPTION
Fixes #896

# Changelog
## Bug Fixes
* Call `withCharSet(Charsets.UTF_8)` on all `GeneralCommandLines` to prevent encoding errors on Windows.