### PR TITLE
Elixir 1.7 debugger compatibility

### DIFF
--- a/src/org/elixir_lang/debugger/node/Binding.kt
+++ b/src/org/elixir_lang/debugger/node/Binding.kt
@@ -41,7 +41,9 @@ data class Binding(val erlangName: String, val value: OtpErlangObject) : Compara
     }
 
     companion object {
-        private val elixirNameRegex = Regex("V(.+)@(\\d+)")
+        // 1.6: V<name>@<binding>
+        // 1.7: _<name>@<binding>
+        private val elixirNameRegex = Regex("(?:V|_)(.+)@(\\d+)")
 
         private const val ARITY = 2
 


### PR DESCRIPTION
# Changelog
## Enhancements
* Elixir 1.7 debugger Variables and Evaluate compatibility
  * Elixir 1.7 names Erlang variables like `_<elixirVariableName>@<counter>` while Elixir 1.6 used `V<elixirVariableName>@<counter>`
  * Elixir 1.7 changed `elixir_erl` record and `%Macro.Env{}`, which changed how `:elixir.quoted_to_erl` needed to be called.