### PR TITLE
Fix manual Kotlin conversion error

### DIFF
--- a/src/org/elixir_lang/psi/scope/call_definition_clause/Variants.kt
+++ b/src/org/elixir_lang/psi/scope/call_definition_clause/Variants.kt
@@ -66,10 +66,10 @@ class Variants : CallDefinitionClause() {
         named.name?.let { name ->
             val lookupElementByPsiElement = lookupElementByPsiElement  ?: mutableMapOf()
 
-            if (lookupElementByPsiElement.containsKey(named)) {
-                lookupElementByPsiElement[named] = LookupElementBuilder.createWithSmartPointer(
+            lookupElementByPsiElement.computeIfAbsent(named) { element ->
+                LookupElementBuilder.createWithSmartPointer(
                         name,
-                        named
+                        element
                 ).withRenderer(
                         org.elixir_lang.code_insight.lookup.element_renderer.CallDefinitionClause(name)
                 )

--- a/src/org/elixir_lang/psi/scope/call_definition_clause/Variants.kt
+++ b/src/org/elixir_lang/psi/scope/call_definition_clause/Variants.kt
@@ -36,10 +36,10 @@ class Variants : CallDefinitionClause() {
      * @return `true` to keep searching up tree; `false` to stop searching.
      */
     override fun executeOnCallDefinitionClause(element: Call, state: ResolveState): Boolean {
-        state.get(ENTRANCE_CALL_DEFINITION_CLAUSE)?.let { entranceCallDefinitionClause ->
-            if (!element.isEquivalentTo(entranceCallDefinitionClause)) {
-                addToLookupElementByPsiElement(element)
-            }
+        val entranceCallDefinitionClause = state.get(ENTRANCE_CALL_DEFINITION_CLAUSE)
+
+        if (entranceCallDefinitionClause == null || !element.isEquivalentTo(entranceCallDefinitionClause)) {
+            addToLookupElementByPsiElement(element)
         }
 
         return true


### PR DESCRIPTION
Fixes #1251

# Changelog
## Bug Fixes
* Fix completion not working for unqualified functions from `import`s.
  * When I switched to using `?.let` I accidentally hid the `if` from running when there was no `ENTRANCE_CALL_DEFINITION_CLAUSE`, so the correct form is add if there is no entrance or if there is a non-equivalent entrance.
  *  I just straight up forgot an ! on a contains check. I moved to computeIfAbsent, so it is more obvious what the intent is.