### PR TITLE
Only attach full projects if the IDE can attach full projects

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -106,13 +106,118 @@ jobs:
       - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
       - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
       - rm -fr $HOME/.gradle/caches/*/fileHashes/
+    - stage: Test
+      language: elixir
+      elixir: 1.7.4
+      env: IDEA_VERSION="2019.1.1"
+      jdk: oraclejdk8
+      otp_release: 20.1
+      addons:
+        apt:
+          packages:
+            - oracle-java8-installer
+      cache:
+        directories:
+          - cache
+          - dependencies
+          - "$HOME/.gradle/caches/"
+          - "$HOME/.gradle/wrapper/"
+      before_install:
+        - mix local.hex --force
+        - "export DISPLAY=:99.0"
+        - "export ELIXIR_VERSION=${TRAVIS_ELIXIR_VERSION}"
+        - "export ORG_GRADLE_PROJECT_elixirVersion=${TRAVIS_ELIXIR_VERSION}"
+        - "export ORG_GRADLE_PROJECT_ideaVersion=${IDEA_VERSION}"
+        - "export OTP_RELEASE=${TRAVIS_OTP_RELEASE}"
+        - export ERLANG_SDK_HOME=`erl -eval 'io:format("~s", [code:root_dir()]).' -noshell -run init stop`
+        - export TERM=dumb
+        - "sh -e /etc/init.d/xvfb start"
+        - export CASHER_TIME_OUT=360
+      install:
+        - "./gradlew compileTestJava"
+      script: travis_wait ./gradlew test
+      before_cache:
+        - rm -fr cache/intellij_elixir-0.1.1/rel/intellij_elixir/log
+        - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
+        - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
+        - rm -fr $HOME/.gradle/caches/*/fileHashes/
+    - stage: Test
+      language: elixir
+      elixir: 1.6.6
+      env: IDEA_VERSION="2019.1.1"
+      jdk: oraclejdk8
+      otp_release: 20.1
+      addons:
+        apt:
+          packages:
+            - oracle-java8-installer
+      cache:
+        directories:
+          - cache
+          - dependencies
+          - "$HOME/.gradle/caches/"
+          - "$HOME/.gradle/wrapper/"
+      before_install:
+        - mix local.hex --force
+        - "export DISPLAY=:99.0"
+        - "export ELIXIR_VERSION=${TRAVIS_ELIXIR_VERSION}"
+        - "export ORG_GRADLE_PROJECT_elixirVersion=${TRAVIS_ELIXIR_VERSION}"
+        - "export ORG_GRADLE_PROJECT_ideaVersion=${IDEA_VERSION}"
+        - "export OTP_RELEASE=${TRAVIS_OTP_RELEASE}"
+        - export ERLANG_SDK_HOME=`erl -eval 'io:format("~s", [code:root_dir()]).' -noshell -run init stop`
+        - export TERM=dumb
+        - "sh -e /etc/init.d/xvfb start"
+        - export CASHER_TIME_OUT=360
+      install:
+        - "./gradlew compileTestJava"
+      script: travis_wait ./gradlew test
+      before_cache:
+        - rm -fr cache/intellij_elixir-0.1.1/rel/intellij_elixir/log
+        - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
+        - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
+        - rm -fr $HOME/.gradle/caches/*/fileHashes/
+    - stage: Test
+      language: elixir
+      elixir: 1.5.3
+      env: IDEA_VERSION="2019.1.1"
+      jdk: oraclejdk8
+      otp_release: 20.1
+      addons:
+        apt:
+          packages:
+            - oracle-java8-installer
+      cache:
+        directories:
+          - cache
+          - dependencies
+          - "$HOME/.gradle/caches/"
+          - "$HOME/.gradle/wrapper/"
+      before_install:
+        - mix local.hex --force
+        - "export DISPLAY=:99.0"
+        - "export ELIXIR_VERSION=${TRAVIS_ELIXIR_VERSION}"
+        - "export ORG_GRADLE_PROJECT_elixirVersion=${TRAVIS_ELIXIR_VERSION}"
+        - "export ORG_GRADLE_PROJECT_ideaVersion=${IDEA_VERSION}"
+        - "export OTP_RELEASE=${TRAVIS_OTP_RELEASE}"
+        - export ERLANG_SDK_HOME=`erl -eval 'io:format("~s", [code:root_dir()]).' -noshell -run init stop`
+        - export TERM=dumb
+        - "sh -e /etc/init.d/xvfb start"
+        - export CASHER_TIME_OUT=360
+      install:
+        - "./gradlew compileTestJava"
+      script: travis_wait ./gradlew test
+      before_cache:
+        - rm -fr cache/intellij_elixir-0.1.1/rel/intellij_elixir/log
+        - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
+        - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
+        - rm -fr $HOME/.gradle/caches/*/fileHashes/
     - stage: Canary Pre-Release Builds
       language: elixir
       # The earliest `elixir` support in `stage: Test`
       elixir: 1.6.6
       # The earliest `IDEA_VERSION` supported in `stage: Test`
       env:
