### PR TITLE
Wrap packagePsiFileToDepSet in read action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -194,6 +194,7 @@ Table of Contents
 * [#1327](https://github.com/KronicDeth/intellij-elixir/pull/1327) - Fix deadlinks to Run Configurations, which broke when section was renamed Run/Debug Configurations and auto-anchor changed name. - [@KronicDeth](https://github.com/KronicDeth)
 * [#1328](https://github.com/KronicDeth/intellij-elixir/pull/1328) - Fix image links in `README`. - [@KronicDeth](https://github.com/KronicDeth)
 * [#1331](https://github.com/KronicDeth/intellij-elixir/pull/1331) - Ensure `defmodule` one-liner isn't mistaken for call definition head in Go To Symbol. - [@KronicDeth](https://github.com/KronicDeth)
+* [#1336](https://github.com/KronicDeth/intellij-elixir/pull/1336) - Wrap `packagePisToDepSet` in read action because checking the validity of the dependencies requires a read action. - [@KronicDeth](https://github.com/KronicDeth)
 
 ## v10.0.1
 

--- a/resources/META-INF/changelog.html
+++ b/resources/META-INF/changelog.html
@@ -40,6 +40,10 @@
       </li>
       <li>Fix image links in <code>README</code>.</li>
       <li>Ensure <code>defmodule</code> one-liner isn't mistaken for call definition head in Go To Symbol.</li>
+      <li>
+        Wrap <code>packagePisToDepSet</code> in read action because checking the validity of the dependencies requires a
+        read action.
+      </li>
     </ul>
   </li>
 </ul>

--- a/src/org/elixir_lang/mix/watcher/Resolution.kt
+++ b/src/org/elixir_lang/mix/watcher/Resolution.kt
@@ -103,12 +103,14 @@ class Resolution(
                 packageManager: PackageManager,
                 packagePsiFile: PsiFile
         ): Set<Dep> =
-                getCachedValue(packagePsiFile, DEP_SET) {
-                    packageManager
-                            .depGatherer()
-                            .apply { packagePsiFile.accept(this) }
-                            .depSet.toSet()
-                            .let { CachedValueProvider.Result.create(it, packagePsiFile) }
+                runReadAction {
+                    getCachedValue(packagePsiFile, DEP_SET) {
+                        packageManager
+                                .depGatherer()
+                                .apply { packagePsiFile.accept(this) }
+                                .depSet.toSet()
+                                .let { CachedValueProvider.Result.create(it, packagePsiFile) }
+                    }
                 }
     }
 }


### PR DESCRIPTION
Fixes #1335

# Changelog
## Bug Fixes
* Wrap `packagePisToDepSet` in read action because checking the validity of the dependencies requires a read action.