### PR TITLE
Resolve unqualified bracket operation identifiers to variable and 0-arity calls

### DIFF
--- a/gen/org/elixir_lang/psi/ElixirIdentifier.java
+++ b/gen/org/elixir_lang/psi/ElixirIdentifier.java
@@ -3,6 +3,7 @@ package org.elixir_lang.psi;
 
 import com.ericsson.otp.erlang.OtpErlangObject;
 import com.intellij.navigation.ItemPresentation;
+import com.intellij.psi.PsiReference;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -10,6 +11,9 @@ public interface ElixirIdentifier extends Quotable {
 
   @Nullable
   ItemPresentation getPresentation();
+
+  @Nullable
+  PsiReference getReference();
 
   @NotNull
   OtpErlangObject quote();

--- a/gen/org/elixir_lang/psi/impl/ElixirIdentifierImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirIdentifierImpl.java
@@ -6,6 +6,7 @@ import com.intellij.extapi.psi.ASTWrapperPsiElement;
 import com.intellij.lang.ASTNode;
 import com.intellij.navigation.ItemPresentation;
 import com.intellij.psi.PsiElementVisitor;
+import com.intellij.psi.PsiReference;
 import org.elixir_lang.psi.ElixirIdentifier;
 import org.elixir_lang.psi.ElixirVisitor;
 import org.jetbrains.annotations.NotNull;
@@ -29,6 +30,11 @@ public class ElixirIdentifierImpl extends ASTWrapperPsiElement implements Elixir
   @Nullable
   public ItemPresentation getPresentation() {
     return ElixirPsiImplUtil.getPresentation(this);
+  }
+
+  @Nullable
+  public PsiReference getReference() {
+    return ElixirPsiImplUtil.getReference(this);
   }
 
   @NotNull

--- a/src/org/elixir_lang/Elixir.bnf
+++ b/src/org/elixir_lang/Elixir.bnf
@@ -652,6 +652,7 @@ identifier ::= IDENTIFIER_TOKEN
                  implements = "org.elixir_lang.psi.Quotable"
                  methods = [
                    getPresentation
+                   getReference
                    quote
                  ]
                }

--- a/src/org/elixir_lang/psi/impl/ElixirIdentifierImpl.kt
+++ b/src/org/elixir_lang/psi/impl/ElixirIdentifierImpl.kt
@@ -1,0 +1,17 @@
+package org.elixir_lang.psi.impl
+
+import com.intellij.psi.PsiReference
+import com.intellij.psi.util.CachedValueProvider
+import com.intellij.psi.util.CachedValuesManager.getCachedValue
+import org.elixir_lang.psi.ElixirIdentifier
+import org.elixir_lang.psi.UnqualifiedBracketOperation
+
+fun getReference(identifier: ElixirIdentifier): PsiReference? =
+        getCachedValue(identifier) { CachedValueProvider.Result.create(identifier.computeReference(), identifier) }
+
+private fun ElixirIdentifier.computeReference(): PsiReference? =
+        if (parent is UnqualifiedBracketOperation) {
+            org.elixir_lang.reference.Identifier(this)
+        } else {
+            null
+        }

--- a/src/org/elixir_lang/psi/impl/ElixirPsiImplUtil.java
+++ b/src/org/elixir_lang/psi/impl/ElixirPsiImplUtil.java
@@ -1103,6 +1103,11 @@ public class ElixirPsiImplUtil {
     }
 
     @Nullable
+    public static PsiReference getReference(@NotNull ElixirIdentifier identifier) {
+        return ElixirIdentifierImplKt.getReference(identifier);
+    }
+
+    @Nullable
     public static PsiReference getReference(@NotNull NonNumeric nonNumeric) {
         return NonNumericImplKt.getReference(nonNumeric);
     }

--- a/src/org/elixir_lang/psi/scope/Identifier.kt
+++ b/src/org/elixir_lang/psi/scope/Identifier.kt
@@ -1,0 +1,19 @@
+package org.elixir_lang.psi.scope
+
+import com.intellij.openapi.util.Key
+import com.intellij.psi.PsiElement
+import com.intellij.psi.ResolveState
+import com.intellij.psi.scope.PsiScopeProcessor
+
+class Identifier : PsiScopeProcessor {
+    /**
+     * @param element candidate element.
+     * @param state   current state of resolver.
+     * @return false to stop processing.
+     */
+    override fun execute(element: PsiElement, state: ResolveState): Boolean = false
+
+    override fun <T> getHint(hintKey: Key<T>): T? = null
+
+    override fun handleEvent(event: PsiScopeProcessor.Event, associated: Any?) {}
+}

--- a/src/org/elixir_lang/psi/scope/call_definition_clause/Variants.kt
+++ b/src/org/elixir_lang/psi/scope/call_definition_clause/Variants.kt
@@ -7,6 +7,7 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.ResolveState
 import com.intellij.psi.util.PsiTreeUtil
 import org.elixir_lang.annotator.Parameter
