### PR TITLE
Assume JavadocOrderRootType only exists in IntelliJ

### DIFF
--- a/src/org/elixir_lang/sdk/elixir/Type.java
+++ b/src/org/elixir_lang/sdk/elixir/Type.java
@@ -114,10 +114,10 @@ public class Type extends org.elixir_lang.sdk.erlang_dependent.Type {
     public static OrderRootType documentationRootType() {
         OrderRootType rootType;
 
-        try {
-            rootType = JavadocOrderRootType.getInstance();
-        } catch (AssertionError assertionError) {
+        if (isSmallIde()) {
             rootType = null;
+        } else {
+            rootType = JavadocOrderRootType.getInstance();
         }
 
         return rootType;


### PR DESCRIPTION
Fixes #961 
Fixes #962 

# Changelog
## Bug FIxes
* https://github.com/JetBrains/intellij-community/commit/9adbba0b6fe279bcc65ad96ab7332d7bf5b59a83 added `@NotNull` to `OrderRootType.getOrderRootType`, which `JavaDocRootType.getInstance` calls, which means any Small IDE using `intellij-community` since 4 months ago, including the newest CLion cannot have `JavadocOrderRootType.getInstance` safely called.