### PR TITLE
Only look in outer nested module for callable completion

### DIFF
--- a/src/org/elixir_lang/psi/scope/CallDefinitionClause.kt
+++ b/src/org/elixir_lang/psi/scope/CallDefinitionClause.kt
@@ -4,6 +4,7 @@ import com.intellij.openapi.util.Key
 import com.intellij.psi.PsiElement
 import com.intellij.psi.ResolveState
 import com.intellij.psi.scope.PsiScopeProcessor
+import com.intellij.psi.util.PsiTreeUtil
 import org.elixir_lang.errorreport.Logger
 import org.elixir_lang.psi.ElixirFile
 import org.elixir_lang.psi.Import
@@ -12,6 +13,7 @@ import org.elixir_lang.psi.Use
 import org.elixir_lang.psi.call.Call
 import org.elixir_lang.psi.call.name.Module.KERNEL
 import org.elixir_lang.psi.call.name.Module.KERNEL_SPECIAL_FORMS
+import org.elixir_lang.psi.impl.ElixirPsiImplUtil.ENTRANCE
 import org.elixir_lang.psi.impl.call.macroChildCalls
 import org.elixir_lang.structure_view.element.modular.Module
 
@@ -77,7 +79,10 @@ abstract class CallDefinitionClause : PsiScopeProcessor {
             }
 
             true
