### PR TITLE
Ignore test case bad-.beams

### DIFF
--- a/src/org/elixir_lang/beam/Beam.kt
+++ b/src/org/elixir_lang/beam/Beam.kt
@@ -113,7 +113,9 @@ class Beam private constructor(chunkCollection: Collection<Chunk>) {
             }
 
             if (HEADER != header) {
-                LOGGER.error("header typeID ($header) did not match expected ($HEADER) from $path")
+                if (!testCase(header)) {
+                    LOGGER.error("header typeID ($header) did not match expected ($HEADER) from $path")
+                }
                 return null
             }
 
@@ -182,5 +184,7 @@ class Beam private constructor(chunkCollection: Collection<Chunk>) {
                         ?.let { Beam.from(it, virtualFile.path) }
 
         fun `is`(virtualFile: VirtualFile): Boolean = !virtualFile.isDirectory && "beam" == virtualFile.extension
+
+        private fun testCase(header: String?): Boolean = header == "baz "
     }
 }


### PR DESCRIPTION
Fixes #1029 

# Changelog
## Bug Fixes
* Certain `.beam` files in the OTP source are purposely invalid, so ignore them when trying to parse and don't log the expected error.