### PR TITLE
Don't assume parent of keywords is a list

### DIFF
--- a/src/org/elixir_lang/psi/ElementDescriptionProvider.kt
+++ b/src/org/elixir_lang/psi/ElementDescriptionProvider.kt
@@ -77,7 +77,7 @@ class ElementDescriptionProvider : com.intellij.psi.ElementDescriptionProvider {
         var elementDescription: String? = keywordKey
                 .parent.let { it as? ElixirKeywordPair }
                 ?.parent?.let { it as? ElixirKeywords }
-                ?.parent?.let { it as ElixirList }
+                ?.parent?.let { it as? ElixirList }
                 ?.parent?.let { it as ElixirAccessExpression }
                 ?.parent?.let { it as? QuotableKeywordPair }
                 ?.keywordKey?.let { outerKeywordKey ->


### PR DESCRIPTION
Fixes #1136
Fixes #1158
Fixes #1164 

# Changelog
## Bug Fixes
* Don't assume parent of keywords is a list