### PR TITLE
Remove assertion that a qualified alias has 3 children

### DIFF
--- a/src/org/elixir_lang/psi/scope/Module.kt
+++ b/src/org/elixir_lang/psi/scope/Module.kt
@@ -49,8 +49,6 @@ abstract class Module : PsiScopeProcessor {
         val operatorIndex = org.elixir_lang.psi.operation.Normalized.operatorIndex(children)
         val unqualified = org.elixir_lang.psi.operation.infix.Normalized.rightOperand(children, operatorIndex)
 
-        assert(children.size == 3)
-
         return (unqualified as? PsiNamedElement)?.name
     }
 


### PR DESCRIPTION
Fixes #1173

# Changelog
## Bug Fixes
* `org.elixir.lang.psi.scope.Module.aliasedName(QualifiedAlias)` was already converted to use `org.elixir_lang.psi.operation.Normalized` and `org.elixir_lang.psi.infix.Normalized`, which makes it work with errors in the PSI tree, so there's no need protect with an assert and that assert would be wrong in times of errors handled by `Normalized`.