### PR TITLE
Ignore `:ref` when finding path to dep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -201,6 +201,7 @@ Table of Contents
 * [#1364](https://github.com/KronicDeth/intellij-elixir/pull/1364) - Use `:path` for deps for paths external to project.  Unfortunately, even though they show up in the Project Structure, only `ebin` directories are shown as it is restricted to those marked as `CLASSES` and the `:path` `lib` is a `SOURCES`. - [@KronicDeth](https://github.com/KronicDeth)
 * [#1367](https://github.com/KronicDeth/intellij-elixir/pull/1367) - Ignore `:tag` when finding path to dep. - [@KronicDeth](https://github.com/KronicDeth)
 * [#1368](https://github.com/KronicDeth/intellij-elixir/pull/1368) - No longer use the forked version of `TerminalExecutionConsole` as `2018.3`'s version doesn't have the text echoing behavior that was being bypassed before. - [@KronicDeth](https://github.com/KronicDeth)
+* [#1372](https://github.com/KronicDeth/intellij-elixir/pull/1372) - Ignore `:ref` when finding path to dep. - [@KronicDeth](https://github.com/KronicDeth)
 
 ## v10.1.0
 

--- a/resources/META-INF/changelog.html
+++ b/resources/META-INF/changelog.html
@@ -49,6 +49,7 @@
         Project Structure, only <code>ebin</code> directories are shown as it is restricted to those marked as
         <code>CLASSES</code> and the <code>:path</code> <code>lib</code> is a <code>SOURCES</code>.
       </li>
+      <li>Ignore <code>:ref</code> when finding path to dep.</li>
     </ul>
   </li>
 </ul>

--- a/src/org/elixir_lang/mix/Dep.kt
+++ b/src/org/elixir_lang/mix/Dep.kt
@@ -43,7 +43,7 @@ data class Dep(val application: String, val path: String, val type: Type = Type.
                                 val key = keywordPair.keywordKey.text
 
                                 when (key) {
-                                    "app", "branch", "commit", "compile", "git", "github", "hex", "only", "optional", "override",  "runtime", "tag" -> acc
+                                    "app", "branch", "commit", "compile", "git", "github", "hex", "only", "optional", "override", "ref", "runtime", "tag" -> acc
                                     "in_umbrella" -> acc.copy(path =  "apps/$name", type = Type.MODULE)
                                     "path" -> putPath(acc, keywordPair.keywordValue)
                                     else -> {


### PR DESCRIPTION
# Changelog
## Bug Fixes
* Ignore `:ref` when finding path to dep.