### PR TITLE
Check parent of Pipe for enclosing macro call

### DIFF
--- a/src/org/elixir_lang/psi/impl/PsiElementImpl.kt
+++ b/src/org/elixir_lang/psi/impl/PsiElementImpl.kt
@@ -14,6 +14,7 @@ import org.elixir_lang.psi.call.name.Function.ALIAS
 import org.elixir_lang.psi.call.name.Function.CREATE
 import org.elixir_lang.psi.call.name.Module.KERNEL
 import org.elixir_lang.psi.operation.Match
+import org.elixir_lang.psi.operation.Pipe
 import org.jetbrains.annotations.Contract
 import java.util.*
 
@@ -55,6 +56,7 @@ tailrec fun PsiElement.selfOrEnclosingMacroCall(): Call? =
             is ElixirStabOperation,
             is ElixirTuple,
             is Match,
+            is Pipe,
             is QualifiedAlias,
             is QualifiedMultipleAliases ->
                 parent.selfOrEnclosingMacroCall()

--- a/testData/org/elixir_lang/navigation/goto_symbol_contributor/issue_1141.ex
+++ b/testData/org/elixir_lang/navigation/goto_symbol_contributor/issue_1141.ex
@@ -1,0 +1,10 @@
+defmodule Phoenix.Router.Helpers do
+  def defhelper_catch_all({helper, routes_and_exprs}) do
+    [quote @anno do
+       defp raise_<caret>route_error(unquote(helper), suffix, arity, action) do
+         Phoenix.Router.Helpers.raise_route_error(__MODULE__, "#{unquote(helper)}_#{suffix}",
+           arity, action, unquote(routes))
+       end
+     end | catch_alls]
+  end
+end

--- a/tests/org/elixir_lang/navigation/GotoSymbolContributorTest.java
+++ b/tests/org/elixir_lang/navigation/GotoSymbolContributorTest.java
@@ -85,4 +85,17 @@ public class GotoSymbolContributorTest extends LightPlatformCodeInsightFixtureTe
         assertNotNull(modular);
     }
 
+    public void testIssue1141() {
+        myFixture.configureByFile("issue_1141.ex");
+        PsiElement elementAtCaret = myFixture.getFile().findElementAt(myFixture.getCaretOffset());
+
+        Call call = (Call) elementAtCaret.getParent().getParent().getParent().getParent();
+
+        Call enclosingModularMacroCall = CallDefinitionClause.Companion.enclosingModularMacroCall(call);
+        assertNotNull(enclosingModularMacroCall);
+
+        Modular modular = CallDefinitionClause.Companion.enclosingModular(call);
+        assertNotNull(modular);
+    }
+
 }


### PR DESCRIPTION
Fixes #1141 

# Changelog
## Enhancements
* Regression test for #1141.

## Bug Fixes
* In `Phoenix.router.Helpers`, a `quote` block appears as the head of `[head
| tail]` list, so add support for search for enclosing macro call above `|`.