### PR TITLE
Improve error logging for unexpected element class unaliased name down

### DIFF
--- a/src/org/elixir_lang/reference/module/UnaliasedName.kt
+++ b/src/org/elixir_lang/reference/module/UnaliasedName.kt
@@ -2,6 +2,7 @@ package org.elixir_lang.reference.module
 
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiNamedElement
+import org.elixir_lang.errorreport.Logger
 import org.elixir_lang.psi.*
 import org.elixir_lang.psi.call.Call
 import org.elixir_lang.psi.call.name.Function.ALIAS
@@ -27,7 +28,15 @@ object UnaliasedName {
                     down(children[0])
                 }
                 is QualifiableAlias -> element.name
-                else -> TODO()
+                else -> {
+                    Logger.error(
+                            javaClass,
+                            "Don't know how to search down below ${element.javaClass} for unaliased name",
+                            element
+                    )
+
+                    "?"
+                }
             }
 
     private fun unaliasedName(qualifiableAlias: QualifiableAlias): String? =


### PR DESCRIPTION
Fixes #1204

# Changelog
## Bug Fixes
* `org.elixir_lang.reference.module.UnaliasedName.down(PsiElement)` only expects `ElixirAccessExpression` or `QualifiableAlias`, but for unexpected classes of elements, it was a simple Kotlin `TODO()`, which didn't log anything useful for enhancements.  Replace the `TODO()` with an `org.elixir_lang.errorreport.Logger.error`, so that the element's class and content can be reported when this happens again.