### PR TITLE
Protect PsiFile being null in Local credo inspector

### DIFF
--- a/src/org/elixir_lang/credo/inspection_tool/Local.kt
+++ b/src/org/elixir_lang/credo/inspection_tool/Local.kt
@@ -16,17 +16,24 @@ class Local: LocalInspectionTool() {
     override fun checkFile(file: PsiFile, manager: InspectionManager, isOnTheFly: Boolean): Array<ProblemDescriptor>? {
         val viewProvider = file.viewProvider
         val language = ElixirLanguage.INSTANCE
-        val psiRoot = viewProvider.getPsi(language)
 
-        return ExternalLanguageAnnotators
-                .allForFile(language, psiRoot)
-                .filterIsInstance<Annotator>()
-                .firstOrNull()
-                ?.let { annotator ->
-                    ExternalAnnotatorInspectionVisitor.checkFileWithExternalAnnotator(file, manager, false, annotator)
+        return viewProvider
+                .getPsi(language)
+                ?.let { psiRoot ->
+                    ExternalLanguageAnnotators
+                            .allForFile(language, psiRoot)
+                            .filterIsInstance<Annotator>()
+                            .firstOrNull()
+                            ?.let { annotator ->
+                                ExternalAnnotatorInspectionVisitor.checkFileWithExternalAnnotator(
+                                        file,
+                                        manager,
+                                        false,
+                                        annotator
+                                )
+                            }
                 }
-                ?:
-                emptyArray()
+                ?: emptyArray()
     }
 
     override fun getDisplayName(): String = "Credo"


### PR DESCRIPTION
Fixes #969

# Changelog
## Bug Fixes
* Protect from `PsiFile` being `null` in `Local` credo inspector
  