### PR TITLE
 Remove unused variables in Elixir debugger server

### DIFF
--- a/resources/debugger/lib/intellij_elixir/debugger/server.ex
+++ b/resources/debugger/lib/intellij_elixir/debugger/server.ex
@@ -401,7 +401,7 @@ defmodule IntelliJElixir.Debugger.Server do
     [head_frame | tail_frames]
   end
 
-  defp to_file(arg = {module, function, arguments}) do
+  defp to_file({module, function, arguments}) do
     source = source(module)
 
     with [_] <- arguments,
@@ -502,7 +502,7 @@ defmodule IntelliJElixir.Debugger.Server do
     end
   else
     defp vars(elixir_variable_tuples) when is_list(elixir_variable_tuples) do
-      Enum.into(elixir_variable_tuples, %{}, fn {elixir_variable_name, counter, erlang_variable_name} ->
+      Enum.into(elixir_variable_tuples, %{}, fn {elixir_variable_name, _counter, erlang_variable_name} ->
         {{elixir_variable_name, nil}, {0, erlang_variable_name}}
       end)
     end

--- a/src/org/elixir_lang/Erl.kt
+++ b/src/org/elixir_lang/Erl.kt
@@ -36,8 +36,22 @@ object Erl {
     private fun prependCodePaths(generalCommandLine: GeneralCommandLine, sdk: Sdk) {
         prependCodePaths(
                 generalCommandLine,
-                sdk.rootProvider.getFiles(OrderRootType.CLASSES).map { it.canonicalPath!! }
+                ebinDirectories(sdk)
         )
+    }
+
+    private fun ebinDirectories(sdk: Sdk): kotlin.collections.List<String> {
+        var ebinDirectories: kotlin.collections.List<String>?
+
+        do {
+            ebinDirectories = try {
+                sdk.rootProvider.getFiles(OrderRootType.CLASSES).map { it.canonicalPath!! }
+            } catch (e: AssertionError) {
+                null
+            }
+        } while (ebinDirectories == null)
+
+        return ebinDirectories
     }
 
     /**


### PR DESCRIPTION
Fixes #1339

# Changelog
## Bug Fixes
* Remove unused variables in Elixir debugger server.
* Protect from `AssertionError` when `VirtualFileCache` is disposed.