+import org.elixir_lang.psi.ElixirIdentifier
 import org.elixir_lang.psi.call.Call
 import org.elixir_lang.psi.call.Named
 import org.elixir_lang.psi.impl.ElixirPsiImplUtil.ENTRANCE
@@ -83,20 +84,26 @@ class Variants : CallDefinitionClause() {
 
         @JvmStatic
         fun lookupElementList(entrance: Call): List<LookupElement> {
-            val variants = Variants()
-
             val parameter = Parameter.putParameterized(Parameter(entrance))
-            var entranceCallDefinitionClause: Call? = null
-
-            if (parameter.isCallDefinitionClauseName) {
-                entranceCallDefinitionClause = parameter.parameterized as Call?
+            val entranceCallDefinitionClause: Call? = if (parameter.isCallDefinitionClauseName) {
+                parameter.parameterized as Call?
+            } else {
+                null
             }
+
+            return lookupElementList(entrance, entranceCallDefinitionClause)
+        }
+
+        @JvmStatic
+        fun lookupElementList(entrance: ElixirIdentifier): List<LookupElement> = lookupElementList(entrance, null)
+
+        private fun lookupElementList(entrance: PsiElement, entranceCallDefinitionClause: Call?): List<LookupElement> {
+            val variants = Variants()
 
             val resolveState = ResolveState
                     .initial()
                     .put(ENTRANCE, entrance)
                     .put(ENTRANCE_CALL_DEFINITION_CLAUSE, entranceCallDefinitionClause)
-
             PsiTreeUtil.treeWalkUp(
                     variants,
                     entrance,

--- a/src/org/elixir_lang/reference/Identifier.kt
+++ b/src/org/elixir_lang/reference/Identifier.kt
@@ -1,0 +1,26 @@
+package org.elixir_lang.reference
+
+import com.intellij.codeInsight.lookup.LookupElement
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiPolyVariantReference
+import com.intellij.psi.PsiReferenceBase
+import com.intellij.psi.ResolveResult
+import com.intellij.psi.impl.source.resolve.ResolveCache
+import org.elixir_lang.psi.ElixirIdentifier
+
+class Identifier(identifier: ElixirIdentifier) :
+        PsiReferenceBase<ElixirIdentifier>(identifier, TextRange.create(0, identifier.textLength)),
+        PsiPolyVariantReference {
+    override fun getVariants(): Array<LookupElement> =
+            (org.elixir_lang.psi.scope.variable.Variants.lookupElementList(myElement) +
+                    org.elixir_lang.psi.scope.call_definition_clause.Variants.lookupElementList(myElement))
+                    .toTypedArray()
+
+    override fun resolve(): PsiElement? = multiResolve(false).singleOrNull()?.element
+
+    override fun multiResolve(incompleteCode: Boolean): Array<ResolveResult> =
+            ResolveCache
+                    .getInstance(myElement.project)
+                    .resolveWithCaching(this, org.elixir_lang.reference.resolver.Identifier, false, incompleteCode)
+}

--- a/src/org/elixir_lang/reference/resolver/Identifier.kt
+++ b/src/org/elixir_lang/reference/resolver/Identifier.kt
@@ -1,0 +1,36 @@
+package org.elixir_lang.reference.resolver
+
+import com.intellij.psi.ResolveResult
+import com.intellij.psi.impl.source.resolve.ResolveCache
+import org.elixir_lang.psi.ElixirIdentifier
+import org.elixir_lang.reference.Identifier
+
+object Identifier : ResolveCache.PolyVariantResolver<org.elixir_lang.reference.Identifier> {
+    override fun resolve(identifier: Identifier, incompleteCode: Boolean): Array<ResolveResult> =
+        resolveElement(identifier.element, incompleteCode).toTypedArray()
+
+    private fun resolveElement(element: ElixirIdentifier, incompleteCode: Boolean): List<ResolveResult> {
+        val name = element.text
+        val resolveResultList = mutableListOf<ResolveResult>()
+
+        val variableResolveList = org.elixir_lang.psi.scope.variable.MultiResolve.resolveResultList(
+                name,
+                incompleteCode,
+                element
+        )
+
+        if (variableResolveList != null) {
+            resolveResultList.addAll(variableResolveList)
+        }
+
+        val callDefinitionClauseResolveResultList = org.elixir_lang.psi.scope.call_definition_clause.MultiResolve.resolveResults(
+                name,
+                0,
+                incompleteCode,
+                element
+        )
+        resolveResultList.addAll(callDefinitionClauseResolveResultList)
+
+        return resolveResultList
+    }
+}


### PR DESCRIPTION
Fixes #306
Fixes #1113

# Changleog
* Resolve unqualified bracket operation identifiers (`var` in `var[key]) to variables or `0`-arity calls.
  * Fixes renames of variables not renaming usage of variables for Access lookups (i.e. `var[key]`).