### PR TITLE
Add .eex to .ex and .exs for accepted file extensions in stacktraces

### DIFF
--- a/src/org/elixir_lang/console/FileReferenceFilter.java
+++ b/src/org/elixir_lang/console/FileReferenceFilter.java
@@ -30,7 +30,7 @@ public final class FileReferenceFilter implements Filter {
     private static final String FILE_PATH_REGEXP = "\\s*([0-9 a-z_A-Z\\-\\\\./]+)";
     private static final String NUMBER_REGEXP = "([0-9]+)";
 
-    private static final Pattern PATTERN_FILENAME = Pattern.compile("[/\\\\]?([^/\\\\]*?\\.exs?)$");
+    private static final Pattern PATTERN_FILENAME = Pattern.compile("[/\\\\]?([^/\\\\]*?\\.e(ex|x|xs))$");
     private final int myColumnMatchGroup;
     private final int myFileMatchGroup;
     private final int myLineMatchGroup;


### PR DESCRIPTION
Fixes #1262

# Changelog
## Bug Fixes
* Add `.eex` to `.ex` and `.exs` for accepted file extensions used to hyperlink files in stacktraces.