### PR TITLE
Use :path for deps for paths external to project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -198,6 +198,7 @@ Table of Contents
   * Remove unused variables in Elixir debugger server.
   * Protect from `AssertionError` when `VirtualFileCache` is disposed.
 * [#1360](https://github.com/KronicDeth/intellij-elixir/pull/1360) - Protect from `AssertionError` when `VirtualFilePointerContainer` is disposed. - [@KronicDeth](https://github.com/KronicDeth)
+* [#1364](https://github.com/KronicDeth/intellij-elixir/pull/1364) - Use `:path` for deps for paths external to project.  Unfortunately, even though they show up in the Project Structure, only `ebin` directories are shown as it is restricted to those marked as `CLASSES` and the `:path` `lib` is a `SOURCES`. - [@KronicDeth](https://github.com/KronicDeth)
 
 ## v10.1.0
 

--- a/resources/META-INF/changelog.html
+++ b/resources/META-INF/changelog.html
@@ -44,6 +44,11 @@
       </li>
       <li>Remove unused variables in Elixir debugger server.</li>
       <li>Protect from <code>AssertionError</code> when <code>VirtualFilePointerContainer</code> is disposed.</li>
+      <li>
+        Use <code>:path</code> for deps for paths external to project.  Unfortunately, even though they show up in the
+        Project Structure, only <code>ebin</code> directories are shown as it is restricted to those marked as
+        <code>CLASSES</code> and the <code>:path</code> <code>lib</code> is a <code>SOURCES</code>.
+      </li>
     </ul>
   </li>
 </ul>

--- a/src/org/elixir_lang/DepsWatcher.kt
+++ b/src/org/elixir_lang/DepsWatcher.kt
@@ -186,7 +186,7 @@ class DepsWatcher(
         }
     }
 
-    private fun syncLibraries(
+    fun syncLibraries(
             deps: Array<VirtualFile>,
             libraryTable: LibraryTable,
             progressIndicator: ProgressIndicator

--- a/src/org/elixir_lang/mix/Dep.kt
+++ b/src/org/elixir_lang/mix/Dep.kt
@@ -1,14 +1,23 @@
 package org.elixir_lang.mix
 
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VfsUtil
+import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.PsiElement
 import org.elixir_lang.errorreport.Logger
 import org.elixir_lang.psi.*
+import org.elixir_lang.psi.impl.stripAccessExpression
 import org.elixir_lang.psi.impl.stripAccessExpressions
+import java.nio.file.Paths
 
 /**
  * `Mix.Dep`
  */
 data class Dep(val application: String, val path: String, val type: Type = Type.LIBRARY) {
+    fun virtualFile(project: Project): VirtualFile? =
+        project.baseDir.findFileByRelativePath(path) ?:
+                                        VfsUtil.findFile(Paths.get(path), true)
+
     enum class Type {
         LIBRARY,
         MODULE
@@ -36,6 +45,7 @@ data class Dep(val application: String, val path: String, val type: Type = Type.
                                 when (key) {
                                     "app", "branch", "commit", "compile", "git", "github", "hex", "only", "optional", "override",  "runtime" -> acc
                                     "in_umbrella" -> acc.copy(path =  "apps/$name", type = Type.MODULE)
+                                    "path" -> putPath(acc, keywordPair.keywordValue)
                                     else -> {
                                         Logger.error(logger, "Don't know if Mix.Dep option `$key` is important for determining location of dependency", depsListElement)
                                         acc
@@ -77,5 +87,20 @@ data class Dep(val application: String, val path: String, val type: Type = Type.
 
             return null
         }
+
+        private fun putPath(dep: Dep, keywordValue: Quotable): Dep {
+            val strippedKeywordValue = keywordValue.stripAccessExpression()
+
+            return when (strippedKeywordValue) {
+                is ElixirStringLine -> putPath(dep, strippedKeywordValue)
+                else -> {
+                    Logger.error(logger, "Don't know how to convert ${keywordValue.text} to path", keywordValue.parent)
+
+                    dep
+                }
+            }
+        }
+
+        private fun putPath(dep: Dep, stringLine: ElixirStringLine): Dep = dep.copy(path = stringLine.body.text)
     }
 }

--- a/src/org/elixir_lang/mix/watcher/Resolution.kt
+++ b/src/org/elixir_lang/mix/watcher/Resolution.kt
@@ -46,7 +46,8 @@ class Resolution(
                            Module deps handle transitivity while Library deps don't */
                         if (dep.type == Dep.Type.LIBRARY) {
                             if (!depToRootVirtualFile.contains(dep)) {
-                                val depRootVirtualFile = project.baseDir.findFileByRelativePath(dep.path)
+                                val depRootVirtualFile = dep.virtualFile(project)
+
                                 depToRootVirtualFile[dep] = depRootVirtualFile
 
                                 if (depRootVirtualFile != null &&


### PR DESCRIPTION
Fixes #1343

# Changelog
## Bug Fixes
*  Use `:path` for deps for paths external to project.  Unfortunately, even though they show up in the Project Structure, only `ebin` directories are shown as it is restricted to those marked as `CLASSES` and the `:path` `lib` is a `SOURCES`.