### PR TITLE
Always use containingFile for QualifiableAlias maxScope

### DIFF
--- a/gen/org/elixir_lang/psi/ElixirAlias.java
+++ b/gen/org/elixir_lang/psi/ElixirAlias.java
@@ -28,9 +28,6 @@ public interface ElixirAlias extends NamedElement, QualifiableAlias, Quotable {
   @Nullable
   PsiReference getReference();
 
-  @Nullable
-  PsiPolyVariantReference getReference(@NotNull PsiElement maxScope);
-
   boolean isModuleName();
 
   boolean processDeclarations(@NotNull PsiScopeProcessor processor, @NotNull ResolveState state, PsiElement lastParent, @NotNull PsiElement place);

--- a/gen/org/elixir_lang/psi/ElixirMatchedQualifiedAlias.java
+++ b/gen/org/elixir_lang/psi/ElixirMatchedQualifiedAlias.java
@@ -37,9 +37,6 @@ public interface ElixirMatchedQualifiedAlias extends ElixirMatchedExpression, Na
   @Nullable
   PsiReference getReference();
 
-  @Nullable
-  PsiPolyVariantReference getReference(@NotNull PsiElement maxScope);
-
   boolean isModuleName();
 
   boolean processDeclarations(@NotNull PsiScopeProcessor processor, @NotNull ResolveState state, PsiElement lastParent, @NotNull PsiElement place);

--- a/gen/org/elixir_lang/psi/ElixirUnmatchedQualifiedAlias.java
+++ b/gen/org/elixir_lang/psi/ElixirUnmatchedQualifiedAlias.java
@@ -37,9 +37,6 @@ public interface ElixirUnmatchedQualifiedAlias extends ElixirUnmatchedExpression
   @Nullable
   PsiReference getReference();
 
-  @Nullable
-  PsiPolyVariantReference getReference(@NotNull PsiElement maxScope);
-
   boolean isModuleName();
 
   boolean processDeclarations(@NotNull PsiScopeProcessor processor, @NotNull ResolveState state, PsiElement lastParent, @NotNull PsiElement place);

--- a/gen/org/elixir_lang/psi/impl/ElixirAliasImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirAliasImpl.java
@@ -52,11 +52,6 @@ public class ElixirAliasImpl extends ASTWrapperPsiElement implements ElixirAlias
     return ElixirPsiImplUtil.getReference(this);
   }
 
-  @Nullable
-  public PsiPolyVariantReference getReference(@NotNull PsiElement maxScope) {
-    return ElixirPsiImplUtil.getReference(this, maxScope);
-  }
-
   public boolean isModuleName() {
     return ElixirPsiImplUtil.isModuleName(this);
   }

--- a/gen/org/elixir_lang/psi/impl/ElixirMatchedQualifiedAliasImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirMatchedQualifiedAliasImpl.java
@@ -69,11 +69,6 @@ public class ElixirMatchedQualifiedAliasImpl extends ElixirMatchedExpressionImpl
     return ElixirPsiImplUtil.getReference(this);
   }
 
-  @Nullable
-  public PsiPolyVariantReference getReference(@NotNull PsiElement maxScope) {
-    return ElixirPsiImplUtil.getReference(this, maxScope);
-  }
-
   public boolean isModuleName() {
     return ElixirPsiImplUtil.isModuleName(this);
   }

--- a/gen/org/elixir_lang/psi/impl/ElixirUnmatchedQualifiedAliasImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirUnmatchedQualifiedAliasImpl.java
@@ -69,11 +69,6 @@ public class ElixirUnmatchedQualifiedAliasImpl extends ElixirUnmatchedExpression
     return ElixirPsiImplUtil.getReference(this);
   }
 
-  @Nullable
-  public PsiPolyVariantReference getReference(@NotNull PsiElement maxScope) {
-    return ElixirPsiImplUtil.getReference(this, maxScope);
-  }
-
   public boolean isModuleName() {
     return ElixirPsiImplUtil.isModuleName(this);
   }

--- a/src/org/elixir_lang/psi/impl/ElixirPsiImplUtil.java
+++ b/src/org/elixir_lang/psi/impl/ElixirPsiImplUtil.java
@@ -1112,14 +1112,8 @@ public class ElixirPsiImplUtil {
     }
 
     @Nullable
