### PR TITLE
Don't add `.bat` to `mix` on Windows

### DIFF
--- a/jps-shared/src/org/elixir_lang/jps/model/JpsElixirSdkType.java
+++ b/jps-shared/src/org/elixir_lang/jps/model/JpsElixirSdkType.java
@@ -31,8 +31,8 @@ public class JpsElixirSdkType extends JpsSdkType<JpsDummyElement> implements Jps
   }
 
   @NotNull
-  public static File getMixExecutable(@NotNull String sdkHome){
-    return getSdkExecutable(sdkHome, ELIXIR_TOOL_MIX);
+  public static File getMixScript(@NotNull String sdkHome) {
+    return getSdkScript(sdkHome, ELIXIR_TOOL_MIX);
   }
 
   @NotNull
@@ -43,6 +43,11 @@ public class JpsElixirSdkType extends JpsSdkType<JpsDummyElement> implements Jps
   @NotNull
   private static File getSdkExecutable(@NotNull String sdkHome, @NotNull String command){
     return new File(new File(sdkHome, "bin").getAbsolutePath(), getExecutableFileName(command));
+  }
+
+  @NotNull
+  private static File getSdkScript(@NotNull String sdkHome, @NotNull String command) {
+    return new File(new File(sdkHome, "bin").getAbsolutePath(), command);
   }
 
   @NotNull

--- a/src/org/elixir_lang/mix/runner/MixRunningStateUtil.java
+++ b/src/org/elixir_lang/mix/runner/MixRunningStateUtil.java
@@ -29,6 +29,7 @@ import org.jetbrains.annotations.Nullable;
 import java.io.File;
 
 import static org.apache.commons.lang.StringUtils.isBlank;
+import static org.elixir_lang.jps.model.JpsElixirSdkType.ELIXIR_TOOL_MIX;
 import static org.elixir_lang.sdk.elixir.Type.mostSpecificSdk;
 
 /**
@@ -179,12 +180,12 @@ public class MixRunningStateUtil {
             String homePath = sdk.getHomePath();
 
             if (homePath != null) {
-                mixPath = JpsElixirSdkType.getMixExecutable(homePath).getPath();
+                mixPath = JpsElixirSdkType.getMixScript(homePath).getPath();
             } else {
-                mixPath = JpsElixirSdkType.getExecutableFileName("mix");
+                mixPath = ELIXIR_TOOL_MIX;
             }
         } else {
-            mixPath = JpsElixirSdkType.getExecutableFileName("mix");
+            mixPath = ELIXIR_TOOL_MIX;
         }
 
         return mixPath;

--- a/src/org/elixir_lang/sdk/elixir/Type.java
+++ b/src/org/elixir_lang/sdk/elixir/Type.java
@@ -585,10 +585,10 @@ public class Type extends org.elixir_lang.sdk.erlang_dependent.Type {
         File elixir = JpsElixirSdkType.getScriptInterpreterExecutable(path);
         File elixirc = JpsElixirSdkType.getByteCodeCompilerExecutable(path);
         File iex = JpsElixirSdkType.getIExExecutable(path);
-        File mix = JpsElixirSdkType.getMixExecutable(path);
+        File mix = JpsElixirSdkType.getMixScript(path);
 
-        // Determine whether everything is executable
-        return elixir.canExecute() && elixirc.canExecute() && iex.canExecute() && mix.canExecute();
+        // Determine whether everything is can run
+        return elixir.canExecute() && elixirc.canExecute() && iex.canExecute() && mix.canRead();
     }
 
     @Override


### PR DESCRIPTION
Fixes #971

# Changelog
## Bug Fixes
* Don't add `.bat` to `mix` on Windows. `mix` is never run as an executable.  It is either run as a script to `elixir.bat` OR as an argument to `erl.exe` when `erl.exe` is running `elixir`.