### PR TITLE
Fix the names of the Gradle tasks in contribution guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,15 +60,15 @@ You can run `./gradlew runIde` or `./gradlew test`.
 1. Open the Gradle Tool Window (`View > Tool Windows > Gradle` OR from the Gradle button on the right tool button bar)
 2. Expand `Elixir (root) > Tasks`
 
-#### `runIdea`
+#### `runIde`
 
 1. Expand `intellij`
-2. Right-click `runIdea`
+2. Right-click `runIde`
 3. Select `Create 'intellij-elixir' [runIdea]`
 
 #### `test`
 
-1. Expand `verifcation`
+1. Expand `verification`
 2. Right-click `test`
 3. Select `Create 'intellij-elixir' [test]`
 


### PR DESCRIPTION
Just some very minor typo fixes in the documentation: the names of `runIde` and `verification` were misspelled in `CONTRIBUTING.md`.