### PR TITLE
More closely match ExUnit.CliFormatter output in Test Runner

### DIFF
--- a/resources/exunit/.formatter.exs
+++ b/resources/exunit/.formatter.exs
@@ -1,5 +1,5 @@
 [
-  inputs: [".credo.exs", ".formatter.exs", "mix.exs", "{config,lib,priv,rel,test}/**/*.{ex,exs}"],
+  inputs: [".formatter.exs", "test_with_formatter.ex", "**/*.{ex,exs}"],
   line_length: 120,
-  rename_deprecated_at: "1.6.0"
+  rename_deprecated_at: "1.1.0"
 ]

--- a/resources/exunit/1.1.0/team_city_ex_unit_formatting.ex
+++ b/resources/exunit/1.1.0/team_city_ex_unit_formatting.ex
@@ -20,9 +20,6 @@ defmodule TeamCityExUnitFormatting do
 
   # Functions
 
-  @doc false
-  def formatter(_color, msg), do: msg
-
   def new(opts) do
     %__MODULE__{
       seed: opts[:seed],
@@ -224,6 +221,12 @@ defmodule TeamCityExUnitFormatting do
     "#{head}#{Enum.map(tail, &String.capitalize/1)}"
   end
 
+  defp colorize(escape, string) do
+    [escape, string, :reset]
+    |> IO.ANSI.format_fragment(true)
+    |> IO.iodata_to_binary()
+  end
+
   # Must escape certain characters
   # see: https://confluence.jetbrains.com/display/TCD9/Build+Script+Interaction+with+TeamCity
   defp escape_output(s) when not is_binary(s), do: escape_output("#{s}")
@@ -268,6 +271,26 @@ defmodule TeamCityExUnitFormatting do
     indented_logs = String.replace(logs, "\n", indent)
     [indent, "The following output was logged:", indent | indented_logs]
   end
+
+  defp formatter(:diff_enabled?, _), do: true
+
+  defp formatter(:error_info, msg), do: colorize(:red, msg)
+
+  defp formatter(:extra_info, msg), do: colorize(:cyan, msg)
+
+  defp formatter(:location_info, msg), do: colorize([:bright, :black], msg)
+
+  defp formatter(:diff_delete, msg), do: colorize(:red, msg)
+
+  defp formatter(:diff_delete_whitespace, msg), do: colorize(IO.ANSI.color_background(2, 0, 0), msg)
+
+  defp formatter(:diff_insert, msg), do: colorize(:green, msg)
+
+  defp formatter(:diff_insert_whitespace, msg), do: colorize(IO.ANSI.color_background(0, 2, 0), msg)
+
+  defp formatter(:blame_diff, msg), do: colorize(:red, msg)
+
+  defp formatter(_, msg), do: msg
 
   defp name(test = %ExUnit.Test{name: name}) do
     named_captures =

--- a/resources/exunit/1.1.0/team_city_ex_unit_formatting.ex
+++ b/resources/exunit/1.1.0/team_city_ex_unit_formatting.ex
@@ -79,6 +79,7 @@ defmodule TeamCityExUnitFormatting do
         width,
         &formatter/2
       )
+
     details = IO.iodata_to_binary([formatted_failure, format_logs(logs)])
 
     put_formatted(
@@ -125,6 +126,7 @@ defmodule TeamCityExUnitFormatting do
         width,
         &formatter/2
       )
+
     details = IO.iodata_to_binary([formatted_failure, format_logs(logs)])
 
     put_formatted(
@@ -266,6 +268,7 @@ defmodule TeamCityExUnitFormatting do
   end
 
   defp format_logs(""), do: ""
+
   defp format_logs(logs) do
     indent = "\n     "
     indented_logs = String.replace(logs, "\n", indent)

--- a/resources/exunit/1.1.0/team_city_ex_unit_formatting.ex
+++ b/resources/exunit/1.1.0/team_city_ex_unit_formatting.ex
@@ -88,7 +88,7 @@ defmodule TeamCityExUnitFormatting do
       Keyword.merge(
         attributes,
         details: formatted,
-        message: inspect(reason)
+        message: ""
       )
     )
 
@@ -127,7 +127,6 @@ defmodule TeamCityExUnitFormatting do
         &formatter/2
       )
 
