### PR TITLE
Add Facet SDK as External Library to re-enable indexing

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -78,6 +78,7 @@
                          parentId="language"
                          provider="org.elixir_lang.facet.configurable.Provider"/>
     <project.converterProvider implementation="org.elixir_lang.facet.conversion.Provider"/>
+    <project.converterProvider implementation="org.elixir_lang.facet.external_library.conversion.Provider"/>
 
     <facetType implementation="org.elixir_lang.facet.Type"/>
     <framework.detector implementation="org.elixir_lang.FrameworkDetector"/>

--- a/src/org/elixir_lang/facet/configurable/Project.kt
+++ b/src/org/elixir_lang/facet/configurable/Project.kt
@@ -7,6 +7,8 @@ import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.module.Module
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.projectRoots.Sdk
+import com.intellij.openapi.roots.ModuleRootModificationUtil
+import com.intellij.openapi.roots.libraries.LibraryTablesRegistrar
 import org.elixir_lang.Facet
 import org.elixir_lang.facet.Configurable
 import org.elixir_lang.facet.Type
@@ -26,9 +28,23 @@ class Project(project: Project) : ModuleAwareProjectConfigurable<Configurable>(p
                 if (facet == null) {
                     ApplicationManager.getApplication().runWriteAction {
                         addFacet(facetManager, sdk)
+
+                        if (sdk != null) {
+                            LibraryTablesRegistrar.getInstance().libraryTable.getLibraryByName(sdk.name)!!.let { library ->
+                                ModuleRootModificationUtil.addDependency(module, library)
+                            }
+                        }
                     }
                 } else {
                     setFacetSdk(facet, sdk)
+
+                    ApplicationManager.getApplication().runWriteAction {
+                        if (sdk != null) {
+                            LibraryTablesRegistrar.getInstance().libraryTable.getLibraryByName(sdk.name)!!.let { library ->
+                                ModuleRootModificationUtil.addDependency(module, library)
+                            }
+                        }
+                    }
                 }
             }
 

