### PR TITLE
Fix unused variables in TeamCityExUnitFormatting

### DIFF
--- a/resources/exunit/1.1.0/team_city_ex_unit_formatting.ex
+++ b/resources/exunit/1.1.0/team_city_ex_unit_formatting.ex
@@ -62,7 +62,7 @@ defmodule TeamCityExUnitFormatting do
             state:
               failed = {
                 :failed,
-                {_, reason, _}
+                {_, _reason, _}
               },
             time: time
           }
@@ -133,7 +133,7 @@ defmodule TeamCityExUnitFormatting do
       :test_failed,
       Keyword.merge(
         attributes,
-        details: formatted_failure,
+        details: details,
         message: ""
       )
     )

--- a/resources/exunit/1.4.0/team_city_ex_unit_formatting.ex
+++ b/resources/exunit/1.4.0/team_city_ex_unit_formatting.ex
@@ -62,7 +62,7 @@ defmodule TeamCityExUnitFormatting do
             state:
               failed = {
                 :failed,
-                {_, reason, _}
+                {_, _reason, _}
               },
             time: time
           }

--- a/resources/exunit/1.6.0/team_city_ex_unit_formatting.ex
+++ b/resources/exunit/1.6.0/team_city_ex_unit_formatting.ex
@@ -66,7 +66,7 @@ defmodule TeamCityExUnitFormatting do
             state:
               failed = {
                 :failed,
-                {_, reason, _}
+                {_, _reason, _}
               },
             time: time
           }
@@ -90,7 +90,7 @@ defmodule TeamCityExUnitFormatting do
       :test_failed,
       Keyword.merge(
         attributes,
-        details: formatted_failure,
+        details: details,
         message: ""
       )
     )


### PR DESCRIPTION
Fixes #1303

# Changelog
## Bug Fixes
* Fix unused variables in `TeamCityExUnitFormatting`
  * `reason` was completely unused.
  * `details` should have been used.