### PR TITLE
Put default Erlang SDK and update paths in project converter

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -19,6 +19,7 @@
     <!-- Elixir Module Structure -->
     <sdkType implementation="org.elixir_lang.sdk.elixir.Type"/>
     <sdkType implementation="org.elixir_lang.sdk.erlang.Type"/>
+    <project.converterProvider implementation="org.elixir_lang.sdk.elixir.conversion.Provider"/>
 
     <moduleConfigurationEditorProvider implementation="org.elixir_lang.module.DefaultModuleEditorsProvider" order="first"/>
 

--- a/src/org/elixir_lang/sdk/elixir/Type.java
+++ b/src/org/elixir_lang/sdk/elixir/Type.java
@@ -175,7 +175,8 @@ public class Type extends org.elixir_lang.sdk.erlang_dependent.Type {
         sdkModificator.commitChanges();
     }
 
-    private static Sdk configureInternalErlangSdk(@NotNull Sdk elixirSdk, @NotNull SdkModificator elixirSdkModificator) {
+    @Nullable
+    public static Sdk configureInternalErlangSdk(@NotNull Sdk elixirSdk, @NotNull SdkModificator elixirSdkModificator) {
         final Sdk erlangSdk = defaultErlangSdk();
 
         if (erlangSdk != null) {
@@ -356,7 +357,7 @@ public class Type extends org.elixir_lang.sdk.erlang_dependent.Type {
     }
 
     @Nullable
-    private static Sdk defaultErlangSdk() {
+    public static Sdk defaultErlangSdk() {
         ProjectJdkTable projectJdkTable = ProjectJdkTable.getInstance();
         SdkType erlangSdkType = erlangSdkType(projectJdkTable);
 
@@ -372,19 +373,6 @@ public class Type extends org.elixir_lang.sdk.erlang_dependent.Type {
         return defaultErlangSdk;
     }
 
-    @Nullable
-    public static Sdk putDefaultErlangSdk(@NotNull Sdk elixirSdk) {
-        assert elixirSdk.getSdkType() == Type.getInstance();
-
-        SdkModificator sdkModificator = elixirSdk.getSdkModificator();
-        Sdk defaultErlangSdk = configureInternalErlangSdk(elixirSdk, sdkModificator);
-        ApplicationManager.getApplication().invokeAndWait(
-                () -> ApplicationManager.getApplication().runWriteAction(sdkModificator::commitChanges),
-                NON_MODAL
-        );
-
-        return defaultErlangSdk;
-    }
 
     @NotNull
     public static Type getInstance() {

--- a/src/org/elixir_lang/sdk/elixir/conversion/Converter.kt
+++ b/src/org/elixir_lang/sdk/elixir/conversion/Converter.kt
@@ -1,0 +1,164 @@
+package org.elixir_lang.sdk.elixir.conversion
+
+import com.intellij.conversion.ProjectConverter
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.application.ModalityState.NON_MODAL
+import com.intellij.openapi.projectRoots.ProjectJdkTable
+import com.intellij.openapi.projectRoots.Sdk
+import com.intellij.openapi.projectRoots.SdkModificator
+import com.intellij.openapi.roots.OrderRootType
+import com.intellij.openapi.vfs.VirtualFileManager
+import org.elixir_lang.sdk.elixir.Type
+import org.elixir_lang.sdk.elixir.Type.*
+import org.elixir_lang.sdk.erlang_dependent.SdkAdditionalData
+import java.nio.file.Paths
+
+private fun commitChanges(sdkModificator: SdkModificator) =
+    ApplicationManager.getApplication().invokeAndWait(
+            { ApplicationManager.getApplication().runWriteAction { sdkModificator.commitChanges() } },
+            NON_MODAL
+    )
+
+private fun isElixir(sdk: Sdk): Boolean = sdk.sdkType is Type
+
+private fun isClassPathConversionNeeded(homePath: String, sdkModificator: SdkModificator): Boolean =
+    isPathConversionNeeded(oldClassPathPath(homePath), sdkModificator, OrderRootType.CLASSES)
+
+private fun isPathConversionNeeded(oldPathPath: String,
+                                   sdkModificator: SdkModificator,
+                                   orderRootType: OrderRootType): Boolean =
+    sdkModificator.getRoots(orderRootType).any { virtualFile ->
+        virtualFile.path == oldPathPath
+    }
+
+private fun isSourcePathConversionNeeded(homePath: String, sdkModificator: SdkModificator): Boolean =
+    isPathConversionNeeded(oldSourcePathPath(homePath), sdkModificator, OrderRootType.SOURCES)
+
+private const val ELIXIR_LANG_DOT_ORG_DOCS_URL = "http://elixir-lang.org/docs/stable/elixir/"
+
+private fun isDocumentationPathConversionNeeded(sdkModificator: SdkModificator): Boolean =
+    documentationRootType()?.let { documentationRootType ->
+        sdkModificator.getRoots(documentationRootType).any { documentationPath ->
+            documentationPath.url == ELIXIR_LANG_DOT_ORG_DOCS_URL
+        }
+    } == true
+
+private fun isErlangSdkConversionNeeded(sdk: Sdk): Boolean =
+        (sdk.sdkAdditionalData as? SdkAdditionalData)?.erlangSdk == null
+
+private fun isConversionNeeded(sdk: Sdk): Boolean =
+        (isErlangSdkConversionNeeded(sdk) && defaultErlangSdk() != null) ||
+                sdk.sdkModificator.let { sdkModificator ->
+                    isDocumentationPathConversionNeeded(sdkModificator) ||
+                            sdk.homePath?.let { homePath ->
+                                isClassPathConversionNeeded(homePath, sdkModificator) ||
+                                        isSourcePathConversionNeeded(homePath, sdkModificator)
+                            } == true
+                }
+
+fun oldClassPathPath(homePath: String): String {
+    return Paths.get(homePath, "lib").toString()
+}
+
+fun oldSourcePathPath(homePath: String): String {
+    return Paths.get(homePath, "lib").toString()
+}
+
+private fun putDefaultErlangSdk(elixirSdk: Sdk): Sdk? {
+    val sdkModificator = elixirSdk.sdkModificator
+    val defaultErlangSdk = configureInternalErlangSdk(elixirSdk, sdkModificator)
+
+    commitChanges(sdkModificator)
+
+    return defaultErlangSdk
+}
+
+private fun sdks(): Sequence<Sdk> = ProjectJdkTable.getInstance().allJdks.asSequence().filter(::isElixir)
+
+private fun updateClassPaths(sdkModificator: SdkModificator, homePath: String): Boolean {
+    val oldClassPathPath = oldClassPathPath(homePath)
+    var modified = false
+
+    for (classPath in sdkModificator.getRoots(OrderRootType.CLASSES)) {
+        val classPathPath = classPath.path
+
+        if (classPathPath == oldClassPathPath) {
+            sdkModificator.removeRoot(classPath, OrderRootType.CLASSES)
+            org.elixir_lang.sdk.Type.addCodePaths(sdkModificator)
+            modified = true
+        }
+    }
+
+    return modified
+}
+
+private fun updateDocumentationPaths(sdkModificator: SdkModificator): Boolean {
+    val documentationRootType = documentationRootType()
+    var modified = false
+
+    if (documentationRootType != null) {
+        val elixirLangDotOrgDocsUrl = "http://elixir-lang.org/docs/stable/elixir/"
+
+        for (documentationPath in sdkModificator.getRoots(documentationRootType)) {
+            if (documentationPath.url == elixirLangDotOrgDocsUrl) {
+                VirtualFileManager
+                        .getInstance()
+                        .findFileByUrl(elixirLangDotOrgDocsUrl)
+                        ?.let { elixirLangDotOrgDocsUrlVirtualFile ->
+                            sdkModificator.removeRoot(elixirLangDotOrgDocsUrlVirtualFile, documentationRootType)
+                        }
+                addDocumentationPaths(sdkModificator)
+                modified = true
+            }
+        }
+    }
+
+    return modified
+}
+
+private fun updateRoots(sdk: Sdk) {
+    val homePath = sdk.homePath
+
+    if (homePath != null) {
+        val sdkModificator = sdk.sdkModificator
+        val modified = updateClassPaths(sdkModificator, homePath) ||
+                updateDocumentationPaths(sdkModificator) ||
+                updateSourcePaths(sdkModificator, homePath)
+
+        if (modified) {
+            ApplicationManager.getApplication().invokeAndWait(
+                    { ApplicationManager.getApplication().runWriteAction { sdkModificator.commitChanges() } },
+                    NON_MODAL
+            )
+        }
+    }
+}
+
+private fun updateSourcePaths(sdkModificator: SdkModificator, homePath: String): Boolean {
+    val oldSourcePathPath = oldSourcePathPath(homePath)
+    var modified = false
+
+    for (classPath in sdkModificator.getRoots(OrderRootType.SOURCES)) {
+        val classPathPath = classPath.path
+
+        if (classPathPath == oldSourcePathPath) {
+            sdkModificator.removeRoot(classPath, OrderRootType.SOURCES)
+            addSourcePaths(sdkModificator)
+            modified = true
+        }
+    }
+
+    return modified
+}
+
+class Converter: ProjectConverter() {
+    override fun isConversionNeeded(): Boolean = sdks().any { sdk -> isConversionNeeded(sdk) }
+    override fun preProcessingFinished() {
+        super.preProcessingFinished()
+
+        sdks().forEach { sdk ->
+            updateRoots(sdk)
+            putDefaultErlangSdk(sdk)
+        }
+    }
+}

--- a/src/org/elixir_lang/sdk/elixir/conversion/Provider.kt
+++ b/src/org/elixir_lang/sdk/elixir/conversion/Provider.kt
@@ -1,0 +1,9 @@
+package org.elixir_lang.sdk.elixir.conversion
+
+import com.intellij.conversion.ConversionContext
+import com.intellij.conversion.ConverterProvider
+
+class Provider : ConverterProvider("elixir-sdk-put-default-erlang-sdk") {
+    override fun createConverter(conversionContext: ConversionContext) = Converter()
+    override fun getConversionDescription() = "Elixir SDKs will now have an Internal Erlang SDK"
+}


### PR DESCRIPTION
Fixes #959

# Changelog
## Enhancements
* `mix` runs will be faster as they will no longer check to see if the SDK is updated.

## Bug Fixes
* Avoid problems with read and write locks when updating Elixir SDK on-demand by instead updating them when any project is open using a project converter.  