-      - IDEA_VERSION="2018.3"
+      - IDEA_VERSION="2019.1.1"
       - secure: "sumWWNvahSNr7w6taGFWUXFZKsbeA5JR8qn3OI04z2sJiTE1VKYqpyJQxmJSDIALMaw7pqdF5KoUKooKJ8jIN6Dsraeg+8YS2ekYTNZL/9wFJjcjViHsscCWQhSxTEexLpUFsB1YcTscip8/nLojsgl6c4RO6zuw1d6ghjCAjak="
       jdk: oraclejdk8
       otp_release: 20.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -191,6 +191,7 @@ Table of Contents
   * The correct home path for `kiex` is `~/.kiex/elixirs/elixir-VERSION/lib/elixir` as that contains the true `lib` and `bin` directory, but users may select other directories by mistake, so doing the following adjustments:
     * Adjust `bin` home path to `lib/elixir`.
     * Adjust `elixirs/elixir-VERSION` home path to `elixirs/elixir-VERSION/lib/elixir`.
+* [#1462](https://github.com/KronicDeth/intellij-elixir/pull/1462) - Use reflections to allow saving settings when creating the projects before in 2018.3 and 2019.1 even though the API changed. - [@KronicDeth](https://github.com/KronicDeth)
 
 ### Bug Fixes
 * [#1443](https://github.com/KronicDeth/intellij-elixir/pull/1443) - [@KronicDeth](https://github.com/KronicDeth)
@@ -212,6 +213,32 @@ Table of Contents
 * [#1449](https://github.com/KronicDeth/intellij-elixir/pull/1449) - Get view provider document in read action. - [@KronicDeth](https://github.com/KronicDeth)
 * [#1450](https://github.com/KronicDeth/intellij-elixir/pull/1450) - Support `rebar.config` deps that are name only. - [@KronicDeth](https://github.com/KronicDeth)
 * [#1456](https://github.com/KronicDeth/intellij-elixir/pull/1456) - Always use `containingFile` for `QualifiableAlias` `maxScope` for `getReference`.  Prevents cache capturing `maxScope`, which can vary based on invocation. - [@KronicDeth](https://github.com/KronicDeth)
+* [#1462](https://github.com/KronicDeth/intellij-elixir/pull/1462) - [@KronicDeth](https://github.com/KronicDeth)
+  * Create new project before attaching it in Small IDEs.
+    When attaching a directory to a project during startup, saving is disallowed, so the attached directory only has a `workspace.xml` in its `.idea` when the attach is attempted.  Attaching requires the `.idea/*.iml` Module file, so the attaching fails, saying the directory is an unsupported format.
+
+    Experimentation showed that manually attaching the directory also did not work, but opening the directory in a separate window, then opening and attaching it again would make the directory have the full project files.  To mimic this manual process:
+
+    1. The internals of `doOpenProject` are copied
+    2. A save of the project files is forced, bypassing the normal "startup" save blocker
+    3. The project is attached to the root project.
+
+    Tested to work when upgrading from 10.4.0 to 10.5.0-pre in Rubymine when no project was already open.
+  *  Check if project can be attached instead of if RubyMine
+     Although GoLand supports attaching projects, it doesn't work for non-Go projects, so it is also excluded.  How the support appears in each non-IntelliJ IDEA is shown below:
+
+     | IDE            | Works? |                                                                                                                                                                                                                                                                                                                                                                    |
+     |:---------------|:-------|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+     | Android Studio | YES    | Android Studio is built on top of IntelliJ, so it has full multi-Module support.  It is not Small IDE.                                                                                                                                                                                                                                                             |
+     | CLion          | NO     | No Attach to Project support to multiple module support.                                                                                                                                                                                                                                                                                                           |
+     | DataGrip       | No     | DataGrip doesn't have a Project View and doesn't support Attach to Project.  You can still run tests if you directly open the file.                                                                                                                                                                                                                                |
+     | GoLand         | NO     | Modules show up, but independent projects are not attached as in other Small IDEs, so disabled.  In general, the Go settings, like Test Runners always win, so it is recommended to not use GoLand at all for Elixir development.                                                                                                                                  |
+     | PHPStorm       | YES    | The projects are listed in Directories.  The Languages & Frameworks > Elixir shows all 3 projects.  Right-clicking on the marked Test directory will not show the Elixir Run Configuration, Python ones win, but subdirectories and `*_test.exs` will show up in the context menu.                                                                                 |
+     | PyCharm        | YES    | The root project is listed in Project.  `app/*` projects are listed listed as Project Dependencies of the root Project.  The Languages & Frameworks > Elixir shows all 3 projects.  Right-clicking on the marked Test directory will not show the Elixir Run Configuration, Python ones win, but subdirectories and `*_test.exs` will show up in the context menu. |
+     | Rider          | No     | Solution system is separate from Project system.                                                                                                                                                                                                                                                                                                                   |
+     | Rubymine       | YES    | The projects are listed in Project Structure. The Languages & Frameworks > Elixir shows all 3 projects.  Right-clicking on the marked Test directory will not show the Elixir Run Configuration, Python ones win, but subdirectories and `*_test.exs` will show up in the context menu.                                                                            |
+     | WebStorm       | NO     | No Attach to Project support or multiple module support.                                                                                                                                                                                                                                                                                                           |
+  *  Don't count Android Studio as a Small IDE.   It includes Project Structure menu with multiple-language, multiple-Module per Project support from IntelliJ.
 
 ## v10.4.0
 

--- a/resources/META-INF/changelog.html
+++ b/resources/META-INF/changelog.html
@@ -17,6 +17,10 @@
           </li>
         </ul>
       </li>
+      <li>
+        Use reflections to allow saving settings when creating the projects before in 2018.3 and 2019.1 even though the
+        API changed.
+      </li>
     </ul>
   </li>
   <li>
@@ -82,6 +86,93 @@
       <li>
         Always use <code>containingFile</code> for <code>QualifiableAlias</code> <code>maxScope</code> for
         <code>getReference</code>.  Prevents cache capturing <code>maxScope</code>, which can vary based on invocation.
+      </li>
+      <li>
+        <p>
+          Create new project before attaching it in Small IDEs.<br>
+          When attaching a directory to a project during startup, saving is disallowed, so the attached directory only
+          has a <code>workspace.xml</code> in its <code>.idea</code> when the attach is attempted.  Attaching requires
+          the <code>.idea/*.iml</code> Module file, so the attaching fails, saying the directory is an unsupported
+          format.
+        </p>
+        <p>
+          Experimentation showed that manually attaching the directory also did not work, but opening the directory in a
+          separate window, then opening and attaching it again would make the directory have the full project files.  To
+          mimic this manual process:
+        </p>
+        <ol>
+          <li>The internals of <code>doOpenProject</code> are copied</li>
+          <li>A save of the project files is forced, bypassing the normal "startup" save blocker</li>
+          <li>The project is attached to the root project.</li>
+        </ol>
+        <p>Tested to work when upgrading from 10.4.0 to 10.5.0-pre in Rubymine when no project was already open.</p>
+      </li>
+      <li>
+        <p>
+          Check if project can be attached instead of if RubyMine<br>
+          Although GoLand supports attaching projects, it doesn't work for non-Go projects, so it is also excluded.  How
+          the support appears in each non-IntelliJ IDEA is shown below:
+        </p>
+        <table>
+          <thead>
+          <tr>
+            <th align="left">IDE</th>
+            <th align="left">Works?</th>
+            <th align="left"></th>
+          </tr>
+          </thead>
+          <tbody>
+          <tr>
+            <td align="left">Android Studio</td>
+            <td align="left">YES</td>
+            <td align="left">Android Studio is built on top of IntelliJ, so it has full multi-Module support.  It is not Small IDE.</td>
+          </tr>
+          <tr>
+            <td align="left">CLion</td>
+            <td align="left">NO</td>
+            <td align="left">No Attach to Project support to multiple module support.</td>
+          </tr>
+          <tr>
+            <td align="left">DataGrip</td>
+            <td align="left">No</td>
+            <td align="left">DataGrip doesn't have a Project View and doesn't support Attach to Project.  You can still run tests if you directly open the file.</td>
+          </tr>
+          <tr>
+            <td align="left">GoLand</td>
+            <td align="left">NO</td>
+            <td align="left">Modules show up, but independent projects are not attached as in other Small IDEs, so disabled.  In general, the Go settings, like Test Runners always win, so it is recommended to not use GoLand at all for Elixir development.</td>
+          </tr>
+          <tr>
+            <td align="left">PHPStorm</td>
+            <td align="left">YES</td>
+            <td align="left">The projects are listed in Directories.  The Languages &amp; Frameworks &gt; Elixir shows all 3 projects.  Right-clicking on the marked Test directory will not show the Elixir Run Configuration, Python ones win, but subdirectories and <code>*_test.exs</code> will show up in the context menu.</td>
+          </tr>
+          <tr>
+            <td align="left">PyCharm</td>
+            <td align="left">YES</td>
+            <td align="left">The root project is listed in Project.  <code>app/*</code> projects are listed listed as Project Dependencies of the root Project.  The Languages &amp; Frameworks &gt; Elixir shows all 3 projects.  Right-clicking on the marked Test directory will not show the Elixir Run Configuration, Python ones win, but subdirectories and <code>*_test.exs</code> will show up in the context menu.</td>
+          </tr>
+          <tr>
+            <td align="left">Rider</td>
+            <td align="left">No</td>
+            <td align="left">Solution system is separate from Project system.</td>
+          </tr>
+          <tr>
+            <td align="left">Rubymine</td>
+            <td align="left">YES</td>
+            <td align="left">The projects are listed in Project Structure. The Languages &amp; Frameworks &gt; Elixir shows all 3 projects.  Right-clicking on the marked Test directory will not show the Elixir Run Configuration, Python ones win, but subdirectories and <code>*_test.exs</code> will show up in the context menu.</td>
+          </tr>
+          <tr>
+            <td align="left">WebStorm</td>
+            <td align="left">NO</td>
+            <td align="left">No Attach to Project support or multiple module support.</td>
+          </tr>
+          </tbody>
+        </table>
+      </li>
+      <li>
+        Don't count Android Studio as a Small IDE.   It includes Project Structure menu with multiple-language,
+        multiple-Module per Project support from IntelliJ.
       </li>
     </ul>
   </li>

--- a/src/org/elixir_lang/code_insight/line_marker_provider/CallDefinition.kt
+++ b/src/org/elixir_lang/code_insight/line_marker_provider/CallDefinition.kt
@@ -22,10 +22,7 @@ import org.elixir_lang.structure_view.element.CallDefinitionSpecification.Compan
 import org.elixir_lang.structure_view.element.CallDefinitionSpecification.Companion.specification
 import org.elixir_lang.structure_view.element.CallDefinitionSpecification.Companion.specificationType
 
-class CallDefinition(
-        private val daemonCodeAnalyzerSettings: DaemonCodeAnalyzerSettings,
-        private val editorColorsManager: EditorColorsManager
-) : LineMarkerProvider {
+class CallDefinition : LineMarkerProvider {
     override fun collectSlowLineMarkers(elements: List<PsiElement>, result: Collection<LineMarkerInfo<*>>) {}
 
     override fun getLineMarkerInfo(element: PsiElement): LineMarkerInfo<*>? =
@@ -34,6 +31,9 @@ class CallDefinition(
                 is Call -> getLineMarkerInfo(element)
                 else -> null
             }
+
+    private val daemonCodeAnalyzerSettings: DaemonCodeAnalyzerSettings = DaemonCodeAnalyzerSettings.getInstance()
+    private val editorColorsManager: EditorColorsManager = EditorColorsManager.getInstance()
 
     private fun callDefinitionSeparator(
             atUnqualifiedNoParenthesesCall: AtUnqualifiedNoParenthesesCall<*>

--- a/src/org/elixir_lang/mix/project/DirectoryConfigurator.kt
+++ b/src/org/elixir_lang/mix/project/DirectoryConfigurator.kt
@@ -4,9 +4,6 @@ import com.intellij.configurationStore.StoreUtil
 import com.intellij.facet.FacetManager
 import com.intellij.facet.FacetType
 import com.intellij.facet.impl.FacetUtil.addFacet
-import com.intellij.notification.Notification
-import com.intellij.notification.NotificationType
-import com.intellij.notification.Notifications
 import com.intellij.openapi.module.Module
 import com.intellij.openapi.module.ModuleManager
 import com.intellij.openapi.progress.ProgressIndicator
@@ -25,7 +22,6 @@ import com.intellij.util.PlatformUtils
 import com.intellij.util.io.exists
 import org.elixir_lang.DepsWatcher
 import org.elixir_lang.Facet
-import org.elixir_lang.Icons
 import org.elixir_lang.mix.Project.addFolders
 import org.elixir_lang.mix.Watcher
 import java.nio.file.Path
@@ -72,9 +68,7 @@ class DirectoryConfigurator : com.intellij.platform.DirectoryProjectConfigurator
     }
 
     private fun configureDescendantOtpApp(rootProject: Project, otpApp: OtpApp) {
-        // Only Rubymine supported attaching Project under apps directory during testing.  See Test Report in
-        // https://github.com/KronicDeth/intellij-elixir/pull/1443 for more information.
-        if (PlatformUtils.isRubyMine()) {
+        if (!PlatformUtils.isGoIde() && ProjectAttachProcessor.canAttachToProject()) {
             newProject(otpApp)?.let { otpAppProject ->
                 attachToProject(rootProject, Paths.get(otpApp.root.path))
 
@@ -90,19 +84,6 @@ class DirectoryConfigurator : com.intellij.platform.DirectoryProjectConfigurator
                     }
                 })
             }
-        } else {
-            Notifications.Bus.notify(
-                    Notification(
-                            "Elixir OTP Application Detector",
-                            Icons.LANGUAGE,
-                            "Multiple OTP Applications detected",
-                            "Multiple OTP Applications Not Supported",
-                            "An OTP Applications has been detected in ${otpApp.root}, which is not at the project root.  If you want to open all OTP applications at once and have proper cross-OTP application dependency resolution, you need to use IntelliJ Community Edition or IntelliJ Ultimate Edition with its multiple Modules per Project, or Rubymine's multiple Projects Open in One Window support.  IntelliJ's multiple Modules per Project is recommended as it supports true Elixir Modules instead of Elixir Facets in Ruby Module as happens in Rubymine.",
-                            NotificationType.INFORMATION,
-                            null
-                    ),
-                    rootProject
-            )
         }
     }
 

--- a/src/org/elixir_lang/mix/project/DirectoryConfigurator.kt
+++ b/src/org/elixir_lang/mix/project/DirectoryConfigurator.kt
@@ -1,5 +1,6 @@
 package org.elixir_lang.mix.project
 
+import com.intellij.configurationStore.StoreUtil
 import com.intellij.facet.FacetManager
 import com.intellij.facet.FacetType
 import com.intellij.facet.impl.FacetUtil.addFacet
@@ -12,11 +13,16 @@ import com.intellij.openapi.progress.ProgressIndicator
 import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.progress.Task
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.project.ex.ProjectManagerEx
 import com.intellij.openapi.roots.ModuleRootModificationUtil
 import com.intellij.openapi.util.Ref
+import com.intellij.openapi.util.io.FileUtil
 import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.platform.PlatformProjectOpenProcessor.runDirectoryProjectConfigurators
+import com.intellij.platform.ProjectBaseDirectory
 import com.intellij.projectImport.ProjectAttachProcessor
 import com.intellij.util.PlatformUtils
+import com.intellij.util.io.exists
 import org.elixir_lang.DepsWatcher
 import org.elixir_lang.Facet
 import org.elixir_lang.Icons
@@ -40,52 +46,84 @@ class DirectoryConfigurator : com.intellij.platform.DirectoryProjectConfigurator
 
         for (otpApp in foundOtpApps) {
             if (otpApp.root == baseDir) {
-                val module = ModuleManager.getInstance(project).modules[0]
-
-                if (FacetManager.getInstance(module).findFacet(Facet.ID, "Elixir") == null) {
-                    addFacet(module, FacetType.findInstance(org.elixir_lang.facet.Type::class.java))
-
-                    ModuleRootModificationUtil.updateModel(module) { modifiableRootModel ->
-                        addFolders(modifiableRootModel, baseDir)
-                    }
-
-                    ProgressManager.getInstance().run(object : Task.Modal(project, "Scanning dependencies for Libraries", true) {
-                        override fun run(indicator: ProgressIndicator) {
-                            project.getComponent(DepsWatcher::class.java).syncLibraries(project, indicator)
-                        }
-                    })
-                }
+                configureRootOtpApp(project, otpApp)
             } else {
-                // Only Rubymine supported attaching Project under apps directory during testing.  See Test Report in
-                // https://github.com/KronicDeth/intellij-elixir/pull/1443 for more information.
-                if (PlatformUtils.isRubyMine()) {
-                    attachToProject(project, Paths.get(otpApp.root.path))
+                configureDescendantOtpApp(project, otpApp)
+            }
+        }
+    }
 
-                    ProgressManager.getInstance().run(object : Task.Modal(project, "Scanning mix.exs to connect libraries for newly attached project for OTP app ${otpApp.name}", true) {
-                        override fun run(progressIndicator: ProgressIndicator) {
-                            for (module in ModuleManager.getInstance(project).modules) {
-                                if (progressIndicator.isCanceled) {
-                                    break
-                                }
+    private fun configureRootOtpApp(project: Project, otpApp: OtpApp) {
+        val module = ModuleManager.getInstance(project).modules[0]
 
-                                module.getComponent(Watcher::class.java).syncLibraries(progressIndicator)
-                            }
-                        }
-                    })
-                } else {
-                    Notifications.Bus.notify(
-                            Notification(
-                                    "Elixir OTP Application Detector",
-                                    Icons.LANGUAGE,
-                                    "Multiple OTP Applications detected",
-                                    "Multiple OTP Applications Not Supported",
-                                    "An OTP Applications has been detected in ${otpApp.root}, which is not at the project root.  If you want to open all OTP applications at once and have proper cross-OTP application dependency resolution, you need to use IntelliJ Community Edition or IntelliJ Ultimate Edition with its multiple Modules per Project, or Rubymine's multiple Projects Open in One Window support.  IntelliJ's multiple Modules per Project is recommended as it supports true Elixir Modules instead of Elixir Facets in Ruby Module as happens in Rubymine.",
-                                    NotificationType.INFORMATION,
-                                    null
-                            ),
-                            project
-                    )
+        if (FacetManager.getInstance(module).findFacet(Facet.ID, "Elixir") == null) {
+            addFacet(module, FacetType.findInstance(org.elixir_lang.facet.Type::class.java))
+
+            ModuleRootModificationUtil.updateModel(module) { modifiableRootModel ->
+                addFolders(modifiableRootModel, otpApp.root)
+            }
+
+            ProgressManager.getInstance().run(object : Task.Modal(project, "Scanning dependencies for Libraries", true) {
+                override fun run(indicator: ProgressIndicator) {
+                    project.getComponent(DepsWatcher::class.java).syncLibraries(project, indicator)
                 }
+            })
+        }
+    }
+
+    private fun configureDescendantOtpApp(rootProject: Project, otpApp: OtpApp) {
+        // Only Rubymine supported attaching Project under apps directory during testing.  See Test Report in
+        // https://github.com/KronicDeth/intellij-elixir/pull/1443 for more information.
+        if (PlatformUtils.isRubyMine()) {
+            newProject(otpApp)?.let { otpAppProject ->
+                attachToProject(rootProject, Paths.get(otpApp.root.path))
+
+                ProgressManager.getInstance().run(object : Task.Modal(otpAppProject, "Scanning mix.exs to connect libraries for newly attached project for OTP app ${otpApp.name}", true) {
+                    override fun run(progressIndicator: ProgressIndicator) {
+                        for (module in ModuleManager.getInstance(otpAppProject).modules) {
+                            if (progressIndicator.isCanceled) {
+                                break
+                            }
+
+                            module.getComponent(Watcher::class.java).syncLibraries(progressIndicator)
+                        }
+                    }
+                })
+            }
+        } else {
+            Notifications.Bus.notify(
+                    Notification(
+                            "Elixir OTP Application Detector",
+                            Icons.LANGUAGE,
+                            "Multiple OTP Applications detected",
+                            "Multiple OTP Applications Not Supported",
+                            "An OTP Applications has been detected in ${otpApp.root}, which is not at the project root.  If you want to open all OTP applications at once and have proper cross-OTP application dependency resolution, you need to use IntelliJ Community Edition or IntelliJ Ultimate Edition with its multiple Modules per Project, or Rubymine's multiple Projects Open in One Window support.  IntelliJ's multiple Modules per Project is recommended as it supports true Elixir Modules instead of Elixir Facets in Ruby Module as happens in Rubymine.",
+                            NotificationType.INFORMATION,
+                            null
+                    ),
+                    rootProject
+            )
+        }
+    }
+
+    /**
+     * @return Only returns a project if it is new.
+     */
+    private fun newProject(otpApp: OtpApp): Project? {
+        val projectDir = Paths.get(FileUtil.toSystemDependentName(otpApp.root.path), Project.DIRECTORY_STORE_FOLDER)
+
+        return if (projectDir.exists()) {
+            null
+        } else {
+            val projectManager = ProjectManagerEx.getInstanceEx()
+
+            projectManager.newProject(otpApp.name, otpApp.root.path, false, false)?.let { project ->
+                ProjectBaseDirectory.getInstance(project).baseDir = otpApp.root
+                runDirectoryProjectConfigurators(otpApp.root, project)
+
+                StoreUtil.saveSettings(project, true)
+
+                project
             }
         }
     }

--- a/src/org/elixir_lang/sdk/ProcessOutput.java
+++ b/src/org/elixir_lang/sdk/ProcessOutput.java
@@ -97,6 +97,6 @@ public class ProcessOutput {
   }
 
   public static boolean isSmallIde(){
-    return !PlatformUtils.isIntelliJ();
+    return !(PlatformUtils.isIntelliJ() || PlatformUtils.getPlatformPrefix().equals("AndroidStudio"));
   }
 }


### PR DESCRIPTION
# Changelog
## Enhancements
* Use reflections to allow saving settings when creating the projects before in 2018.3 and 2019.1 even though the API changed.

## Bug Fixes
* Create new project before attaching it in Small IDEs.
  When attaching a directory to a project during startup, saving is disallowed, so the attached directory only has a `workspace.xml` in its `.idea` when the attach is attempted.  Attaching requires the `.idea/*.iml` Module file, so the attaching fails, saying the directory is an unsupported format.

  Experimentation showed that manually attaching the directory also did not work, but opening the directory in a separate window, then opening and attaching it again would make the directory have the full project files.  To mimic this manual process:

  1. The internals of `doOpenProject` are copied
  2. A save of the project files is forced, bypassing the normal "startup" save blocker
  3. The project is attached to the root project.

  Tested to work when upgrading from 10.4.0 to 10.5.0-pre in Rubymine when no project was already open.
*  Check if project can be attached instead of if RubyMine
   Although GoLand supports attaching projects, it doesn't work for non-Go projects, so it is also excluded.  How the support appears in each non-IntelliJ IDEA is shown below:

     | IDE            | Works? |                                                                                                                                                                                                                                                                                                                                                                    |
     |:---------------|:-------|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
    | Android Studio | YES    | Android Studio is built on top of IntelliJ, so it has full multi-Module support.  It is not Small IDE.                                                                                                                                                                                                                                                             |
     | CLion          | NO     | No Attach to Project support to multiple module support.                                                                                                                                                                                                                                                                                                           |
     | DataGrip       | No     | DataGrip doesn't have a Project View and doesn't support Attach to Project.  You can still run tests if you directly open the file.                                                                                                                                                                                                                                |
     | GoLand         | NO     | Modules show up, but independent projects are not attached as in other Small IDEs, so disabled.  In general, the Go settings, like Test Runners always win, so it is recommended to not use GoLand at all for Elixir development.                                                                                                                                  |
     | PHPStorm       | YES    | The projects are listed in Directories.  The Languages & Frameworks > Elixir shows all 3 projects.  Right-clicking on the marked Test directory will not show the Elixir Run Configuration, Python ones win, but subdirectories and `*_test.exs` will show up in the context menu.                                                                                 |
     | PyCharm        | YES    | The root project is listed in Project.  `app/*` projects are listed listed as Project Dependencies of the root Project.  The Languages & Frameworks > Elixir shows all 3 projects.  Right-clicking on the marked Test directory will not show the Elixir Run Configuration, Python ones win, but subdirectories and `*_test.exs` will show up in the context menu. |
     | Rider          | No     | Solution system is separate from Project system.                                                                                                                                                                                                                                                                                                                   |
     | Rubymine       | YES    | The projects are listed in Project Structure. The Languages & Frameworks > Elixir shows all 3 projects.  Right-clicking on the marked Test directory will not show the Elixir Run Configuration, Python ones win, but subdirectories and `*_test.exs` will show up in the context menu.                                                                            |
     | WebStorm       | NO     | No Attach to Project support or multiple module support.                                                                                                                                                                                                                                                                                                           |
*  Don't count Android Studio as a Small IDE.   It includes Project Structure menu with multiple-language, multiple-Module per Project support from IntelliJ.