### PR TITLE
Don't show decompiled in Go To Symbol or Declaration if source exists

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 # https://www.jetbrains.com/intellij-repository/releases
 # https://www.jetbrains.com/intellij-repository/snapshots
 
-version = 8.1.0
+version = 9.0.0
 ideaVersion = 2018.2.1
 javaVersion = 1.8
 javaTargetVersion = 1.8

--- a/src/org/elixir_lang/navigation/GotoSymbolContributor.kt
+++ b/src/org/elixir_lang/navigation/GotoSymbolContributor.kt
@@ -210,9 +210,7 @@ class GotoSymbolContributor : ChooseByNameContributor {
                     items.add(forNameOverriddenImplementation)
                 }
             }
-        }
-
-        if (forNameCollection == null || forNameCollection.size < 2) {
+        } else {
             val implementation = Implementation(modular, call)
             items.add(implementation)
         }

--- a/src/org/elixir_lang/navigation/GotoSymbolContributor.kt
+++ b/src/org/elixir_lang/navigation/GotoSymbolContributor.kt
@@ -7,7 +7,6 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.psi.stubs.StubIndex
 import com.intellij.util.ArrayUtil
-import com.intellij.util.containers.ContainerUtil
 import org.elixir_lang.Visibility
 import org.elixir_lang.errorreport.Logger
 import org.elixir_lang.psi.AtUnqualifiedNoParenthesesCall
