### PR TITLE
Prevent the module attribute annotator from running in EEx files.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -194,6 +194,7 @@ Table of Contents
   * Only show Run/Debug ESpec when `*_spec.exs` files exist.
 * [#1415](https://github.com/KronicDeth/intellij-elixir/pull/1415) - Wrap `UnqualifiedNoArgumentCall.quote` `identifier.text` in `runReadAction`. - [@KronicDeth](https://github.com/KronicDeth)
 * [#1419](https://github.com/KronicDeth/intellij-elixir/pull/1419) - Fix typos in `CONTRIBUTING.md` - [@nschulzke](https://github.com/nschulzke)
+* [#1420](https://github.com/KronicDeth/intellij-elixir/pull/1420) - Prevent the module attribute annotator from running in EEx files. - [@nschulzke](https://github.com/nschulzke)
 
 ## v10.3.0
 

--- a/resources/META-INF/changelog.html
+++ b/resources/META-INF/changelog.html
@@ -18,6 +18,7 @@
         Wrap <code>UnqualifiedNoArgumentCall.quote</code> <code>identifier.text</code> in <code>runReadAction</code>.
       </li>
       <li>Fix typos in <code>CONTRIBUTING.md</code></li>
+      <li>Prevent the module attribute annotator from running in EEx files.</li>
     </ul>
   </li>
 </ul>

--- a/src/org/elixir_lang/annotator/ModuleAttribute.java
+++ b/src/org/elixir_lang/annotator/ModuleAttribute.java
@@ -51,84 +51,86 @@ public class ModuleAttribute implements Annotator, DumbAware {
      */
     @Override
     public void annotate(@NotNull final PsiElement element, @NotNull final AnnotationHolder holder) {
-        element.accept(
-                new PsiRecursiveElementVisitor() {
-                    /*
-                     *
-                     * Instance Methods
-                     *
-                     */
+        if (!element.getContainingFile().getViewProvider().getLanguages().contains(org.elixir_lang.eex.Language.INSTANCE)) { // if there exists an EEx tag as a parent, we're in an EEx file
+            element.accept(
+                    new PsiRecursiveElementVisitor() {
+                        /*
+                         *
+                         * Instance Methods
+                         *
+                         */
 
-                    /*
-                     * Public Instance Methods
-                     */
+                        /*
+                         * Public Instance Methods
+                         */
 
-                    @Override
-                    public void visitElement(@NotNull final PsiElement element) {
-                        if (element instanceof AtNonNumericOperation) {
-                            visitMaybeUsage((AtNonNumericOperation) element);
-                        } else if (element instanceof AtUnqualifiedNoParenthesesCall) {
-                            visitDeclaration((AtUnqualifiedNoParenthesesCall) element);
+                        @Override
+                        public void visitElement(@NotNull final PsiElement element) {
+                            if (element instanceof AtNonNumericOperation) {
+                                visitMaybeUsage((AtNonNumericOperation) element);
+                            } else if (element instanceof AtUnqualifiedNoParenthesesCall) {
+                                visitDeclaration((AtUnqualifiedNoParenthesesCall) element);
+                            }
                         }
-                    }
 
-                    /*
-                     * Private Instance Methods
-                     */
+                        /*
+                         * Private Instance Methods
+                         */
 
-                    private void visitDeclaration(@NotNull final AtUnqualifiedNoParenthesesCall atUnqualifiedNoParenthesesCall) {
-                        ElixirAtIdentifier atIdentifier = atUnqualifiedNoParenthesesCall.getAtIdentifier();
-                        TextRange textRange = atIdentifier.getTextRange();
+                        private void visitDeclaration(@NotNull final AtUnqualifiedNoParenthesesCall atUnqualifiedNoParenthesesCall) {
+                            ElixirAtIdentifier atIdentifier = atUnqualifiedNoParenthesesCall.getAtIdentifier();
+                            TextRange textRange = atIdentifier.getTextRange();
 
-                        String identifier = identifierName(atIdentifier);
+                            String identifier = identifierName(atIdentifier);
 
-                        if (Companion.isCallbackName(identifier)) {
-                            highlight(textRange, holder, ElixirSyntaxHighlighter.MODULE_ATTRIBUTE);
+                            if (Companion.isCallbackName(identifier)) {
+                                highlight(textRange, holder, ElixirSyntaxHighlighter.MODULE_ATTRIBUTE);
 
-                            highlightCallback(atUnqualifiedNoParenthesesCall, holder);
-                        } else if (Companion.isDocumentationName(identifier)) {
-                            highlight(textRange, holder, ElixirSyntaxHighlighter.DOCUMENTATION_MODULE_ATTRIBUTE);
+                                highlightCallback(atUnqualifiedNoParenthesesCall, holder);
+                            } else if (Companion.isDocumentationName(identifier)) {
+                                highlight(textRange, holder, ElixirSyntaxHighlighter.DOCUMENTATION_MODULE_ATTRIBUTE);
 
-                            highlightDocumentationText(atUnqualifiedNoParenthesesCall, holder);
-                        } else if (Companion.isTypeName(identifier)) {
-                            highlight(textRange, holder, ElixirSyntaxHighlighter.MODULE_ATTRIBUTE);
+                                highlightDocumentationText(atUnqualifiedNoParenthesesCall, holder);
+                            } else if (Companion.isTypeName(identifier)) {
+                                highlight(textRange, holder, ElixirSyntaxHighlighter.MODULE_ATTRIBUTE);
 
-                            highlightType(atUnqualifiedNoParenthesesCall, holder);
-                        } else if (Companion.isSpecificationName(identifier)) {
-                            highlight(textRange, holder, ElixirSyntaxHighlighter.MODULE_ATTRIBUTE);
+                                highlightType(atUnqualifiedNoParenthesesCall, holder);
+                            } else if (Companion.isSpecificationName(identifier)) {
+                                highlight(textRange, holder, ElixirSyntaxHighlighter.MODULE_ATTRIBUTE);
 
-                            highlightSpecification(atUnqualifiedNoParenthesesCall, holder);
-                        } else {
-                            highlight(textRange, holder, ElixirSyntaxHighlighter.MODULE_ATTRIBUTE);
+                                highlightSpecification(atUnqualifiedNoParenthesesCall, holder);
+                            } else {
+                                highlight(textRange, holder, ElixirSyntaxHighlighter.MODULE_ATTRIBUTE);
+                            }
                         }
-                    }
 
 
-                    private void visitMaybeUsage(@NotNull final AtNonNumericOperation element) {
-                        PsiElement operand = element.operand();
+                        private void visitMaybeUsage(@NotNull final AtNonNumericOperation element) {
+                            PsiElement operand = element.operand();
 
-                        if (operand != null && !(operand instanceof ElixirAccessExpression)) {
-                            visitUsage(element);
+                            if (operand != null && !(operand instanceof ElixirAccessExpression)) {
+                                visitUsage(element);
+                            }
                         }
-                    }
 
-                    private void visitUsage(@NotNull final AtNonNumericOperation atNonNumericOperation) {
-                        highlight(
-                                atNonNumericOperation.getTextRange(),
-                                holder,
-                                ElixirSyntaxHighlighter.MODULE_ATTRIBUTE
-                        );
+                        private void visitUsage(@NotNull final AtNonNumericOperation atNonNumericOperation) {
+                            highlight(
+                                    atNonNumericOperation.getTextRange(),
+                                    holder,
+                                    ElixirSyntaxHighlighter.MODULE_ATTRIBUTE
+                            );
 
-                        if (!Companion.isNonReferencing(atNonNumericOperation)) {
-                            PsiReference reference = atNonNumericOperation.getReference();
+                            if (!Companion.isNonReferencing(atNonNumericOperation)) {
+                                PsiReference reference = atNonNumericOperation.getReference();
 
-                            if (reference != null && reference.resolve() == null) {
-                                holder.createErrorAnnotation(atNonNumericOperation, "Unresolved module attribute");
+                                if (reference != null && reference.resolve() == null) {
+                                    holder.createErrorAnnotation(atNonNumericOperation, "Unresolved module attribute");
+                                }
                             }
                         }
                     }
-                }
-        );
+            );
+        }
     }
 
     /*


### PR DESCRIPTION
EEx files do not have enough context to correctly recognize `@conn` and other attributes used in EEx files. Fixes issue #924.

The condition in the `if` statement checks if the file we're currently in has EEx enabled. If it does, then we skip applying the annotator to the element. I tested this both with the unit tests and interactively, and it works as intended.