### PR TITLE
Filter directories of homePath lib to find apps

### DIFF
--- a/jps-shared/src/org/elixir_lang/jps/HomePath.java
+++ b/jps-shared/src/org/elixir_lang/jps/HomePath.java
@@ -32,7 +32,7 @@ public class HomePath {
     public static void eachEbinPath(@NotNull String homePath, @NotNull Consumer<Path> ebinPathConsumer) {
         Path lib = Paths.get(homePath, "lib");
 
-        try (DirectoryStream<Path> libDirectoryStream = Files.newDirectoryStream(lib)) {
+        try (DirectoryStream<Path> libDirectoryStream = Files.newDirectoryStream(lib, path -> Files.isDirectory(path))) {
             libDirectoryStream.forEach(
                     app -> {
                         try (DirectoryStream<Path> ebinDirectoryStream = Files.newDirectoryStream(app, "ebin")) {


### PR DESCRIPTION
Fixes #1143 

# Changelog
## Bug Fixes
* In `eachEbinPath`, the ebin directories were found by iterating `<SDK_HOME_PATH>/lib` and then iterating grandchild of that, so that all paths matching `<SDK_HOME_PATH>/lib/<APP>/ebin` would be added, but for some installs from source, like SDK, there are non-OTP-app files in `<SDK_HOME_PATH>/lib`, so filter `<SDK_HOME_PATH>/lib/<APP>` to only directories.