### PR TITLE
Debugger fixes

### DIFF
--- a/resources/META-INF/rich-platform-plugin.xml
+++ b/resources/META-INF/rich-platform-plugin.xml
@@ -10,6 +10,7 @@
 
       <projectImportProvider implementation="org.elixir_lang.mix.importWizard.MixProjectImportProvider" />
       <projectImportBuilder implementation="org.elixir_lang.mix.importWizard.MixProjectImportBuilder" />
+      <project.converterProvider implementation="org.elixir_lang.mix.importWizard.conversion.Provider"/>
 
       <!-- for doQuickImport when open directory which contains mix.exs file -->
       <projectOpenProcessor implementation="org.elixir_lang.mix.importWizard.MixProjectOpenProcessor" />

--- a/resources/debugger/lib/debug_server.ex
+++ b/resources/debugger/lib/debug_server.ex
@@ -136,7 +136,7 @@ defmodule IntellijElixir.DebugServer do
       |> Stream.map(&erlang_module_name_pattern_to_regex_pattern/1)
       |> Enum.join("|")
 
-    Regex.compile!("^#{unpinned_pattern}$")
+    Regex.compile!("^(#{unpinned_pattern})$")
   end
 
   defp meta_pid_to_stack(meta_pid, %{line: break_line}) do

--- a/resources/debugger/lib/debug_task.ex
+++ b/resources/debugger/lib/debug_task.ex
@@ -112,9 +112,9 @@ defmodule Mix.Tasks.IntellijElixir.DebugTask do
       |> Stream.map(&Path.basename(&1, ".beam"))
       |> Enum.reduce({[], []}, fn basename, {filter, reject} ->
         if Regex.match?(reject_regex, basename) do
-          {[basename | filter], reject}
-        else
           {filter, [basename | reject]}
+        else
+          {[basename | filter], reject}
         end
       end)
 

--- a/src/org/elixir_lang/mix/importWizard/MixProjectImportBuilder.java
+++ b/src/org/elixir_lang/mix/importWizard/MixProjectImportBuilder.java
@@ -183,6 +183,8 @@ public class MixProjectImportBuilder extends ProjectImportBuilder<ImportedOtpApp
         _buildDir = myProjectRoot != null && myProjectRoot.equals(ideaModuleDir) ? ideaModuleDir : ideaModuleDir.getParent().getParent();
         compilerModuleExt.setCompilerOutputPath(_buildDir + StringUtil.replace("/_build/dev/lib/" + importedOtpApp.getName() + "/ebin", "/", File.separator));
         compilerModuleExt.setCompilerOutputPathForTests(_buildDir + StringUtil.replace("/_build/test/lib/" + importedOtpApp.getName() + "/ebin", "/", File.separator));
+        // output paths need to be included, so that they are indexed for Phoenix EEx Template Elixir Line Breakpoints
+        compilerModuleExt.setExcludeOutput(false);
 
         createdRootModels.add(rootModel);
 

--- a/src/org/elixir_lang/mix/importWizard/conversion/Converter.kt
+++ b/src/org/elixir_lang/mix/importWizard/conversion/Converter.kt
@@ -1,0 +1,10 @@
+package org.elixir_lang.mix.importWizard.conversion
+
+import com.intellij.conversion.ConversionProcessor
+import com.intellij.conversion.ModuleSettings
+import com.intellij.conversion.ProjectConverter
+
+class Converter : ProjectConverter() {
+    override fun isConversionNeeded()= false
+    override fun createModuleFileConverter(): ConversionProcessor<ModuleSettings> = ModuleSettings()
+}

--- a/src/org/elixir_lang/mix/importWizard/conversion/ModuleSettings.kt
+++ b/src/org/elixir_lang/mix/importWizard/conversion/ModuleSettings.kt
@@ -1,0 +1,20 @@
+package org.elixir_lang.mix.importWizard.conversion
+
+import com.intellij.conversion.ConversionProcessor
+import com.intellij.conversion.ModuleSettings
+import org.jetbrains.jps.model.serialization.java.JpsJavaModelSerializerExtension.EXCLUDE_OUTPUT_TAG
+
+class ModuleSettings : ConversionProcessor<ModuleSettings>() {
+    override fun isConversionNeeded(moduleSettings: ModuleSettings) =
+            moduleSettings.moduleType == "ELIXIR_MODULE" &&
+        parentElement(moduleSettings)?.getChild(EXCLUDE_OUTPUT_TAG) != null
+
+    override fun process(moduleSettings: ModuleSettings) {
+        parentElement(moduleSettings)!!.removeChild(EXCLUDE_OUTPUT_TAG)
+    }
+
+    companion object {
+        private fun parentElement(moduleSettings: ModuleSettings) =
+            moduleSettings.getComponentElement(ModuleSettings.MODULE_ROOT_MANAGER_COMPONENT)
+    }
+}