-    message = Enum.map_join(failed, "", fn {_kind, reason, _stack} -> inspect(reason) end)
     attributes = attributes(test)
 
     put_formatted(
@@ -135,7 +134,7 @@ defmodule TeamCityExUnitFormatting do
       Keyword.merge(
         attributes,
         details: formatted,
-        message: message
+        message: ""
       )
     )
 

--- a/resources/exunit/1.4.0/team_city_ex_unit_formatting.ex
+++ b/resources/exunit/1.4.0/team_city_ex_unit_formatting.ex
@@ -88,7 +88,7 @@ defmodule TeamCityExUnitFormatting do
       Keyword.merge(
         attributes,
         details: formatted,
-        message: inspect(reason)
+        message: ""
       )
     )
 
@@ -135,7 +135,7 @@ defmodule TeamCityExUnitFormatting do
       Keyword.merge(
         attributes,
         details: formatted,
-        message: message
+        message: ""
       )
     )
 

--- a/resources/exunit/1.4.0/team_city_ex_unit_formatting.ex
+++ b/resources/exunit/1.4.0/team_city_ex_unit_formatting.ex
@@ -79,6 +79,7 @@ defmodule TeamCityExUnitFormatting do
         width,
         &formatter/2
       )
+
     details = IO.iodata_to_binary([formatted_failure, format_logs(logs)])
 
     put_formatted(
@@ -125,6 +126,7 @@ defmodule TeamCityExUnitFormatting do
         width,
         &formatter/2
       )
+
     details = IO.iodata_to_binary([formatted_failure, format_logs(logs)])
 
     message = Enum.map_join(failed, "", fn {_kind, reason, _stack} -> inspect(reason) end)
@@ -268,6 +270,7 @@ defmodule TeamCityExUnitFormatting do
   end
 
   defp format_logs(""), do: ""
+
   defp format_logs(logs) do
     indent = "\n     "
     indented_logs = String.replace(logs, "\n", indent)

--- a/resources/exunit/1.4.0/team_city_ex_unit_formatting.ex
+++ b/resources/exunit/1.4.0/team_city_ex_unit_formatting.ex
@@ -20,9 +20,6 @@ defmodule TeamCityExUnitFormatting do
 
   # Functions
 
-  @doc false
-  def formatter(_color, msg), do: msg
-
   def new(opts) do
     %__MODULE__{
       seed: opts[:seed],
@@ -226,6 +223,12 @@ defmodule TeamCityExUnitFormatting do
     "#{head}#{Enum.map(tail, &String.capitalize/1)}"
   end
 
+  defp colorize(escape, string) do
+    [escape, string, :reset]
+    |> IO.ANSI.format_fragment(true)
+    |> IO.iodata_to_binary()
+  end
+
   # Must escape certain characters
   # see: https://confluence.jetbrains.com/display/TCD9/Build+Script+Interaction+with+TeamCity
   defp escape_output(s) when not is_binary(s), do: escape_output("#{s}")
@@ -270,6 +273,26 @@ defmodule TeamCityExUnitFormatting do
     indented_logs = String.replace(logs, "\n", indent)
     [indent, "The following output was logged:", indent | indented_logs]
   end
+
+  defp formatter(:diff_enabled?, _), do: true
+
+  defp formatter(:error_info, msg), do: colorize(:red, msg)
+
+  defp formatter(:extra_info, msg), do: colorize(:cyan, msg)
+
+  defp formatter(:location_info, msg), do: colorize([:bright, :black], msg)
+
+  defp formatter(:diff_delete, msg), do: colorize(:red, msg)
+
+  defp formatter(:diff_delete_whitespace, msg), do: colorize(IO.ANSI.color_background(2, 0, 0), msg)
+
+  defp formatter(:diff_insert, msg), do: colorize(:green, msg)
+
+  defp formatter(:diff_insert_whitespace, msg), do: colorize(IO.ANSI.color_background(0, 2, 0), msg)
+
+  defp formatter(:blame_diff, msg), do: colorize(:red, msg)
+
+  defp formatter(_, msg), do: msg
 
   defp name(test = %ExUnit.Test{name: name}) do
     named_captures =

--- a/resources/exunit/1.4.0/team_city_ex_unit_formatting.ex
+++ b/resources/exunit/1.4.0/team_city_ex_unit_formatting.ex
@@ -61,6 +61,7 @@ defmodule TeamCityExUnitFormatting do
         {
           :test_finished,
           test = %ExUnit.Test{
+            logs: logs,
             state:
               failed = {
                 :failed,
@@ -71,8 +72,9 @@ defmodule TeamCityExUnitFormatting do
         }
       ) do
     updated_failures_counter = failures_counter + 1
+    attributes = attributes(test)
 
-    formatted =
+    formatted_failure =
       ExUnit.Formatter.format_test_failure(
         test,
         failed,
@@ -80,14 +82,13 @@ defmodule TeamCityExUnitFormatting do
         width,
         &formatter/2
       )
-
-    attributes = attributes(test)
+    details = IO.iodata_to_binary([formatted_failure, format_logs(logs)])
 
     put_formatted(
       :test_failed,
       Keyword.merge(
         attributes,
-        details: formatted,
+        details: details,
         message: ""
       )
     )
@@ -113,12 +114,13 @@ defmodule TeamCityExUnitFormatting do
           width: width,
           tests_counter: tests_counter
         },
-        {:test_finished, test = %ExUnit.Test{state: {:failed, failed}, time: time}}
+        {:test_finished, test = %ExUnit.Test{logs: logs, state: {:failed, failed}, time: time}}
       )
       when is_list(failed) do
     updated_failures_counter = failures_counter + 1
