### PR TITLE
Improve error message for module_filter.editor.table.Model.getValueAt

### DIFF
--- a/src/org/elixir_lang/debugger/settings/stepping/module_filter/editor/table/Model.kt
+++ b/src/org/elixir_lang/debugger/settings/stepping/module_filter/editor/table/Model.kt
@@ -39,7 +39,7 @@ class Model : AbstractTableModel(), ItemRemovable {
 
     override fun getValueAt(rowIndex: Int, columnIndex: Int): Any {
         if (rowIndex !in 0 until rowCount) {
-            throw IllegalArgumentException("Row $rowIndex out of bounds")
+            throw IndexOutOfBoundsException("Row $rowIndex out of bounds (0-$rowCount)")
         }
 
         val filter = _filterList[rowIndex]


### PR DESCRIPTION
Fixes #1296

# Changelog
## Bug Fixes
* `Improve error message for `org.elixir_lang.debugger.settings.stepping.module_filter.editor.table.Model.getValueAt`, so we can detect if there is an off-by-1 error.