### PR TITLE
LevelPropertyPusher

### DIFF
--- a/gen/org/elixir_lang/parser/ElixirParser.java
+++ b/gen/org/elixir_lang/parser/ElixirParser.java
@@ -10,6 +10,9 @@ import com.intellij.psi.tree.IElementType;
 import com.intellij.psi.tree.TokenSet;
 
 import static org.elixir_lang.grammar.parser.GeneratedParserUtilBase.*;
+import static org.elixir_lang.Level.V_1_5;
+import static org.elixir_lang.parser.ExternalRules.Operator.GE;
+import static org.elixir_lang.parser.ExternalRules.Operator.LT;
 import static org.elixir_lang.parser.ExternalRules.ifVersion;
 import static org.elixir_lang.psi.ElixirTypes.*;
 
@@ -896,12 +899,12 @@ public class ElixirParser implements PsiParser, LightPsiParser {
   }
 
   /* ********************************************************** */
-  // <<ifVersion "LT" "1.5">> atPrefixOperator numeric
+  // <<ifVersion 'LT' 'V_1_5'>> atPrefixOperator numeric
   public static boolean atNumericOperation(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "atNumericOperation")) return false;
     boolean r;
     Marker m = enter_section_(b, l, _NONE_, AT_NUMERIC_OPERATION, "<at numeric operation>");
-    r = ifVersion(b, l + 1, "LT", "1.5");
+    r = ifVersion(b, l + 1, LT, V_1_5);
     r = r && atPrefixOperator(b, l + 1);
     r = r && numeric(b, l + 1);
     exit_section_(b, l, m, r, false, null);
@@ -4838,12 +4841,12 @@ public class ElixirParser implements PsiParser, LightPsiParser {
   }
 
   /* ********************************************************** */
-  // <<ifVersion "LT" "1.5">> unaryPrefixOperator numeric
+  // <<ifVersion 'LT' 'V_1_5'>> unaryPrefixOperator numeric
   public static boolean unaryNumericOperation(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "unaryNumericOperation")) return false;
     boolean r;
     Marker m = enter_section_(b, l, _NONE_, UNARY_NUMERIC_OPERATION, "<unary numeric operation>");
-    r = ifVersion(b, l + 1, "LT", "1.5");
+    r = ifVersion(b, l + 1, LT, V_1_5);
     r = r && unaryPrefixOperator(b, l + 1);
     r = r && numeric(b, l + 1);
     exit_section_(b, l, m, r, false, null);
@@ -5212,12 +5215,12 @@ public class ElixirParser implements PsiParser, LightPsiParser {
     return r;
   }
 
-  // <<ifVersion "GE" "1.5.0">> notInfixOperator inInfixOperator
+  // <<ifVersion 'GE' 'V_1_5'>> notInfixOperator inInfixOperator
   private static boolean matchedNotInOperation_0(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "matchedNotInOperation_0")) return false;
     boolean r;
     Marker m = enter_section_(b);
-    r = ifVersion(b, l + 1, "GE", "1.5.0");
+    r = ifVersion(b, l + 1, GE, V_1_5);
     r = r && notInfixOperator(b, l + 1);
     r = r && inInfixOperator(b, l + 1);
     exit_section_(b, m, null, r);
@@ -5235,12 +5238,12 @@ public class ElixirParser implements PsiParser, LightPsiParser {
     return r || p;
   }
 
-  // <<ifVersion "LT" "1.5.0">> unaryPrefixOperator nonNumeric
+  // <<ifVersion 'LT' 'V_1_5'>> unaryPrefixOperator nonNumeric
   private static boolean matchedUnaryNonNumericOperation_0(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "matchedUnaryNonNumericOperation_0")) return false;
     boolean r;
     Marker m = enter_section_(b);
-    r = ifVersion(b, l + 1, "LT", "1.5.0");
+    r = ifVersion(b, l + 1, LT, V_1_5);
     r = r && unaryPrefixOperator(b, l + 1);
     r = r && nonNumeric(b, l + 1);
     exit_section_(b, m, null, r);
@@ -5258,12 +5261,12 @@ public class ElixirParser implements PsiParser, LightPsiParser {
     return r || p;
   }
 
-  // <<ifVersion "GE" "1.5.0" >> unaryPrefixOperator
+  // <<ifVersion 'GE' 'V_1_5'>> unaryPrefixOperator
   private static boolean matchedUnaryOperation_0(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "matchedUnaryOperation_0")) return false;
     boolean r;
     Marker m = enter_section_(b);
-    r = ifVersion(b, l + 1, "GE", "1.5.0");
+    r = ifVersion(b, l + 1, GE, V_1_5);
     r = r && unaryPrefixOperator(b, l + 1);
     exit_section_(b, m, null, r);
     return r;
@@ -5324,12 +5327,12 @@ public class ElixirParser implements PsiParser, LightPsiParser {
     return r;
   }
 
-  // <<ifVersion "GE" "1.5.0">> atPrefixOperator numeric bracketArguments
+  // <<ifVersion 'GE' 'V_1_5'>> atPrefixOperator numeric bracketArguments
   public static boolean matchedAtNumericBracketOperation(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "matchedAtNumericBracketOperation")) return false;
     boolean r;
     Marker m = enter_section_(b, l, _NONE_, MATCHED_AT_NUMERIC_BRACKET_OPERATION, "<matched at numeric bracket operation>");
-    r = ifVersion(b, l + 1, "GE", "1.5.0");
+    r = ifVersion(b, l + 1, GE, V_1_5);
     r = r && atPrefixOperator(b, l + 1);
     r = r && numeric(b, l + 1);
     r = r && bracketArguments(b, l + 1);
@@ -5430,12 +5433,12 @@ public class ElixirParser implements PsiParser, LightPsiParser {
     return r || p;
   }
 
-  // <<ifVersion "LT" "1.5.0">> atPrefixOperator nonNumeric
+  // <<ifVersion 'LT' 'V_1_5'>> atPrefixOperator nonNumeric
   private static boolean matchedAtNonNumericOperation_0(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "matchedAtNonNumericOperation_0")) return false;
     boolean r;
     Marker m = enter_section_(b);
-    r = ifVersion(b, l + 1, "LT", "1.5.0");
+    r = ifVersion(b, l + 1, LT, V_1_5);
     r = r && atPrefixOperator(b, l + 1);
     r = r && nonNumeric(b, l + 1);
     exit_section_(b, m, null, r);
@@ -5453,12 +5456,12 @@ public class ElixirParser implements PsiParser, LightPsiParser {
     return r || p;
   }
 
-  // <<ifVersion "GE" "1.5.0">> atPrefixOperator
+  // <<ifVersion 'GE' 'V_1_5'>> atPrefixOperator
   private static boolean matchedAtOperation_0(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "matchedAtOperation_0")) return false;
     boolean r;
     Marker m = enter_section_(b);
-    r = ifVersion(b, l + 1, "GE", "1.5.0");
+    r = ifVersion(b, l + 1, GE, V_1_5);
     r = r && atPrefixOperator(b, l + 1);
     exit_section_(b, m, null, r);
     return r;
@@ -5723,12 +5726,12 @@ public class ElixirParser implements PsiParser, LightPsiParser {
     return r;
   }
 
-  // <<ifVersion "GE" "1.5.0">> notInfixOperator inInfixOperator
+  // <<ifVersion 'GE' 'V_1_5'>> notInfixOperator inInfixOperator
   private static boolean unmatchedNotInOperation_0(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "unmatchedNotInOperation_0")) return false;
     boolean r;
     Marker m = enter_section_(b);
-    r = ifVersion(b, l + 1, "GE", "1.5.0");
+    r = ifVersion(b, l + 1, GE, V_1_5);
     r = r && notInfixOperator(b, l + 1);
     r = r && inInfixOperator(b, l + 1);
     exit_section_(b, m, null, r);
@@ -5746,12 +5749,12 @@ public class ElixirParser implements PsiParser, LightPsiParser {
     return r || p;
   }
 
-  // <<ifVersion "LT" "1.5.0">> unaryPrefixOperator nonNumeric
+  // <<ifVersion 'LT' 'V_1_5'>> unaryPrefixOperator nonNumeric
   private static boolean unmatchedUnaryNonNumericOperation_0(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "unmatchedUnaryNonNumericOperation_0")) return false;
     boolean r;
     Marker m = enter_section_(b);
-    r = ifVersion(b, l + 1, "LT", "1.5.0");
+    r = ifVersion(b, l + 1, LT, V_1_5);
     r = r && unaryPrefixOperator(b, l + 1);
     r = r && nonNumeric(b, l + 1);
     exit_section_(b, m, null, r);
@@ -5769,12 +5772,12 @@ public class ElixirParser implements PsiParser, LightPsiParser {
     return r || p;
   }
 
-  // <<ifVersion "GE" "1.5.0">> unaryPrefixOperator
+  // <<ifVersion 'GE' 'V_1_5'>> unaryPrefixOperator
   private static boolean unmatchedUnaryOperation_0(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "unmatchedUnaryOperation_0")) return false;
     boolean r;
     Marker m = enter_section_(b);
-    r = ifVersion(b, l + 1, "GE", "1.5.0");
+    r = ifVersion(b, l + 1, GE, V_1_5);
     r = r && unaryPrefixOperator(b, l + 1);
     exit_section_(b, m, null, r);
     return r;
@@ -5839,12 +5842,12 @@ public class ElixirParser implements PsiParser, LightPsiParser {
     return r;
   }
 
-  // <<ifVersion "GE" "1.5.0">> atPrefixOperator numeric bracketArguments
+  // <<ifVersion 'GE' 'V_1_5'>> atPrefixOperator numeric bracketArguments
   public static boolean unmatchedAtNumericBracketOperation(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "unmatchedAtNumericBracketOperation")) return false;
     boolean r;
     Marker m = enter_section_(b, l, _NONE_, UNMATCHED_AT_NUMERIC_BRACKET_OPERATION, "<unmatched at numeric bracket operation>");
