### PR TITLE
Check for suffix instead of full match to detect predefined macros

### DIFF
--- a/src/org/elixir_lang/annotator/Callable.kt
+++ b/src/org/elixir_lang/annotator/Callable.kt
@@ -375,17 +375,13 @@ class Callable : Annotator, DumbAware {
                 standardTextAttributeKeys: Array<TextAttributesKey>,
                 predefinedTextAttributesKeys: Array<TextAttributesKey>
         ): Array<TextAttributesKey> =
-                if (psiElement is NavigationItem) {
-                    psiElement.presentation?.let { presentation ->
-                        if (PREDEFINED_LOCATION_STRING_SET.contains(presentation.locationString)) {
-                            predefinedTextAttributesKeys
-                        } else {
-                            null
-                        }
-                    } ?: standardTextAttributeKeys
-                } else {
-                    standardTextAttributeKeys
-                }
+                psiElement.let { it as? NavigationItem }?.presentation?.locationString?.let { locationString ->
+                    if (PREDEFINED_LOCATION_STRING_SET.any { locationString.endsWith(it) }) {
+                        predefinedTextAttributesKeys
+                    } else {
+                        null
+                    }
+                } ?: standardTextAttributeKeys
 
         private fun sameFile(referrer: PsiElement, resolved: PsiElement): Boolean =
             referrer.containingFile.virtualFile == resolved.containingFile.virtualFile


### PR DESCRIPTION
# Changelog
## Bug Fixes
* Check for suffix instead of full match to detect predefined macros when annotating.  Location strings have become more complex, such as including the file path for root level modules, so the old exact matching on the module name no longer works.