+    attributes = attributes(test)
 
-    formatted =
+    formatted_failure =
       ExUnit.Formatter.format_test_failure(
         test,
         failed,
@@ -126,15 +128,15 @@ defmodule TeamCityExUnitFormatting do
         width,
         &formatter/2
       )
+    details = IO.iodata_to_binary([formatted_failure, format_logs(logs)])
 
     message = Enum.map_join(failed, "", fn {_kind, reason, _stack} -> inspect(reason) end)
-    attributes = attributes(test)
 
     put_formatted(
       :test_failed,
       Keyword.merge(
         attributes,
-        details: formatted,
+        details: details,
         message: ""
       )
     )
@@ -260,6 +262,13 @@ defmodule TeamCityExUnitFormatting do
     case_name
     |> to_string()
     |> String.replace(~r/\bElixir\./, "")
+  end
+
+  defp format_logs(""), do: ""
+  defp format_logs(logs) do
+    indent = "\n     "
+    indented_logs = String.replace(logs, "\n", indent)
+    [indent, "The following output was logged:", indent | indented_logs]
   end
 
   defp name(test = %ExUnit.Test{name: name}) do

--- a/resources/exunit/1.6.0/team_city_ex_unit_formatting.ex
+++ b/resources/exunit/1.6.0/team_city_ex_unit_formatting.ex
@@ -87,7 +87,7 @@ defmodule TeamCityExUnitFormatting do
                   Keyword.merge(
                     attributes,
                     details: formatted,
-                    message: inspect(reason)
+                    message: ""
                   )
     put_formatted :test_finished,
                   Keyword.merge(
@@ -118,14 +118,13 @@ defmodule TeamCityExUnitFormatting do
       width,
       &formatter/2
     )
