### PR TITLE
Map Elixir 1.7 excluded and skipped tests to teamcity testIgnored message

### DIFF
--- a/resources/exunit/1.6.0/team_city_ex_unit_formatting.ex
+++ b/resources/exunit/1.6.0/team_city_ex_unit_formatting.ex
@@ -162,8 +162,8 @@ defmodule TeamCityExUnitFormatting do
           tests_counter: tests_counter,
           skipped_counter: skipped_counter
         },
-        {:test_finished, test = %ExUnit.Test{state: {:skip, _}}}
-      ) do
+        {:test_finished, test = %ExUnit.Test{state: {ignored, _}}}
+      ) when ignored in ~w(excluded skip skipped)a do
     attributes = attributes(test)
 
     put_formatted(:test_ignored, attributes)

--- a/src/org/elixir_lang/mix/Dep.kt
+++ b/src/org/elixir_lang/mix/Dep.kt
@@ -34,7 +34,7 @@ data class Dep(val application: String, val path: String, val type: Type = Type.
                                 val key = keywordPair.keywordKey.text
 
                                 when (key) {
-                                    "app", "commit", "compile", "git", "github", "only", "optional", "override",  "runtime" -> acc
+                                    "app", "branch", "commit", "compile", "git", "github", "hex", "only", "optional", "override",  "runtime" -> acc
                                     "in_umbrella" -> acc.copy(path =  "apps/$name", type = Type.MODULE)
                                     else -> {
                                         Logger.error(logger, "Don't know if Mix.Dep option `$key` is important for determining location of dependency", depsListElement)


### PR DESCRIPTION
Fixes #1290

# Changelog
## Bug Fixes
* Ignore branch and hex options when finding path of Mix.Dep
* Map Elixir 1.7 `:excluded` and `:skipped` (added in elixir-lang/elixir#7245) to `testIgnored` teamcity message, thereby restoring ignored test counts and markers from Elixir 1.6.