-    r = ifVersion(b, l + 1, "GE", "1.5.0");
+    r = ifVersion(b, l + 1, GE, V_1_5);
     r = r && atPrefixOperator(b, l + 1);
     r = r && numeric(b, l + 1);
     r = r && bracketArguments(b, l + 1);
@@ -5947,12 +5950,12 @@ public class ElixirParser implements PsiParser, LightPsiParser {
     return r || p;
   }
 
-  // <<ifVersion "LT" "1.5.0">> atPrefixOperator nonNumeric
+  // <<ifVersion 'LT' 'V_1_5'>> atPrefixOperator nonNumeric
   private static boolean unmatchedAtNonNumericOperation_0(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "unmatchedAtNonNumericOperation_0")) return false;
     boolean r;
     Marker m = enter_section_(b);
-    r = ifVersion(b, l + 1, "LT", "1.5.0");
+    r = ifVersion(b, l + 1, LT, V_1_5);
     r = r && atPrefixOperator(b, l + 1);
     r = r && nonNumeric(b, l + 1);
     exit_section_(b, m, null, r);
@@ -5970,12 +5973,12 @@ public class ElixirParser implements PsiParser, LightPsiParser {
     return r || p;
   }
 
-  // <<ifVersion "GE" "1.5.0">> atPrefixOperator
+  // <<ifVersion 'GE' 'V_1_5'>> atPrefixOperator
   private static boolean unmatchedAtOperation_0(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "unmatchedAtOperation_0")) return false;
     boolean r;
     Marker m = enter_section_(b);
-    r = ifVersion(b, l + 1, "GE", "1.5.0");
+    r = ifVersion(b, l + 1, GE, V_1_5);
     r = r && atPrefixOperator(b, l + 1);
     exit_section_(b, m, null, r);
     return r;

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -46,6 +46,7 @@
 
     <colorSettingsPage implementation="org.elixir_lang.ElixirColorSettingsPage"/>
     <fileTypeFactory implementation="org.elixir_lang.ElixirFileTypeFactory"/>
+    <filePropertyPusher implementation="org.elixir_lang.file.LevelPropertyPusher"/>
 
     <!-- for template -->
     <internalFileTemplate name="Elixir Module"/>

--- a/src/org/elixir_lang/Elixir.bnf
+++ b/src/org/elixir_lang/Elixir.bnf
@@ -1,7 +1,9 @@
 {
   parserClass="org.elixir_lang.parser.ElixirParser"
   parserImports=[
+    "static org.elixir_lang.Level.*"
     "static org.elixir_lang.parser.ExternalRules.*"
+    "static org.elixir_lang.parser.ExternalRules.Operator.*"
   ]
 
   extends="com.intellij.extapi.psi.ASTWrapperPsiElement"
@@ -1424,7 +1426,7 @@ notInfixOperator ::= NOT_OPERATOR
                        ]
                        name = "not"
                      }
-matchedNotInOperation ::= matchedExpression <<ifVersion "GE" "1.5.0">> notInfixOperator inInfixOperator matchedExpression
+matchedNotInOperation ::= matchedExpression <<ifVersion 'GE' 'V_1_5'>> notInfixOperator inInfixOperator matchedExpression
 
 /*
  * Three Operation - left-associative
@@ -1526,13 +1528,13 @@ unaryPrefixOperator ::= (significantWhiteSpaceMaybe DUAL_OPERATOR | SIGN_OPERATO
  *
  */
 
-matchedUnaryNonNumericOperation ::= <<ifVersion "LT" "1.5.0">> unaryPrefixOperator nonNumeric matchedExpression
+matchedUnaryNonNumericOperation ::= <<ifVersion 'LT' 'V_1_5'>> unaryPrefixOperator nonNumeric matchedExpression
 
 /*
  * Unary Operation - non-associative (Elixir >= 1.5.0)
  */
 
-matchedUnaryOperation ::= <<ifVersion "GE" "1.5.0" >> unaryPrefixOperator matchedExpression
+matchedUnaryOperation ::= <<ifVersion 'GE' 'V_1_5'>> unaryPrefixOperator matchedExpression
 
 /*
  * Dot Operations
@@ -1872,7 +1874,7 @@ matchedAtUnqualifiedBracketOperation ::= atPrefixOperator IDENTIFIER_TOKEN CALL 
  * Needed so that At consumes numeric, but brackets consume both of them.
  */
 
-matchedAtNumericBracketOperation ::= <<ifVersion "GE" "1.5.0">> atPrefixOperator numeric bracketArguments
+matchedAtNumericBracketOperation ::= <<ifVersion 'GE' 'V_1_5'>> atPrefixOperator numeric bracketArguments
                                      { implements = "org.elixir_lang.psi.AtNumericBracketOperation" methods = [quote] }
 
 /*
@@ -1909,13 +1911,13 @@ atPrefixOperator ::= AT_OPERATOR
  * @see https://github.com/elixir-lang/elixir/blob/de39bbaca277002797e52ffbde617ace06233a2b/lib/elixir/src/elixir_tokenizer.erl#L574-L578
  */
 
-matchedAtNonNumericOperation ::= <<ifVersion "LT" "1.5.0">> atPrefixOperator nonNumeric matchedExpression
+matchedAtNonNumericOperation ::= <<ifVersion 'LT' 'V_1_5'>> atPrefixOperator nonNumeric matchedExpression
 
 /*
  * At Operation - non-associative (Elixir >= 1.5.0)
  */
 
-matchedAtOperation ::= <<ifVersion "GE" "1.5.0">> atPrefixOperator matchedExpression
+matchedAtOperation ::= <<ifVersion 'GE' 'V_1_5'>> atPrefixOperator matchedExpression
 
 /*
  * Unqualified Bracket Operation
@@ -1953,9 +1955,9 @@ matchedAccessExpression ::= accessExpression
  *
  */
 
-atNumericOperation ::= <<ifVersion "LT" "1.5">> atPrefixOperator numeric
+atNumericOperation ::= <<ifVersion 'LT' 'V_1_5'>> atPrefixOperator numeric
 captureNumericOperation ::= capturePrefixOperator numeric
-unaryNumericOperation ::= <<ifVersion "LT" "1.5">> unaryPrefixOperator numeric
+unaryNumericOperation ::= <<ifVersion 'LT' 'V_1_5'>> unaryPrefixOperator numeric
 
 /*
  *
@@ -2438,7 +2440,7 @@ unmatchedArrowOperation ::= unmatchedExpression arrowInfixOperator unmatchedExpr
 // methods defined by "infix operations" section above
 unmatchedInOperation ::= unmatchedExpression inInfixOperator unmatchedExpression
 
-unmatchedNotInOperation ::= unmatchedExpression <<ifVersion "GE" "1.5.0">> notInfixOperator inInfixOperator unmatchedExpression
+unmatchedNotInOperation ::= unmatchedExpression <<ifVersion 'GE' 'V_1_5'>> notInfixOperator inInfixOperator unmatchedExpression
 
 /*
  * Three Operation - left-associative
@@ -2485,13 +2487,13 @@ unmatchedMultiplicationOperation ::= unmatchedExpression multiplicationInfixOper
  *
  */
 
-unmatchedUnaryNonNumericOperation ::= <<ifVersion "LT" "1.5.0">> unaryPrefixOperator nonNumeric unmatchedExpression
+unmatchedUnaryNonNumericOperation ::= <<ifVersion 'LT' 'V_1_5'>> unaryPrefixOperator nonNumeric unmatchedExpression
 
 /*
  * Unary Operation - non-associative (Elixir >= 1.5.0)
  */
 
-unmatchedUnaryOperation ::= <<ifVersion "GE" "1.5.0">> unaryPrefixOperator unmatchedExpression
+unmatchedUnaryOperation ::= <<ifVersion 'GE' 'V_1_5'>> unaryPrefixOperator unmatchedExpression
 
 /*
  * Dot Operations
@@ -2677,7 +2679,7 @@ unmatchedAtUnqualifiedBracketOperation ::= atPrefixOperator IDENTIFIER_TOKEN CAL
  * Needed so that At consumes numeric, but brackets consume both of them.
  */
 
-unmatchedAtNumericBracketOperation ::= <<ifVersion "GE" "1.5.0">> atPrefixOperator numeric bracketArguments
+unmatchedAtNumericBracketOperation ::= <<ifVersion 'GE' 'V_1_5'>> atPrefixOperator numeric bracketArguments
                                        { implements = "org.elixir_lang.psi.AtNumericBracketOperation" methods = [quote] }
 
 
@@ -2702,7 +2704,7 @@ unmatchedUnqualifiedParenthesesCall ::= identifier matchedParenthesesArguments d
  * @see https://github.com/elixir-lang/elixir/blob/de39bbaca277002797e52ffbde617ace06233a2b/lib/elixir/src/elixir_tokenizer.erl#L574-L578
  */
 
-unmatchedAtNonNumericOperation ::= <<ifVersion "LT" "1.5.0">> atPrefixOperator nonNumeric unmatchedExpression
+unmatchedAtNonNumericOperation ::= <<ifVersion 'LT' 'V_1_5'>> atPrefixOperator nonNumeric unmatchedExpression
 
 /*
  * At Operation - non-associative (Elixir >= 1.5.0)
@@ -2712,7 +2714,7 @@ unmatchedAtNonNumericOperation ::= <<ifVersion "LT" "1.5.0">> atPrefixOperator n
  * @see https://github.com/elixir-lang/elixir/blob/de39bbaca277002797e52ffbde617ace06233a2b/lib/elixir/src/elixir_tokenizer.erl#L574-L578
  */
 