-    message = Enum.map_join(failed, "", fn {_kind, reason, _stack} -> inspect(reason) end)
     attributes = attributes(test)
 
     put_formatted :test_failed,
                   Keyword.merge(
                     attributes,
                     details: formatted,
-                    message: message
+                    message: ""
                   )
     put_formatted :test_finished,
                   Keyword.merge(

--- a/resources/exunit/1.6.0/team_city_ex_unit_formatting.ex
+++ b/resources/exunit/1.6.0/team_city_ex_unit_formatting.ex
@@ -20,9 +20,6 @@ defmodule TeamCityExUnitFormatting do
 
   # Functions
 
-  @doc false
-  def formatter(_color, msg), do: msg
-
   def new(opts) do
     %__MODULE__{
       seed: opts[:seed],
@@ -215,6 +212,12 @@ defmodule TeamCityExUnitFormatting do
     "#{head}#{Enum.map tail, &String.capitalize/1}"
   end
 
+  defp colorize(escape, string) do
+    [escape, string, :reset]
+    |> IO.ANSI.format_fragment(true)
+    |> IO.iodata_to_binary()
+  end
+
   # Must escape certain characters
   # see: https://confluence.jetbrains.com/display/TCD9/Build+Script+Interaction+with+TeamCity
   defp escape_output(s) when not is_binary(s), do: escape_output("#{s}")
@@ -254,6 +257,26 @@ defmodule TeamCityExUnitFormatting do
     |> to_string()
     |> String.replace(~r/\bElixir\./, "")
   end
+
+  defp formatter(:diff_enabled?, _), do: true
+
+  defp formatter(:error_info, msg), do: colorize(:red, msg)
+
+  defp formatter(:extra_info, msg), do: colorize(:cyan, msg)
+
+  defp formatter(:location_info, msg), do: colorize([:bright, :black], msg)
+
+  defp formatter(:diff_delete, msg), do: colorize(:red, msg)
+
+  defp formatter(:diff_delete_whitespace, msg), do: colorize(IO.ANSI.color_background(2, 0, 0), msg)
+
+  defp formatter(:diff_insert, msg), do: colorize(:green, msg)
+
+  defp formatter(:diff_insert_whitespace, msg), do: colorize(IO.ANSI.color_background(0, 2, 0), msg)
+
+  defp formatter(:blame_diff, msg), do: colorize(:red, msg)
+
+  defp formatter(_, msg), do: msg
 
   defp name(test = %ExUnit.Test{name: name}) do
     named_captures = Regex.named_captures(

--- a/resources/exunit/1.6.0/team_city_ex_unit_formatting.ex
+++ b/resources/exunit/1.6.0/team_city_ex_unit_formatting.ex
@@ -32,13 +32,13 @@ defmodule TeamCityExUnitFormatting do
   def put_event(state = %__MODULE__{}, {:case_started, %ExUnit.TestCase{}}), do: state
 
   def put_event(state = %__MODULE__{}, {:module_finished, test_module = %ExUnit.TestModule{}}) do
-    put_formatted :test_suite_finished, attributes(test_module)
+    put_formatted(:test_suite_finished, attributes(test_module))
 
     state
   end
 
   def put_event(state = %__MODULE__{}, {:module_started, test_module = %ExUnit.TestModule{}}) do
-    put_formatted :test_suite_started, attributes(test_module)
+    put_formatted(:test_suite_started, attributes(test_module))
 
     state
   end
@@ -48,7 +48,7 @@ defmodule TeamCityExUnitFormatting do
   def put_event(state = %__MODULE__{}, {:suite_started, opts}) do
     seed = opts[:seed]
 
-    IO.puts "Suite started with seed #{seed}"
+    IO.puts("Suite started with seed #{seed}")
 
     %__MODULE__{state | seed: seed, trace: opts[:trace]}
   end
@@ -63,10 +63,11 @@ defmodule TeamCityExUnitFormatting do
           :test_finished,
           test = %ExUnit.Test{
             logs: logs,
-            state: failed = {
-              :failed,
-              {_, reason, _}
-            },
+            state:
+              failed = {
+                :failed,
+                {_, reason, _}
+              },
             time: time
           }
         }
@@ -74,31 +75,38 @@ defmodule TeamCityExUnitFormatting do
     updated_failures_counter = failures_counter + 1
     attributes = attributes(test)
 
-    formatted_failure = ExUnit.Formatter.format_test_failure(
-      test,
-      failed,
-      updated_failures_counter,
-      width,
-      &formatter/2
-    )
+    formatted_failure =
+      ExUnit.Formatter.format_test_failure(
+        test,
+        failed,
+        updated_failures_counter,
+        width,
+        &formatter/2
+      )
+
     details = IO.iodata_to_binary([formatted_failure, format_logs(logs)])
 
-    put_formatted :test_failed,
-                  Keyword.merge(
-                    attributes,
-                    details: formatted_failure,
-                    message: ""
-                  )
-    put_formatted :test_finished,
-                  Keyword.merge(
-                    attributes,
-                    duration: div(time, 1000)
-                  )
+    put_formatted(
+      :test_failed,
+      Keyword.merge(
+        attributes,
+        details: formatted_failure,
+        message: ""
+      )
+    )
+
+    put_formatted(
+      :test_finished,
+      Keyword.merge(
+        attributes,
+        duration: div(time, 1000)
+      )
+    )
 
     %{
-      state |
-      tests_counter: tests_counter + 1,
-      failures_counter: updated_failures_counter
+      state
+      | tests_counter: tests_counter + 1,
+        failures_counter: updated_failures_counter
     }
   end
 
@@ -109,35 +117,43 @@ defmodule TeamCityExUnitFormatting do
           tests_counter: tests_counter
         },
         {:test_finished, test = %ExUnit.Test{logs: logs, state: {:failed, failed}, time: time}}
-      ) when is_list(failed) do
+      )
+      when is_list(failed) do
     updated_failures_counter = failures_counter + 1
     attributes = attributes(test)
 
