### PR TITLE
alias __MODULE__ and alias M, as: N support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -236,6 +236,10 @@ task stopQuoter(type: Exec, dependsOn: getQuoter) {
   args "stop"
 }
 
+runIde {
+  jvmArgs "-Didea.ProcessCanceledException=disabled"
+}
+
 test {
   dependsOn runQuoter
   finalizedBy stopQuoter

--- a/src/org/elixir_lang/psi/__module__/AliasPresentation.kt
+++ b/src/org/elixir_lang/psi/__module__/AliasPresentation.kt
@@ -1,0 +1,22 @@
+package org.elixir_lang.psi.__module__
+
+import com.intellij.navigation.ItemPresentation
+import com.intellij.psi.PsiNamedElement
+import org.elixir_lang.psi.call.Call
+import org.elixir_lang.psi.impl.locationString
+import org.elixir_lang.reference.module.UnaliasedName
+import javax.swing.Icon
+
+class AliasPresentation(private val __MODULE__Call: Call) : ItemPresentation {
+    override fun getIcon(unused: Boolean): Icon? = null
+    override fun getLocationString(): String = _locationString
+    override fun getPresentableText(): String = _presentableText
+
+    private val _locationString by lazy {
+        __MODULE__Call.containingFile.locationString(__MODULE__Call.project)
+    }
+
+    private val _presentableText by lazy {
+        "alias ${UnaliasedName.unaliasedName(__MODULE__Call as PsiNamedElement)}"
+    }
+}

--- a/src/org/elixir_lang/psi/impl/PresentationImpl.kt
+++ b/src/org/elixir_lang/psi/impl/PresentationImpl.kt
@@ -10,7 +10,11 @@ import org.elixir_lang.annotator.Parameter
 import org.elixir_lang.beam.psi.BeamFileImpl
 import org.elixir_lang.psi.ElixirIdentifier
 import org.elixir_lang.psi.QualifiableAlias
+import org.elixir_lang.psi.__module__.AliasPresentation
 import org.elixir_lang.psi.call.Call
+import org.elixir_lang.psi.call.name.Function
+import org.elixir_lang.psi.call.name.Function.ALIAS
+import org.elixir_lang.psi.call.name.Module.KERNEL
 import org.elixir_lang.psi.outerMostQualifiableAlias
 import org.elixir_lang.structure_view.element.CallDefinition
 import org.elixir_lang.structure_view.element.CallDefinitionClause
@@ -39,6 +43,13 @@ object PresentationImpl {
                 org.elixir_lang.structure_view.element.modular.Module.`is`(call) -> {
                     val modular = CallDefinitionClause.enclosingModular(call)
                     org.elixir_lang.structure_view.element.modular.Module(modular, call).presentation
+                }
+                call.isCalling(KERNEL, Function.__MODULE__, 0) -> {
+                    if (call.parent?.parent?.let { it as? Call }?.isCalling(KERNEL, ALIAS) == true) {
+                        AliasPresentation(call)
+                    } else {
+                        getDefaultPresentation(call)
+                    }
                 }
                 else -> getDefaultPresentation(call)
             }

--- a/src/org/elixir_lang/psi/impl/qualifiable_alias/ItemPresentation.kt
+++ b/src/org/elixir_lang/psi/impl/qualifiable_alias/ItemPresentation.kt
@@ -2,10 +2,13 @@ package org.elixir_lang.psi.impl.qualifiable_alias
 
 import com.intellij.navigation.ItemPresentation
 import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiNamedElement
 import org.elixir_lang.psi.*
 import org.elixir_lang.psi.call.Call
 import org.elixir_lang.psi.call.name.Function.ALIAS
 import org.elixir_lang.psi.call.name.Module.KERNEL
+import org.elixir_lang.psi.impl.call.finalArguments
+import org.elixir_lang.psi.impl.hasKeywordKey
 import org.elixir_lang.psi.impl.locationString
 import org.elixir_lang.reference.module.UnaliasedName
 import javax.swing.Icon
@@ -42,7 +45,32 @@ class ItemPresentation(private val qualifiableAlias: QualifiableAlias) : ItemPre
                 is ElixirMultipleAliases,
                 is QualifiedMultipleAliases->
                     getPresentableText(ancestor.parent)
+                is QuotableKeywordPair -> {
+                    if (ancestor.hasKeywordKey("as")) {
+                        aliasFirstArgument(ancestor)?.let { aliasFirstArgument ->
+                            "alias ${UnaliasedName.unaliasedName(aliasFirstArgument)}, as: ${qualifiableAlias.name}"
+                        } ?: qualifiableAlias.name
+                    } else {
+                        null
+                    }
+                }
                 else ->
                     qualifiableAlias.fullyQualifiedName()
+            }
+
+    private tailrec fun aliasFirstArgument(ancestor: PsiElement): PsiNamedElement? =
+            when (ancestor) {
+                is Arguments,
+                is QuotableKeywordList,
+                is QuotableKeywordPair ->
+                    aliasFirstArgument(ancestor.parent)
+                is Call -> {
+                    if (ancestor.isCalling(KERNEL, ALIAS)) {
+                        ancestor.finalArguments()!![0] as? PsiNamedElement
+                    } else {
+                        null
+                    }
+                }
+                else -> null
             }
 }

