### PR TITLE
Don't assume part of list access expression is QuotableKeywordPair

### DIFF
--- a/src/org/elixir_lang/psi/ElementDescriptionProvider.kt
+++ b/src/org/elixir_lang/psi/ElementDescriptionProvider.kt
@@ -79,7 +79,7 @@ class ElementDescriptionProvider : com.intellij.psi.ElementDescriptionProvider {
                 ?.parent?.let { it as? ElixirKeywords }
                 ?.parent?.let { it as ElixirList }
                 ?.parent?.let { it as ElixirAccessExpression }
-                ?.parent?.let { it as QuotableKeywordPair }
+                ?.parent?.let { it as? QuotableKeywordPair }
                 ?.keywordKey?.let { outerKeywordKey ->
             if (outerKeywordKey.text == "bind_quoted" && location === UsageViewTypeLocation.INSTANCE) {
                 "quote bound variable"


### PR DESCRIPTION
Fixes #1135
Fixes #1139 

# Changelog
## Bug Fixes
* Don't assume parent of list access expression is `QuotableKeywordPair`