-        } else if (Module.`is`(element)) {
+        } else if (Module.`is`(element) &&
+                /* Only allow scanning back down in outer nested modules for siblings.  Prevents scanning in sibling
+                   nested modules in https://github.com/KronicDeth/intellij-elixir/issues/1270 */
+                state.get(ENTRANCE)?.let { entrance -> PsiTreeUtil.isAncestor(element, entrance, false) } == true) {
             val childCalls = element.macroChildCalls()
 
             for (childCall in childCalls) {

--- a/testData/org/elixir_lang/reference/callable/issue_1270/nested_module_bare_words.ex
+++ b/testData/org/elixir_lang/reference/callable/issue_1270/nested_module_bare_words.ex
@@ -1,0 +1,13 @@
+defmodule Autocomplete do
+  defmodule State do
+    def another_test do
+      t<caret>
+    end
+  end
+
+  def test do
+  end
+
+  defp internal_test do
+  end
+end

--- a/testData/org/elixir_lang/reference/callable/issue_1270/nested_module_full_qualifier.ex
+++ b/testData/org/elixir_lang/reference/callable/issue_1270/nested_module_full_qualifier.ex
@@ -1,0 +1,13 @@
+defmodule Autocomplete do
+  defmodule State do
+    def another_test do
+      Autocomplete.t<caret>
+    end
+  end
+
+  def test do
+  end
+
+  defp internal_test do
+  end
+end

--- a/testData/org/elixir_lang/reference/callable/issue_1270/nested_module_relative_qualifier.ex
+++ b/testData/org/elixir_lang/reference/callable/issue_1270/nested_module_relative_qualifier.ex
@@ -1,0 +1,13 @@
+defmodule Autocomplete do
+  defmodule State do
+    def another_test do
+      State.t<caret>
+    end
+  end
+
+  def test do
+  end
+
+  defp internal_test do
+  end
+end

--- a/testData/org/elixir_lang/reference/callable/issue_1270/outer_module_bare_words.ex
+++ b/testData/org/elixir_lang/reference/callable/issue_1270/outer_module_bare_words.ex
@@ -1,0 +1,13 @@
+defmodule Autocomplete do
+  defmodule State do
+    def another_test do
+    end
+  end
+
+  def test do
+    t<caret>
+  end
+
+  defp internal_test do
+  end
+end

--- a/testData/org/elixir_lang/reference/callable/issue_1270/outer_module_relative_qualifier.ex
+++ b/testData/org/elixir_lang/reference/callable/issue_1270/outer_module_relative_qualifier.ex
@@ -1,0 +1,13 @@
+defmodule Autocomplete do
+  defmodule State do
+    def another_test do
+    end
+  end
+
+  def test do
+    State.<caret>
+  end
+
+  defp internal_test do
+  end
+end

--- a/tests/org/elixir_lang/reference/callable/Issue1270Test.kt
+++ b/tests/org/elixir_lang/reference/callable/Issue1270Test.kt
@@ -1,0 +1,107 @@
+package org.elixir_lang.reference.callable
+
+import com.intellij.codeInsight.completion.CompletionType
+import com.intellij.codeInsight.lookup.LookupElementBuilder
+import com.intellij.testFramework.fixtures.LightCodeInsightFixtureTestCase
+import junit.framework.TestCase
+
+/**
+ * https://github.com/KronicDeth/intellij-elixir/issues/1270
+ */
+class Issue1270Test : LightCodeInsightFixtureTestCase() {
+    /**
+     * Does not complete functions from nested module when bare word is used
+     */
+    fun testOuterModuleBareWords() {
+        myFixture.configureByFile("outer_module_bare_words.ex")
+        val completions = myFixture.complete(CompletionType.BASIC, 1)
+
+        assertEquals(2, completions.size)
+
+        assertInstanceOf(completions[0], LookupElementBuilder::class.java)
+
+        val firstCompletion = completions[0] as LookupElementBuilder
+
+        assertEquals("test", firstCompletion.lookupString)
+
+        assertInstanceOf(completions[1], LookupElementBuilder::class.java)
+
+        val secondCompletion = completions[1] as LookupElementBuilder
+
+        assertEquals("internal_test", secondCompletion.lookupString)
+    }
+
+    /**
+     * When the relative qualifier (`State.`) is used from the outer module, its local functions are completed.
+     */
+    fun testOuterModuleRelativeQualifier() {
+        myFixture.configureByFile("outer_module_relative_qualifier.ex")
+        val completions = myFixture.complete(CompletionType.BASIC, 1)
+
+        assertEquals(1, completions.size)
+
+        assertInstanceOf(completions[0], LookupElementBuilder::class.java)
+
+        val firstCompletion = completions[0] as LookupElementBuilder
+
+        assertEquals("another_test", firstCompletion.lookupString)
+    }
+
+    /**
+     * The nested module cannot resolve the outer module's local functions as bare words.
+     */
+    fun testNestedModuleBareWords() {
+        myFixture.configureByFile("nested_module_bare_words.ex")
+        val completions = myFixture.complete(CompletionType.BASIC, 1)
+
+        assertEquals(1, completions.size)
+
+        assertInstanceOf(completions[0], LookupElementBuilder::class.java)
+
+        val firstCompletion = completions[0] as LookupElementBuilder
+
+        assertEquals("another_test", firstCompletion.lookupString)
+    }
+
+    /**
+     * The nested module can resolve outer module using fully-qualified name
+     */
+    fun testNestedModuleFullQualifier() {
+        myFixture.configureByFile("nested_module_full_qualifier.ex")
+        val completions = myFixture.complete(CompletionType.BASIC, 1)
+
+        assertEquals(2, completions.size)
+
+        assertInstanceOf(completions[0], LookupElementBuilder::class.java)
+
+        val firstCompletion = completions[0] as LookupElementBuilder
+
+        assertEquals("test", firstCompletion.lookupString)
+
+        assertInstanceOf(completions[1], LookupElementBuilder::class.java)
+
+        val secondCompletion = completions[1] as LookupElementBuilder
+
+        assertEquals("internal_test", secondCompletion.lookupString)
+    }
+
+    /**
+     * The nested module can resolve own functions when its relative name is used as a qualifier
+     */
+    fun testNestedModuleRelativeQualifier() {
+        myFixture.configureByFile("nested_module_relative_qualifier.ex")
+        val completions = myFixture.complete(CompletionType.BASIC, 1)
+
+        assertEquals(1, completions.size)
+
+        assertInstanceOf(completions[0], LookupElementBuilder::class.java)
+
+        val firstCompletion = completions[0] as LookupElementBuilder
+
+        assertEquals("another_test", firstCompletion.lookupString)
+    }
+
+    override fun getTestDataPath(): String {
+        return "testData/org/elixir_lang/reference/callable/issue_1270"
+    }
+}


### PR DESCRIPTION
Fixes #1270

# Changelog
## Enhancements
* Regression test for #1270.

## Bug Fixes
* When finding a `defmodule`, check that it is an ancestor of the entrance of the `ResolveState`, so that nested sibling modules are not scanned for potential call definition clauses, but only the outer module of the entrance.