### PR TITLE
Ignore targets when calculating Dep path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -207,6 +207,7 @@ Table of Contents
   * Remove obsolete `SdkType`.  I keep confusing it with its replacement `org.elixir_lang.sdk.elixir.Type`!
   * Check that HomePath has `ebin` paths when validation.  Prevents selecting false HomePaths for `kiex`.
 * [#1446](https://github.com/KronicDeth/intellij-elixir/pull/1446) - Adding missing ESpec template.  When reviewing #1410 I missed that the template wasn't in `resources`. 🤦‍♂️ - [@KronicDeth](https://github.com/KronicDeth)
+* [#1447](https://github.com/KronicDeth/intellij-elixir/pull/1447) - Ignore `targets` when calculating `Dep` path. - [@KronicDeth](https://github.com/KronicDeth)
 
 ## v10.4.0
 

--- a/resources/META-INF/changelog.html
+++ b/resources/META-INF/changelog.html
@@ -75,7 +75,7 @@
         <a href="https://github.com/KronicDeth/intellij-elixir/pull/1410">#1410</a>
         I missed that the template wasn't in <code>resources</code>. 🤦‍♂️
       </li>
-
+      <li>Ignore <code>targets</code> when calculating <code>Dep</code> path.</li>
     </ul>
   </li>
 </ul>

--- a/src/org/elixir_lang/mix/Dep.kt
+++ b/src/org/elixir_lang/mix/Dep.kt
@@ -43,7 +43,7 @@ data class Dep(val application: String, val path: String, val type: Type = Type.
                                 val key = keywordPair.keywordKey.text
 
                                 when (key) {
-                                    "app", "branch", "commit", "compile", "git", "github", "hex", "only", "optional", "override", "ref", "runtime", "tag" -> acc
+                                    "app", "branch", "commit", "compile", "git", "github", "hex", "only", "optional", "override", "ref", "runtime", "tag", "targets" -> acc
                                     "in_umbrella" -> acc.copy(path =  "apps/$name", type = Type.MODULE)
                                     "path" -> putPath(acc, keywordPair.keywordValue)
                                     else -> {


### PR DESCRIPTION
Fixes #1431

# Changelog
## Bug Fixes
* Ignore `targets` when calculating `Dep` path.