### PR TITLE
Create BEAM Chunks tab panels only when switching to them

### DIFF
--- a/src/org/elixir_lang/beam/FileEditor.kt
+++ b/src/org/elixir_lang/beam/FileEditor.kt
@@ -76,7 +76,7 @@ class FileEditor(
             Chunk.TypeID.CINF.toString() ->
                 JBScrollPane(Table(org.elixir_lang.beam.chunk.keyword.Model(cache.compileInfo)))
             Chunk.TypeID.CODE.toString() ->
-                org.elixir_lang.beam.chunk.code.Component(cache, project)
+                org.elixir_lang.beam.chunk.code.Component(cache, project, tabbedPane)
             Chunk.TypeID.DBGI.toString() ->
                 org.elixir_lang.beam.chunk.debug_info.term.component(cache.debugInfo, project)
             Chunk.TypeID.EXDC.toString() ->

--- a/src/org/elixir_lang/beam/FileEditor.kt
+++ b/src/org/elixir_lang/beam/FileEditor.kt
@@ -76,7 +76,7 @@ class FileEditor(
             Chunk.TypeID.CINF.toString() ->
                 JBScrollPane(Table(org.elixir_lang.beam.chunk.keyword.Model(cache.compileInfo)))
             Chunk.TypeID.CODE.toString() ->
-                org.elixir_lang.beam.chunk.code.component(cache, project)
+                org.elixir_lang.beam.chunk.code.Component(cache, project)
             Chunk.TypeID.DBGI.toString() ->
                 org.elixir_lang.beam.chunk.debug_info.term.component(cache.debugInfo, project)
             Chunk.TypeID.EXDC.toString() ->

--- a/src/org/elixir_lang/beam/FileEditor.kt
+++ b/src/org/elixir_lang/beam/FileEditor.kt
@@ -78,7 +78,7 @@ class FileEditor(
             Chunk.TypeID.CODE.toString() ->
                 org.elixir_lang.beam.chunk.code.Component(cache, project, tabbedPane)
             Chunk.TypeID.DBGI.toString() ->
-                org.elixir_lang.beam.chunk.debug_info.term.component(cache.debugInfo, project)
+                org.elixir_lang.beam.chunk.debug_info.term.component(cache.debugInfo, project, tabbedPane)
             Chunk.TypeID.EXDC.toString() ->
                 org.elixir_lang.beam.chunk.elixir_documentation.component(
                         cache.elixirDocumentation,

--- a/src/org/elixir_lang/beam/FileEditor.kt
+++ b/src/org/elixir_lang/beam/FileEditor.kt
@@ -83,7 +83,8 @@ class FileEditor(
                 org.elixir_lang.beam.chunk.elixir_documentation.component(
                         cache.elixirDocumentation,
                         project,
-                        cache.atoms?.moduleName()
+                        cache.atoms?.moduleName(),
+                        tabbedPane
                 )
             Chunk.TypeID.EXPT.toString() ->
                 JBScrollPane(Table(org.elixir_lang.beam.chunk.call_definitions.Model(cache.exports)))

--- a/src/org/elixir_lang/beam/chunk/code/Component.kt
+++ b/src/org/elixir_lang/beam/chunk/code/Component.kt
@@ -9,16 +9,18 @@ import org.elixir_lang.beam.assembly.Controls
 import org.elixir_lang.beam.assembly.file.Type
 import javax.swing.JComponent
 
+class Component(private val cache: Cache, private val project: Project) : BorderLayoutPanel() {
+    override fun addNotify() {
+        val controls = Controls(cache, project)
+        addToTop(controls)
 
-fun component(cache: Cache, project: Project): JComponent {
-    val controls = Controls(cache, project)
-    val document = controls.document
-    val editorComponent = editorComponent(document, project)
+        val document = controls.document
+        val editorComponent = editorComponent(document, project)
+        addToCenter(editorComponent)
 
-    return BorderLayoutPanel().addToTop(controls).addToCenter(editorComponent)
+        super.addNotify()
+    }
 }
-
-// Private functions
 
 private fun editorComponent(document: Document, project: Project): JComponent =
     EditorFactory.getInstance().createEditor(document, project, Type, true).component

--- a/src/org/elixir_lang/beam/chunk/code/Component.kt
+++ b/src/org/elixir_lang/beam/chunk/code/Component.kt
@@ -19,26 +19,29 @@ class Component(private val cache: Cache, private val project: Project, tabbedPa
     }
 
     override fun stateChanged(changeEvent: ChangeEvent) {
-        if (changeEvent.source.let { it  as JBTabbedPane }.selectedComponent == this) {
+        if (changeEvent.source.let { it as JBTabbedPane }.selectedComponent == this) {
             ensureChildrenAdded()
         }
     }
 
     private var childrenAdded = false
 
+    private fun addChildren() {
+        val controls = Controls(cache, project)
+        addToTop(controls)
+
+        val document = controls.document
+        val editorComponent = editorComponent(document, project)
+        addToCenter(editorComponent)
+    }
+
     private fun ensureChildrenAdded() {
         if (!childrenAdded) {
-            val controls = Controls(cache, project)
-            addToTop(controls)
-
-            val document = controls.document
-            val editorComponent = editorComponent(document, project)
-            addToCenter(editorComponent)
-
+            addChildren()
             childrenAdded = true
         }
     }
 }
 
 private fun editorComponent(document: Document, project: Project): JComponent =
-    EditorFactory.getInstance().createEditor(document, project, Type, true).component
+        EditorFactory.getInstance().createEditor(document, project, Type, true).component

--- a/src/org/elixir_lang/beam/chunk/code/Component.kt
+++ b/src/org/elixir_lang/beam/chunk/code/Component.kt
@@ -3,22 +3,40 @@ package org.elixir_lang.beam.chunk.code
 import com.intellij.openapi.editor.Document
 import com.intellij.openapi.editor.EditorFactory
 import com.intellij.openapi.project.Project
+import com.intellij.ui.components.JBTabbedPane
 import com.intellij.util.ui.components.BorderLayoutPanel
 import org.elixir_lang.beam.Cache
 import org.elixir_lang.beam.assembly.Controls
 import org.elixir_lang.beam.assembly.file.Type
 import javax.swing.JComponent
+import javax.swing.event.ChangeEvent
+import javax.swing.event.ChangeListener
 
-class Component(private val cache: Cache, private val project: Project) : BorderLayoutPanel() {
-    override fun addNotify() {
-        val controls = Controls(cache, project)
-        addToTop(controls)
+class Component(private val cache: Cache, private val project: Project, tabbedPane: JBTabbedPane) :
+        BorderLayoutPanel(), ChangeListener {
+    init {
+        tabbedPane.addChangeListener(this)
+    }
 
-        val document = controls.document
-        val editorComponent = editorComponent(document, project)
-        addToCenter(editorComponent)
+    override fun stateChanged(changeEvent: ChangeEvent) {
+        if (changeEvent.source.let { it  as JBTabbedPane }.selectedComponent == this) {
+            ensureChildrenAdded()
+        }
+    }
 
-        super.addNotify()
+    private var childrenAdded = false
+
+    private fun ensureChildrenAdded() {
+        if (!childrenAdded) {
+            val controls = Controls(cache, project)
+            addToTop(controls)
+
+            val document = controls.document
+            val editorComponent = editorComponent(document, project)
+            addToCenter(editorComponent)
+
+            childrenAdded = true
+        }
     }
 }
 

--- a/src/org/elixir_lang/beam/chunk/debug_info/term/Model.kt
+++ b/src/org/elixir_lang/beam/chunk/debug_info/term/Model.kt
@@ -3,6 +3,7 @@ package org.elixir_lang.beam.chunk.debug_info.term
 import com.ericsson.otp.erlang.OtpErlangObject
 import com.intellij.openapi.project.Project
 import com.intellij.ui.components.JBScrollPane
+import com.intellij.ui.components.JBTabbedPane
 import org.elixir_lang.beam.chunk.DebugInfo
 import org.elixir_lang.beam.chunk.Table
 import org.elixir_lang.beam.chunk.debug_info.Term
@@ -11,10 +12,10 @@ import javax.swing.JComponent
 import javax.swing.JPanel
 import javax.swing.table.AbstractTableModel
 
-fun component(debugInfo: DebugInfo?, project: Project): JComponent =
+fun component(debugInfo: DebugInfo?, project: Project, tabbedPane: JBTabbedPane): JComponent =
     when (debugInfo) {
         is org.elixir_lang.beam.chunk.debug_info.v1.elixir_erl.V1 ->
-            org.elixir_lang.beam.chunk.debug_info.v1.elixir_erl.v1.Component(debugInfo, project)
+            org.elixir_lang.beam.chunk.debug_info.v1.elixir_erl.v1.Component(debugInfo, project, tabbedPane)
         is org.elixir_lang.beam.chunk.debug_info.v1.erl_abstract_code.AbstractCodeCompileOptions ->
             org.elixir_lang.beam.chunk.debug_info.v1.erl_abstract_code.abstract_code_compiler_options.Component(
                     debugInfo,

--- a/src/org/elixir_lang/beam/chunk/debug_info/term/Model.kt
+++ b/src/org/elixir_lang/beam/chunk/debug_info/term/Model.kt
@@ -19,7 +19,8 @@ fun component(debugInfo: DebugInfo?, project: Project, tabbedPane: JBTabbedPane)
         is org.elixir_lang.beam.chunk.debug_info.v1.erl_abstract_code.AbstractCodeCompileOptions ->
             org.elixir_lang.beam.chunk.debug_info.v1.erl_abstract_code.abstract_code_compiler_options.Component(
                     debugInfo,
-                    project
+                    project,
+                    tabbedPane
             )
         is ElixirErl ->
             JBScrollPane(Table(org.elixir_lang.beam.chunk.debug_info.v1.elixir_erl.Model(debugInfo)))

--- a/src/org/elixir_lang/beam/chunk/debug_info/v1/elixir_erl/v1/Component.kt
+++ b/src/org/elixir_lang/beam/chunk/debug_info/v1/elixir_erl/v1/Component.kt
@@ -18,7 +18,7 @@ class Component(private val debugInfo: V1, private val project: Project, tabbedP
     }
 
     override fun stateChanged(changeEvent: ChangeEvent) {
-        if (changeEvent.let { it as JBTabbedPane }.selectedComponent == this) {
+        if (changeEvent.source.let { it as JBTabbedPane }.selectedComponent == this) {
             ensureChildrenAdded()
         }
     }

--- a/src/org/elixir_lang/beam/chunk/debug_info/v1/elixir_erl/v1/Component.kt
+++ b/src/org/elixir_lang/beam/chunk/debug_info/v1/elixir_erl/v1/Component.kt
@@ -2,15 +2,30 @@ package org.elixir_lang.beam.chunk.debug_info.v1.elixir_erl.v1
 
 import com.intellij.openapi.project.Project
 import com.intellij.ui.components.JBScrollPane
+import com.intellij.ui.components.JBTabbedPane
 import org.elixir_lang.beam.chunk.debug_info.v1.elixir_erl.V1
 import java.awt.GridBagConstraints
 import java.awt.GridBagConstraints.BOTH
 import java.awt.GridBagConstraints.HORIZONTAL
 import java.awt.GridBagLayout
 import javax.swing.JPanel
+import javax.swing.event.ChangeEvent
+import javax.swing.event.ChangeListener
 
-class Component(debugInfo: V1, project: Project) : JPanel(GridBagLayout()) {
+class Component(private val debugInfo: V1, private val project: Project, tabbedPane: JBTabbedPane) : JPanel(GridBagLayout()), ChangeListener {
     init {
+        tabbedPane.addChangeListener(this)
+    }
+
+    override fun stateChanged(changeEvent: ChangeEvent) {
+        if (changeEvent.let { it as JBTabbedPane }.selectedComponent == this) {
+            ensureChildrenAdded()
+        }
+    }
+
+    private var childrenAdded = false
+
+    private fun addChildren() {
         val shrink = Double.MIN_VALUE
         val expand = 1.0 - shrink
 
@@ -30,5 +45,12 @@ class Component(debugInfo: V1, project: Project) : JPanel(GridBagLayout()) {
                     weightx = 1.0; weighty = expand
                 }
         )
+    }
+
+    private fun ensureChildrenAdded() {
+        if (!childrenAdded) {
+            addChildren()
+            childrenAdded = true
+        }
     }
 }

--- a/src/org/elixir_lang/beam/chunk/debug_info/v1/erl_abstract_code/abstract_code_compiler_options/Component.kt
+++ b/src/org/elixir_lang/beam/chunk/debug_info/v1/erl_abstract_code/abstract_code_compiler_options/Component.kt
@@ -1,15 +1,42 @@
 package org.elixir_lang.beam.chunk.debug_info.v1.erl_abstract_code.abstract_code_compiler_options
 
 import com.intellij.openapi.project.Project
+import com.intellij.ui.components.JBTabbedPane
 import org.elixir_lang.beam.chunk.debug_info.v1.erl_abstract_code.AbstractCodeCompileOptions
 import org.elixir_lang.beam.chunk.debug_info.v1.erl_abstract_code.abstract_code_compiler_options.abstract_code.Splitter
 import javax.swing.JPanel
 import javax.swing.JTabbedPane
+import javax.swing.event.ChangeEvent
+import javax.swing.event.ChangeListener
 
-class Component(debugInfo: AbstractCodeCompileOptions, project: Project):
-        JTabbedPane(JTabbedPane.TOP, JTabbedPane.WRAP_TAB_LAYOUT) {
+class Component(
+        private val debugInfo: AbstractCodeCompileOptions,
+        private val project: Project,
+        tabbedPane: JBTabbedPane
+):
+        JTabbedPane(JTabbedPane.TOP, JTabbedPane.WRAP_TAB_LAYOUT), ChangeListener {
+
     init {
+        tabbedPane.addChangeListener(this)
+    }
+
+    override fun stateChanged(changeEvent: ChangeEvent) {
+        if (changeEvent.source.let { it as JBTabbedPane }.selectedComponent == this) {
+            ensureChildrenAdded()
+        }
+    }
+
+    private var childrenAdded = false
+
+    private fun addChildren() {
         addTab("Abstract Code", Splitter(debugInfo, project))
         addTab("Compile Options", JPanel())
+    }
+
+    private fun ensureChildrenAdded() {
+        if (!childrenAdded) {
+            addChildren()
+            childrenAdded = true
+        }
     }
 }

--- a/src/org/elixir_lang/beam/chunk/elixir_documentation/Splitter.kt
+++ b/src/org/elixir_lang/beam/chunk/elixir_documentation/Splitter.kt
@@ -3,13 +3,40 @@ package org.elixir_lang.beam.chunk.elixir_documentation
 import com.intellij.openapi.project.Project
 import com.intellij.ui.OnePixelSplitter
 import com.intellij.ui.components.JBScrollPane
+import com.intellij.ui.components.JBTabbedPane
 import org.elixir_lang.beam.chunk.ElixirDocumentation
+import javax.swing.event.ChangeEvent
+import javax.swing.event.ChangeListener
 
-class Splitter(elixirDocumentation: ElixirDocumentation, project: Project, moduleName: String?): OnePixelSplitter(false) {
+class Splitter(
+        private val elixirDocumentation: ElixirDocumentation,
+        private val project: Project,
+        private val moduleName: String?,
+        tabbedPane: JBTabbedPane
+): OnePixelSplitter(false), ChangeListener {
     init {
+        tabbedPane.addChangeListener(this)
+    }
+
+    override fun stateChanged(changeEvent: ChangeEvent) {
+        if (changeEvent.source.let { it as JBTabbedPane }.selectedComponent == this) {
+            ensureChildrenAdded()
+        }
+    }
+
+    private var childrenAdded = false
+
+    private fun addChildren() {
         val tree = Tree(moduleName, Model(elixirDocumentation))
 
         firstComponent = JBScrollPane(tree)
         secondComponent = Panel(tree, project, moduleName)
+    }
+
+    private fun ensureChildrenAdded() {
+        if (!childrenAdded) {
+            addChildren()
+            childrenAdded = true
+        }
     }
 }

--- a/src/org/elixir_lang/beam/chunk/elixir_documentation/namespace.kt
+++ b/src/org/elixir_lang/beam/chunk/elixir_documentation/namespace.kt
@@ -2,13 +2,19 @@ package org.elixir_lang.beam.chunk.elixir_documentation
 
 import com.intellij.openapi.project.Project
 import com.intellij.ui.components.JBScrollPane
+import com.intellij.ui.components.JBTabbedPane
 import org.elixir_lang.beam.chunk.ElixirDocumentation
 import javax.swing.JComponent
 import javax.swing.JPanel
 
-fun component(elixirDocumentation: ElixirDocumentation?, project: Project, moduleName: String?): JComponent =
+fun component(
+        elixirDocumentation: ElixirDocumentation?,
+        project: Project,
+        moduleName: String?,
+        tabbedPane: JBTabbedPane
+): JComponent =
         if (elixirDocumentation != null) {
-            Splitter(elixirDocumentation, project, moduleName)
+            Splitter(elixirDocumentation, project, moduleName, tabbedPane)
         } else {
             JBScrollPane(JPanel())
         }


### PR DESCRIPTION
Fixes #1031 
Fixes #1039

# Changelog
## Bug Fixes
* In order to prevent `Access is allowed from event dispatch thread only` errors when creating read-only code editor in subtabs of the BEAM Chunks editor, only create those editors when their parent tab is selected.

  Affected tabs:
  * Code (Elixir & Erlang)
  * ExDc
  * Dbgi (Elixir & Erlang)