### PR TITLE
Restore rename module attributes

### DIFF
--- a/src/org/elixir_lang/UsageTypeProvider.kt
+++ b/src/org/elixir_lang/UsageTypeProvider.kt
@@ -18,6 +18,7 @@ import org.elixir_lang.structure_view.element.modular.Module
 class UsageTypeProvider : com.intellij.usages.impl.rules.UsageTypeProviderEx {
     override fun getUsageType(element: PsiElement?, targets: Array<out UsageTarget>): UsageType? =
             when (element) {
+                is AtUnqualifiedNoParenthesesCall<*> -> MODULE_ATTRIBUTE_ACCUMULATE_OR_OVERRIDE
                 is AtNonNumericOperation -> MODULE_ATTRIBUTE_READ
                 is QualifiableAlias -> qualifiableAliasUsageType(element, entrance = element)
                 is Call -> getUsageType(element, targets)
@@ -129,6 +130,7 @@ class UsageTypeProvider : com.intellij.usages.impl.rules.UsageTypeProviderEx {
         internal val CALL_DEFINITION_CLAUSE = UsageType("Call definition clause")
         internal val FUNCTION_PARAMETER = UsageType("Parameter declaration")
         internal val MODULE_DEFINITION = UsageType("Module definition")
+        internal val MODULE_ATTRIBUTE_ACCUMULATE_OR_OVERRIDE = UsageType("Module attribute accumulate or override")
         internal val MODULE_ATTRIBUTE_READ = UsageType("Module attribute read")
     }
 }

--- a/src/org/elixir_lang/psi/impl/AtUnqualifiedNoParenthesesCallImpl.kt
+++ b/src/org/elixir_lang/psi/impl/AtUnqualifiedNoParenthesesCallImpl.kt
@@ -4,13 +4,10 @@ import com.intellij.psi.PsiReference
 import com.intellij.psi.util.CachedValueProvider
 import com.intellij.psi.util.CachedValuesManager
 import org.elixir_lang.psi.AtUnqualifiedNoParenthesesCall
-import org.elixir_lang.psi.impl.call.computeReference
-
-private fun AtUnqualifiedNoParenthesesCall<*>.computeReference(): PsiReference? =
-        org.elixir_lang.reference.ModuleAttribute(this)
 
 fun AtUnqualifiedNoParenthesesCall<*>.getReference(): PsiReference? =
         CachedValuesManager.getCachedValue(this) {
-            CachedValueProvider.Result.create(computeReference(), this)
+            org.elixir_lang.reference.ModuleAttribute(this)
+                    .let { CachedValueProvider.Result.create(it, this) }
         }
 

--- a/src/org/elixir_lang/refactoring/module_attribute/rename/Handler.kt
+++ b/src/org/elixir_lang/refactoring/module_attribute/rename/Handler.kt
@@ -1,11 +1,18 @@
 package org.elixir_lang.refactoring.module_attribute.rename
 
+import com.intellij.codeInsight.TargetElementUtil
+import com.intellij.openapi.actionSystem.CommonDataKeys
+import com.intellij.openapi.actionSystem.DataContext
 import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiNamedElement
-import com.intellij.refactoring.rename.inplace.VariableInplaceRenameHandler
+import com.intellij.psi.PsiReference
+import com.intellij.refactoring.rename.RenameHandler
+import com.intellij.refactoring.rename.RenameHandlerRegistry
 import com.intellij.refactoring.rename.inplace.VariableInplaceRenamer
+import org.elixir_lang.find_usages.toPsiElementList
 import org.elixir_lang.psi.AtUnqualifiedNoParenthesesCall
 
 /**
@@ -14,14 +21,104 @@ import org.elixir_lang.psi.AtUnqualifiedNoParenthesesCall
  * [com.intellij.lang.refactoring.NamesValidator.isIdentifier] can't be customized to the
  * element.
  */
-class Handler : VariableInplaceRenameHandler() {
-    override fun createRenamer(elementToRename: PsiElement, editor: Editor): VariableInplaceRenamer? =
+// Can't subclass `VariableInplaceRenameHandler` because it declares `isAvailableOnDataContext` as `final`
+class Handler : RenameHandler {
+    // called during rename action update. should not perform any user interactions
+    override fun isAvailableOnDataContext(dataContext: DataContext): Boolean {
+        val editor = CommonDataKeys.EDITOR.getData(dataContext)
+        val file = CommonDataKeys.PSI_FILE.getData(dataContext)
+
+        return reference(editor, file) != null
+    }
+
+    // called on rename actionPerformed. Can obtain additional info from user
+    override fun isRenaming(dataContext: DataContext): Boolean = isAvailableOnDataContext(dataContext)
+
+    /**
+     * Invokes refactoring action from editor. The refactoring obtains
+     * all data from editor selection.
+     *
+     * @param project     the project in which the refactoring is invoked.
+     * @param editor      editor that refactoring is invoked in
+     * @param file        file should correspond to <code>editor</code>
+     * @param dataContext can be null for some but not all of refactoring action handlers
+     *                    (it is recommended to pass DataManager.getDataContext() instead of null)
+     */
+    override fun invoke(project: Project, editor: Editor?, file: PsiFile?, dataContext: DataContext?) {
+        val elements = reference(editor, file)?.toPsiElementList()?.toTypedArray() ?: emptyArray()
+
+        invoke(editor, elements, dataContext)
+    }
+
+    /**
+     * Invokes refactoring action from elsewhere (not from editor). Some refactorings
+     * do not implement this method.
+     *
+     * @param project     the project in which the refactoring is invoked.
+     * @param elements    list of elements that refactoring should work on. Refactoring-dependent.
+     * @param dataContext can be null for some but not all of refactoring action handlers
+     *                    (it is recommended to pass DataManager.getDataContext() instead of null)
+     */
+    override fun invoke(project: Project, elements: Array<out PsiElement>, dataContext: DataContext?) {
+        invoke(dataContext?.let { CommonDataKeys.EDITOR.getData(it) }, elements, dataContext)
+    }
+
+    private fun createRenamer(elementToRename: PsiElement, editor: Editor?): VariableInplaceRenamer? =
             Inplace(elementToRename as PsiNamedElement, editor)
 
-    override fun isAvailable(element: PsiElement?, editor: Editor, file: PsiFile): Boolean =
-            editor.settings.isVariableInplaceRenameEnabled && isAvailable(element)
+    // See `com.intellij.refactoring.rename.inplace.VariableInplaceRenameHandler.doRename`
+    private fun invoke(editor: Editor?, element: PsiElement, dataContext: DataContext?) {
+        val renamer = createRenamer(element, editor)
+        val startedRename = renamer?.performInplaceRename() ?: false
+
+        if (!startedRename) {
+            performDialogRename(element, editor, dataContext)
+        }
+    }
+
+    private fun invoke(editor: Editor?, elements: Array<out PsiElement>, dataContext: DataContext?) {
+        elements.forEach { element ->
+            invoke(editor, element, dataContext)
+        }
+    }
+
+    private fun isAvailableOnReference(psiReference: PsiReference) =
+            psiReference
+                    .toPsiElementList()
+                    .any { isAvailableOnResolved(it) }
+
+    private fun performDialogRename(element: PsiElement, editor: Editor?, dataContext: DataContext?) {
+        RenameHandlerRegistry
+                .getInstance()
+                .getRenameHandler(dataContext)!!
+                .invoke(
+                        element.project,
+                        editor,
+                        element.containingFile,
+                        dataContext
+                )
+    }
+
+    private fun reference(editor: Editor?, file: PsiFile?): PsiReference? =
+            if (editor != null && file != null) {
+                // matches logic in `UsageTargetProvider`, but with null checks for editor and file
+                val document = editor.document
+                val offset = editor.caretModel.offset
+
+                val adjustOffset = TargetElementUtil.adjustOffset(file, document, offset)
+
+                file.findReferenceAt(adjustOffset)?.let { reference ->
+                    if (isAvailableOnReference(reference)) {
+                        reference
+                    } else {
+                        null
+                    }
+                }
+            } else {
+                null
+            }
 
     companion object {
-        internal fun isAvailable(element: PsiElement?): Boolean = element is AtUnqualifiedNoParenthesesCall<*>
+        internal fun isAvailableOnResolved(element: PsiElement): Boolean = element is AtUnqualifiedNoParenthesesCall<*>
     }
 }

--- a/src/org/elixir_lang/refactoring/module_attribute/rename/Inplace.kt
+++ b/src/org/elixir_lang/refactoring/module_attribute/rename/Inplace.kt
@@ -8,7 +8,7 @@ import org.elixir_lang.ElixirLanguage
 
 import java.util.regex.Pattern
 
-internal class Inplace (elementToRename: PsiNamedElement, editor: Editor) :
+internal class Inplace (elementToRename: PsiNamedElement, editor: Editor?) :
         VariableInplaceRenamer(elementToRename, editor) {
     override fun isIdentifier(newName: String, language: Language): Boolean =
             language === ElixirLanguage && isIdentifier(newName)

--- a/src/org/elixir_lang/refactoring/module_attribute/rename/InputValidator.kt
+++ b/src/org/elixir_lang/refactoring/module_attribute/rename/InputValidator.kt
@@ -8,7 +8,7 @@ import com.intellij.refactoring.rename.RenameInputValidator
 import com.intellij.refactoring.rename.RenameInputValidatorEx
 import com.intellij.util.ProcessingContext
 import org.elixir_lang.psi.call.Call
-import org.elixir_lang.refactoring.module_attribute.rename.Handler.Companion.isAvailable
+import org.elixir_lang.refactoring.module_attribute.rename.Handler.Companion.isAvailableOnResolved
 import org.elixir_lang.refactoring.module_attribute.rename.Inplace.Companion.isIdentifier
 
 class InputValidator : RenameInputValidatorEx {
@@ -36,7 +36,7 @@ class InputValidator : RenameInputValidatorEx {
             override fun accepts(o: Any?): Boolean = false
 
             override fun accepts(o: Any?, context: ProcessingContext): Boolean =
-                    o is PsiElement && isAvailable(o)
+                    o is PsiElement && isAvailableOnResolved(o)
 
             override fun getCondition(): ElementPatternCondition<Call>? = null
         }

--- a/src/org/elixir_lang/refactoring/module_attribute/rename/Processor.kt
+++ b/src/org/elixir_lang/refactoring/module_attribute/rename/Processor.kt
@@ -2,8 +2,8 @@ package org.elixir_lang.refactoring.module_attribute.rename
 
 import com.intellij.psi.PsiElement
 import com.intellij.refactoring.rename.RenamePsiElementProcessor
-import org.elixir_lang.refactoring.module_attribute.rename.Handler.Companion.isAvailable
+import org.elixir_lang.refactoring.module_attribute.rename.Handler.Companion.isAvailableOnResolved
 
 class Processor : RenamePsiElementProcessor() {
-    override fun canProcessElement(element: PsiElement): Boolean = isAvailable(element)
+    override fun canProcessElement(element: PsiElement): Boolean = isAvailableOnResolved(element)
 }

--- a/src/org/elixir_lang/refactoring/variable/rename/Handler.kt
+++ b/src/org/elixir_lang/refactoring/variable/rename/Handler.kt
@@ -35,16 +35,17 @@ class Handler : RenameHandler {
 
     // called on rename actionPerformed. Can obtain additional info from user
     override fun isRenaming(dataContext: DataContext): Boolean = isAvailableOnDataContext(dataContext)
+
     /**
-   * Invokes refactoring action from editor. The refactoring obtains
-   * all data from editor selection.
-   *
-   * @param project     the project in which the refactoring is invoked.
-   * @param editor      editor that refactoring is invoked in
-   * @param file        file should correspond to <code>editor</code>
-   * @param dataContext can be null for some but not all of refactoring action handlers
-   *                    (it is recommended to pass DataManager.getDataContext() instead of null)
-   */
+     * Invokes refactoring action from editor. The refactoring obtains
+     * all data from editor selection.
+     *
+     * @param project     the project in which the refactoring is invoked.
+     * @param editor      editor that refactoring is invoked in
+     * @param file        file should correspond to <code>editor</code>
+     * @param dataContext can be null for some but not all of refactoring action handlers
+     *                    (it is recommended to pass DataManager.getDataContext() instead of null)
+     */
     override fun invoke(project: Project, editor: Editor?, file: PsiFile?, dataContext: DataContext?) {
         val elements = reference(editor, file)?.toPsiElementList()?.toTypedArray() ?: emptyArray()
 
@@ -52,14 +53,14 @@ class Handler : RenameHandler {
     }
 
     /**
-   * Invokes refactoring action from elsewhere (not from editor). Some refactorings
-   * do not implement this method.
-   *
-   * @param project     the project in which the refactoring is invoked.
-   * @param elements    list of elements that refactoring should work on. Refactoring-dependent.
-   * @param dataContext can be null for some but not all of refactoring action handlers
-   *                    (it is recommended to pass DataManager.getDataContext() instead of null)
-   */
+     * Invokes refactoring action from elsewhere (not from editor). Some refactorings
+     * do not implement this method.
+     *
+     * @param project     the project in which the refactoring is invoked.
+     * @param elements    list of elements that refactoring should work on. Refactoring-dependent.
+     * @param dataContext can be null for some but not all of refactoring action handlers
+     *                    (it is recommended to pass DataManager.getDataContext() instead of null)
+     */
     override fun invoke(project: Project, elements: Array<out PsiElement>, dataContext: DataContext?) {
         invoke(dataContext?.let { CommonDataKeys.EDITOR.getData(it) }, elements, dataContext)
     }
@@ -101,23 +102,23 @@ class Handler : RenameHandler {
     }
 
     private fun reference(editor: Editor?, file: PsiFile?): PsiReference? =
-         if (editor != null && file != null) {
-            // matches logic in `UsageTargetProvider`, but with null checks for editor and file
-            val document = editor.document
-            val offset = editor.caretModel.offset
+            if (editor != null && file != null) {
+                // matches logic in `UsageTargetProvider`, but with null checks for editor and file
+                val document = editor.document
+                val offset = editor.caretModel.offset
 
-            val adjustOffset = adjustOffset(file, document, offset)
+                val adjustOffset = adjustOffset(file, document, offset)
 
-            file.findReferenceAt(adjustOffset)?.let { reference ->
-                if (isAvailableOnReference(reference)) {
-                    reference
-                } else {
-                    null
+                file.findReferenceAt(adjustOffset)?.let { reference ->
+                    if (isAvailableOnReference(reference)) {
+                        reference
+                    } else {
+                        null
+                    }
                 }
+            } else {
+                null
             }
-        } else {
-            null
-        }
 
     companion object {
         internal fun isAvailableOnResolved(element: PsiElement): Boolean = element is Call && (

--- a/src/org/elixir_lang/reference/ModuleAttribute.kt
+++ b/src/org/elixir_lang/reference/ModuleAttribute.kt
@@ -32,24 +32,24 @@ class ModuleAttribute(psiElement: PsiElement) : PsiPolyVariantReferenceBase<PsiE
     override fun getVariants(): Array<Any> = getVariantsUpFromElement(myElement).toTypedArray()
 
     override fun handleElementRename(newModuleAttributeName: String): PsiElement =
-        when (myElement) {
-            is AtNonNumericOperation -> {
-                val moduleAttributeUsage = ElementFactory.createModuleAttributeUsage(
-                        myElement.getProject(),
-                        newModuleAttributeName
-                )
-                myElement.replace(moduleAttributeUsage)
+            when (myElement) {
+                is AtNonNumericOperation -> {
+                    val moduleAttributeUsage = ElementFactory.createModuleAttributeUsage(
+                            myElement.getProject(),
+                            newModuleAttributeName
+                    )
+                    myElement.replace(moduleAttributeUsage)
+                }
+                is ElixirAtIdentifier -> {
+                    // do nothing; handled by setName on ElixirAtUnqualifiedNoParenthesesCall
+                    myElement
+                }
+                else -> throw NotImplementedException(
+                        "Renaming module attribute reference on " + myElement.javaClass.canonicalName +
+                                " PsiElements is not implemented yet.  Please open an issue " +
+                                "(https://github.com/KronicDeth/intellij-elixir/issues/new) with the class name and the " +
+                                "sample text:\n" + myElement.text)
             }
-            is ElixirAtIdentifier -> {
-                // do nothing; handled by setName on ElixirAtUnqualifiedNoParenthesesCall
-                myElement
-            }
-            else -> throw NotImplementedException(
-                    "Renaming module attribute reference on " + myElement.javaClass.canonicalName +
-                            " PsiElements is not implemented yet.  Please open an issue " +
-                            "(https://github.com/KronicDeth/intellij-elixir/issues/new) with the class name and the " +
-                            "sample text:\n" + myElement.text)
-        }
 
     /**
      * Returns the results of resolving the reference.
@@ -90,38 +90,38 @@ class ModuleAttribute(psiElement: PsiElement) : PsiPolyVariantReferenceBase<PsiE
     }
 
     private fun getVariantsSibling(lastSibling: PsiElement): List<LookupElement> =
-        lastSibling
-                .prevSiblingSequence()
-                .mapNotNull {
-                    when (it) {
-                        is AtUnqualifiedNoParenthesesCall<*> -> {
-                            LookupElementBuilder.createWithSmartPointer(
-                                    ElixirPsiImplUtil.moduleAttributeName(it),
-                                    it
-                            )
-                        }
-                        is Call -> {
-                            if (Implementation.`is`(it)) {
-                                val element = Implementation.protocolNameElement(it) ?: it
-
+            lastSibling
+                    .prevSiblingSequence()
+                    .mapNotNull {
+                        when (it) {
+                            is AtUnqualifiedNoParenthesesCall<*> -> {
                                 LookupElementBuilder.createWithSmartPointer(
-                                        "@protocol",
-                                        element
+                                        ElixirPsiImplUtil.moduleAttributeName(it),
+                                        it
                                 )
-                            } else {
-                                null
                             }
+                            is Call -> {
+                                if (Implementation.`is`(it)) {
+                                    val element = Implementation.protocolNameElement(it) ?: it
+
+                                    LookupElementBuilder.createWithSmartPointer(
+                                            "@protocol",
+                                            element
+                                    )
+                                } else {
+                                    null
+                                }
+                            }
+                            else -> null
                         }
-                        else -> null
                     }
-                }
-                .toList()
+                    .toList()
 
     private fun getVariantsUpFromElement(element: PsiElement): List<LookupElement> =
-        element
-                .ancestorSequence()
-                .flatMap { getVariantsSibling(it).asSequence() }
-                .toList()
+            element
+                    .ancestorSequence()
+                    .flatMap { getVariantsSibling(it).asSequence() }
+                    .toList()
 
     companion object {
         private const val BEHAVIOUR_NAME = "behaviour"

--- a/tests/org/elixir_lang/FindUsagesTest.kt
+++ b/tests/org/elixir_lang/FindUsagesTest.kt
@@ -1018,17 +1018,30 @@ class FindUsagesTest : LightCodeInsightFixtureTestCase() {
 
         val usages = myFixture.findUsages(target).sortedBy { it.element!!.textOffset }
 
-        assertEquals(1, usages.size)
+        assertEquals(2, usages.size)
 
         val firstElement = usages[0].element!!
 
-        assertEquals(69, firstElement.textOffset)
+        assertEquals(31, firstElement.textOffset)
 
-        assertFalse(readWriteAccessDetector.isDeclarationWriteAccess(firstElement))
+        assertTrue(readWriteAccessDetector.isDeclarationWriteAccess(firstElement))
         assertTrue(readWriteAccessDetector.isReadWriteAccessible(firstElement))
-        assertEquals(ReadWriteAccessDetector.Access.Read, readWriteAccessDetector.getExpressionAccess(firstElement))
+        assertEquals(ReadWriteAccessDetector.Access.Write, readWriteAccessDetector.getExpressionAccess(firstElement))
 
-        assertEquals(UsageTypeProvider.MODULE_ATTRIBUTE_READ, getUsageType(firstElement, usageTargets))
+        assertEquals(
+                UsageTypeProvider.MODULE_ATTRIBUTE_ACCUMULATE_OR_OVERRIDE,
+                getUsageType(firstElement, usageTargets)
+        )
+
+        val secondElement = usages[1].element!!
+
+        assertEquals(69, secondElement.textOffset)
+
+        assertFalse(readWriteAccessDetector.isDeclarationWriteAccess(secondElement))
+        assertTrue(readWriteAccessDetector.isReadWriteAccessible(secondElement))
+        assertEquals(ReadWriteAccessDetector.Access.Read, readWriteAccessDetector.getExpressionAccess(secondElement))
+
+        assertEquals(UsageTypeProvider.MODULE_ATTRIBUTE_READ, getUsageType(secondElement, usageTargets))
     }
 
     fun testModuleAttributeUsage() {
@@ -1049,17 +1062,30 @@ class FindUsagesTest : LightCodeInsightFixtureTestCase() {
 
         val usages = myFixture.findUsages(target).sortedBy { it.element!!.textOffset }
 
-        assertEquals(1, usages.size)
+        assertEquals(2, usages.size)
 
         val firstElement = usages[0].element!!
 
-        assertEquals(69, firstElement.textOffset)
+        assertEquals(31, firstElement.textOffset)
 
-        assertFalse(readWriteAccessDetector.isDeclarationWriteAccess(firstElement))
+        assertTrue(readWriteAccessDetector.isDeclarationWriteAccess(firstElement))
         assertTrue(readWriteAccessDetector.isReadWriteAccessible(firstElement))
-        assertEquals(ReadWriteAccessDetector.Access.Read, readWriteAccessDetector.getExpressionAccess(firstElement))
+        assertEquals(ReadWriteAccessDetector.Access.Write, readWriteAccessDetector.getExpressionAccess(firstElement))
 
-        assertEquals(UsageTypeProvider.MODULE_ATTRIBUTE_READ, getUsageType(firstElement, usageTargets))
+        assertEquals(
+                UsageTypeProvider.MODULE_ATTRIBUTE_ACCUMULATE_OR_OVERRIDE,
+                getUsageType(firstElement, usageTargets)
+        )
+
+        val secondElement = usages[1].element!!
+
+        assertEquals(69, secondElement.textOffset)
+
+        assertFalse(readWriteAccessDetector.isDeclarationWriteAccess(secondElement))
+        assertTrue(readWriteAccessDetector.isReadWriteAccessible(secondElement))
+        assertEquals(ReadWriteAccessDetector.Access.Read, readWriteAccessDetector.getExpressionAccess(secondElement))
+
+        assertEquals(UsageTypeProvider.MODULE_ATTRIBUTE_READ, getUsageType(secondElement, usageTargets))
     }
 
     private val findUsagesProvider by lazy { LanguageFindUsages.INSTANCE.forLanguage(ElixirLanguage) }


### PR DESCRIPTION
Fixes #1119 

# Changelog
## Bug Fixes
* Allow module attribute declaration to resolve to itself, so that unused module attributes don't say they can't find the declaration.
* Restore rename module attributes.