### PR TITLE
Apply ProjectSdksModel changes after Editor changes

### DIFF
--- a/src/org/elixir_lang/facet/sdks/Configurable.kt
+++ b/src/org/elixir_lang/facet/sdks/Configurable.kt
@@ -39,12 +39,10 @@ abstract class Configurable: SearchableConfigurable, com.intellij.openapi.option
     })
 
     override fun apply() {
-        projectSdksModel.apply()
         editorByProjectJdkImpl.forEach { _, editor ->
-            // TODO figure out why a single apply does not work
-            editor.apply()
             editor.apply()
         }
+        projectSdksModel.apply()
     }
 
     override fun createComponent(): JComponent? {


### PR DESCRIPTION
# Changelog
## Bug FIxes
* Path changes were not being written back to disk because the `projectSdksModel.apply()` was being called before the `editor.apply()`, which would have copied to the `editor'`s path changes to the `projectSdksModel`.