### PR TITLE
Don't allow uninterpretable modules to kill debugger

### DIFF
--- a/resources/debugger/lib/debug_server.ex
+++ b/resources/debugger/lib/debug_server.ex
@@ -3,7 +3,8 @@ defmodule IntellijElixir.DebugServer do
 
   use GenServer
 
-  defstruct port: nil,
+  defstruct reason_by_uninterpretable: %{},
+            port: nil,
             ref: nil,
             reject_erlang_module_name_patterns: [],
             reject_regex: nil,
@@ -30,6 +31,15 @@ defmodule IntellijElixir.DebugServer do
   ## GenServer callbacks
 
   @impl GenServer
+
+  def handle_cast(
+        :reason_by_uninterpretable,
+        state = %__MODULE__{socket: socket, reason_by_uninterpretable: reason_by_uninterpretable}
+      ) do
+    send_message(socket, {:reason_by_uninterpretable, reason_by_uninterpretable})
+    {:noreply, state}
+  end
+
   def handle_cast(
         :rejected_module_names,
         state = %__MODULE__{rejected_module_names: rejected_module_names, socket: socket}

--- a/src/org/elixir_lang/debugger/Node.java
+++ b/src/org/elixir_lang/debugger/Node.java
@@ -75,6 +75,10 @@ public class Node {
     addCommand(new SetBreakpoint(ElixirModulesUtil.INSTANCE.elixirModuleNameToErlang(module), line, file));
   }
 
+  public void reasonByUninterpretable() {
+    addCommand(new ReasonByUninterpretable());
+  }
+
   public void rejectedModuleNames() {
     addCommand(new RejectedModuleNames());
   }

--- a/src/org/elixir_lang/debugger/Settings.kt
+++ b/src/org/elixir_lang/debugger/Settings.kt
@@ -62,6 +62,8 @@ class Settings(moduleFilters: List<ModuleFilter> = defaultModuleFilters()):
                 ModuleFilter(pattern = "Application"),
                 ModuleFilter(pattern = "Atom"),
                 ModuleFilter(pattern = "Base"),
+                // bcrypt_elixir
+                ModuleFilter(pattern = "Bcrypt.Base"),
                 ModuleFilter(pattern = "Behaviour"),
                 ModuleFilter(pattern = "Bitwise"),
                 ModuleFilter(pattern = "Calendar"),

--- a/src/org/elixir_lang/debugger/Settings.kt
+++ b/src/org/elixir_lang/debugger/Settings.kt
@@ -155,7 +155,9 @@ class Settings(moduleFilters: List<ModuleFilter> = defaultModuleFilters()):
                 ModuleFilter(pattern = ":elixir_*"),
                 // See https://github.com/KronicDeth/intellij-elixir/issues/989
                 ModuleFilter(pattern = ":lz4"),
-                ModuleFilter(pattern = ":ranch*")
+                ModuleFilter(pattern = ":ranch*"),
+                // See https://github.com/KronicDeth/intellij-elixir/issues/989
+                ModuleFilter(pattern = ":re2")
         )
 
         fun getInstance(): Settings = XDebuggerSettings.getInstance(Settings::class.java)

--- a/src/org/elixir_lang/debugger/Settings.kt
+++ b/src/org/elixir_lang/debugger/Settings.kt
@@ -151,11 +151,11 @@ class Settings(moduleFilters: List<ModuleFilter> = defaultModuleFilters()):
                 ModuleFilter(pattern = "Tuple"),
                 ModuleFilter(pattern = "URI"),
                 ModuleFilter(pattern = "Version"),
-                ModuleFilter(pattern = "cow*"),
-                ModuleFilter(pattern = "elixir_*"),
+                ModuleFilter(pattern = ":cow*"),
+                ModuleFilter(pattern = ":elixir_*"),
                 // See https://github.com/KronicDeth/intellij-elixir/issues/989
                 ModuleFilter(pattern = ":lz4"),
-                ModuleFilter(pattern = "ranch*")
+                ModuleFilter(pattern = ":ranch*")
         )
 
         fun getInstance(): Settings = XDebuggerSettings.getInstance(Settings::class.java)

--- a/src/org/elixir_lang/debugger/Settings.kt
+++ b/src/org/elixir_lang/debugger/Settings.kt
@@ -155,6 +155,8 @@ class Settings(moduleFilters: List<ModuleFilter> = defaultModuleFilters()):
                 ModuleFilter(pattern = "Version"),
                 ModuleFilter(pattern = ":cow*"),
                 ModuleFilter(pattern = ":elixir_*"),
+                // See https://github.com/KronicDeth/intellij-elixir/issues/915
+                ModuleFilter(pattern = ":erocksdb"),
                 // See https://github.com/KronicDeth/intellij-elixir/issues/989
                 ModuleFilter(pattern = ":lz4"),
                 ModuleFilter(pattern = ":ranch*"),

--- a/src/org/elixir_lang/debugger/Settings.kt
+++ b/src/org/elixir_lang/debugger/Settings.kt
@@ -153,6 +153,8 @@ class Settings(moduleFilters: List<ModuleFilter> = defaultModuleFilters()):
                 ModuleFilter(pattern = "Version"),
                 ModuleFilter(pattern = "cow*"),
                 ModuleFilter(pattern = "elixir_*"),
+                // See https://github.com/KronicDeth/intellij-elixir/issues/989
+                ModuleFilter(pattern = ":lz4"),
                 ModuleFilter(pattern = "ranch*")
         )
 

--- a/src/org/elixir_lang/debugger/node/command/ReasonByUninterpretable.kt
+++ b/src/org/elixir_lang/debugger/node/command/ReasonByUninterpretable.kt
@@ -1,0 +1,8 @@
+package org.elixir_lang.debugger.node.command
+
+import com.ericsson.otp.erlang.OtpErlangAtom
+import org.elixir_lang.debugger.node.Command
+
+class ReasonByUninterpretable : Command {
+    override fun toMessage() = OtpErlangAtom("reason_by_uninterpretable")
+}


### PR DESCRIPTION
Fixes #837
Fixes #891
Fixes #915  
Fixes #989

# Changelog
## Enhancements
* Exclude known uninterpretable modules
  * `Bcrypt.Base`
  * `:erocksdb`
  * `:lz4`
  * `:re2`

## Bug Fixes
* Some modules, like NIF modules, can't be loaded into the debugger. Individual modules not being debuggable shouldn't kill the debugger task, so rescue the known error and record it for later debugging of the debugger.
* Add `:` to start of Erlang module names for included debugger excludes