### PR TITLE
Disable credo annotator by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@
     - [Commenter](#commenter)
     - [Credo](#credo)
       - [Annotator](#annotator)
+        - [Enable](#enable)
+        - [Disable](#disable)
       - [Inspection](#inspection)
         - [Batch Mode](#batch-mode)
       - [Configuration](#configuration)
@@ -1424,7 +1426,7 @@ Using the menus
 
 #### Annotator
 
-If [`credo`](https://github.com/rrrene/credo) is not installed as a project dependency, nothing will happen, but if it is installed, `mix credo PATH` will be called on any files after updates have quieted.  Any `credo` check failures will show up as warning annotations
+When enabled, if [`credo`](https://github.com/rrrene/credo) is not installed as a project dependency, nothing will happen, but if it is installed, `mix credo PATH` will be called on any files after updates have quieted.  Any `credo` check failures will show up as warning annotations
 
 ![Warning Annotations](/screenshots/features/credo/external_annotator/Warning%20Annotations.png?raw=true "Warning Annotations")
 
@@ -1433,6 +1435,20 @@ Individual check failures will show the explanation (from `mix credo PATH:LINE(:
 ![Explanation](/screenshots/features/credo/external_annotator/Explanation.png?raw=true "Credo Check Failure Explanation")
 
 You can hover over the explanation and click the embedded links to jump to the line (and column) where the failure occurred.
+
+##### Enable
+
+The [`credo`](https://github.com/rrrene/credo) annotator is disabled by default as numerous users find running `mix credo` in the background has a negative impact on their system performance.  If you like to try enabling the annotation, you can turn it on using the [configuration](#configuration).
+
+1. Preferences > Editor > Inspections > Elixir
+2. Check "Credo"
+
+##### Disable
+
+If you notice a degradation the in the responsiveness of the editor, it is recommended you disable the annotator again.
+
+1. Preferences > Editor > Inspections > Elixir
+2. Uncheck "Credo"
 
 #### Inspection
 

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -88,7 +88,7 @@
 
     <!-- credo -->
     <externalAnnotator implementationClass="org.elixir_lang.credo.Annotator" language="Elixir"/>
-    <globalInspection cleanupTool="true" displayName="Credo" enabledByDefault="true" groupName="Elixir"
+    <globalInspection cleanupTool="true" displayName="Credo" enabledByDefault="false" groupName="Elixir"
                       implementationClass="org.elixir_lang.credo.inspection_tool.Global" language="Elixir" level="WARNING"
                       shortName="Credo"/>
     // groupId/parentId "Errors" is Editor > Inspections


### PR DESCRIPTION
Fixes #970

# Changelog
## Bug Fix
* The [`credo`](https://github.com/rrrene/credo) annotator is disabled by default as numerous users find running `mix credo` in the background has a negative impact on their system performance.  If you like to try enabling the annotation, you can turn it on using the configuration.

  1. Preferences > Editor > Inspections > Elixir
  2. Check "Credo"
  3. Click OK to save and close Preferences

  If you notice a degradation the in the responsiveness of the editor, it is recommended you disable the annotator again.

  1. Preferences > Editor > Inspections > Elixir
  2. Uncheck "Credo"
  3. Click OK to save and close Preferences