### PR TITLE
Protect from null containingFile for modular names during completion

### DIFF
--- a/src/org/elixir_lang/code_insight/completion/provider/CallDefinitionClause.kt
+++ b/src/org/elixir_lang/code_insight/completion/provider/CallDefinitionClause.kt
@@ -58,14 +58,16 @@ class CallDefinitionClause : CompletionProvider<CompletionParameters>() {
                                 context: ProcessingContext,
                                 resultSet: CompletionResultSet) {
         maybeModularName(parameters)?.let { maybeModularName ->
-            maybeModularName.maybeModularNameToModular(maxScope = maybeModularName.containingFile, useCall = null)?.let { modular ->
-                if (resultSet.prefixMatcher.prefix.endsWith(".")) {
-                    resultSet.withPrefixMatcher("")
-                } else {
-                    resultSet
-                }.addAllElements(
-                        callDefinitionClauseLookupElements(modular)
-                )
+            maybeModularName.containingFile?.let { containingFile ->
+                maybeModularName.maybeModularNameToModular(maxScope = containingFile, useCall = null)?.let { modular ->
+                    if (resultSet.prefixMatcher.prefix.endsWith(".")) {
+                        resultSet.withPrefixMatcher("")
+                    } else {
+                        resultSet
+                    }.addAllElements(
+                            callDefinitionClauseLookupElements(modular)
+                    )
+                }
             }
         }
     }


### PR DESCRIPTION
Fixes #1309

# Changelog
## Bug Fixes
* Protect from `null` `containingFile` for modular names during completion.