--- a/src/org/elixir_lang/mix/importWizard/conversion/Provider.kt
+++ b/src/org/elixir_lang/mix/importWizard/conversion/Provider.kt
@@ -1,0 +1,14 @@
+package org.elixir_lang.mix.importWizard.conversion
+
+import com.intellij.conversion.ConversionContext
+import com.intellij.conversion.ConverterProvider
+import com.intellij.conversion.ProjectConverter
+
+class Provider : ConverterProvider("elixir-include-compiler-output") {
+    override fun getConversionDescription(): String {
+        return "No longer excludes compiler output paths (`ebin` directories), so that Phoenix View `.beam` files " +
+                "can be indexed to resolve EEx Template Elixir Line Breakpoints"
+    }
+
+    override fun createConverter(conversionContext: ConversionContext): ProjectConverter = Converter()
+}

--- a/testData/org/elixir_lang/mix/import/fromRootMixExsFile/expected/14/kv.iml
+++ b/testData/org/elixir_lang/mix/import/fromRootMixExsFile/expected/14/kv.iml
@@ -2,7 +2,6 @@
 <root inherit-compiler-output="false">
   <output url="file://$MODULE_DIR$/_build/dev/lib/kv/ebin" />
   <output-test url="file://$MODULE_DIR$/_build/test/lib/kv/ebin" />
-  <exclude-output />
   <content url="file://$MODULE_DIR$">
     <sourceFolder url="file://$MODULE_DIR$/lib" isTestSource="false" />
   </content>

--- a/testData/org/elixir_lang/mix/import/fromRootMixExsFile/expected/2017.1/kv.iml
+++ b/testData/org/elixir_lang/mix/import/fromRootMixExsFile/expected/2017.1/kv.iml
@@ -2,7 +2,6 @@
 <root>
   <output url="file://$MODULE_DIR$/_build/dev/lib/kv/ebin" />
   <output-test url="file://$MODULE_DIR$/_build/test/lib/kv/ebin" />
-  <exclude-output />
   <content url="file://$MODULE_DIR$">
     <sourceFolder url="file://$MODULE_DIR$/lib" isTestSource="false" />
   </content>

--- a/tests/org/elixir_lang/mix/importWizard/MixProjectImportBuilderTest.java
+++ b/tests/org/elixir_lang/mix/importWizard/MixProjectImportBuilderTest.java
@@ -18,7 +18,6 @@ import org.jdom.Element;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.File;
-import java.util.Arrays;
 
 /**
  * Created by zyuyou on 15/7/17.
@@ -80,7 +79,7 @@ public class MixProjectImportBuilderTest extends ProjectWizardTestCase{
       File expectedImlFile = new File(projectPath + "/expected/" + format + "/" + module.getName() + ".iml");
       Document expectedIml = JDOMUtil.loadDocument(expectedImlFile);
       Element expectedImlElement = expectedIml.getRootElement();
-      expected.append(Arrays.toString(JDOMUtil.printDocument(expectedIml, "\n"))).append('\n');
+      expected.append(JDOMUtil.writeDocument(expectedIml, "\n")).append('\n');
 
       if (JDOMUtil.areElementsEqual(expectedImlElement, actualImlElement)) {
         assertTrue(true);
@@ -91,7 +90,7 @@ public class MixProjectImportBuilderTest extends ProjectWizardTestCase{
     if (!formattedFound) {
       String errorMsg = expected
               .append("\nBut got:\n")
-              .append(Arrays.toString(JDOMUtil.printDocument(new Document(actualImlElement), "\n")))
+              .append(JDOMUtil.writeDocument(new Document(actualImlElement), "\n"))
               .toString();
      assertTrue(errorMsg, false);
     }


### PR DESCRIPTION
# Changelog
## Enhancements
* When importing Mix projects, don't exclude compiler output from indexing because it is needed to resolve Elixir Line Breakpoints in EEx files.
  * For pre-existing Elixir modules, they will be converted to not exclude compiler output.

## Bug Fixes
* Group alternatives in `erlang_module_name_patterns_to_regex` before pinning: I always forget that the `|` swallows the `^` and `$` in regexes.
* Reject vs filter accumulation got flipped when switching to `Enum.reduce` to track rejections.