### PR TITLE
Don't log test failures unless a test has started

### DIFF
--- a/src/org/elixir_lang/mix/runner/Status.java
+++ b/src/org/elixir_lang/mix/runner/Status.java
@@ -220,18 +220,11 @@ public class Status {
         if (isCompilationError()) {
             messageList = new ArrayList<>();
             Map<String, String> maybeTestStartedAttributes = maybeTestStartedAttributes();
-            String name;
 
             if (maybeTestStartedAttributes != null) {
                 messageList.add(teamCityTestStarted(maybeTestStartedAttributes));
-                name = maybeTestStartedAttributes.get("name");
-            } else {
-                name = "mix test";
-            }
-
-            messageList.add(toTeamCityTestFailed(name));
-
-            if (maybeTestStartedAttributes != null) {
+                String name = maybeTestStartedAttributes.get("name");
+                messageList.add(toTeamCityTestFailed(name));
                 messageList.add(teamCityTestFinished(maybeTestStartedAttributes));
             }
         } else {


### PR DESCRIPTION
# Changelog
## Bug Fixes
* Don't log compilation errors as test failures unless a test has started.   Test name being called `mix test` does not work, so log those compilation errors as normal build messages instead.