### PR TITLE
Prefer source over decompiled for ResolveResultOrderedSet

### DIFF
--- a/src/org/elixir_lang/navigation/SourcePreferredItems.kt
+++ b/src/org/elixir_lang/navigation/SourcePreferredItems.kt
@@ -3,11 +3,15 @@ package org.elixir_lang.navigation
 import com.intellij.ide.structureView.StructureViewTreeElement
 import com.intellij.navigation.NavigationItem
 import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiElementResolveResult
 import org.elixir_lang.beam.psi.BeamFileImpl
 import org.elixir_lang.structure_view.element.*
 import org.elixir_lang.structure_view.element.modular.Modular
 import org.elixir_lang.structure_view.element.modular.Module
 import org.elixir_lang.structure_view.element.modular.Quote
+
+fun <E> List<E>.isDecompiled(): Boolean = all { it!!.isDecompiled() }
+fun PsiElement.isDecompiled(): Boolean = containingFile.originalFile is BeamFileImpl
 
 /**
  * Navigation items for [GotoSymbolContributor.getItemsByName] that will only return Source version if both Source and Decompiled version are added.
@@ -176,14 +180,14 @@ class SourcePreferredItems  {
     private val modularListByName = mutableMapOf<Name, MutableList<Modular>>()
 }
 
-private fun <E> List<E>.isDecompiled(): Boolean = all { it!!.isDecompiled() }
-
 private fun Any.isDecompiled(): Boolean =
     when (this) {
         is CallDefinition -> isDecompiled()
         is CallDefinitionClause -> isDecompiled()
         is Module -> isDecompiled()
-        else -> TODO()
+        is PsiElement -> isDecompiled()
+        is PsiElementResolveResult -> isDecompiled()
+        else -> TODO("Don't know how to check if ${this.javaClass} is decompiled")
     }
 
 private fun CallDefinition.isDecompiled(): Boolean = modular.isDecompiled()
@@ -197,6 +201,7 @@ private fun Modular.isDecompiled(): Boolean =
         }
 
 private fun Module.isDecompiled(): Boolean = (value as PsiElement).containingFile.originalFile is BeamFileImpl
+private fun PsiElementResolveResult.isDecompiled(): Boolean = element.isDecompiled()
 
 typealias ModularName = String
 typealias Name = String

--- a/src/org/elixir_lang/psi/scope/ResolveResultOrderedSet.kt
+++ b/src/org/elixir_lang/psi/scope/ResolveResultOrderedSet.kt
@@ -2,6 +2,7 @@ package org.elixir_lang.psi.scope
 
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiElementResolveResult
+import org.elixir_lang.navigation.isDecompiled
 
 class ResolveResultOrderedSet : Collection<PsiElementResolveResult> {
    override val size: Int
@@ -42,8 +43,27 @@ class ResolveResultOrderedSet : Collection<PsiElementResolveResult> {
    private val resolvedResultList = mutableListOf<PsiElementResolveResult>()
 
    private fun addConfirmedUnique(element: PsiElement, resolveResult: PsiElementResolveResult) {
-      resolvedResultList.add(resolveResult)
-      resolvedSet.add(element)
+      if (resolvedResultList.isDecompiled()) {
+         if (element.isDecompiled()) {
+            // collect all decompiled
+            resolvedResultList.add(resolveResult)
+            resolvedSet.add(element)
+         } else {
+            // prefer source over decompiled
+            resolvedResultList.clear()
+            resolvedSet.add(element)
+            resolvedResultList.add(resolveResult)
+            resolvedSet.add(element)
+         }
+      } else {
+         // ignore decompiled when there is source
+         if (!element.isDecompiled()) {
+            // collect all source
+            resolvedResultList.add(resolveResult)
+            resolvedSet.add(element)
+         }
+      }
+
    }
 
    private fun hasValidResult() = any { it.isValidResult }

--- a/src/org/elixir_lang/reference/resolver/Module.kt
+++ b/src/org/elixir_lang/reference/resolver/Module.kt
@@ -1,13 +1,13 @@
 package org.elixir_lang.reference.resolver
 
 import com.intellij.openapi.project.Project
-import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiElementResolveResult
 import com.intellij.psi.impl.source.resolve.ResolveCache
 import org.elixir_lang.Reference.forEachNavigationElement
-import org.elixir_lang.beam.psi.BeamFileImpl
+import org.elixir_lang.navigation.isDecompiled
 import org.elixir_lang.psi.scope.module.MultiResolve
 import org.elixir_lang.reference.module.ResolvableName.resolvableName
+
 
 object Module : ResolveCache.PolyVariantResolver<org.elixir_lang.reference.Module> {
     override fun resolve(
@@ -52,5 +52,3 @@ object Module : ResolveCache.PolyVariantResolver<org.elixir_lang.reference.Modul
         }
     }
 }
-
-private fun PsiElement.isDecompiled(): Boolean = containingFile.originalFile is BeamFileImpl


### PR DESCRIPTION
# Changelog
## Bug Fixes
* Ensures that Go To Declaration for qualified calls such as `Module.function(...)` where `Module` is an alias does not return the decompiled version of `Module` when the source is available.