### PR TITLE
Switch out the path separator on Windows

### DIFF
--- a/src/org/elixir_lang/ElixirModules.kt
+++ b/src/org/elixir_lang/ElixirModules.kt
@@ -12,7 +12,8 @@ object ElixirModules {
     fun add(parametersList: MutableList<String>, fileList: kotlin.collections.List<File>): MutableList<String> {
         for (file in fileList) {
             parametersList.add("-r")
-            parametersList.add(file.path)
+            // Erlang expects file paths to be separated by '/', even on Windows.
+            parametersList.add(file.path.replace('\\', '/'))
         }
 
         return parametersList


### PR DESCRIPTION
Using paths with the Erlang CLI with backslash separators caused this error:

    -r : No files matched pattern C:\Users\notriddle\AppData\Local\Temp\intellij_elixir2\exunit\1.6.0\team_city_ex_unit_formatting.ex

When the backslashes are replaced with UNIX-style forward slashes, it works correctly.