### PR TITLE
1.8 debugger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -185,6 +185,13 @@ Table of Contents
 
 # Changelog
 
+## v10.5.2
+
+### Bug Fixes
+* [#1491](https://github.com/KronicDeth/intellij-elixir/pull/1491) - [@KronicDeth](https://github.com/KronicDeth)
+  * Elixir 1.8 made `:elixir.quoted_to_erl/3` private, so in Elixir 1.8+, the debugger needs to inline the private version to maintain < 1.8 and >= 1.8 compatibility.
+  * Reformat debugger for Elixir 1.8
+
 ## v10.5.1
 
 ### Bug Fixes

--- a/resources/META-INF/changelog.html
+++ b/resources/META-INF/changelog.html
@@ -1,5 +1,18 @@
 <html>
 <body>
+<h1>v10.5.2</h1>
+<ul>
+  <li>
+    <p>Bug Fixes</p>
+    <ul>
+      <li>
+        Elixir 1.8 made <code>:elixir.quoted_to_erl/3</code> private, so in Elixir 1.8+, the debugger needs to inline
+        the private version to maintain &lt; 1.8 and &gt;= 1.8 compatibility.
+      </li>
+      <li>Reformat debugger for Elixir 1.8</li>
+    </ul>
+  </li>
+</ul>
 <h1>v10.5.1</h1>
 <ul>
   <li>

--- a/resources/debugger/lib/intellij_elixir/debugger/server.ex
+++ b/resources/debugger/lib/intellij_elixir/debugger/server.ex
@@ -256,7 +256,7 @@ defmodule IntelliJElixir.Debugger.Server do
             end
 
             # https://github.com/elixir-lang/elixir/blob/8a971fcb44391bd8b16456666f3033b633c6ff77/lib/elixir/src/elixir.erl#L256
-            {erl, _new_env, _new_scope} = :elixir.quoted_to_erl(quoted, current_vars_env, parsed_scope)
+            {erl, _new_env, _new_scope} = quoted_to_erl(quoted, current_vars_env, parsed_scope)
 
             code =
               [:erl_pp.expr(erl), ?.]
@@ -368,6 +368,20 @@ defmodule IntelliJElixir.Debugger.Server do
     |> Enum.each(&time_interpret/1)
 
     :ok
+  end
+
+  # `:elixir.quoted_to_erl/3` became private in Elixir 1.8, so need to inline it here.
+  if Version.compare(System.version(), "1.8.0") == :lt do
+    defp quoted_to_erl(quoted, env, scope) do
+      :elixir.quoted_to_erl(quoted, env, scope)
+    end
+  else
+    defp quoted_to_erl(quoted, env, scope) do
+      {expanded, new_env} = :elixir_expand.expand(quoted, env)
+      {erl, new_scope} = :elixir_erl_pass.translate(expanded, scope)
+
+      {erl, new_env, new_scope}
+    end
   end
 
   defp time_interpret(module) when is_atom(module) do

--- a/resources/debugger/lib/intellij_elixir/debugger/server.ex
+++ b/resources/debugger/lib/intellij_elixir/debugger/server.ex
@@ -249,11 +249,12 @@ defmodule IntelliJElixir.Debugger.Server do
             vars_env = %{env | vars: parsed_vars}
 
             # Elixir 1.7+ uses current_vars
-            current_vars_env = if Map.has_key?(vars_env, :current_vars) do
-              %{vars_env | current_vars: Enum.into(parsed_vars, %{}, fn parsed_var -> {parsed_var, {0, :term}} end)}
-            else
-              vars_env
-            end
+            current_vars_env =
+              if Map.has_key?(vars_env, :current_vars) do
+                %{vars_env | current_vars: Enum.into(parsed_vars, %{}, fn parsed_var -> {parsed_var, {0, :term}} end)}
+              else
+                vars_env
+              end
 
             # https://github.com/elixir-lang/elixir/blob/8a971fcb44391bd8b16456666f3033b633c6ff77/lib/elixir/src/elixir.erl#L256
             {erl, _new_env, _new_scope} = quoted_to_erl(quoted, current_vars_env, parsed_scope)


### PR DESCRIPTION
# Test Report

Tested using `eex_test_umbrella` and evaluating parameters using Elixir 1.7.4 and 1.8.1.

# Changelog
## Bug Fixes
* Elixir 1.8 made `:elixir.quoted_to_erl/3` private, so in Elixir 1.8+, the debugger needs to inline the private version to maintain < 1.8 and >= 1.8 compatibility.
* Reformat debugger for Elixir 1.8