-    public static PsiReference getReference(@NotNull QualifiableAlias qualifiableAlias) {
-        return QualifiableAliasImplKt.getReference(qualifiableAlias, qualifiableAlias.getContainingFile());
-    }
-
-    @Nullable
-    public static PsiPolyVariantReference getReference(@NotNull QualifiableAlias qualifiableAlias,
-                                                       @NotNull PsiElement maxScope) {
-        return QualifiableAliasImplKt.getReference(qualifiableAlias, maxScope);
+    public static PsiPolyVariantReference getReference(@NotNull QualifiableAlias qualifiableAlias) {
+        return QualifiableAliasImplKt.getReference(qualifiableAlias);
     }
 
     @Contract(pure = true)

--- a/src/org/elixir_lang/psi/impl/QualifiableAliasImpl.kt
+++ b/src/org/elixir_lang/psi/impl/QualifiableAliasImpl.kt
@@ -19,16 +19,16 @@ import org.elixir_lang.reference.Module
 import org.elixir_lang.structure_view.element.CallDefinitionClause.Companion.enclosingModularMacroCall
 import org.jetbrains.annotations.Contract
 
-fun QualifiableAlias.computeReference(maxScope: PsiElement): PsiPolyVariantReference? =
+fun QualifiableAlias.computeReference(): PsiPolyVariantReference? =
         if (isOutermostQualifiableAlias()) {
-            Module(this, maxScope)
+            Module(this)
         } else {
             null
         }
 
-fun QualifiableAlias.getReference(maxScope: PsiElement): PsiPolyVariantReference? =
+fun QualifiableAlias.getReference(): PsiPolyVariantReference? =
         CachedValuesManager.getCachedValue(this) {
-            CachedValueProvider.Result.create(computeReference(maxScope), this)
+            CachedValueProvider.Result.create(computeReference(), this)
         }
 
 fun QualifiableAlias.fullyResolve(startingReference: PsiReference?): PsiElement {
@@ -135,7 +135,7 @@ fun QualifiableAlias.maybeModularNameToModular(maxScope: PsiElement): Call? =
     if (!recursiveKernelImport(maxScope)) {
         /* need to construct reference directly as qualified aliases don't return a reference except for the
            outermost */
-        getReference(maxScope)?.let { this.toModular(it) }
+        getReference()?.let { this.toModular(it) }
     } else {
         null
     }

--- a/src/org/elixir_lang/psi/scope/module/MultiResolve.kt
+++ b/src/org/elixir_lang/psi/scope/module/MultiResolve.kt
@@ -102,9 +102,8 @@ class MultiResolve internal constructor(private val name: String, private val in
     companion object {
         fun resolveResults(name: String,
                            incompleteCode: Boolean,
-                           entrance: PsiElement,
-                           maxScope: PsiElement): Array<PsiElementResolveResult> =
-                resolveResults(name, incompleteCode, entrance, maxScope, ResolveState.initial())
+                           entrance: PsiElement): Array<PsiElementResolveResult> =
+                resolveResults(name, incompleteCode, entrance, ResolveState.initial())
 
         private fun indexedNamedElements(match: PsiNamedElement, unaliasedName: String): Collection<NamedElement> {
             val project = match.project
@@ -125,14 +124,13 @@ class MultiResolve internal constructor(private val name: String, private val in
         private fun resolveResults(name: String,
                                    incompleteCode: Boolean,
                                    entrance: PsiElement,
-                                   maxScope: PsiElement,
                                    state: ResolveState): Array<PsiElementResolveResult> {
             val multiResolve = MultiResolve(name, incompleteCode)
 
             PsiTreeUtil.treeWalkUp(
                     multiResolve,
                     entrance,
-                    maxScope,
+                    entrance.containingFile,
                     state.put(ENTRANCE, entrance)
             )
 

--- a/src/org/elixir_lang/reference/Module.kt
+++ b/src/org/elixir_lang/reference/Module.kt
@@ -10,7 +10,7 @@ import com.intellij.psi.impl.source.resolve.ResolveCache
 import org.elixir_lang.psi.QualifiableAlias
 import org.elixir_lang.psi.scope.module.Variants
 
-class Module(qualifiableAlias: QualifiableAlias, val maxScope: PsiElement) :
+class Module(qualifiableAlias: QualifiableAlias) :
         PsiReferenceBase<QualifiableAlias>(qualifiableAlias, TextRange.create(0, qualifiableAlias.textLength)),
         PsiPolyVariantReference {
     override fun getVariants(): Array<LookupElement> = Variants.lookupElementList(myElement).toTypedArray()

--- a/src/org/elixir_lang/reference/resolver/Module.kt
+++ b/src/org/elixir_lang/reference/resolver/Module.kt
@@ -17,7 +17,7 @@ object Module : ResolveCache.PolyVariantResolver<org.elixir_lang.reference.Modul
             module.element.let { element ->
                 resolvableName(element)?.let { name ->
                     val sameFileResolveResultList =
-                            MultiResolve.resolveResults(name, incompleteCode, element, module.maxScope)
+                            MultiResolve.resolveResults(name, incompleteCode, element)
 
                     if (sameFileResolveResultList.isNotEmpty()) {
                         sameFileResolveResultList


### PR DESCRIPTION
Fixes #1416

# Changelog
## Bug Fixes
* Always use `containingFile` for `QualifiableAlias` `maxScope` for `getReference`.  Prevents cache capturing `maxScope`, which can vary based on invocation.