### PR TITLE
Don't assume callDefinitionClause is non-null

### DIFF
--- a/src/org/elixir_lang/psi/impl/PresentationImpl.kt
+++ b/src/org/elixir_lang/psi/impl/PresentationImpl.kt
@@ -27,10 +27,14 @@ object PresentationImpl {
                     if (callDefinitionClause == null) {
                         val callDefinition = CallDefinition.fromCall(call)
 
-                        CallDefinitionClause(callDefinition!!, call)
+                        if (callDefinition != null) {
+                            CallDefinitionClause(callDefinition, call).presentation
+                        } else {
+                            getDefaultPresentation(call)
+                        }
+                    } else {
+                        callDefinitionClause.presentation
                     }
-
-                    callDefinitionClause!!.presentation
                 }
                 org.elixir_lang.structure_view.element.modular.Module.`is`(call) -> {
                     val modular = CallDefinitionClause.enclosingModular(call)


### PR DESCRIPTION
Fixes #1131 

# Changelog
## Bug Fixes
* Don't assume `callDefinitionClause` is non-`null`.