### PR TITLE
Show ... when Dbgi has no module name

### DIFF
--- a/src/org/elixir_lang/beam/chunk/debug_info/v1/erl_abstract_code/abstract_code_compiler_options/abstract_code/Panel.kt
+++ b/src/org/elixir_lang/beam/chunk/debug_info/v1/erl_abstract_code/abstract_code_compiler_options/abstract_code/Panel.kt
@@ -171,7 +171,7 @@ class Panel(private val formsTree: Tree, project: Project): JPanel(GridLayout(1,
     }
 
     private fun moduleContext(debugInfo: AbstractCodeCompileOptions, inner: () -> String): String =
-            "defmodule ${debugInfo.inspectedModule!!} do \n" +
+            "defmodule ${debugInfo.inspectedModule ?: "..."} do \n" +
                     "  # ... \n" +
                     "  ${adjustNewLines(inner(), "\n  ")}\n" +
                     "  # ...\n" +


### PR DESCRIPTION
# Changelog
## Bug Fixes
* Show `...` for module name when `Dbgi` has no module name as happens for instrumented modules from `IEx.break/4`.