### PR TITLE
 Check if SdkAdditionalData is null before getting ErlangSDK

### DIFF
--- a/src/org/elixir_lang/sdk/erlang_dependent/AdditionalDataConfigurable.java
+++ b/src/org/elixir_lang/sdk/erlang_dependent/AdditionalDataConfigurable.java
@@ -143,10 +143,17 @@ public class AdditionalDataConfigurable implements com.intellij.openapi.projectR
         return wholePanel;
     }
 
-    private void internalErlangSdkUpdate(final Sdk sdk) {
-        final Sdk erlangSdk = ((SdkAdditionalData) sdk.getSdkAdditionalData()).getErlangSdk();
+    private void internalErlangSdkUpdate(@NotNull final Sdk sdk) {
+        SdkAdditionalData sdkAdditionalData = (SdkAdditionalData) sdk.getSdkAdditionalData();
+        Sdk erlangSdk;
 
-        if (internalErlangSdksComboBoxModel.getIndexOf(erlangSdk) == -1) {
+        if (sdkAdditionalData != null) {
+            erlangSdk = sdkAdditionalData.getErlangSdk();
+        } else {
+            erlangSdk = null;
+        }
+
+        if (erlangSdk == null || internalErlangSdksComboBoxModel.getIndexOf(erlangSdk) == -1) {
             internalErlangSdksComboBoxModel.addElement(erlangSdk);
         } else {
             internalErlangSdksComboBoxModel.setSelectedItem(erlangSdk);


### PR DESCRIPTION
# Changelog
## Bug Fixes
* Check if `SdkAdditionalData` is `null` before getting `ErlangSDK` as it can be `null` in certain scenarios in Rubymine.