--- a/src/org/elixir_lang/reference/module/UnaliasedName.kt
+++ b/src/org/elixir_lang/reference/module/UnaliasedName.kt
@@ -5,6 +5,7 @@ import com.intellij.psi.PsiNamedElement
 import org.elixir_lang.errorreport.Logger
 import org.elixir_lang.psi.*
 import org.elixir_lang.psi.call.Call
+import org.elixir_lang.psi.call.name.Function
 import org.elixir_lang.psi.call.name.Function.ALIAS
 import org.elixir_lang.psi.call.name.Module.KERNEL
 import org.elixir_lang.psi.impl.call.finalArguments
@@ -15,6 +16,12 @@ object UnaliasedName {
     fun unaliasedName(namedElement: PsiNamedElement): String? =
             if (namedElement is QualifiableAlias) {
                 unaliasedName(namedElement)
+            } else if (namedElement is Call && namedElement.isCalling(KERNEL, Function.__MODULE__, 0)) {
+                __MODULE__
+                        .reference(namedElement, useCall = null)
+                        .resolve()
+                        ?.let { it as? PsiNamedElement }
+                        ?.name
             } else {
                 namedElement.name
             }

--- a/src/org/elixir_lang/reference/module/UnaliasedName.kt
+++ b/src/org/elixir_lang/reference/module/UnaliasedName.kt
@@ -8,6 +8,7 @@ import org.elixir_lang.psi.call.Call
 import org.elixir_lang.psi.call.name.Function.ALIAS
 import org.elixir_lang.psi.call.name.Module.KERNEL
 import org.elixir_lang.psi.impl.call.finalArguments
+import org.elixir_lang.psi.impl.call.maybeModularNameToModular
 import org.elixir_lang.psi.impl.hasKeywordKey
 
 object UnaliasedName {
@@ -20,6 +21,7 @@ object UnaliasedName {
 
     private tailrec fun down(element: PsiElement): String? =
             when (element) {
+                is Call -> element.maybeModularNameToModular(null)?.name
                 is ElixirAccessExpression -> {
                     val children = element.children
 

--- a/tests/org/elixir_lang/reference/module/AsTest.java
+++ b/tests/org/elixir_lang/reference/module/AsTest.java
@@ -46,15 +46,20 @@ public class AsTest extends LightPlatformCodeInsightFixtureTestCase {
 
         ResolveResult[] resolveResults = polyVariantReference.multiResolve(false);
 
-        assertEquals(2, resolveResults.length);
+        assertEquals(3, resolveResults.length);
 
-        // alias
+        // alias .., as:
         assertEquals(
                 "alias Prefix.Suffix1, as: As",
                 resolveResults[0].getElement().getParent().getParent().getParent().getParent().getParent().getText()
         );
-        // defmodule
-        assertEquals("defmodule Prefix.Suffix1 do\nend", resolveResults[1].getElement().getText());
+        // alias ..
+        assertEquals(
+                "alias Prefix.Suffix1, as: As",
+                resolveResults[1].getElement().getParent().getParent().getText()
+        );
+        // defmodule ..
+        assertEquals("defmodule Prefix.Suffix1 do\nend", resolveResults[2].getElement().getText());
     }
 
     /*


### PR DESCRIPTION
Resolves #1266

# Changelog
## Enhancements
* Resolve unaliased name when using `alias __MODULE__, as: Mod`
* Resolve usage of `Mod` in `alias __MODULE__, as Mod`
  1. `Mod`
  2. `__MODULE__` in `alias __MODULE__`
  3. `defmodule MyModule` that is enclosing `__MODULE__`.
* Disable `ProcessCanceledException` for `runIde` gradle task, to allow for easier manual testing of completion and Go To actions during development.
* Completion of functions in current module when using `Mod.` after `alias __MODULE__, as: Mod`.
* Show more context for `alias` calls in presentations, like "Choose Declaration" pop up for Go To Declaration.
  * Show resolved `__MODULE__` name (`alias MyModule`) when using `alias __MODULE__`.
  * Show full `alias MyModule, as: Mod` when listing `Mod` in `alias __MODULE__, as Mod`.