-unmatchedAtOperation ::= <<ifVersion "GE" "1.5.0">> atPrefixOperator unmatchedExpression
+unmatchedAtOperation ::= <<ifVersion 'GE' 'V_1_5'>> atPrefixOperator unmatchedExpression
 
 /*
  * Unqualified Bracket Operation

--- a/src/org/elixir_lang/Level.java
+++ b/src/org/elixir_lang/Level.java
@@ -11,12 +11,12 @@ import java.util.Map;
 import java.util.Optional;
 
 public enum Level {
-    V_1_1(1, 1, false, "to_char_list", false),
-    V_1_2(1, 2, true, "to_char_list", false),
-    V_1_3(1, 3, true, "to_charlist", false),
-    V_1_4(1, 4, true, "to_charlist", true),
-    V_1_5(1, 5, true, "to_charlist", true),
-    V_1_6(1, 6, true, "to_charlist", true);
+    V_1_1(1, 1, true, false, "to_char_list", false),
+    V_1_2(1, 2, true, true, "to_char_list", false),
+    V_1_3(1, 3, false, true, "to_charlist", false),
+    V_1_4(1, 4, false, true, "to_charlist", true),
+    V_1_5(1, 5, false, true, "to_charlist", true),
+    V_1_6(1, 6, false, true, "to_charlist", true);
 
     public static final Key<Level> KEY = new Key<>("elixir.level");
 
@@ -45,16 +45,19 @@ public enum Level {
 
     private final int major;
     private final int minor;
+    public final boolean supportsOpenHexadecimalEscapeSequence;
     public final boolean supportsMultipleAliases;
     public final String quoteBinaryFunctionIdentifier;
     public final boolean supportsMixTestFormatterFlag;
 
     Level(int major, int minor,
+          boolean supportsOpenHexadecimalEscapeSequence,
           boolean supportsMultipleAliases,
           @NotNull String quoteBinaryFunctionIdentifier,
           boolean supportsMixTestFormatterFlag) {
         this.major = major;
         this.minor = minor;
+        this.supportsOpenHexadecimalEscapeSequence = supportsOpenHexadecimalEscapeSequence;
         this.supportsMultipleAliases = supportsMultipleAliases;
         this.quoteBinaryFunctionIdentifier = quoteBinaryFunctionIdentifier;
         this.supportsMixTestFormatterFlag = supportsMixTestFormatterFlag;

--- a/src/org/elixir_lang/Level.java
+++ b/src/org/elixir_lang/Level.java
@@ -11,10 +11,12 @@ import java.util.Map;
 import java.util.Optional;
 
 public enum Level {
-    V_1_3(1, 3, false),
-    V_1_4(1, 4, true),
-    V_1_5(1, 5, true),
-    V_1_6(1, 6, true);
+    V_1_1(1, 1, false, "to_char_list", false),
+    V_1_2(1, 2, true, "to_char_list", false),
+    V_1_3(1, 3, true, "to_charlist", false),
+    V_1_4(1, 4, true, "to_charlist", true),
+    V_1_5(1, 5, true, "to_charlist", true),
+    V_1_6(1, 6, true, "to_charlist", true);
 
     public static final Key<Level> KEY = new Key<>("elixir.level");
 
@@ -43,11 +45,18 @@ public enum Level {
 
     private final int major;
     private final int minor;
+    public final boolean supportsMultipleAliases;
+    public final String quoteBinaryFunctionIdentifier;
     public final boolean supportsMixTestFormatterFlag;
 
-    Level(int major, int minor, boolean supportsMixTestFormatterFlag) {
+    Level(int major, int minor,
+          boolean supportsMultipleAliases,
+          @NotNull String quoteBinaryFunctionIdentifier,
+          boolean supportsMixTestFormatterFlag) {
         this.major = major;
         this.minor = minor;
+        this.supportsMultipleAliases = supportsMultipleAliases;
+        this.quoteBinaryFunctionIdentifier = quoteBinaryFunctionIdentifier;
         this.supportsMixTestFormatterFlag = supportsMixTestFormatterFlag;
     }
 

--- a/src/org/elixir_lang/Level.java
+++ b/src/org/elixir_lang/Level.java
@@ -43,7 +43,7 @@ public enum Level {
 
     private final int major;
     private final int minor;
-    private final boolean supportsMixTestFormatterFlag;
+    public final boolean supportsMixTestFormatterFlag;
 
     Level(int major, int minor, boolean supportsMixTestFormatterFlag) {
         this.major = major;

--- a/src/org/elixir_lang/Level.java
+++ b/src/org/elixir_lang/Level.java
@@ -1,0 +1,149 @@
+package org.elixir_lang;
+
+import com.intellij.openapi.util.Key;
+import gnu.trove.THashMap;
+import org.apache.commons.lang.math.IntRange;
+import org.elixir_lang.sdk.elixir.Release;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Map;
+import java.util.Optional;
+
+public enum Level {
+    V_1_3(1, 3, false),
+    V_1_4(1, 4, true),
+    V_1_5(1, 5, true),
+    V_1_6(1, 6, true);
+
+    public static final Key<Level> KEY = new Key<>("elixir.level");
+
+    private static final Map<Integer, Map<Integer, Level>> VALUE_BY_MINOR_BY_MAJOR = new THashMap<>();
+    private static final Map<Integer, IntRange>  MINOR_RANGE_BY_MAJOR = new THashMap<>();
+    private static final int MAJOR_MINIMUM;
+    private static final int MAJOR_MAXIMUM;
+    private static final Level MINIMUM;
+    public static final Level MAXIMUM;
+
+    static {
+        Level[] values = values();
+
+        MINIMUM = values[0];
+        MAXIMUM = values[values.length - 1];
+        MAJOR_MINIMUM = MINIMUM.major;
+        MAJOR_MAXIMUM = MAXIMUM.major;
+
+        for (Level value : values) {
+            int major = value.major;
+
+            MINOR_RANGE_BY_MAJOR.compute(major, (key, minorRange) -> expand(minorRange, value.minor));
+            VALUE_BY_MINOR_BY_MAJOR.computeIfAbsent(major, key -> new THashMap<>()).put(value.minor, value);
+        }
+    }
+
+    private final int major;
+    private final int minor;
+    private final boolean supportsMixTestFormatterFlag;
+
+    Level(int major, int minor, boolean supportsMixTestFormatterFlag) {
+        this.major = major;
+        this.minor = minor;
+        this.supportsMixTestFormatterFlag = supportsMixTestFormatterFlag;
+    }
+
+    @NotNull
+    private static IntRange expand(@Nullable IntRange range, int value) {
+        IntRange expandedRange;
+
+        if (range != null) {
+            int minorMinimum = range.getMinimumInteger();
+            int minorMaximum = range.getMaximumInteger();
+
+            if (value < minorMinimum) {
+                expandedRange = new IntRange(value, minorMaximum);
+            } else if (minorMaximum < value) {
+                expandedRange = new IntRange(minorMinimum, value);
+            } else {
+                expandedRange = range;
+            }
+        } else {
+            expandedRange = new IntRange(value, value);
+        }
+
+        return expandedRange;
+    }
+
+    @NotNull
+    private static Optional<Integer> releaseToMajor(@NotNull Release release) {
+        Optional<Integer> major;
+
+        try {
+            major = Optional.of(Integer.parseUnsignedInt(release.major));
+        } catch (NumberFormatException numberFormatException) {
+            major = Optional.empty();
+        }
+
+        return major;
+    }
+
+    @NotNull
+    public static Level fromRelease(@NotNull Release release) {
+        Level level;
+
+        Optional<Integer> optionalMajor = releaseToMajor(release);
+
+        if (optionalMajor.isPresent()) {
+            int major = optionalMajor.get();
+
+            if (major < MAJOR_MINIMUM) {
+                level = MINIMUM;
+            } else if (major > MAJOR_MAXIMUM) {
+                level = MAXIMUM;
+            } else {
+                @NotNull IntRange minorRange = MINOR_RANGE_BY_MAJOR.get(major);
+                int minorMinimum = minorRange.getMinimumInteger();
+                int minorMaximum = minorRange.getMaximumInteger();
+
+                Optional<Integer> optionalMinor = releaseToMinor(release);
+
+                if (optionalMinor.isPresent()) {
+                    int minor = optionalMinor.get();
+
+                    if (minor < minorMinimum) {
+                        level = VALUE_BY_MINOR_BY_MAJOR.get(major).get(minorMinimum);
+                    } else if (minor > minorMaximum) {
+                        level = VALUE_BY_MINOR_BY_MAJOR.get(major).get(minorMaximum);
+                    } else {
+                        level = VALUE_BY_MINOR_BY_MAJOR.get(major).get(minor);
+                    }
+                } else {
+                    level = VALUE_BY_MINOR_BY_MAJOR.get(major).get(minorMaximum);
+                }
+
+
+            }
+        } else {
+            level = MAXIMUM;
+        }
+
+        return level;
+    }
+
+    @NotNull
+    private static Optional<Integer> releaseToMinor(@NotNull Release release) {
+        Optional<Integer> minor;
+        @Nullable String releaseMinor = release.minor;
+
+        if (releaseMinor != null) {
+            try {
+                minor = Optional.of(Integer.parseUnsignedInt(release.minor));
+            } catch (NumberFormatException numberFormatException) {
+                minor = Optional.empty();
+            }
+        } else {
+            minor = Optional.empty();
+        }
+
+        return minor;
+    }
+}

--- a/src/org/elixir_lang/eex/element_type/EmbeddedElixir.java
+++ b/src/org/elixir_lang/eex/element_type/EmbeddedElixir.java
@@ -6,6 +6,8 @@ import com.intellij.psi.*;
 import com.intellij.psi.tree.IFileElementType;
 import org.elixir_lang.ElixirLanguage;
 
+import static org.elixir_lang.file.LevelPropertyPusher.VIRTUAL_FILE;
+
 /**
  * Both Elixir and enough of the EEx tags and {@link org.elixir_lang.eex.psi.Types#DATA}, so that Elixir parses
  * correctly, such as separating {@link org.elixir_lang.eex.psi.Types#ELIXIR} inside {@code <%= %>} tags, so that the
@@ -33,6 +35,7 @@ public class EmbeddedElixir extends IFileElementType {
                 chameleon.getChars()
         );
         PsiParser parser = LanguageParserDefinitions.INSTANCE.forLanguage(languageForParser).createParser(project);
+        builder.putUserData(VIRTUAL_FILE, psi.getContainingFile().getVirtualFile());
         ASTNode node = parser.parse(this, builder);
         return node.getFirstChildNode();
     }

--- a/src/org/elixir_lang/exunit/ElixirModules.java
+++ b/src/org/elixir_lang/exunit/ElixirModules.java
@@ -1,14 +1,15 @@
 package org.elixir_lang.exunit;
 
+import org.elixir_lang.Level;
 import org.elixir_lang.jps.builder.ParametersList;
-import org.elixir_lang.sdk.elixir.Release;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+
+import static org.elixir_lang.Level.V_1_4;
 
 public class ElixirModules {
     private static final String BASE_PATH = "exunit";
@@ -26,11 +27,10 @@ public class ElixirModules {
     }
 
     private static void addFormatterPath(@NotNull List<String> relativeSourcePathList,
-                                         @Nullable Release elixirSdkRelease) {
-
+                                         @NotNull Level level) {
         String versionDirectory = "1.4.0";
 
-        if (elixirSdkRelease != null && elixirSdkRelease.compareTo(Release.V_1_4) < 0) {
+        if (level.compareTo(V_1_4) < 0) {
             versionDirectory = "1.1.0";
         }
 
@@ -40,21 +40,20 @@ public class ElixirModules {
     }
 
     @NotNull
-    private static List<File> copy(@Nullable Release elixirSdkRelease, boolean useCustomMixTask) throws IOException {
-        return org.elixir_lang.ElixirModules.copy(BASE_PATH, relativeSourcePathList(elixirSdkRelease, useCustomMixTask));
+    private static List<File> copy(@NotNull Level level, boolean useCustomMixTask) throws IOException {
+        return org.elixir_lang.ElixirModules.copy(BASE_PATH, relativeSourcePathList(level, useCustomMixTask));
     }
 
     @NotNull
-    public static ParametersList parametersList(@Nullable Release elixirSdkRelease,
-                                                boolean useCustomMixTask) throws IOException {
-        return org.elixir_lang.ElixirModules.parametersList(copy(elixirSdkRelease, useCustomMixTask));
+    public static ParametersList parametersList(@NotNull Level level, boolean useCustomMixTask) throws IOException {
+        return org.elixir_lang.ElixirModules.parametersList(copy(level, useCustomMixTask));
     }
 
-    private static List<String> relativeSourcePathList(@Nullable Release elixirSdkRelease, boolean useCustomMixTask) {
+    private static List<String> relativeSourcePathList(@NotNull Level level, boolean useCustomMixTask) {
         List<String> relativeSourcePathList = new ArrayList<>();
         relativeSourcePathList.add(FORMATTING_FILE_NAME);
 
-        addFormatterPath(relativeSourcePathList, elixirSdkRelease);
+        addFormatterPath(relativeSourcePathList, level);
         addCustomMixTask(relativeSourcePathList, useCustomMixTask);
 
         return relativeSourcePathList;

--- a/src/org/elixir_lang/file/LevelPropertyPusher.java
+++ b/src/org/elixir_lang/file/LevelPropertyPusher.java
@@ -160,7 +160,7 @@ public class LevelPropertyPusher implements FilePropertyPusher<Level> {
 
     @NotNull
     @Contract(pure = true)
-    private static Level level(@NotNull Sdk sdk) {
+    public static Level level(@Nullable Sdk sdk) {
         Release release = Type.getRelease(sdk);
         Level level;
 

--- a/src/org/elixir_lang/file/LevelPropertyPusher.java
+++ b/src/org/elixir_lang/file/LevelPropertyPusher.java
@@ -1,0 +1,498 @@
+package org.elixir_lang.file;
+
+import com.intellij.ProjectTopics;
+import com.intellij.diagnostic.PerformanceWatcher;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.application.ReadAction;
+import com.intellij.openapi.fileTypes.FileTypeManager;
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.module.ModuleManager;
+import com.intellij.openapi.module.ModuleType;
+import com.intellij.openapi.module.ModuleUtilCore;
+import com.intellij.openapi.progress.ProgressIndicator;
+import com.intellij.openapi.project.DumbModeTask;
+import com.intellij.openapi.project.DumbService;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.projectRoots.Sdk;
+import com.intellij.openapi.roots.ModuleRootEvent;
+import com.intellij.openapi.roots.ModuleRootListener;
+import com.intellij.openapi.roots.ModuleRootManager;
+import com.intellij.openapi.roots.OrderRootType;
+import com.intellij.openapi.roots.impl.FilePropertyPusher;
+import com.intellij.openapi.roots.impl.PushedFilePropertiesUpdater;
+import com.intellij.openapi.roots.impl.PushedFilePropertiesUpdaterImpl;
+import com.intellij.openapi.util.Key;
+import com.intellij.openapi.vfs.LocalFileSystem;
+import com.intellij.openapi.vfs.VfsUtilCore;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.openapi.vfs.VirtualFileVisitor;
+import com.intellij.openapi.vfs.newvfs.FileAttribute;
+import com.intellij.util.FileContentUtil;
+import com.intellij.util.io.DataInputOutputUtil;
+import com.intellij.util.messages.MessageBus;
+import one.util.streamex.StreamEx;
+import org.apache.commons.lang.StringUtils;
+import org.elixir_lang.Level;
+import org.elixir_lang.module.ElixirModuleType;
+import org.elixir_lang.sdk.ProcessOutput;
+import org.elixir_lang.sdk.elixir.ForSmallIdes;
+import org.elixir_lang.sdk.elixir.Release;
+import org.elixir_lang.sdk.elixir.Type;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.lang.ref.WeakReference;
+import java.util.*;
+import java.util.stream.Collectors;
+
+import static org.elixir_lang.Level.KEY;
+import static org.elixir_lang.Level.MAXIMUM;
+
+public class LevelPropertyPusher implements FilePropertyPusher<Level> {
+    private static final Key<Level> LEVEL = Key.create("ELIXIR_LEVEL");
+    public static final Key<VirtualFile> VIRTUAL_FILE = Key.create("VIRTUAL_FILE");
+    private static final FileAttribute PERSISTENCE = new FileAttribute("elixir_level_persistence", 1, true);
+    // For rich IDEs
+    private final Map<Module, Sdk> sdkByModule = new WeakHashMap<>();
+    // For small IDEs
+    private WeakReference<String> sdkHome = new WeakReference<>(null);
+
+    private static void putLevel(@NotNull Project project) {
+        project.putUserData(LEVEL, level(project));
+    }
+
+    @NotNull
+    private static Level level(@NotNull Module module) {
+        Level level;
+
+        if (ProcessOutput.isSmallIde()) {
+            level = smallIDELevel(module.getProject());
+        } else {
+            Sdk sdk = ModuleRootManager.getInstance(module).getSdk();
+
+            if (sdk != null) {
+                level = level(sdk);
+            } else {
+                level = MAXIMUM;
+            }
+        }
+
+        return level;
+    }
+
+    @NotNull
+    public static Level level(@NotNull Project project, @Nullable VirtualFile virtualFile) {
+        Level level;
+
+        if (virtualFile == null) {
+            level = level(project);
+        } else {
+            Module module = ModuleUtilCore.findModuleForFile(virtualFile, project);
+
+            if (module != null) {
+                level = level(module);
+            } else {
+                level = level(project);
+            }
+        }
+
+        return level;
+    }
+
+    @NotNull
+    private static Level level(@NotNull Project project) {
+        Level level;
+
+        if (ProcessOutput.isSmallIde()) {
+            level = smallIDELevel(project);
+        } else {
+            level = richIDELevel(project);
+        }
+
+        return level;
+    }
+
+    @NotNull
+    private static Level smallIDELevel(@NotNull Project project) {
+        Release release = Type.getReleaseForSmallIde(project);
+        Level level;
+
+        if (release != null) {
+            level = release.level();
+        } else {
+            level = MAXIMUM;
+        }
+
+        return level;
+    }
+
+    @NotNull
+    private static Level richIDELevel(@NotNull Project project) {
+        final ModuleManager moduleManager = ModuleManager.getInstance(project);
+        Level projectLevel = MAXIMUM;
+
+        if (moduleManager != null) {
+            Level maxLevel = null;
+
+            for (Module module : moduleManager.getModules()) {
+                final Sdk sdk = ModuleRootManager.getInstance(module).getSdk();
+
+                if (sdk != null) {
+                    final Level sdkLevel = level(sdk);
+
+                    if (maxLevel == null || maxLevel.ordinal() < sdkLevel.ordinal()) {
+                        maxLevel = sdkLevel;
+                    }
+                }
+            }
+
+            if (maxLevel != null) {
+                projectLevel = maxLevel;
+            }
+        }
+
+        return projectLevel;
+    }
+
+    @NotNull
+    @Contract(pure = true)
+    private static Level level(@NotNull Sdk sdk) {
+        Release release = Type.getRelease(sdk);
+        Level level;
+
+        if (release != null) {
+            level = release.level();
+        } else {
+            level = MAXIMUM;
+        }
+
+        return level;
+    }
+
+    private static Optional<Integer> levelOrdinal(@NotNull VirtualFile fileOrDirectory) throws IOException {
+        DataInputStream dataInputStream = PERSISTENCE.readAttribute(fileOrDirectory);
+        Optional<Integer> levelOrdinal = Optional.empty();
+
+        if (dataInputStream != null) {
+            try {
+                levelOrdinal = Optional.of(DataInputOutputUtil.readINT(dataInputStream));
+            } finally {
+                dataInputStream.close();
+            }
+        }
+
+        return levelOrdinal;
+    }
+
+    private static void deleteLevel(@NotNull Project project) {
+        project.putUserData(LEVEL, null);
+    }
+
+    @Override
+    public void initExtra(@NotNull Project project, @NotNull MessageBus bus, @NotNull Engine languageLevelUpdater) {
+        if (ProcessOutput.isSmallIde()) {
+            smallIDEInitExtra(project);
+        } else {
+            richIDEInitExtra(project);
+        }
+    }
+
+    private void richIDEInitExtra(@NotNull Project project) {
+        Map<Module, Sdk> sdkByModule = sdkByModule(project);
+        Set<Sdk> sdkSet = StreamEx.ofValues(sdkByModule).nonNull().collect(Collectors.toCollection(LinkedHashSet::new));
+
+        this.sdkByModule.putAll(sdkByModule);
+        deleteLevel(project);
+        updateSdkLevels(project, sdkSet);
+        putLevel(project);
+    }
+
+    private Map<Module, Sdk> sdkByModule(@NotNull Project project) {
+        final Map<Module, Sdk> sdkByModule = new LinkedHashMap<>();
+        final Module[] modules = ModuleManager.getInstance(project).getModules();
+
+        for (Module module : modules) {
+            ModuleType moduleType = ModuleType.get(module);
+
+            if (moduleType instanceof ElixirModuleType) {
+                Sdk sdk = ModuleRootManager.getInstance(module).getSdk();
+
+                if (sdk != null && sdk.getSdkType() instanceof Type) {
+                    sdkByModule.put(module, sdk);
+                }
+            }
+        }
+
+        return sdkByModule;
+    }
+
+    private void updateSdkLevels(@NotNull Project project, @NotNull Set<Sdk> sdkSet) {
+        final DumbService dumbService = DumbService.getInstance(project);
+        final DumbModeTask task = new DumbModeTask() {
+            @Override
+            public void performInDumbMode(@NotNull ProgressIndicator indicator) {
+                if (!project.isDisposed()) {
+                    final PerformanceWatcher.Snapshot snapshot = PerformanceWatcher.takeSnapshot();
+                    final List<Runnable> tasks = ReadAction.compute(() -> rootUpdateTaskList(project, sdkSet));
+                    PushedFilePropertiesUpdaterImpl.invokeConcurrentlyIfPossible(tasks);
+
+                    if (!ApplicationManager.getApplication().isUnitTestMode()) {
+                        snapshot.logResponsivenessSinceCreation(
+                                "Pushing Elixir language level to " + tasks.size() + " roots in " +
+                                        sdkSet.size() + " SDKs");
+                    }
+                }
+            }
+        };
+
+        project.getMessageBus().connect(task).subscribe(ProjectTopics.PROJECT_ROOTS, new ModuleRootListener() {
+            @Override
+            public void rootsChanged(ModuleRootEvent event) {
+                DumbService.getInstance(project).cancelTask(task);
+            }
+        });
+
+        dumbService.queueTask(task);
+    }
+
+    private List<Runnable> rootUpdateTaskList(@NotNull Project project, @NotNull Set<Sdk> sdkSet) {
+        final List<Runnable> rootUpdateTaskList = new ArrayList<>();
+
+        for (Sdk sdk : sdkSet) {
+            final Level level = level(sdk);
+
+            for (VirtualFile root : sdk.getRootProvider().getFiles(OrderRootType.CLASSES)) {
+                if (root.isValid()) {
+                    rootUpdateTaskList.add(new UpdateRootTask(project, root, level));
+                }
+            }
+        }
+
+        return rootUpdateTaskList;
+    }
+
+    private List<Runnable> rootUpdateTaskList(@NotNull Project project, @NotNull String sdkHome) {
+        final List<Runnable> rootUpdateTaskList = new ArrayList<>();
+        VirtualFile root = LocalFileSystem.getInstance().findFileByPath(sdkHome);
+
+        if (root != null && root.isValid()) {
+            final Level level = level(project);
+
+            rootUpdateTaskList.add(new UpdateRootTask(project, root, level));
+        }
+
+        return rootUpdateTaskList;
+    }
+
+    private void smallIDEInitExtra(@NotNull Project project) {
+        String sdkHome = ForSmallIdes.getSdkHome(project);
+
+        this.sdkHome = new WeakReference<>(sdkHome);
+        deleteLevel(project);
+        updateSdkHomeLevel(project, sdkHome);
+        putLevel(project);
+    }
+
+    private void updateSdkHomeLevel(@NotNull Project project, @Nullable String sdkHome) {
+        final DumbService dumbService = DumbService.getInstance(project);
+        final DumbModeTask task = new DumbModeTask() {
+            @Override
+            public void performInDumbMode(@NotNull ProgressIndicator indicator) {
+                if (!project.isDisposed()) {
+                    final PerformanceWatcher.Snapshot snapshot = PerformanceWatcher.takeSnapshot();
+                    final List<Runnable> tasks = ReadAction.compute(() -> rootUpdateTaskList(project, sdkHome));
+                    PushedFilePropertiesUpdaterImpl.invokeConcurrentlyIfPossible(tasks);
+
+                    if (!ApplicationManager.getApplication().isUnitTestMode()) {
+                        snapshot.logResponsivenessSinceCreation(
+                                "Pushing Python language level to " + tasks.size() + " roots"
+                        );
+                    }
+                }
+            }
+        };
+
+        project.getMessageBus().connect(task).subscribe(ProjectTopics.PROJECT_ROOTS, new ModuleRootListener() {
+            @Override
+            public void rootsChanged(ModuleRootEvent event) {
+                DumbService.getInstance(project).cancelTask(task);
+            }
+        });
+
+        dumbService.queueTask(task);
+    }
+
+    @NotNull
+    private Map<Module, String> sdkHomeByModule(@NotNull Project project) {
+        final Map<Module, String> sdkHomeByModule = new LinkedHashMap<>();
+        String sdkHome = ForSmallIdes.getSdkHome(project);
+
+        for (Module module : ModuleManager.getInstance(project).getModules()) {
+            sdkHomeByModule.put(module, sdkHome);
+        }
+
+        return sdkHomeByModule;
+    }
+
+    @NotNull
+    @Override
+    public Key<Level> getFileDataKey() {
+        return KEY;
+    }
+
+    @Override
+    public boolean pushDirectoriesOnly() {
+        return true;
+    }
+
+    @NotNull
+    @Override
+    public Level getDefaultValue() {
+        return MAXIMUM;
+    }
+
+    @Nullable
+    @Override
+    public Level getImmediateValue(@NotNull Project project, @Nullable VirtualFile file) {
+        return level(project, file);
+    }
+
+    @Nullable
+    @Override
+    public Level getImmediateValue(@NotNull Module module) {
+        return level(module);
+    }
+
+    @Override
+    public boolean acceptsFile(@NotNull VirtualFile file) {
+        return false;
+    }
+
+    @Override
+    public boolean acceptsDirectory(@NotNull VirtualFile file, @NotNull Project project) {
+        return true;
+    }
+
+    @Override
+    public void persistAttribute(@NotNull Project project, @NotNull VirtualFile fileOrDir, @NotNull Level level)
+            throws IOException {
+        Optional<Integer> oldLevelOrdinal = levelOrdinal(fileOrDir);
+
+        if (!oldLevelOrdinal.isPresent() || oldLevelOrdinal.get() == level.ordinal()) {
+            DataOutputStream dataOutputStream = PERSISTENCE.writeAttribute(fileOrDir);
+            DataInputOutputUtil.writeINT(dataOutputStream, level.ordinal());
+            dataOutputStream.close();
+        }
+    }
+
+    @Override
+    public void afterRootsChanged(@NotNull Project project) {
+        if (ProcessOutput.isSmallIde()) {
+            smallIDEAfterRootsChanged(project);
+        } else {
+            richIDEAfterRootsChanged(project);
+        }
+    }
+
+    private void smallIDEAfterRootsChanged(@NotNull Project project) {
+        String sdkHome = ForSmallIdes.getSdkHome(project);
+        String oldSdkHome = this.sdkHome.get();
+
+        final boolean needToReparseOpenFiles = !StringUtils.equals(sdkHome, oldSdkHome);
+
+        this.sdkHome = new WeakReference<>(sdkHome);
+        deleteLevel(project);
+        updateSdkHomeLevel(project, sdkHome);
+
+        if (needToReparseOpenFiles) {
+            reparseFiles(project);
+        }
+    }
+
+    private void reparseFiles(@NotNull Project project) {
+        ApplicationManager.getApplication().invokeLater(() -> {
+            if (project.isDisposed()) {
+                return;
+            }
+
+            FileContentUtil.reparseFiles(project, Collections.emptyList(), true);
+        });
+    }
+
+    private void richIDEAfterRootsChanged(@NotNull Project project) {
+        Map<Module, Sdk> sdkByModule = sdkByModule(project);
+        Set<Sdk> sdkSet = StreamEx.ofValues(sdkByModule).nonNull().collect(Collectors.toCollection(LinkedHashSet::new));
+
+        final boolean needToReparseOpenFiles = StreamEx.of(sdkByModule.entrySet()).anyMatch((entry -> {
+            final Module module = entry.getKey();
+            final Sdk newSdk = entry.getValue();
+            final Sdk oldSdk = this.sdkByModule.get(module);
+
+            return this.sdkByModule.containsKey(module) && (newSdk != null || oldSdk != null) && newSdk != oldSdk;
+        }));
+
+        this.sdkByModule.putAll(sdkByModule);
+        deleteLevel(project);
+        updateSdkLevels(project, sdkSet);
+
+        if (needToReparseOpenFiles) {
+            reparseFiles(project);
+        }
+    }
+
+    private final class UpdateRootTask implements Runnable {
+        @NotNull
+        private final Project project;
+        @NotNull
+        private final VirtualFile root;
+        @NotNull
+        private final Level level;
+
+        UpdateRootTask(@NotNull Project project, @NotNull VirtualFile root, @NotNull Level level) {
+            this.project = project;
+            this.root = root;
+            this.level = level;
+        }
+
+        @Override
+        public void run() {
+            if (project.isDisposed() || !ReadAction.compute(root::isValid)) return;
+
+            final FileTypeManager fileTypeManager = FileTypeManager.getInstance();
+            final PushedFilePropertiesUpdater propertiesUpdater = PushedFilePropertiesUpdater.getInstance(project);
+
+            VfsUtilCore.visitChildrenRecursively(root, new VirtualFileVisitor() {
+                @Override
+                public boolean visitFile(@NotNull VirtualFile file) {
+
+                    return ReadAction.compute(() -> {
+                        boolean proceedToChildren;
+
+                        if (fileTypeManager.isFileIgnored(file)) {
+                            proceedToChildren = false;
+                        } else {
+                            proceedToChildren = true;
+
+                            if (file.isDirectory()) {
+                                propertiesUpdater.findAndUpdateValue(file, LevelPropertyPusher.this, level);
+                            }
+                        }
+
+                        return proceedToChildren;
+                    });
+                }
+            });
+        }
+
+        @Contract(pure = true)
+        @NotNull
+        @Override
+        public String toString() {
+            return "UpdateRootTask{" + "root=" + root + ", level=" + level + '}';
+        }
+    }
+}

--- a/src/org/elixir_lang/file/LevelPropertyPusher.java
+++ b/src/org/elixir_lang/file/LevelPropertyPusher.java
@@ -14,10 +14,7 @@ import com.intellij.openapi.project.DumbModeTask;
 import com.intellij.openapi.project.DumbService;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.projectRoots.Sdk;
-import com.intellij.openapi.roots.ModuleRootEvent;
-import com.intellij.openapi.roots.ModuleRootListener;
-import com.intellij.openapi.roots.ModuleRootManager;
-import com.intellij.openapi.roots.OrderRootType;
+import com.intellij.openapi.roots.*;
 import com.intellij.openapi.roots.impl.FilePropertyPusher;
 import com.intellij.openapi.roots.impl.PushedFilePropertiesUpdater;
 import com.intellij.openapi.roots.impl.PushedFilePropertiesUpdaterImpl;
@@ -139,10 +136,10 @@ public class LevelPropertyPusher implements FilePropertyPusher<Level> {
             Level maxLevel = null;
 
             for (Module module : moduleManager.getModules()) {
-                final Sdk sdk = ModuleRootManager.getInstance(module).getSdk();
+                final Sdk moduleSdk = ModuleRootManager.getInstance(module).getSdk();
 
-                if (sdk != null) {
-                    final Level sdkLevel = level(sdk);
+                if (moduleSdk != null) {
+                    final Level sdkLevel = level(moduleSdk);
 
                     if (maxLevel == null || maxLevel.ordinal() < sdkLevel.ordinal()) {
                         maxLevel = sdkLevel;
@@ -152,6 +149,9 @@ public class LevelPropertyPusher implements FilePropertyPusher<Level> {
 
             if (maxLevel != null) {
                 projectLevel = maxLevel;
+            } else {
+                Sdk projectSdk = ProjectRootManager.getInstance(project).getProjectSdk();
+                projectLevel = level(projectSdk);
             }
         }
 

--- a/src/org/elixir_lang/mix/runner/exunit/MixExUnitRunningState.java
+++ b/src/org/elixir_lang/mix/runner/exunit/MixExUnitRunningState.java
@@ -8,8 +8,8 @@ import com.intellij.execution.configurations.RunConfiguration;
 import com.intellij.execution.process.ProcessHandler;
 import com.intellij.execution.runners.ExecutionEnvironment;
 import com.intellij.execution.runners.ProgramRunner;
-import com.intellij.execution.testframework.autotest.ToggleAutoTestAction;
 import com.intellij.execution.testframework.TestConsoleProperties;
+import com.intellij.execution.testframework.autotest.ToggleAutoTestAction;
 import com.intellij.execution.testframework.sm.SMTestRunnerConnectionUtil;
 import com.intellij.execution.ui.ConsoleView;
 import com.intellij.openapi.diagnostic.Logger;
@@ -22,13 +22,14 @@ import org.elixir_lang.jps.builder.ParametersList;
 import org.elixir_lang.mix.runner.MixRunningState;
 import org.elixir_lang.mix.runner.MixTestConsoleProperties;
 import org.elixir_lang.mix.settings.MixSettings;
-import org.elixir_lang.sdk.elixir.Type;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+
+import static org.elixir_lang.file.LevelPropertyPusher.level;
 
 final class MixExUnitRunningState extends MixRunningState {
     private static final Logger LOGGER = com.intellij.openapi.diagnostic.Logger.getInstance(MixExUnitRunningState.class);
@@ -54,7 +55,7 @@ final class MixExUnitRunningState extends MixRunningState {
 
     @NotNull
     private static ParametersList elixirParametersList(@Nullable Sdk sdk, boolean useCustomMixTask) throws IOException {
-        return ElixirModules.parametersList(Type.getRelease(sdk), useCustomMixTask);
+        return ElixirModules.parametersList(level(sdk), useCustomMixTask);
     }
 
     /**

--- a/src/org/elixir_lang/mix/settings/MixConfigurationForm.java
+++ b/src/org/elixir_lang/mix/settings/MixConfigurationForm.java
@@ -28,6 +28,7 @@ import java.awt.*;
 import java.io.File;
 import java.util.List;
 
+import static org.elixir_lang.Level.V_1_4;
 import static org.elixir_lang.sdk.ProcessOutput.transformStdoutLine;
 
 /**
@@ -143,7 +144,7 @@ public class MixConfigurationForm {
           Release elixirSdkRelease = Release.fromString(versionString);
 
           if (elixirSdkRelease != null) {
-            supportsFormatterOptionCheckBox.setSelected(elixirSdkRelease.compareTo(Release.V_1_4) >= 0);
+            supportsFormatterOptionCheckBox.setSelected(elixirSdkRelease.level().supportsMixTestFormatterFlag);
           }
 
           valid = true;

--- a/src/org/elixir_lang/psi/impl/ElixirPsiImplUtil.java
+++ b/src/org/elixir_lang/psi/impl/ElixirPsiImplUtil.java
@@ -27,6 +27,7 @@ import com.intellij.util.containers.SmartHashSet;
 import org.apache.commons.lang.NotImplementedException;
 import org.apache.commons.lang.math.IntRange;
 import org.elixir_lang.ElixirLanguage;
+import org.elixir_lang.Level;
 import org.elixir_lang.Macro;
 import org.elixir_lang.annotator.Parameter;
 import org.elixir_lang.psi.*;
@@ -64,6 +65,7 @@ import java.util.*;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
+import static org.elixir_lang.Level.V_1_3;
 import static org.elixir_lang.errorreport.Logger.error;
 import static org.elixir_lang.psi.call.name.Function.*;
 import static org.elixir_lang.psi.call.name.Module.*;
@@ -5870,10 +5872,10 @@ if (quoted == null) {
         }
 
         Body body = line.getBody();
-        Release release = getNonNullRelease(line);
+        Level level = getNonNullRelease(line).level();
         ASTNode[] childNodes = childNodes(body);
 
-        if (release.compareTo(Release.V_1_3) < 0 &&
+        if (level.compareTo(V_1_3) < 0 &&
                 childNodes.length >= 1 &&
                 childNodes[childNodes.length - 1].getElementType().equals(ElixirTypes.ESCAPED_EOL)) {
             heredocDescendantNodes.addAll(Arrays.asList(childNodes).subList(0, childNodes.length - 1));
@@ -5973,9 +5975,9 @@ if (quoted == null) {
                                               @NotNull @SuppressWarnings("unused") ASTNode child) {
         List<Integer> codePointList = ensureCodePointList(maybeCodePointList);
 
-        Release release = getNonNullRelease(parent);
+        Level level = getNonNullRelease(parent).level();
 
-        if (release.compareTo(Release.V_1_3) >= 0) {
+        if (level.compareTo(V_1_3) >= 0) {
             if (parent instanceof LiteralSigilHeredoc) {
                 codePointList = addStringCodePoints(codePointList, "\\");
             } else if (parent instanceof LiteralSigilLine) {

--- a/src/org/elixir_lang/psi/impl/ElixirPsiImplUtil.java
+++ b/src/org/elixir_lang/psi/impl/ElixirPsiImplUtil.java
@@ -5006,13 +5006,8 @@ if (quoted == null) {
     @NotNull
     private static String quoteBinaryFunctionIdentifier(@NotNull final InterpolatedCharList interpolatedCharList) {
         Release release = getNonNullRelease(interpolatedCharList);
-        String functionIdentifier = "to_charlist";
 
-        if (release.compareTo(Release.V_1_3) < 0) {
-            functionIdentifier = "to_char_list";
-        }
-
-        return functionIdentifier;
+        return release.level().quoteBinaryFunctionIdentifier;
     }
 
     @Contract(pure = true)

--- a/src/org/elixir_lang/psi/stub/type/File.java
+++ b/src/org/elixir_lang/psi/stub/type/File.java
@@ -1,5 +1,8 @@
 package org.elixir_lang.psi.stub.type;
 
+import com.intellij.lang.*;
+import com.intellij.openapi.project.Project;
+import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
 import com.intellij.psi.StubBuilder;
 import com.intellij.psi.stubs.DefaultStubBuilder;
@@ -10,8 +13,11 @@ import com.intellij.psi.tree.IStubFileElementType;
 import org.elixir_lang.ElixirLanguage;
 import org.elixir_lang.psi.ElixirFile;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.io.IOException;
+
+import static org.elixir_lang.file.LevelPropertyPusher.VIRTUAL_FILE;
 
 public class File extends IStubFileElementType<org.elixir_lang.psi.stub.File> {
     public static final int VERSION = 3;
@@ -53,5 +59,17 @@ public class File extends IStubFileElementType<org.elixir_lang.psi.stub.File> {
     @Override
     public String getExternalId() {
         return "elixir.FILE";
+    }
+
+    @Nullable
+    @Override
+    protected ASTNode doParseContents(@NotNull ASTNode chameleon, @NotNull PsiElement psi) {
+        Project project = psi.getProject();
+        Language languageForParser = getLanguageForParser(psi);
+        PsiBuilder builder = PsiBuilderFactory.getInstance().createBuilder(project, chameleon, null, languageForParser, chameleon.getChars());
+        PsiParser parser = LanguageParserDefinitions.INSTANCE.forLanguage(languageForParser).createParser(project);
+        builder.putUserData(VIRTUAL_FILE, psi.getContainingFile().getVirtualFile());
+        ASTNode node = parser.parse(this, builder);
+        return node.getFirstChildNode();
     }
 }

--- a/src/org/elixir_lang/sdk/ProcessOutput.java
+++ b/src/org/elixir_lang/sdk/ProcessOutput.java
@@ -97,11 +97,6 @@ public class ProcessOutput {
   }
 
   public static boolean isSmallIde(){
-    return PlatformUtils.isRubyMine()
-        || PlatformUtils.isPyCharm()
-        || PlatformUtils.isPhpStorm()
-        || PlatformUtils.isWebStorm()
-        || PlatformUtils.isAppCode()
-        || PlatformUtils.isCLion();
+    return !PlatformUtils.isIntelliJ();
   }
 }

--- a/src/org/elixir_lang/sdk/elixir/Release.java
+++ b/src/org/elixir_lang/sdk/elixir/Release.java
@@ -14,12 +14,7 @@ public final class Release implements Comparable<Release> {
    */
 
   public static final Release V_1_0_4 = new Release("1", "0", "4", null, null);
