### PR TITLE
Don't inclue null useCall as __MODULE__ dependency

### DIFF
--- a/src/org/elixir_lang/psi/__MODULE__.kt
+++ b/src/org/elixir_lang/psi/__MODULE__.kt
@@ -18,11 +18,17 @@ object __MODULE__ {
                 .getParameterizedCachedValue(__MODULE__Call, KEY, Provider(__MODULE__Call), false, useCall)
 
     private class Provider(private val __MODULE__Call: Call) : ParameterizedCachedValueProvider<PsiReference, Call?> {
-        override fun compute(useCall: Call?): CachedValueProvider.Result<PsiReference>? =
-                CachedValueProvider.Result.create(
-                        Reference(call = __MODULE__Call, useCall = useCall),
-                        __MODULE__Call,
-                        useCall
-                )
+        override fun compute(useCall: Call?): CachedValueProvider.Result<PsiReference>? {
+            val dependencies: Array<Call> = if (useCall != null) {
+                arrayOf(__MODULE__Call, useCall)
+            } else {
+                arrayOf(__MODULE__Call)
+            }
+
+            return CachedValueProvider.Result.create(
+                    Reference(call = __MODULE__Call, useCall = useCall),
+                    dependencies
+            )
+        }
     }
 }


### PR DESCRIPTION
Fixes #1268

# Changelog
## Bug Fixes
* Don't include `null` `useCall` as `__MODULE__` dependency.