### PR TITLE
Wrap UnqualifiedNoArgumentCall identifier.text in runReadAction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -192,6 +192,7 @@ Table of Contents
 * [#1410](https://github.com/KronicDeth/intellij-elixir/pull/1410) - [@KronicDeth](https://github.com/KronicDeth)
   * Only show Run/Debug ExUnit when `*_test.exs` files exist.
   * Only show Run/Debug ESpec when `*_spec.exs` files exist.
+* [#1415](https://github.com/KronicDeth/intellij-elixir/pull/1415) - Wrap `UnqualifiedNoArgumentCall.quote` `identifier.text` in `runReadAction`. - [@KronicDeth](https://github.com/KronicDeth)
 
 ## v10.3.0
 

--- a/resources/META-INF/changelog.html
+++ b/resources/META-INF/changelog.html
@@ -14,6 +14,9 @@
     <ul>
       <li>Only show Run/Debug ExUnit when <code>*_test.exs</code> files exist.</li>
       <li>Only show Run/Debug Espec when <code>*_spec.exs</code> files exist.</li>
+      <li>
+        Wrap <code>UnqualifiedNoArgumentCall.quote</code> <code>identifier.text</code> in <code>runReadAction</code>.
+      </li>
     </ul>
   </li>
 </ul>

--- a/src/org/elixir_lang/psi/impl/QuotableImpl.kt
+++ b/src/org/elixir_lang/psi/impl/QuotableImpl.kt
@@ -4,6 +4,7 @@ package org.elixir_lang.psi.impl
 
 import com.ericsson.otp.erlang.*
 import com.intellij.lang.ASTNode
+import com.intellij.openapi.application.runReadAction
 import com.intellij.openapi.util.Computable
 import com.intellij.psi.*
 import com.intellij.psi.impl.source.tree.Factory
@@ -925,7 +926,9 @@ object QuotableImpl {
         val quoted: OtpErlangObject
         val identifier = unqualifiedNoArgumentsCall.identifier
 
-        val identifierText = identifier.text
+        val identifierText = runReadAction {
+            identifier.text
+        }
         val callMetadata = metadata(identifier)
 
         // if a variable has a `do` block is no longer a variable because the do block acts as keyword arguments.


### PR DESCRIPTION
Fixes #1381

# Changelog
## Bug Fixes
* Wrap `UnqualifiedNoArgumentCall.quote` `identifier.text` in `runReadAction`.