### PR TITLE
Protect JavaDocRootType.getInstance in erlang/Type

### DIFF
--- a/src/org/elixir_lang/sdk/Type.java
+++ b/src/org/elixir_lang/sdk/Type.java
@@ -1,18 +1,30 @@
 package org.elixir_lang.sdk;
 
 import com.intellij.openapi.projectRoots.SdkModificator;
+import com.intellij.openapi.roots.JavadocOrderRootType;
 import com.intellij.openapi.roots.OrderRootType;
 import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VirtualFile;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.nio.file.Path;
 import java.util.function.Consumer;
 
 import static org.elixir_lang.sdk.HomePath.eachEbinPath;
+import static org.elixir_lang.sdk.ProcessOutput.isSmallIde;
 
 public class Type {
     private Type() {
+    }
+
+    public static void addCodePaths(@NotNull SdkModificator sdkModificator) {
+        eachEbinPath(
+                sdkModificator.getHomePath(),
+                ebin -> ebinPathChainVirtualFile(
+                        ebin, virtualFile -> sdkModificator.addRoot(virtualFile, OrderRootType.CLASSES)
+                )
+        );
     }
 
     public static void ebinPathChainVirtualFile(@NotNull Path ebinPath, Consumer<VirtualFile> virtualFileConsumer) {
@@ -25,12 +37,16 @@ public class Type {
         }
     }
 
-    public static void addCodePaths(@NotNull SdkModificator sdkModificator) {
-        eachEbinPath(
-                sdkModificator.getHomePath(),
-                ebin -> ebinPathChainVirtualFile(
-                        ebin, virtualFile -> sdkModificator.addRoot(virtualFile, OrderRootType.CLASSES)
-                )
-        );
+    @Nullable
+    public static OrderRootType documentationRootType() {
+        OrderRootType rootType;
+
+        if (isSmallIde()) {
+            rootType = null;
+        } else {
+            rootType = JavadocOrderRootType.getInstance();
+        }
+
+        return rootType;
     }
 }

--- a/src/org/elixir_lang/sdk/elixir/Type.java
+++ b/src/org/elixir_lang/sdk/elixir/Type.java
@@ -52,6 +52,7 @@ import static org.elixir_lang.sdk.ProcessOutput.STANDARD_TIMEOUT;
 import static org.elixir_lang.sdk.ProcessOutput.isSmallIde;
 import static org.elixir_lang.sdk.ProcessOutput.transformStdoutLine;
 import static org.elixir_lang.sdk.Type.addCodePaths;
+import static org.elixir_lang.sdk.Type.documentationRootType;
 import static org.elixir_lang.sdk.Type.ebinPathChainVirtualFile;
 
 public class Type extends org.elixir_lang.sdk.erlang_dependent.Type {
@@ -108,19 +109,6 @@ public class Type extends org.elixir_lang.sdk.erlang_dependent.Type {
                 sdkModificator.addRoot(hexdocUrlVirtualFile, documentationRootType);
             }
         }
-    }
-
-    @Nullable
-    public static OrderRootType documentationRootType() {
-        OrderRootType rootType;
-
-        if (isSmallIde()) {
-            rootType = null;
-        } else {
-            rootType = JavadocOrderRootType.getInstance();
-        }
-
-        return rootType;
     }
 
     private static void addDocumentationPath(@NotNull SdkModificator sdkModificator,

--- a/src/org/elixir_lang/sdk/elixir/conversion/Converter.kt
+++ b/src/org/elixir_lang/sdk/elixir/conversion/Converter.kt
@@ -8,6 +8,7 @@ import com.intellij.openapi.projectRoots.Sdk
 import com.intellij.openapi.projectRoots.SdkModificator
 import com.intellij.openapi.roots.OrderRootType
 import com.intellij.openapi.vfs.VirtualFileManager
+import org.elixir_lang.sdk.Type.documentationRootType
 import org.elixir_lang.sdk.elixir.Type
 import org.elixir_lang.sdk.elixir.Type.*
 import org.elixir_lang.sdk.erlang_dependent.SdkAdditionalData

--- a/src/org/elixir_lang/sdk/erlang/Type.java
+++ b/src/org/elixir_lang/sdk/erlang/Type.java
@@ -7,7 +7,6 @@ import com.intellij.openapi.projectRoots.Sdk;
 import com.intellij.openapi.projectRoots.SdkModel;
 import com.intellij.openapi.projectRoots.SdkModificator;
 import com.intellij.openapi.projectRoots.SdkType;
-import com.intellij.openapi.roots.JavadocOrderRootType;
 import com.intellij.openapi.roots.OrderRootType;
 import com.intellij.openapi.util.SystemInfo;
 import com.intellij.openapi.util.Version;
@@ -26,6 +25,7 @@ import java.util.regex.Pattern;
 
 import static org.elixir_lang.sdk.HomePath.*;
 import static org.elixir_lang.sdk.Type.addCodePaths;
+import static org.elixir_lang.sdk.Type.documentationRootType;
 
 /**
  * An Erlang SdkType for use when `intellij-erlang` is not installed
@@ -145,7 +145,7 @@ public class Type extends SdkType {
     public boolean isRootTypeApplicable(@NotNull OrderRootType type) {
         return type == OrderRootType.CLASSES ||
                 type == OrderRootType.SOURCES ||
-                type == JavadocOrderRootType.getInstance();
+                type == documentationRootType();
     }
 
     @Override


### PR DESCRIPTION
Fixes #976 

# Changelog
## Bug Fixes
* Use `documentionRootType` to indirectly get the documentation `OrderRootType`
in the Erlang SDK Type, so that it works in Small IDEs that have more than `CLASSES` and `SOURCES` root types installed.