### PR TITLE
Log nameSet when it reaches suspect size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -176,6 +176,9 @@ Table of Contents
     * Run library syncing in tasks: When importing projects, run sync as a modal task while when `VirtualFileSystem` events occur, run sync as background tasks.  Either style of task is cancellable and importantly, it allows to show what is happening during the syncing.  This converts the unresponsive UI beachball on macOS during import to an updating progress bar.
     * Calculate dep sets iteratively with a work queue instead of recursively to limit the calculation of dep set for a root to 1 time.  Then use normal transitive walk to get complete dep set for module.  Vastly speeds up project import.
     * Cache dep set on package `PsiFile` to allow faster refreshes when indirect dependencies don't change.
+* [#1323](https://github.com/KronicDeth/intellij-elixir/pull/1323) - [@KronicDeth](https://github.com/KronicDeth)
+  * Log `nameSet` when it reaches suspect size (`10`) to allow triaging if it is a real bug or just something with a lot of valid names.
+  * Fix inverted condition around when to warn and when to error and use `readAheadLength`.
 
 ## v10.0.0
 

--- a/resources/META-INF/changelog.html
+++ b/resources/META-INF/changelog.html
@@ -24,6 +24,11 @@
           </li>
         </ul>
       </li>
+      <li>
+        Log <code>nameSet</code> when it reaches suspect size (<code>10</code>) to allow triaging if it is a real bug or
+        just something with a lot of valid names.
+      </li>
+      <li>Fix inverted condition around when to warn and when to error and use <code>readAheadLength</code>.</li>
     </ul>
   </li>
 </ul>

--- a/src/org/elixir_lang/psi/stub/call/Deserialized.java
+++ b/src/org/elixir_lang/psi/stub/call/Deserialized.java
@@ -174,7 +174,7 @@ public class Deserialized {
                     .append(SUSPECT_NAME_SET_SIZE)
                     .append(").");
 
-            if (readAheadLength > 0) {
+            if (readAheadLength == 0) {
                 stringBuilder = stringBuilder.append("StubIndex may be corrupt.");
                 LOGGER.warn(stringBuilder.toString());
             } else {
@@ -193,9 +193,31 @@ public class Deserialized {
         }
         Set<StringRef> nameSet = new THashSet<>(nameSetSize);
 
-        for (int i = 0; i < nameSetSize; i++) {
-            StringRef name = dataStream.readName();
-            nameSet.add(name);
+        if (nameSetSize >= SUSPECT_NAME_SET_SIZE) {
+            StringBuilder stringBuilder = new StringBuilder("readNameSet nameSet of suspect (>= ")
+                    .append(SUSPECT_NAME_SET_SIZE)
+                    .append(") size (").append(nameSetSize).append("):\n");
+
+            for (int i = 0; i < nameSetSize; i++) {
+                StringRef name = dataStream.readName();
+                nameSet.add(name);
+
+                String nameString;
+                if (name != null) {
+                    nameString = name.toString();
+                } else {
+                    nameString = "(null)";
+                }
+
+                stringBuilder.append(i + 1).append(". ").append(nameString).append('\n');
+            }
+
+            LOGGER.error(stringBuilder.toString());
+        } else {
+            for (int i = 0; i < nameSetSize; i++) {
+                StringRef name = dataStream.readName();
+                nameSet.add(name);
+            }
         }
 
         assertGuard(dataStream, END);


### PR DESCRIPTION
Fixes #1320

# Changelog
## Bug Fixes
* Log `nameSet` when it reaches suspect size (`10`) to allow triaging if it is a real bug or just something with a lot of valid names.
* Fix inverted condition around when to warn and when to error and use `readAheadLength`.