### PR TITLE
Don't treat redefinition of defmodule as module definition in distillery

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 # https://www.jetbrains.com/intellij-repository/releases
 # https://www.jetbrains.com/intellij-repository/snapshots
 
-version = 9.0.0
+version = 9.0.2
 ideaVersion = 2018.2.1
 javaVersion = 1.8
 javaTargetVersion = 1.8

--- a/src/org/elixir_lang/psi/stub/index/AllName.java
+++ b/src/org/elixir_lang/psi/stub/index/AllName.java
@@ -8,7 +8,9 @@ import org.jetbrains.annotations.NotNull;
 public class AllName extends StringStubIndexExtension<NamedElement> {
     public static final StubIndexKey<String, NamedElement> KEY = StubIndexKey.createIndexKey("elixir.all.name");
     // 4 - adds defp and defmacrop to decompiled beam files
-    public static final int VERSION = 4;
+    /* 5 - fix bug in Module.is (https://github.com/KronicDeth/intellij-elixir/issues/1301) that caused defmodule macro
+           redefinition to count as actual module */
+    public static final int VERSION = 5;
 
     @Override
     public int getVersion() {


### PR DESCRIPTION
Fixes #1301

# Changelog
## Bug Fixes
* Don't treat redefinition of `defmodule` macro as module definition (as occurs in @bitwalker's distillery' `Mix.Tasks.Release.Init.MixMock`
  * Bump `AllName` `VERSION` to re-index and drop bad call definition head from #1301.