### PR TITLE
Release 7.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,16 @@ matrix:
   include:
     # version groups based on https://www.jetbrains.com/idea/download/previous.html
 
+
+    - elixir: 1.5.2
+      env: IDEA_VERSION="2017.3"
+      jdk: oraclejdk8
+      otp_release: 20.1
+    - elixir: 1.4.5
+      env: IDEA_VERSION="2017.3"
+      jdk: oraclejdk8
+      otp_release: 19.3
+
     - elixir: 1.5.2
       env: IDEA_VERSION="2017.2.5"
       jdk: oraclejdk8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,7 +135,7 @@
 
 # Changelog
 
-## v6.8.0
+## v7.0.0
 
 ### Enhancements
 * [#944](https://github.com/KronicDeth/intellij-elixir/pull/944) - [@KronicDeth](https://github.com/KronicDeth)
@@ -166,10 +166,20 @@
     1. Change the "Inspection scope" from "Whole project", which would include the `deps` to "Custom scope"
     2. Select "Project Production Files" from the "Custom scope" dropdown
     3. Click "OK"
+* [#951](https://github.com/KronicDeth/intellij-elixir/pull/951) - [@KronicDeth](https://github.com/KronicDeth)
+  * Setup `VirtualFilePointerManager` during `ParsingTestCase`
+  * Put `LineMarkerInfo` on leaf elements for Method (Call Definition) Separators for a performance improvement.
+  * Add IntelliJ IDEA 2017.3 to the build matrix
 
 ### Bug Fixes
 * [#947](https://github.com/KronicDeth/intellij-elixir/pull/947) - When the SDK changes, record what `Release` of Elixir is used indirectly, using a `Level` `enum` that only cares about the major and minor version. Changing the `Level`, will mark the open files and .beam files as invalidated, so that if the SDK is changed, the stubs and code `Level` will agree, so there isn't a stub incompatibility with the PSI. - [@KronicDeth](https://github.com/KronicDeth)
 * [#950](https://github.com/KronicDeth/intellij-elixir/pull/950) - Allow credo section to be empty when processing credo explanations - [@KronicDeth](https://github.com/KronicDeth)
+* [#951](https://github.com/KronicDeth/intellij-elixir/pull/951) - [@KronicDeth](https://github.com/KronicDeth)
+  * Prevent negative indent, not supported in 2017.3
+  * Cleanup SDKs from MixProjectImportBuilderTest
+
+## Incompatible Changes
+* [#951](https://github.com/KronicDeth/intellij-elixir/pull/951) - Drop support for IntelliJ IDEA before 2016.3 - [@KronicDeth](https://github.com/KronicDeth)
 
 ## v6.7.0
 

--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,9 @@ allprojects {
   intellij {
     def intellij_erlang_version
 
-    if (ideaVersion.startsWith("2017.2")) {
+    if (ideaVersion.startsWith("2017.3")) {
+      intellij_erlang_version = "0.10.966"
+    } else if (ideaVersion.startsWith("2017.2")) {
       intellij_erlang_version = "0.9.958"
     } else if (ideaVersion.startsWith("2017.1.")) {
       intellij_erlang_version = "0.9.939"

--- a/build.gradle
+++ b/build.gradle
@@ -47,12 +47,6 @@ allprojects {
       intellij_erlang_version = "0.9.939"
     } else if (ideaVersion.startsWith("2016.3.")) {
       intellij_erlang_version = "0.9.912"
-    } else if (ideaVersion.startsWith("2016.2.")) {
-      intellij_erlang_version = "0.8.913"
-    } else if (ideaVersion.startsWith("2016.1.")) {
-      intellij_erlang_version = "0.7.876"
-    } else if (ideaVersion.startsWith("15.0.")) {
-      intellij_erlang_version = "0.6.873"
     } else {
       throw new IllegalArgumentException("ideaVersion is not a recognized MAJOR.MINOR for IntelliJ Erlang compatibility")
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@
 # https://www.jetbrains.com/intellij-repository/snapshots
 
 version = 7.0.0
-ideaVersion = 2016.3.7
+ideaVersion = 2017.3
 javaVersion = 1.8
 javaTargetVersion = 1.8
 sources = true

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,8 +2,8 @@
 # https://www.jetbrains.com/intellij-repository/releases
 # https://www.jetbrains.com/intellij-repository/snapshots
 
-version = 6.8.0
-ideaVersion = 2017.2.5
+version = 7.0.0
+ideaVersion = 2016.3.7
 javaVersion = 1.8
 javaTargetVersion = 1.8
 sources = true

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 # https://www.jetbrains.com/intellij-repository/releases
 # https://www.jetbrains.com/intellij-repository/snapshots
 
-version = 6.7.0
+version = 6.8.0
 ideaVersion = 2017.2.5
 javaVersion = 1.8
 javaTargetVersion = 1.8

--- a/resources/META-INF/changelog.html
+++ b/resources/META-INF/changelog.html
@@ -1,6 +1,6 @@
 <html>
 <body>
-<h1>v6.8.0</h1>
+<h1>v7.0.0</h1>
 <ul>
   <li>
     <p>Enhancements</p>
@@ -47,6 +47,12 @@
           <li>Click "OK"</li>
         </ol>
       </li>
+      <li>Setup <code>VirtualFilePointerManager</code> during <code>ParsingTestCase</code></li>
+      <li>
+        Put <code>LineMarkerInfo</code> on leaf elements for Method (Call Definition) Separators for a performance
+        improvement.
+      </li>
+      <li>Add IntelliJ IDEA 2017.3 to the build matrix</li>
     </ul>
   </li>
   <li>
@@ -59,6 +65,14 @@
         <code>Level</code> will agree, so there isn't a stub incompatibility with the PSI.
       </li>
       <li>Allow credo section to be empty when processing credo explanations</li>
+      <li>Prevent negative indent as it is not supported in IntelliJ IDEA 2017.3</li>
+      <li>Cleanup SDKs from MixProjectImportBuilderTest</li>
+    </ul>
+  </li>
+  <li>
+    <p>Incompatible Changes</p>
+    <ul>
+      <li>Drop support for IntelliJ IDEA before 2016.3</li>
     </ul>
   </li>
 </ul>

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -5,7 +5,7 @@
 
   <!-- please see http://confluence.jetbrains.com/display/IDEADEV/Build+Number+Ranges for description -->
   <!-- 141 == IntelliJ IDEA 14.1, which is the oldest version compatible with GrammarKit 1.3.0 -->
-  <idea-version since-build="141"/>
+  <idea-version since-build="163.15529.5"/>
 
   <!-- please see http://confluence.jetbrains.com/display/IDEADEV/Plugin+Compatibility+with+IntelliJ+Platform+Products
        on how to target different products -->

--- a/src/org/elixir_lang/beam/psi/BeamFileImpl.java
+++ b/src/org/elixir_lang/beam/psi/BeamFileImpl.java
@@ -270,7 +270,6 @@ public class BeamFileImpl extends ModuleElementImpl implements ModuleOwner, PsiC
     }
 
     @Nullable
-    @Override
     public ASTNode findTreeForStub(StubTree stubTree, StubElement<?> stubElement) {
         return null;
     }

--- a/src/org/elixir_lang/code_insight/line_marker_provider/CallDefinition.java
+++ b/src/org/elixir_lang/code_insight/line_marker_provider/CallDefinition.java
@@ -11,8 +11,10 @@ import com.intellij.openapi.editor.markup.GutterIconRenderer;
 import com.intellij.openapi.editor.markup.SeparatorPlacement;
 import com.intellij.openapi.util.Pair;
 import com.intellij.psi.*;
+import com.intellij.psi.impl.source.tree.LeafPsiElement;
 import org.apache.commons.lang.math.IntRange;
 import org.elixir_lang.psi.AtUnqualifiedNoParenthesesCall;
+import org.elixir_lang.psi.ElixirTypes;
 import org.elixir_lang.psi.call.Call;
 import org.elixir_lang.structure_view.element.CallDefinitionClause;
 import org.jetbrains.annotations.NotNull;
@@ -80,11 +82,28 @@ public class CallDefinition implements LineMarkerProvider {
      */
 
     @NotNull
-    private LineMarkerInfo callDefinitionSeparator(@NotNull Call call) {
+    private LineMarkerInfo callDefinitionSeparator(
+            @NotNull AtUnqualifiedNoParenthesesCall atUnqualifiedNoParenthesesCall
+    ) {
+        LeafPsiElement leafPsiElement = (LeafPsiElement) atUnqualifiedNoParenthesesCall
+                        .getAtIdentifier()
+                        .getNode()
+                        .findChildByType(ElixirTypes.IDENTIFIER_TOKEN);
+
+        assert leafPsiElement != null :
+                "AtUnqualifiedNoParenthesesCall (" +
+                        atUnqualifiedNoParenthesesCall.getText() +
+                        ") does not have an Identifier token";
+
+        return callDefinitionSeparator(leafPsiElement);
+    }
+
+    @NotNull
+    private LineMarkerInfo callDefinitionSeparator(@NotNull PsiElement psiElement) {
         LineMarkerInfo lineMarkerInfo;
-        lineMarkerInfo = new LineMarkerInfo<Call>(
-                call,
-                call.getTextRange(),
+        lineMarkerInfo = new LineMarkerInfo<>(
+                psiElement,
+                psiElement.getTextRange(),
                 null,
                 Pass.UPDATE_ALL,
                 null,

--- a/src/org/elixir_lang/formatter/Block.java
+++ b/src/org/elixir_lang/formatter/Block.java
@@ -2030,12 +2030,14 @@ public class Block extends AbstractBlock implements BlockEx {
                                                    start of `fn` */
                                                 int stabParentStartOffset = stabParent.getStartOffset();
                                                 int directParentStartOffset = stabOperation.getStartOffset();
+                                                int spaces = normalIndentSize(stabParent) -
+                                                        (directParentStartOffset - stabParentStartOffset);
 
-                                                childrenIndent = Indent.getSpaceIndent(
-                                                        normalIndentSize(stabParent) -
-                                                                (directParentStartOffset - stabParentStartOffset),
-                                                        true
-                                                );
+                                                if (spaces < 0) {
+                                                    spaces = 0;
+                                                }
+
+                                                childrenIndent = Indent.getSpaceIndent(spaces, true);
                                             }
                                         } else {
                                             childrenIndent = null;

--- a/testData/org/elixir_lang/formatting/no_parentheses_call_anonymous_function_call_alignment.ex
+++ b/testData/org/elixir_lang/formatting/no_parentheses_call_anonymous_function_call_alignment.ex
@@ -1,0 +1,4 @@
+one fn two ->
+       two
+    end,
+    three

--- a/testData/org/elixir_lang/formatting/no_parentheses_call_multiple_anonymous_function_stab_body_alignment.ex
+++ b/testData/org/elixir_lang/formatting/no_parentheses_call_multiple_anonymous_function_stab_body_alignment.ex
@@ -17,11 +17,6 @@ one fn two -> two end, fn three ->
   three
 end
 
-one fn two ->
-      two
-    end,
-    three
-
 one fn
       ^two ->
         :three

--- a/tests/org/elixir_lang/FormattingTest.java
+++ b/tests/org/elixir_lang/FormattingTest.java
@@ -185,6 +185,10 @@ public class FormattingTest extends LightCodeInsightFixtureTestCase {
         assertFormatted("bit_string_only_indent_nested_keywords.ex");
     }
 
+    public void testNoParenthesesCallAnonymousFunctionCallAlignment() {
+        assertFormatted("no_parentheses_call_anonymous_function_call_alignment.ex");
+    }
+
     public void testNoParenthesesCallDoNotWrapUnlessKeywordsMultiline() {
         myFixture.configureByFile("no_parentheses_call_do_not_wrap_unless_keywords_multiline_before.ex");
 

--- a/tests/org/elixir_lang/mix/importWizard/MixProjectImportBuilderTest.java
+++ b/tests/org/elixir_lang/mix/importWizard/MixProjectImportBuilderTest.java
@@ -2,20 +2,16 @@ package org.elixir_lang.mix.importWizard;
 
 import com.intellij.compiler.CompilerWorkspaceConfiguration;
 import com.intellij.ide.projectWizard.ProjectWizardTestCase;
-import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.application.PathMacros;
 import com.intellij.openapi.components.PathMacroManager;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.module.ModuleManager;
 import com.intellij.openapi.project.Project;
-import com.intellij.openapi.projectRoots.ProjectJdkTable;
-import com.intellij.openapi.projectRoots.Sdk;
 import com.intellij.openapi.roots.ModuleRootManager;
 import com.intellij.openapi.roots.impl.ModuleRootManagerImpl;
 import com.intellij.openapi.util.JDOMUtil;
 import com.intellij.openapi.util.io.FileUtil;
 import org.elixir_lang.configuration.ElixirCompilerSettings;
-import org.elixir_lang.sdk.elixir.Release;
 import org.elixir_lang.sdk.elixir.Type;
 import org.jdom.Document;
 import org.jdom.Element;
@@ -32,7 +28,6 @@ public class MixProjectImportBuilderTest extends ProjectWizardTestCase{
   private static final String MODULE_DIR = "MODULE_DIR";
   private static final String TEST_DATA = "testData/org/elixir_lang/";
   private static final String TEST_DATA_IMPORT = TEST_DATA + "mix/import/";
-  private static final String MOCK_SDK_DIR = TEST_DATA + "mockSdk-1.0.4/";
 
   public void testFromRootMixExsFile() throws Exception{ doTest(); }
 
@@ -44,14 +39,9 @@ public class MixProjectImportBuilderTest extends ProjectWizardTestCase{
   @Override
   protected void setUp() throws Exception {
     super.setUp();
-    createMockSdk();
+    createSdk("Elixir", Type.getInstance());
     File currentTestRoot = new File(TEST_DATA_IMPORT, getTestName(true));
     FileUtil.copyDir(currentTestRoot, new File(getProject().getBaseDir().getPath()));
-  }
-
-  private static void createMockSdk(){
-    final Sdk mockSdk = Type.createMockSdk(MOCK_SDK_DIR, Release.V_1_0_4);
-    ApplicationManager.getApplication().runWriteAction(() -> ProjectJdkTable.getInstance().addJdk(mockSdk));
   }
 
   private void doTest() throws Exception{

--- a/tests/org/elixir_lang/parser_definition/ParsingTestCase.java
+++ b/tests/org/elixir_lang/parser_definition/ParsingTestCase.java
@@ -3,6 +3,7 @@ package org.elixir_lang.parser_definition;
 import com.ericsson.otp.erlang.OtpErlangObject;
 import com.intellij.lang.Language;
 import com.intellij.lang.ParserDefinition;
+import com.intellij.mock.MockApplicationEx;
 import com.intellij.mock.MockLocalFileSystem;
 import com.intellij.openapi.extensions.Extensions;
 import com.intellij.openapi.extensions.ExtensionsArea;
@@ -19,7 +20,9 @@ import com.intellij.openapi.roots.*;
 import com.intellij.openapi.roots.impl.*;
 import com.intellij.openapi.vfs.VirtualFileManager;
 import com.intellij.openapi.vfs.VirtualFileSystem;
+import com.intellij.openapi.vfs.impl.CoreVirtualFilePointerManager;
 import com.intellij.openapi.vfs.impl.VirtualFileManagerImpl;
+import com.intellij.openapi.vfs.pointers.VirtualFilePointerManager;
 import com.intellij.psi.*;
 import com.intellij.util.messages.MessageBus;
 import org.elixir_lang.ElixirLanguage;
@@ -303,8 +306,9 @@ public abstract class ParsingTestCase extends com.intellij.testFramework.Parsing
 
         registerExtensionPoint(OrderRootType.EP_NAME, OrderRootType.class);
         registerExtension(OrderRootType.EP_NAME, new JavadocOrderRootType());
+        MockApplicationEx application = getApplication();
 
-        getApplication().addComponent(
+        application.addComponent(
                 VirtualFileManager.class,
                 new VirtualFileManagerImpl(
                         new VirtualFileSystem[]{
@@ -313,6 +317,7 @@ public abstract class ParsingTestCase extends com.intellij.testFramework.Parsing
                         messageBus
                 )
         );
+        application.addComponent(VirtualFilePointerManager.class, new CoreVirtualFilePointerManager());
 
         ProjectJdkTable projectJdkTable = new ProjectJdkTableImpl();
         registerApplicationService(ProjectJdkTable.class, projectJdkTable);


### PR DESCRIPTION
# Changelog
## Enhancements
* Bump version number to 7.0.0 to account for Incompatible Changes of dropping support for IntelliJ IDEA < 2016.3 because it does not include `ReadAction.compute` and `StreamEx` used for credo performance improvements in #950.
* Add 2017.3 to build matrix

## Incompatible Changes
* Drop support for IntelliJ IDEA < 2016.3 because it does not include `ReadAction.compute` and `StreamEx` used for credo performance improvements in #950.