### PR TITLE
Look above `Enum.reduce` for enclosing macro call

### DIFF
--- a/src/org/elixir_lang/psi/impl/PsiElementImpl.kt
+++ b/src/org/elixir_lang/psi/impl/PsiElementImpl.kt
@@ -31,12 +31,12 @@ tailrec fun PsiElement.selfOrEnclosingMacroCall(): Call? =
                         parent.let { it as? ElixirMatchedParenthesesArguments }?.
                         parent.let { it as?  Call }?.
                         let { call ->
-                            if (call.isCalling("Enum", "map") ||
-                                        call.isCalling("Enum", "each")) {
-                                    call
-                                } else {
-                                    null
-                                }
+                            if (call.resolvedModuleName() == "Enum" &&
+                                    call.functionName() in arrayOf("each", "map", "reduce")) {
+                                call
+                            } else {
+                                null
+                            }
                         }?.
                         parent?.
                         selfOrEnclosingMacroCall()

--- a/testData/org/elixir_lang/navigation/goto_symbol_contributor/issue_1228.ex
+++ b/testData/org/elixir_lang/navigation/goto_symbol_contributor/issue_1228.ex
@@ -1,0 +1,8 @@
+defmodule Decimal do
+  pow10_max =
+    Enum.reduce(0..104, 1, fn int, acc ->
+      defp pow10(unquote(int)), do: unquote(acc)
+      defp base<caret>10?(unquote(acc)), do: true
+      acc * 10
+    end)
+end

--- a/tests/org/elixir_lang/navigation/GotoSymbolContributorTest.java
+++ b/tests/org/elixir_lang/navigation/GotoSymbolContributorTest.java
@@ -98,4 +98,16 @@ public class GotoSymbolContributorTest extends LightPlatformCodeInsightFixtureTe
         assertNotNull(modular);
     }
 
+    public void testIssue1228() {
+        myFixture.configureByFile("issue_1228.ex");
+        PsiElement elementAtCaret = myFixture.getFile().findElementAt(myFixture.getCaretOffset());
+
+        Call call = (Call) elementAtCaret.getParent().getParent().getParent().getParent();
+
+        Call enclosingModularMacroCall = CallDefinitionClause.Companion.enclosingModularMacroCall(call);
+        assertNotNull(enclosingModularMacroCall);
+
+        Modular modular = CallDefinitionClause.Companion.enclosingModular(call);
+        assertNotNull(modular);
+    }
 }


### PR DESCRIPTION
Fixes #1228 

# Changelog
## Enhancements
* Regression test for #1228 

## Bug Fixes
* Look above `Enum.reduce` for enclosing macro call.