-    formatted_failure = ExUnit.Formatter.format_test_failure(
-      test,
-      failed,
-      updated_failures_counter,
-      width,
-      &formatter/2
-    )
+    formatted_failure =
+      ExUnit.Formatter.format_test_failure(
+        test,
+        failed,
+        updated_failures_counter,
+        width,
+        &formatter/2
+      )
+
     details = IO.iodata_to_binary([formatted_failure, format_logs(logs)])
 
-    put_formatted :test_failed,
-                  Keyword.merge(
-                    attributes,
-                    details: details,
-                    message: ""
-                  )
-    put_formatted :test_finished,
-                  Keyword.merge(
-                    attributes,
-                    duration: div(time, 1000)
-                  )
+    put_formatted(
+      :test_failed,
+      Keyword.merge(
+        attributes,
+        details: details,
+        message: ""
+      )
+    )
+
+    put_formatted(
+      :test_finished,
+      Keyword.merge(
+        attributes,
+        duration: div(time, 1000)
+      )
+    )
 
     %{
-      state |
-      tests_counter: tests_counter + 1,
-      failures_counter: updated_failures_counter
+      state
+      | tests_counter: tests_counter + 1,
+        failures_counter: updated_failures_counter
     }
   end
 
@@ -150,13 +166,13 @@ defmodule TeamCityExUnitFormatting do
       ) do
     attributes = attributes(test)
 
-    put_formatted :test_ignored, attributes
-    put_formatted :test_finished, attributes
+    put_formatted(:test_ignored, attributes)
+    put_formatted(:test_finished, attributes)
 
     %{
-      state |
-      tests_counter: tests_counter + 1,
-      skipped_counter: skipped_counter + 1
+      state
+      | tests_counter: tests_counter + 1,
+        skipped_counter: skipped_counter + 1
     }
   end
 
@@ -169,30 +185,32 @@ defmodule TeamCityExUnitFormatting do
           }
         }
       ) do
-    put_formatted :test_finished,
-                  test
-                  |> attributes()
-                  |> Keyword.merge(
-                       duration: div(time, 1000)
-                     )
+    put_formatted(
+      :test_finished,
+      test
+      |> attributes()
+      |> Keyword.merge(duration: div(time, 1000))
+    )
 
     state
   end
 
   def put_event(state = %__MODULE__{}, {:test_started, test = %ExUnit.Test{tags: tags}}) do
-    put_formatted :test_started,
-                  test
-                  |> attributes()
-                  |> Keyword.merge(
-                    locationHint: "file://#{tags[:file]}:#{tags[:line]}"
-                  )
+    put_formatted(
+      :test_started,
+      test
+      |> attributes()
+      |> Keyword.merge(locationHint: "file://#{tags[:file]}:#{tags[:line]}")
+    )
 
     state
   end
 
   def put_event(state = %__MODULE__{}, event) do
-    IO.warn "#{inspect(__MODULE__)} does not know how to process event (#{inspect(event)}).  " <>
-            "Please report this message to https://github.com/KronicDeth/intellij-elixir/issues/new."
+    IO.warn(
+      "#{inspect(__MODULE__)} does not know how to process event (#{inspect(event)}).  " <>
+        "Please report this message to https://github.com/KronicDeth/intellij-elixir/issues/new."
+    )
 
     state
   end
@@ -208,8 +226,8 @@ defmodule TeamCityExUnitFormatting do
   end
 
   defp camelize(s) do
