### PR TITLE
Add missing ESpec template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -206,6 +206,7 @@ Table of Contents
 * [#1445](https://github.com/KronicDeth/intellij-elixir/pull/1445) - [@KronicDeth](https://github.com/KronicDeth)
   * Remove obsolete `SdkType`.  I keep confusing it with its replacement `org.elixir_lang.sdk.elixir.Type`!
   * Check that HomePath has `ebin` paths when validation.  Prevents selecting false HomePaths for `kiex`.
+* [#1446](https://github.com/KronicDeth/intellij-elixir/pull/1446) - Adding missing ESpec template.  When reviewing #1410 I missed that the template wasn't in `resources`. 🤦‍♂️ - [@KronicDeth](https://github.com/KronicDeth)
 
 ## v10.4.0
 

--- a/resources/META-INF/changelog.html
+++ b/resources/META-INF/changelog.html
@@ -70,6 +70,12 @@
         Check that HomePath has <code>ebin</code> paths when validation.  Prevents selecting false HomePaths for
         <code>kiex</code>.
       </li>
+      <li>
+        Adding missing ESpec template.  When reviewing
+        <a href="https://github.com/KronicDeth/intellij-elixir/pull/1410">#1410</a>
+        I missed that the template wasn't in <code>resources</code>. 🤦‍♂️
+      </li>
+
     </ul>
   </li>
 </ul>

--- a/resources/fileTemplates/internal/ESpec.exs.ft
+++ b/resources/fileTemplates/internal/ESpec.exs.ft
@@ -1,0 +1,11 @@
+defmodule ${NAME} do
+  use ESpec
+
+  alias ${SOURCE_NAME}
+
+  doctest ${ALIAS}
+
+  it "exists" do
+    assert is_list(${ALIAS}.module_info())
+  end
+end

--- a/resources/fileTemplates/internal/ESpec.exs.html
+++ b/resources/fileTemplates/internal/ESpec.exs.html
@@ -1,0 +1,5 @@
+<html>
+    <body>
+      This is Elixir <a href="https://hexdocs.pm/espec/ESpec.htm"><code>ESpec</code></a> file template.
+    </body>
+</html>


### PR DESCRIPTION
Fixes #1427

# Changleog
## Bug Fixes
* Adding missing ESpec template.  When reviewing #1410 I missed that the template wasn't in `resources`. 🤦‍♂️ 