### PR TITLE
Don't interpret :crypto by default

### DIFF
--- a/src/org/elixir_lang/debugger/Settings.kt
+++ b/src/org/elixir_lang/debugger/Settings.kt
@@ -174,6 +174,8 @@ class Settings(moduleFilters: List<ModuleFilter> = defaultModuleFilters()):
                 ModuleFilter(pattern = "URI"),
                 ModuleFilter(pattern = "Version"),
                 ModuleFilter(pattern = ":cow*"),
+                // See https://github.com/KronicDeth/intellij-elixir/issues/1307
+                ModuleFilter(pattern = ":crypto"),
                 ModuleFilter(pattern = ":elixir_*"),
                 // See https://github.com/KronicDeth/intellij-elixir/issues/915
                 ModuleFilter(pattern = ":erocksdb"),


### PR DESCRIPTION
Fixes #1307

# Changelog
## Bug Fixes
* Don't interpret `:crypto` by default: `:crypto` includes NIFs that can't be reloaded and so kills the debugger.