-    [head | tail] = String.split s, "_"
-    "#{head}#{Enum.map tail, &String.capitalize/1}"
+    [head | tail] = String.split(s, "_")
+    "#{head}#{Enum.map(tail, &String.capitalize/1)}"
   end
 
   defp colorize(escape, string) do
@@ -221,6 +239,7 @@ defmodule TeamCityExUnitFormatting do
   # Must escape certain characters
   # see: https://confluence.jetbrains.com/display/TCD9/Build+Script+Interaction+with+TeamCity
   defp escape_output(s) when not is_binary(s), do: escape_output("#{s}")
+
   defp escape_output(s) do
     s
     |> String.replace("|", "||")
@@ -232,20 +251,25 @@ defmodule TeamCityExUnitFormatting do
   end
 
   defp format(type, attributes) do
-    messageName = type
-                  |> Atom.to_string()
-                  |> camelize()
-    attrs = attributes
-            |> Enum.map(&format_attribute/1)
-            |> Enum.join(" ")
+    messageName =
+      type
+      |> Atom.to_string()
+      |> camelize()
+
+    attrs =
+      attributes
+      |> Enum.map(&format_attribute/1)
+      |> Enum.join(" ")
+
     "##teamcity[#{messageName} #{attrs}]"
   end
 
   defp format_attribute({k, v}) do
-    "#{Atom.to_string k}='#{escape_output v}'"
+    "#{Atom.to_string(k)}='#{escape_output(v)}'"
   end
 
   defp format_logs(""), do: ""
+
   defp format_logs(logs) do
     indent = "\n     "
     indented_logs = String.replace(logs, "\n", indent)
@@ -279,15 +303,19 @@ defmodule TeamCityExUnitFormatting do
   defp formatter(_, msg), do: msg
 
   defp name(test = %ExUnit.Test{name: name}) do
-    named_captures = Regex.named_captures(
-      ~r|test doc at (?<module>.+)\.(?<function>\w+)/(?<arity>\d+) \((?<count>\d+)\)|,
-      to_string(name)
-    )
+    named_captures =
+      Regex.named_captures(
+        ~r|test doc at (?<module>.+)\.(?<function>\w+)/(?<arity>\d+) \((?<count>\d+)\)|,
+        to_string(name)
+      )
+
     name(test, named_captures)
   end
+
   defp name(%ExUnit.TestModule{name: name}), do: format_module_name(name)
 
   defp name(%ExUnit.Test{name: name}, nil), do: to_string(name)
+
   defp name(
          %ExUnit.Test{module: module_name},
          %{"arity" => arity, "count" => count, "function" => function, "module" => module}

--- a/resources/exunit/test_with_formatter.ex
+++ b/resources/exunit/test_with_formatter.ex
@@ -256,8 +256,7 @@ defmodule Mix.Tasks.TestWithFormatter do
 
     matched_test_files = Mix.Utils.extract_files(test_files, test_pattern)
 
-    matched_warn_test_files =
-      Mix.Utils.extract_files(test_files, warn_test_pattern) -- matched_test_files
+    matched_warn_test_files = Mix.Utils.extract_files(test_files, warn_test_pattern) -- matched_test_files
 
     display_warn_test_pattern(matched_warn_test_files, test_pattern)
 
@@ -296,8 +295,7 @@ defmodule Mix.Tasks.TestWithFormatter do
       |> filter_only_opts()
       |> formatter_opts()
 
-    default_opts(opts) ++
-      Keyword.take(opts, [:trace, :max_cases, :include, :exclude, :seed, :timeout, :formatters])
+    default_opts(opts) ++ Keyword.take(opts, [:trace, :max_cases, :include, :exclude, :seed, :timeout, :formatters])
   end
 
   defp merge_helper_opts(opts) do


### PR DESCRIPTION
Fixes #1276

# Changelog
## Bug Fixes
* More closely match [ExUnit.CliFormatter](https://github.com/elixir-lang/elixir/blob/v1.7.3/lib/ex_unit/lib/ex_unit/cli_formatter.ex) output in Test Runner.
  * Don't `inspect` ExUnit failure `reason` as `##teamcity` `message`.
  * Add captured logs to failure
  * Colorize test failures - including diff colorization
* `.formatter.exs` input globs would not match file paths because it was default that needed `lib` on top and not version-dependent paths used in `resources/exunit`.