### PR TITLE
Fix parameter/variable checks when in eex files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,7 @@ before_install:
 - java -version
 install:
 - ./gradlew compileTestJava
-script: ./gradlew test
+script: travis_wait ./gradlew test
 before_cache:
 - rm -fr cache/intellij_elixir-0.1.1/rel/intellij_elixir/log
 - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock

--- a/src/org/elixir_lang/annotator/Parameter.java
+++ b/src/org/elixir_lang/annotator/Parameter.java
@@ -139,6 +139,7 @@ public class Parameter {
                 parent instanceof ElixirAccessExpression ||
                 parent instanceof ElixirAssociations ||
                 parent instanceof ElixirAssociationsBase ||
+                parent instanceof ElixirEexTag ||
                 parent instanceof ElixirBitString ||
                 parent instanceof ElixirBracketArguments ||
                 parent instanceof ElixirContainerAssociationOperation ||

--- a/src/org/elixir_lang/annotator/Parameter.java
+++ b/src/org/elixir_lang/annotator/Parameter.java
@@ -139,6 +139,7 @@ public class Parameter {
                 parent instanceof ElixirAccessExpression ||
                 parent instanceof ElixirAssociations ||
                 parent instanceof ElixirAssociationsBase ||
+                parent instanceof ElixirEex ||
                 parent instanceof ElixirEexTag ||
                 parent instanceof ElixirBitString ||
                 parent instanceof ElixirBracketArguments ||

--- a/src/org/elixir_lang/reference/Callable.java
+++ b/src/org/elixir_lang/reference/Callable.java
@@ -280,6 +280,8 @@ public class Callable extends PsiReferenceBase<Call> implements PsiPolyVariantRe
                 ancestor instanceof ElixirBracketArguments ||
                 ancestor instanceof ElixirContainerAssociationOperation ||
                 ancestor instanceof ElixirDoBlock ||
+                ancestor instanceof ElixirEex ||
+                ancestor instanceof ElixirEexTag ||
                 ancestor instanceof ElixirKeywordPair ||
                 ancestor instanceof ElixirKeywords ||
                 ancestor instanceof ElixirList ||


### PR DESCRIPTION
Fixes #929

# Changelog
## Bug Fixes
* Look at parent of `eexTag` to resolve `fn` parameters
* Ensure functions `fn` in `eex` tags don't error by looking at `eex` element parent.
* Search above `eexTag` and `eex` to determine if variable.