--- a/src/org/elixir_lang/facet/external_library/conversion/Converter.kt
+++ b/src/org/elixir_lang/facet/external_library/conversion/Converter.kt
@@ -1,0 +1,46 @@
+package org.elixir_lang.facet.external_library.conversion
+
+import com.intellij.conversion.ConversionProcessor
+import com.intellij.conversion.ModuleSettings
+import com.intellij.conversion.ProjectConverter
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.roots.libraries.LibraryTablesRegistrar
+import org.elixir_lang.facet.SdksService
+import org.elixir_lang.facet.sdks.addRoots
+import org.elixir_lang.sdk.elixir.Type
+
+class Converter : ProjectConverter() {
+    override fun isConversionNeeded(): Boolean = missingLibraryNameSet().isNotEmpty()
+
+    /**
+     * Create Application-level External Libraries before they are added to modules in [createModuleFileConverter]
+     */
+    override fun preProcessingFinished() {
+        super.preProcessingFinished()
+
+        val libraryTable = LibraryTablesRegistrar.getInstance().libraryTable
+
+        missingLibraryNameSet().forEach { missingLibraryName ->
+            SdksService.getInstance()!!.getModel().findSdk(missingLibraryName)!!.let { sdk ->
+                libraryTable.createLibrary(sdk.name).let { library ->
+                    ApplicationManager.getApplication().runWriteAction {
+                        library.modifiableModel.apply {
+                            addRoots(sdk)
+                            commit()
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    override fun createModuleFileConverter(): ConversionProcessor<ModuleSettings> = ModuleSettings()
+}
+
+private fun missingLibraryNameSet(): Set<String> = sdkNameSet() - libraryNameSet()
+
+private fun sdkNameSet(): Set<String> =
+        SdksService.getInstance()!!.getModel().sdks.filter { it.sdkType == Type.getInstance() }.map { it.name }.toSet()
+
+private fun libraryNameSet(): Set<String> =
+        LibraryTablesRegistrar.getInstance().libraryTable.libraryIterator.asSequence().mapNotNull { it.name }.toSet()

--- a/src/org/elixir_lang/facet/external_library/conversion/ModuleSettings.kt
+++ b/src/org/elixir_lang/facet/external_library/conversion/ModuleSettings.kt
@@ -1,0 +1,40 @@
+package org.elixir_lang.facet.external_library.conversion
+
+import com.intellij.conversion.ConversionProcessor
+import com.intellij.conversion.ModuleSettings
+import com.intellij.conversion.ModuleSettings.MODULE_ROOT_MANAGER_COMPONENT
+import org.elixir_lang.facet.Type
+import org.jdom.Element
+
+class ModuleSettings : ConversionProcessor<ModuleSettings>() {
+    override fun isConversionNeeded(moduleSettings: ModuleSettings): Boolean {
+        val sdkName = moduleSettings.sdkName()
+
+        return sdkName != null && sdkName.isNotBlank() && moduleSettings.applicationLibrary(sdkName) == null
+    }
+
+    override fun process(moduleSettings: ModuleSettings) {
+        moduleSettings.sdkName()?.let { sdkName ->
+            moduleSettings.getComponentElement(MODULE_ROOT_MANAGER_COMPONENT)?.let { moduleRootManagerComponentElement ->
+                val orderEntryElement = Element("orderEntry")
+                orderEntryElement.setAttribute("type", "library")
+                orderEntryElement.setAttribute("name", sdkName)
+                orderEntryElement.setAttribute("level", "application")
+                moduleRootManagerComponentElement.addContent(orderEntryElement)
+            }
+        }
+    }
+}
+
+private fun ModuleSettings.sdkName(): String? =
+        getFacetElement(Type.ID)?.let { facetElement ->
+            facetElement
+                    .getChildren("configuration")
+                    .mapNotNull { it.getAttributeValue("sdkName") }
+                    .singleOrNull()
+        }
+
+private fun ModuleSettings.applicationLibrary(name: String): Element? =
+        orderEntries.find {
+            it.getAttributeValue("type") == "library" && it.getAttributeValue("level") == "application" && it.getAttributeValue("name") == name
+        }

--- a/src/org/elixir_lang/facet/external_library/conversion/Provider.kt
+++ b/src/org/elixir_lang/facet/external_library/conversion/Provider.kt
@@ -1,0 +1,17 @@
+package org.elixir_lang.facet.external_library.conversion
+
+import com.intellij.conversion.ConversionContext
+import com.intellij.conversion.ConverterProvider
+import com.intellij.conversion.ProjectConverter
+
+class Provider : ConverterProvider("elixir-facet-add-external-library") {
+    override fun getPrecedingConverterIds(): Array<String> = arrayOf("elixir-external-tools-to-facet")
+
+    override fun getConversionDescription(): String =
+            "Small (single-language, non-IntelliJ) IDEs require the Elixir Facet SDK to be replicated as an External Library, so that the IDE will index the SDK files, which enables Completion, Find Usages, Go To Definition and Go To Symbol for SDK modules and functions.\n" +
+                    "\n" +
+                    "The SDK will appear in Project (Cmd+1) > External Libraries and can be expanded to see the `.beam` files within, which replicates how the Elixir SDK is shown in IntelliJ IDEA."
+
+    override fun createConverter(conversionContext: ConversionContext): ProjectConverter  = Converter()
+
+}

--- a/src/org/elixir_lang/facet/sdks/Configurable.kt
+++ b/src/org/elixir_lang/facet/sdks/Configurable.kt
@@ -24,6 +24,12 @@ import org.elixir_lang.facet.sdk.Editor
 import javax.swing.JComponent
 import javax.swing.JPanel
 
+fun Library.ModifiableModel.addRoots(sdk: Sdk) =
+        sdk
+                .rootProvider
+                .getFiles(OrderRootType.CLASSES)
+                .let { addRoots(it) }
+
 abstract class Configurable: SearchableConfigurable, com.intellij.openapi.options.Configurable.NoScroll {
     internal val sdksService by lazy { SdksService.getInstance()!! }
     private val projectSdksModel by lazy { sdksService.getModel() }
@@ -188,12 +194,6 @@ abstract class Configurable: SearchableConfigurable, com.intellij.openapi.option
         sdkPanel.select(selectedEditor, true)
     }
 }
-
-private fun Library.ModifiableModel.addRoots(sdk: Sdk) =
-        sdk
-                .rootProvider
-                .getFiles(OrderRootType.CLASSES)
-                .let { addRoots(it) }
 
 private fun Library.ModifiableModel.addRoots(roots: Array<VirtualFile>) =
         roots.forEach {


### PR DESCRIPTION
Fixes #1230

# Changelog
## Bug Fixes
* Add Facet SDK as External Library to re-enable indexing.  When the External Library was removed in
4297287 in favor of a real SDK, completion for SDK `.beam` modules was lost because Small IDEs don't index SDKs, but only External Libraries, so add Application-wide External Libraries for SDKs when they are created (and update, remove on edit or delete), which are then added as a Dependency for the facet's module when the SDK is set for the Small IDE project.
  * Convert old moduels with Elixir facets to also have External Library, so that users don't need to remove and add the SDKs to get the External Library.