@@ -52,7 +51,7 @@ class GotoSymbolContributor : ChooseByNameContributor {
         val scope = globalSearchScope(project, includeNonProjectItems)
 
         val result = StubIndex.getElements(AllName.KEY, name, project, scope, NamedElement::class.java)
-        val items = ContainerUtil.newArrayListWithCapacity<NavigationItem>(result.size)
+        val items = SourcePreferredItems()
         val enclosingModularByCall = EnclosingModularByCall()
         val callDefinitionByTuple = HashMap<CallDefinition.Tuple, CallDefinition>()
 
@@ -75,7 +74,7 @@ class GotoSymbolContributor : ChooseByNameContributor {
     }
 
     private fun getItemsByNameFromCall(name: String,
-                                       items: MutableList<NavigationItem>,
+                                       items: SourcePreferredItems,
                                        enclosingModularByCall: EnclosingModularByCall,
                                        callDefinitionByTuple: MutableMap<CallDefinition.Tuple, CallDefinition>,
                                        call: Call) {
@@ -90,7 +89,7 @@ class GotoSymbolContributor : ChooseByNameContributor {
         }
     }
 
-    private fun getItemsFromCallback(items: MutableList<NavigationItem>,
+    private fun getItemsFromCallback(items: SourcePreferredItems,
                                      enclosingModularByCall: EnclosingModularByCall,
                                      call: Call) {
         enclosingModularByCall.putNew(call)?.let { Callback(it, call) }?.run {
@@ -100,7 +99,7 @@ class GotoSymbolContributor : ChooseByNameContributor {
     }
 
     private fun getItemsFromCallDefinitionClause(
-            items: MutableList<NavigationItem>,
+            items: SourcePreferredItems,
             enclosingModularByCall: EnclosingModularByCall,
             callDefinitionByTuple: MutableMap<CallDefinition.Tuple, CallDefinition>,
             call: Call
@@ -130,7 +129,7 @@ class GotoSymbolContributor : ChooseByNameContributor {
     }
 
     private fun getItemsFromCallDefinitionHead(
-            items: MutableList<NavigationItem>,
+            items: SourcePreferredItems,
             enclosingModularByCall: EnclosingModularByCall,
             callDefinitionByTuple: MutableMap<CallDefinition.Tuple, CallDefinition>,
             call: Call
@@ -178,7 +177,7 @@ class GotoSymbolContributor : ChooseByNameContributor {
         }
     }
 
-    private fun getItemsFromCallDefinitionSpecification(items: MutableList<NavigationItem>,
+    private fun getItemsFromCallDefinitionSpecification(items: SourcePreferredItems,
                                                         enclosingModularByCall: EnclosingModularByCall,
                                                         call: Call) {
         enclosingModularByCall.putNew(call)?.let { modular ->
@@ -195,7 +194,7 @@ class GotoSymbolContributor : ChooseByNameContributor {
     }
 
     private fun getItemsFromImplementation(name: String,
-                                           items: MutableList<NavigationItem>,
+                                           items: SourcePreferredItems,
                                            enclosingModularByCall: EnclosingModularByCall,
                                            call: Call) {
         val modular = enclosingModularByCall.putNew(call)
@@ -219,7 +218,7 @@ class GotoSymbolContributor : ChooseByNameContributor {
         }
     }
 
-    private fun getItemsFromModule(items: MutableList<NavigationItem>,
+    private fun getItemsFromModule(items: SourcePreferredItems,
                                    enclosingModularByCall: EnclosingModularByCall,
                                    call: Call) {
         enclosingModularByCall.putNew(call).let { Module(it, call) }.run {
@@ -227,7 +226,7 @@ class GotoSymbolContributor : ChooseByNameContributor {
         }
     }
 
-    private fun getItemsFromProtocol(items: MutableList<NavigationItem>,
+    private fun getItemsFromProtocol(items: SourcePreferredItems,
                                      enclosingModularByCall: EnclosingModularByCall,
                                      call: Call) {
         enclosingModularByCall.putNew(call).let { Protocol(it, call) }.run {

--- a/src/org/elixir_lang/navigation/GotoSymbolContributor.kt
+++ b/src/org/elixir_lang/navigation/GotoSymbolContributor.kt
@@ -117,9 +117,7 @@ class GotoSymbolContributor : ChooseByNameContributor {
                 for (arity in arityRange) {
                     val tuple = CallDefinition.Tuple(modular, time, name, arity)
                     callDefinitionByTuple.computeIfAbsent(tuple) { (modular, time, name, arity) ->
-                        CallDefinition(modular, time, name, arity).also {
-                            items.add(it)
-                        }
+                        CallDefinition(modular, time, name, arity)
                     }.clause(call).run {
                         items.add(this)
                     }

--- a/src/org/elixir_lang/navigation/SourcePreferredItems.kt
+++ b/src/org/elixir_lang/navigation/SourcePreferredItems.kt
@@ -1,5 +1,6 @@
 package org.elixir_lang.navigation
 
+import com.intellij.ide.structureView.StructureViewTreeElement
 import com.intellij.navigation.NavigationItem
 import com.intellij.psi.PsiElement
 import org.elixir_lang.beam.psi.BeamFileImpl
@@ -148,14 +149,24 @@ class SourcePreferredItems  {
         }
     }
 
-    fun toTypedArray(): Array<NavigationItem> =
-            (modularListByName.values.flatten() as List<NavigationItem> +
-                    callDefinitionClauseListByArityByNameByModularName.values.flatMap { it.values.flatMap { it.values.flatten() } } +
-                    callDefinitionListByArityByNameByModularName.values.flatMap { it.values.flatMap { it.values.flatten() } } +
-                    callDefinitionSpecificationList +
-                    callDefinitionHeadListByArityByNameByModularName.values.flatMap { it.values.flatMap { it.values.flatten() } } +
-                    callbackList
-                    ).toTypedArray()
+    fun toTypedArray(): Array<NavigationItem> {
+        val navigationItemList =
+                modularListByName.values.flatten() as List<NavigationItem> +
+                        callDefinitionClauseListByArityByNameByModularName.values.flatMap { it.values.flatMap { it.values.flatten() } } +
+                        callDefinitionListByArityByNameByModularName.values.flatMap { it.values.flatMap { it.values.flatten() } } +
+                        callDefinitionSpecificationList +
+                        callDefinitionHeadListByArityByNameByModularName.values.flatMap { it.values.flatMap { it.values.flatten() } } +
+                        callbackList
+
+        return navigationItemList
+                .distinctBy { navigationItem ->
+                    navigationItem
+                            .let { it as? StructureViewTreeElement }
+                            ?.value
+                            ?: navigationItem
+                }
+                .toTypedArray()
+    }
 
     private val callDefinitionListByArityByNameByModularName = mutableMapOf<ModularName, MutableMap<Name, MutableMap<Arity, MutableList<CallDefinition>>>>()
     private val callDefinitionClauseListByArityByNameByModularName = mutableMapOf<ModularName, MutableMap<Name, MutableMap<Arity, MutableList<CallDefinitionClause>>>>()

--- a/src/org/elixir_lang/navigation/SourcePreferredItems.kt
+++ b/src/org/elixir_lang/navigation/SourcePreferredItems.kt
@@ -1,0 +1,232 @@
+package org.elixir_lang.navigation
+
+import com.intellij.navigation.NavigationItem
+import com.intellij.psi.PsiElement
+import org.elixir_lang.beam.psi.BeamFileImpl
+import org.elixir_lang.structure_view.element.*
+import org.elixir_lang.structure_view.element.modular.Implementation
+import org.elixir_lang.structure_view.element.modular.Modular
+import org.elixir_lang.structure_view.element.modular.Module
+import org.elixir_lang.structure_view.element.modular.Quote
+
+/**
+ * Navigation items for [GotoSymbolContributor.getItemsByName] that will only return Source version if both Source and Decompiled version are added.
+ */
+class SourcePreferredItems  {
+    fun add(callback: Callback) {
+        // currently we don't decompile callbacks, so no need to check
+        callbackList.add(callback)
+    }
+
+    fun add(callDefinition: CallDefinition) {
+        val modularName = callDefinition.modularName()
+        val callDefinitionByArityByName = callDefinitionListByArityByNameByModularName.computeIfAbsent(modularName) { mutableMapOf() }
+        val callDefinitionListByArity = callDefinitionByArityByName.computeIfAbsent(callDefinition.name()) { mutableMapOf() }
+
+        callDefinitionListByArity.compute(callDefinition.arity) { _, currentCallDefinitionList ->
+            if (currentCallDefinitionList != null) {
+                if (currentCallDefinitionList.isDecompiled()) {
+                    if (callDefinition.isDecompiled()) {
+                        // collect all decompiled for all environments
+                        currentCallDefinitionList.add(callDefinition)
+                        currentCallDefinitionList
+                    } else {
+                        // prefer source over all decompiled
+                       mutableListOf(callDefinition)
+                    }
+                } else {
+                    if (callDefinition.isDecompiled()) {
+                        // ignore decompiled when there is source
+                        currentCallDefinitionList
+                    } else {
+                        // collect all source
+                        currentCallDefinitionList.add(callDefinition)
+                        currentCallDefinitionList
+                    }
+                }
+            } else {
+                mutableListOf(callDefinition)
+            }
+        }
+    }
+
+    fun add(callDefinitionHead: CallDefinitionHead) {
+        val callDefinition = callDefinitionHead.callDefinition
+        val modularName = callDefinition.modularName()
+        val callDefinitionHeadListByArityByName = callDefinitionHeadListByArityByNameByModularName.computeIfAbsent(modularName) { mutableMapOf() }
+        val callDefinitionHeadListByArity = callDefinitionHeadListByArityByName.computeIfAbsent(callDefinition.name()) { mutableMapOf() }
+
+        callDefinitionHeadListByArity.compute(callDefinition.arity) { _, currentCallDefinitionHeadList ->
+            if (currentCallDefinitionHeadList != null) {
+                if (currentCallDefinitionHeadList.isDecompiled()) {
+                    if (callDefinitionHead.isDecompiled()) {
+                        // collect all decompiled for all environments
+                        currentCallDefinitionHeadList.add(callDefinitionHead)
+                        currentCallDefinitionHeadList
+                    } else {
+                        // prefer source over all decompiled
+                        mutableListOf(callDefinitionHead)
+                    }
+                } else {
+                    if (callDefinitionHead.isDecompiled()) {
+                        // ignore decompiled when there is source
+                        currentCallDefinitionHeadList
+                    } else {
+                        // collect all source
+                        currentCallDefinitionHeadList.add(callDefinitionHead)
+                        currentCallDefinitionHeadList
+                    }
+                }
+            } else {
+                mutableListOf(callDefinitionHead)
+            }
+        }
+    }
+
+    fun add(callDefinitionClause: CallDefinitionClause) {
+        val callDefinition = callDefinitionClause.callDefinition
+        val modularName = callDefinition.modularName()
+        val callDefinitionClauseListByArityByName = callDefinitionClauseListByArityByNameByModularName.computeIfAbsent(modularName) { mutableMapOf() }
+        val callDefinitionClauseListByArity = callDefinitionClauseListByArityByName.computeIfAbsent(callDefinition.name()) { mutableMapOf() }
+
+        callDefinitionClauseListByArity.compute(callDefinition.arity) { arity, currentCallDefinitionClauseList ->
+            if (currentCallDefinitionClauseList != null) {
+                if (currentCallDefinitionClauseList.isDecompiled()) {
+                    if (callDefinitionClause.isDecompiled()) {
+                        // collect all decompiled for all environments
+                        currentCallDefinitionClauseList.add(callDefinitionClause)
+                        currentCallDefinitionClauseList
+                    } else {
+                        // prefer source over all decompiled
+                        mutableListOf(callDefinitionClause)
+                    }
+                } else {
+                    if (callDefinitionClause.isDecompiled()) {
+                        // ignore decompiled when there is source
+                        currentCallDefinitionClauseList
+                    } else {
+                        // collect all source
+                        currentCallDefinitionClauseList.add(callDefinitionClause)
+                        currentCallDefinitionClauseList
+                    }
+                }
+            } else {
+                mutableListOf(callDefinitionClause)
+            }
+        }
+    }
+
+    fun add(callDefinitionSpecification: CallDefinitionSpecification) {
+        // currently we don't decompile specifications, so no need to check
+        callDefinitionSpecificationList.add(callDefinitionSpecification)
+    }
+
+    fun add(implementation: Implementation) {
+        implementationListByName.compute(implementation.name ?: "?") { _, currentImplementationList ->
+            if (currentImplementationList != null) {
+                if (currentImplementationList.isDecompiled()) {
+                    if (implementation.isDecompiled()) {
+                        // collect all decompiled for all environments
+                        currentImplementationList.add(implementation)
+                        currentImplementationList
+                    } else {
+                        // prefer source over all decompiled
+                        mutableListOf(implementation)
+                    }
+                } else {
+                    if (implementation.isDecompiled()) {
+                        // ignore decompiled when there is source
+                        currentImplementationList
+                    } else {
+                        // collect all source
+                        currentImplementationList.add(implementation)
+                        currentImplementationList
+                    }
+                }
+            } else {
+                mutableListOf(implementation)
+            }
+        }
+    }
+
+    fun add(module: Module) {
+        moduleListByName.compute(module.name ?: "?") { _, currentModuleList ->
+            if (currentModuleList != null) {
+                if (currentModuleList.isDecompiled()) {
+                    if (module.isDecompiled()) {
+                        // collect all decompiled for all environments
+                        currentModuleList.add(module)
+                        currentModuleList
+                    } else {
+                        // prefer source over all decompiled
+                        mutableListOf(module)
+                    }
+                } else {
+                    if (module.isDecompiled()) {
+                        // ignore decompiled when there is source
+                        currentModuleList
+                    } else {
+                        // collect all source
+                        currentModuleList.add(module)
+                        currentModuleList
+                    }
+                }
+            } else {
+                mutableListOf(module)
+            }
+        }
+    }
+
+    fun toTypedArray(): Array<NavigationItem> =
+            (moduleListByName.values.flatten() as List<NavigationItem> +
+                    callDefinitionClauseListByArityByNameByModularName.values.flatMap { it.values.flatMap { it.values.flatten() } } +
+                    callDefinitionListByArityByNameByModularName.values.flatMap { it.values.flatMap { it.values.flatten() } } +
+                    callDefinitionSpecificationList +
+                    callDefinitionHeadListByArityByNameByModularName.values.flatMap { it.values.flatMap { it.values.flatten() } } +
+                    callbackList +
+                    implementationListByName.values.flatten()
+                    ).toTypedArray()
+
+    private val callDefinitionListByArityByNameByModularName = mutableMapOf<ModularName, MutableMap<Name, MutableMap<Arity, MutableList<CallDefinition>>>>()
+    private val callDefinitionClauseListByArityByNameByModularName = mutableMapOf<ModularName, MutableMap<Name, MutableMap<Arity, MutableList<CallDefinitionClause>>>>()
+    private val callDefinitionHeadListByArityByNameByModularName = mutableMapOf<ModularName, MutableMap<Name, MutableMap<Arity, MutableList<CallDefinitionHead>>>>()
+    private val callDefinitionSpecificationList = mutableListOf<CallDefinitionSpecification>()
+    private val callbackList = mutableListOf<Callback>()
+    private val implementationListByName = mutableMapOf<Name, MutableList<Implementation>>()
+    private val moduleListByName = mutableMapOf<Name, MutableList<Module>>()
+}
+
+private fun <E> List<E>.isDecompiled(): Boolean = all { it!!.isDecompiled() }
+
+private fun Any.isDecompiled(): Boolean =
+    when (this) {
+        is CallDefinition -> isDecompiled()
+        is CallDefinitionClause -> isDecompiled()
+        is Module -> isDecompiled()
+        else -> TODO()
+    }
+
+private fun CallDefinition.isDecompiled(): Boolean = modular.isDecompiled()
+private fun CallDefinitionClause.isDecompiled(): Boolean = callDefinition.isDecompiled()
+
+private fun Modular.isDecompiled(): Boolean =
+        when (this) {
+            is Module -> isDecompiled()
+            is Quote -> callDefinitionClause.isDecompiled()
+            else -> false
+        }
+
+private fun Module.isDecompiled(): Boolean = (value as PsiElement).containingFile.originalFile is BeamFileImpl
+
+typealias ModularName = String
+typealias Name = String
+typealias Arity = Int
+
+private fun CallDefinition.modularName() = modularName(modular)
+private fun modularName(presentable: Presentable): String =
+        when (presentable) {
+            is CallDefinitionClause -> presentable.callDefinition.modularName()
+            is Module -> presentable.name
+            is Quote -> "${modularName(presentable.callDefinitionClause)} quote"
+            else -> null
+        } ?: "?"

--- a/src/org/elixir_lang/reference/resolver/Module.kt
+++ b/src/org/elixir_lang/reference/resolver/Module.kt
@@ -1,9 +1,11 @@
 package org.elixir_lang.reference.resolver
 
 import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiElementResolveResult
 import com.intellij.psi.impl.source.resolve.ResolveCache
 import org.elixir_lang.Reference.forEachNavigationElement
+import org.elixir_lang.beam.psi.BeamFileImpl
 import org.elixir_lang.psi.scope.module.MultiResolve
 import org.elixir_lang.reference.module.ResolvableName.resolvableName
 
@@ -41,6 +43,14 @@ object Module : ResolveCache.PolyVariantResolver<org.elixir_lang.reference.Modul
             true
         }
 
-        return resolveResultList.toTypedArray()
+        val sourceResolveResultList = resolveResultList.filter { !it.element.isDecompiled() }
+
+        return if (sourceResolveResultList.isNotEmpty()) {
+            sourceResolveResultList.toTypedArray()
+        } else {
+            resolveResultList.toTypedArray()
+        }
     }
 }
+
+private fun PsiElement.isDecompiled(): Boolean = containingFile.originalFile is BeamFileImpl

--- a/src/org/elixir_lang/structure_view/element/CallDefinitionClause.kt
+++ b/src/org/elixir_lang/structure_view/element/CallDefinitionClause.kt
@@ -25,7 +25,7 @@ import java.util.*
  * @param callDefinition holds all sibling clauses for `call` for the same name, arity. and time
  * @param call           a def(macro)?p? call
  */
-class CallDefinitionClause(private val callDefinition: CallDefinition, call: Call) :
+class CallDefinitionClause(val callDefinition: CallDefinition, call: Call) :
         Element<Call>(call), Presentable, Visible {
     private val visibility: Visibility = visibility(call)!!
 

--- a/src/org/elixir_lang/structure_view/element/CallDefinitionHead.kt
+++ b/src/org/elixir_lang/structure_view/element/CallDefinitionHead.kt
@@ -14,7 +14,7 @@ import org.elixir_lang.psi.impl.PsiNamedElementImpl.unquoteName
 import org.elixir_lang.psi.impl.stripAccessExpression
 import org.elixir_lang.psi.operation.Normalized.operatorIndex
 
-class CallDefinitionHead(private val callDefinition: CallDefinition, private val visibility: Visibility, call: Call) :
+class CallDefinitionHead(val callDefinition: CallDefinition, private val visibility: Visibility, call: Call) :
         Element<Call>(call), Presentable, Visible {
     /**
      * Heads have no children since they have no body.

--- a/src/org/elixir_lang/structure_view/element/Quote.java
+++ b/src/org/elixir_lang/structure_view/element/Quote.java
@@ -23,7 +23,7 @@ public class Quote extends Element<Call> {
      */
 
     @Nullable
-    private final Presentable parent;
+    public final Presentable parent;
 
     /*
      * Static Methods

--- a/src/org/elixir_lang/structure_view/element/modular/Quote.java
+++ b/src/org/elixir_lang/structure_view/element/modular/Quote.java
@@ -9,7 +9,7 @@ import org.jetbrains.annotations.NotNull;
  */
 public class Quote implements Modular {
     @NotNull
-    private final CallDefinitionClause callDefinitionClause;
+    public final CallDefinitionClause callDefinitionClause;
 
     /*
      * Constructors

--- a/tests/org/elixir_lang/navigation/GotoSymbolContributorTest.java
+++ b/tests/org/elixir_lang/navigation/GotoSymbolContributorTest.java
@@ -48,14 +48,10 @@ public class GotoSymbolContributorTest extends LightPlatformCodeInsightFixtureTe
                 false
         );
 
-        assertEquals(2, itemsByName.length);
+        assertEquals(1, itemsByName.length);
 
-        assertInstanceOf(itemsByName[0], CallDefinition.class);
-        CallDefinition callDefinition = (CallDefinition) itemsByName[0];
-        assertEquals("decode_auth_type", callDefinition.name());
-
-        assertInstanceOf(itemsByName[1], CallDefinitionClause.class);
-        CallDefinitionClause callDefinitionClause = (CallDefinitionClause) itemsByName[1];
+        assertInstanceOf(itemsByName[0], CallDefinitionClause.class);
+        CallDefinitionClause callDefinitionClause = (CallDefinitionClause) itemsByName[0];
         assertEquals("decode_auth_type", callDefinitionClause.getName());
     }
 


### PR DESCRIPTION
Fixes #667 

# Changelog
## Bug Fixes
* Go To Symbol will no longer show redundant entries
  * Call Definitions (`name/arity`) is no longer shown if the Call Definition Clause is also included.  This isn't a large loss because the `/arity` was not searchable and only part of the presentation.
  * If there is a decompiled and a source version of a symbol, only the source version will be shown.
    * The source Implementation will be shown and not the decompiled Module with the same fully-qualified name (`<protocol>.<for>`).
  * Items will be deduped if they point to the same element, such as function clauses with default arguments because when presented they look the same even if internally one is representing `/1` and `/2`, for example.

## Incompatible Changes
* Go To Symbol and Go To Declaration will no longer suggest decompiled modules or functions if source modules or functions of the same name or module/name/arity exists. 

# Upgrading

If you depended on the ability of go to either the source or decompiled module or function from Go To Symbol or Go To Declaration, you now need to open the `.beam` file directly using Find File or the Project Tool pane.