-  public static final Release V_1_2 = new Release("1", "2", null, null, null);
-  public static final Release V_1_3 = new Release("1", "3", null, null, null);
-  public static final Release V_1_4 = new Release("1", "4", null, null, null);
-  public static final Release V_1_5 = new Release("1", "5", null, null, null);
-  public static final Release V_1_5_2 = new Release("1", "5", "2", null, null);
-  public static final Release LATEST = V_1_5_2;
+  public static final Release LATEST = new Release("1", "6", "0", "dev", null);
 
   private static final Pattern VERSION_PATTERN = Pattern.compile(
           // @version_regex from Version in elixir itself

--- a/src/org/elixir_lang/sdk/elixir/Release.java
+++ b/src/org/elixir_lang/sdk/elixir/Release.java
@@ -1,5 +1,6 @@
 package org.elixir_lang.sdk.elixir;
 
+import org.elixir_lang.Level;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -109,13 +110,15 @@ public final class Release implements Comparable<Release> {
   @Nullable
   private final String build;
   @NotNull
-  private final String major;
+  public final String major;
   @Nullable
-  private final String minor;
+  public final String minor;
   @Nullable
   private final String patch;
   @Nullable
   private final String pre;
+  @NotNull
+  private final Level level;
 
   /*
    * Constructors
@@ -126,6 +129,15 @@ public final class Release implements Comparable<Release> {
                  @Nullable String patch,
                  @Nullable String pre,
                  @Nullable String build) {
+    this(major, minor, patch, pre, build, null);
+  }
+
+  public Release(@NotNull String major,
+                 @Nullable String minor,
+                 @Nullable String patch,
+                 @Nullable String pre,
+                 @Nullable String build,
+                 @Nullable Level level) {
     this.major = major;
     this.minor = minor;
     this.patch = patch;
@@ -134,6 +146,12 @@ public final class Release implements Comparable<Release> {
 
     if (minor == null && patch != null) {
       throw new IllegalArgumentException("patch MUST be null if minor is null");
+    }
+
+    if (level != null) {
+      this.level = level;
+    } else {
+      this.level = Level.fromRelease(this);
     }
   }
 
@@ -158,6 +176,12 @@ public final class Release implements Comparable<Release> {
     }
 
     return comparison;
+  }
+
+  @Contract(pure = true)
+  @NotNull
+  public Level level() {
+    return level;
   }
 
   @Override

--- a/src/org/elixir_lang/sdk/elixir/Type.java
+++ b/src/org/elixir_lang/sdk/elixir/Type.java
@@ -430,7 +430,7 @@ public class Type extends org.elixir_lang.sdk.erlang_dependent.Type {
     }
 
     @Nullable
-    private static Release getReleaseForSmallIde(@NotNull Project project) {
+    public static Release getReleaseForSmallIde(@NotNull Project project) {
         String sdkPath = getSdkPath(project);
         return StringUtil.isEmpty(sdkPath) ? null : getInstance().detectSdkVersion(sdkPath);
     }

--- a/tests/org/elixir_lang/parser_definition/BracketOperationParsingTestCase.java
+++ b/tests/org/elixir_lang/parser_definition/BracketOperationParsingTestCase.java
@@ -1,8 +1,9 @@
 package org.elixir_lang.parser_definition;
 
-import org.elixir_lang.sdk.elixir.Release;
 
-import static org.elixir_lang.test.ElixirVersion.elixirSdkRelease;
+import static org.elixir_lang.Level.V_1_4;
+import static org.elixir_lang.Level.V_1_5;
+import static org.elixir_lang.test.ElixirVersion.elixirSdkLevel;
 
 /**
  * Created by luke.imhoff on 9/17/14.
@@ -81,10 +82,13 @@ public class BracketOperationParsingTestCase extends ParsingTestCase {
     }
 
     public void testStructOperator() {
-        if (elixirSdkRelease().compareTo(Release.V_1_4) < 0) {
+        int compareToV_1_4 = elixirSdkLevel().compareTo(V_1_4);
+
+        if (compareToV_1_4 < 0) {
             assertParsedAndQuotedCorrectly(false);
         } else {
-            assertTrue(elixirSdkRelease().compareTo(Release.V_1_4) >= 0);
+            //noinspection ConstantConditions
+            assertTrue(compareToV_1_4 >= 0);
         }
     }
 
@@ -137,10 +141,13 @@ public class BracketOperationParsingTestCase extends ParsingTestCase {
     }
 
     public void testUnaryNumericOperation() {
-        if (elixirSdkRelease().compareTo(Release.V_1_5) < 0) {
+        int compareToV_1_5 = elixirSdkLevel().compareTo(V_1_5);
+
+        if (compareToV_1_5 < 0) {
             assertParsedAndQuotedCorrectly(false);
         } else {
-            assertTrue(elixirSdkRelease().compareTo(Release.V_1_5) >= 0);
+            //noinspection ConstantConditions
+            assertTrue(compareToV_1_5 >= 0);
         }
     }
 

--- a/tests/org/elixir_lang/parser_definition/CharTokenParsingTestCase.java
+++ b/tests/org/elixir_lang/parser_definition/CharTokenParsingTestCase.java
@@ -41,7 +41,7 @@ public class CharTokenParsingTestCase extends ParsingTestCase {
      */
 
     public void testOpenHexadecimalEscapeSequence() {
-        if (elixirSdkRelease().compareTo(Release.V_1_3) < 0) {
+        if (elixirSdkRelease().level().supportsOpenHexadecimalEscapeSequence) {
             assertParsedAndQuotedCorrectly();
         } else {
             assertParsedAndQuotedAroundError();

--- a/tests/org/elixir_lang/parser_definition/CharTokenParsingTestCase.java
+++ b/tests/org/elixir_lang/parser_definition/CharTokenParsingTestCase.java
@@ -1,8 +1,7 @@
 package org.elixir_lang.parser_definition;
 
-import org.elixir_lang.sdk.elixir.Release;
-
-import static org.elixir_lang.test.ElixirVersion.elixirSdkRelease;
+import static org.elixir_lang.Level.V_1_3;
+import static org.elixir_lang.test.ElixirVersion.elixirSdkLevel;
 
 /**
  * Created by luke.imhoff on 9/17/14.
@@ -41,7 +40,7 @@ public class CharTokenParsingTestCase extends ParsingTestCase {
      */
 
     public void testOpenHexadecimalEscapeSequence() {
-        if (elixirSdkRelease().level().supportsOpenHexadecimalEscapeSequence) {
+        if (elixirSdkLevel().supportsOpenHexadecimalEscapeSequence) {
             assertParsedAndQuotedCorrectly();
         } else {
             assertParsedAndQuotedAroundError();
@@ -49,7 +48,7 @@ public class CharTokenParsingTestCase extends ParsingTestCase {
     }
 
     public void testEnclosedHexadecimalEscapeSequence() {
-        if (elixirSdkRelease().compareTo(Release.V_1_3) < 0) {
+        if (elixirSdkLevel().compareTo(V_1_3) < 0) {
             assertParsedAndQuotedCorrectly();
         } else {
             assertParsedAndQuotedAroundError();

--- a/tests/org/elixir_lang/parser_definition/ElixirLangElixirParsingTestCase.java
+++ b/tests/org/elixir_lang/parser_definition/ElixirLangElixirParsingTestCase.java
@@ -4,14 +4,15 @@ import com.intellij.openapi.util.io.FileUtil;
 import com.intellij.openapi.util.io.FileUtilRt;
 import com.intellij.openapi.vfs.CharsetToolkit;
 import org.elixir_lang.intellij_elixir.Quoter;
-import org.elixir_lang.sdk.elixir.Release;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 
-import static org.elixir_lang.test.ElixirVersion.elixirSdkRelease;
+import static org.elixir_lang.Level.V_1_3;
+import static org.elixir_lang.Level.V_1_5;
+import static org.elixir_lang.test.ElixirVersion.elixirSdkLevel;
 
 public class ElixirLangElixirParsingTestCase extends ParsingTestCase {
     private enum Parse {
@@ -354,10 +355,13 @@ public class ElixirLangElixirParsingTestCase extends ParsingTestCase {
     }
 
     public void testParallelCompilerBat() {
-        if (elixirSdkRelease().compareTo(Release.V_1_3) < 0) {
+        boolean beforeV_1_3 = elixirSdkLevel().compareTo(V_1_3) < 0;
+
+        if (beforeV_1_3) {
             assertParsed("lib/elixir/test/elixir/fixtures/parallel_compiler/bat.ex", Parse.ERROR);
         } else {
-            assertTrue(elixirSdkRelease().compareTo(Release.V_1_3) >= 0);
+            //noinspection ConstantConditions
+            assertTrue(!beforeV_1_3);
         }
     }
 
@@ -538,10 +542,13 @@ public class ElixirLangElixirParsingTestCase extends ParsingTestCase {
     }
 
     public void testMixArchive() {
-        if (elixirSdkRelease().compareTo(Release.V_1_3) < 0) {
+        boolean beforeV_1_3 = elixirSdkLevel().compareTo(V_1_3) < 0;
+
+        if (beforeV_1_3) {
             assertParsed("lib/mix/lib/mix/archive.ex", Parse.CORRECT);
         } else {
-            assertTrue(elixirSdkRelease().compareTo(Release.V_1_3) >= 0);
+            //noinspection ConstantConditions
+            assertTrue(!beforeV_1_3);
         }
     }
 
@@ -550,10 +557,12 @@ public class ElixirLangElixirParsingTestCase extends ParsingTestCase {
     }
 
     public void testMixCompilersElixir() {
-        if (elixirSdkRelease().compareTo(Release.V_1_5) >= 0) {
+        boolean atLeastV_1_5 = elixirSdkLevel().compareTo(V_1_5) >= 0;
+
+        if (atLeastV_1_5) {
             assertParsed("lib/mix/lib/mix/compilers/elixir.ex", Parse.CORRECT);
         } else {
-            assertTrue(elixirSdkRelease().compareTo(Release.V_1_5) < 0);
+            assertTrue(!atLeastV_1_5);
         }
     }
 
@@ -722,10 +731,12 @@ public class ElixirLangElixirParsingTestCase extends ParsingTestCase {
     }
 
     public void testMixTasksDepsCheck() {
-        if (elixirSdkRelease().compareTo(Release.V_1_3) < 0) {
+        boolean beforeV_1_3 = elixirSdkLevel().compareTo(V_1_3) < 0;
+
+        if (beforeV_1_3) {
             assertParsed("lib/mix/lib/mix/tasks/deps.check.ex", Parse.CORRECT);
         } else {
-            assertTrue(elixirSdkRelease().compareTo(Release.V_1_3) >= 0);
+            assertTrue(!beforeV_1_3);
         }
     }
 
@@ -833,10 +844,13 @@ public class ElixirLangElixirParsingTestCase extends ParsingTestCase {
     }
 
     public void testEscripttestLibEscripttest() {
-        if (elixirSdkRelease().compareTo(Release.V_1_5) < 0) {
+        boolean beforeV_1_5 = elixirSdkLevel().compareTo(V_1_5) < 0;
+
+        if (beforeV_1_5) {
             assertParsed("lib/mix/test/fixtures/escripttest/lib/escripttest.ex", Parse.CORRECT);
         } else {
-            assertTrue(elixirSdkRelease().compareTo(Release.V_1_5) >= 0);
+            //noinspection ConstantConditions
+            assertTrue(!beforeV_1_5);
         }
     }
 
@@ -849,10 +863,12 @@ public class ElixirLangElixirParsingTestCase extends ParsingTestCase {
     }
 
     public void testNoMixfileLibC() {
-        if (elixirSdkRelease().compareTo(Release.V_1_3) < 0) {
+        boolean beforeV_1_3 = elixirSdkLevel().compareTo(V_1_3) < 0;
+
+        if (beforeV_1_3) {
             assertParsed("lib/mix/test/fixtures/no_mixfile/lib/c.ex", Parse.CORRECT);
         } else {
-            assertTrue(elixirSdkRelease().compareTo(Release.V_1_3) >= 0);
+            assertTrue(!beforeV_1_3);
         }
     }
 

--- a/tests/org/elixir_lang/parser_definition/FunctionReferenceParsingTestCase.java
+++ b/tests/org/elixir_lang/parser_definition/FunctionReferenceParsingTestCase.java
@@ -1,8 +1,7 @@
 package org.elixir_lang.parser_definition;
 
-import org.elixir_lang.sdk.elixir.Release;
-
-import static org.elixir_lang.test.ElixirVersion.elixirSdkRelease;
+import static org.elixir_lang.Level.V_1_5;
+import static org.elixir_lang.test.ElixirVersion.elixirSdkLevel;
 
 public class FunctionReferenceParsingTestCase extends ParsingTestCase {
     public void testAliasDotIdentifier() {
@@ -10,10 +9,13 @@ public class FunctionReferenceParsingTestCase extends ParsingTestCase {
     }
 
     public void testAliasDotOperator() {
-        if (elixirSdkRelease().compareTo(Release.V_1_5) < 0) {
+        boolean beforeV_1_5 = elixirSdkLevel().compareTo(V_1_5) < 0;
+
+        if (beforeV_1_5) {
             assertParsedAndQuotedCorrectly();
         } else {
-            assertTrue(elixirSdkRelease().compareTo(Release.V_1_5) >= 0);
+            //noinspection ConstantConditions
+            assertTrue(!beforeV_1_5);
         }
     }
 
@@ -22,10 +24,13 @@ public class FunctionReferenceParsingTestCase extends ParsingTestCase {
     }
 
     public void testAtomDotOperator() {
-        if (elixirSdkRelease().compareTo(Release.V_1_5) < 0) {
+        boolean beforeV_1_5 = elixirSdkLevel().compareTo(V_1_5) < 0;
+
+        if (beforeV_1_5) {
             assertParsedAndQuotedCorrectly();
         } else {
-            assertTrue(elixirSdkRelease().compareTo(Release.V_1_5) >= 0);
+            //noinspection ConstantConditions
+            assertTrue(!beforeV_1_5);
         }
     }
 

--- a/tests/org/elixir_lang/parser_definition/MatchedArrowOperationParsingTestCase.java
+++ b/tests/org/elixir_lang/parser_definition/MatchedArrowOperationParsingTestCase.java
@@ -1,8 +1,7 @@
 package org.elixir_lang.parser_definition;
 
-import org.elixir_lang.sdk.elixir.Release;
-
-import static org.elixir_lang.test.ElixirVersion.elixirSdkRelease;
+import static org.elixir_lang.Level.V_1_2;
+import static org.elixir_lang.test.ElixirVersion.elixirSdkLevel;
 
 /**
  * Created by luke.imhoff on 9/17/14.
@@ -23,7 +22,7 @@ public class MatchedArrowOperationParsingTestCase extends ParsingTestCase {
     }
 
     public void testMatchedInOperation() {
-        if (!isTravis() && elixirSdkRelease().compareTo(Release.V_1_2) > 0) {
+        if (!isTravis() && elixirSdkLevel().compareTo(V_1_2) > 0) {
             assertParsedAndQuotedCorrectly();
         }
     }

--- a/tests/org/elixir_lang/parser_definition/MatchedQualifiedMultipleAliasesParsingTestCase.java
+++ b/tests/org/elixir_lang/parser_definition/MatchedQualifiedMultipleAliasesParsingTestCase.java
@@ -205,7 +205,7 @@ public class MatchedQualifiedMultipleAliasesParsingTestCase extends ParsingTestC
     }
 
     private void assertParsedAndQuotedCorrectlyInOneThree(boolean checkResult) {
-        if (elixirSdkRelease().compareTo(Release.V_1_2) >= 0) {
+        if (elixirSdkRelease().level().supportsMultipleAliases) {
             assertParsedAndQuotedCorrectly(checkResult);
         } else {
             assertParsedAndQuotedAroundError(checkResult);

--- a/tests/org/elixir_lang/parser_definition/MatchedThreeOperationParsingTestCase.java
+++ b/tests/org/elixir_lang/parser_definition/MatchedThreeOperationParsingTestCase.java
@@ -2,7 +2,8 @@ package org.elixir_lang.parser_definition;
 
 import org.elixir_lang.sdk.elixir.Release;
 
-import static org.elixir_lang.test.ElixirVersion.elixirSdkRelease;
+import static org.elixir_lang.Level.V_1_2;
+import static org.elixir_lang.test.ElixirVersion.elixirSdkLevel;
 
 /**
  * Created by luke.imhoff on 9/17/14.
@@ -23,7 +24,7 @@ public class MatchedThreeOperationParsingTestCase extends ParsingTestCase {
     }
 
     public void testMatchedInOperation() {
-        if (!isTravis() && elixirSdkRelease().compareTo(Release.V_1_2) > 0) {
+        if (!isTravis() && elixirSdkLevel().compareTo(V_1_2) > 0) {
             assertParsedAndQuotedCorrectly();
         }
     }

--- a/tests/org/elixir_lang/parser_definition/NotInParsingTestCase.java
+++ b/tests/org/elixir_lang/parser_definition/NotInParsingTestCase.java
@@ -1,16 +1,19 @@
 package org.elixir_lang.parser_definition;
 
-import org.elixir_lang.sdk.elixir.Release;
 import org.jetbrains.annotations.NotNull;
 
-import static org.elixir_lang.test.ElixirVersion.elixirSdkRelease;
+import static org.elixir_lang.Level.V_1_5;
+import static org.elixir_lang.test.ElixirVersion.elixirSdkLevel;
 
 public class NotInParsingTestCase extends ParsingTestCase {
     public void testIssue844() {
-        if (elixirSdkRelease().compareTo(Release.V_1_5) >= 0) {
+        boolean atLeastV_1_5 = elixirSdkLevel().compareTo(V_1_5) >= 0;
+
+        if (atLeastV_1_5) {
             assertParsedAndQuotedCorrectly();
         } else {
-            assertTrue(elixirSdkRelease().compareTo(Release.V_1_5) < 0);
+            //noinspection ConstantConditions
+            assertTrue(!atLeastV_1_5);
         }
     }
 

--- a/tests/org/elixir_lang/test/ElixirVersion.java
+++ b/tests/org/elixir_lang/test/ElixirVersion.java
@@ -1,10 +1,18 @@
 package org.elixir_lang.test;
 
+import org.elixir_lang.Level;
 import org.elixir_lang.sdk.elixir.Release;
+import org.jetbrains.annotations.NotNull;
 
 import static junit.framework.TestCase.assertNotNull;
 
 public class ElixirVersion {
+    @NotNull
+    public static Level elixirSdkLevel() {
+        return elixirSdkRelease().level();
+    }
+
+    @NotNull
     public static Release elixirSdkRelease() {
         String elixirVersion = elixirVersion();
         Release elixirSdkRelease = Release.fromString((elixirVersion));


### PR DESCRIPTION
Fixes #946 

# Changelog
## Bug Fixes
* When the SDK changes, record what `Release` of Elixir is used indirectly, using a `Level` `enum` that only cares about the major and minor version. Changing the `Level`, will mark the open files and .beam files as invalidated, so that if the SDK is changed, the stubs and code `Level` will agree, so there isn't a stub incompatibility with the PSI.