### PR TITLE
Don't pass argument to OutputEventSplitter

### DIFF
--- a/src/org/elixir_lang/espec/MixOutputToGeneralTestEventsConverter.java
+++ b/src/org/elixir_lang/espec/MixOutputToGeneralTestEventsConverter.java
@@ -21,7 +21,7 @@ public class MixOutputToGeneralTestEventsConverter extends OutputToGeneralTestEv
     MixOutputToGeneralTestEventsConverter(@NotNull String testFrameworkName, @NotNull TestConsoleProperties consoleProperties) {
         super(testFrameworkName, consoleProperties);
 
-        splitter = new OutputEventSplitter(consoleProperties.isEditable()) {
+        splitter = new OutputEventSplitter() {
             @Override
             public void onTextAvailable(@NotNull String text, @NotNull Key outputType) {
                 processConsistentText(text, outputType);

--- a/src/org/elixir_lang/exunit/MixOutputToGeneralTestEventsConverter.java
+++ b/src/org/elixir_lang/exunit/MixOutputToGeneralTestEventsConverter.java
@@ -20,7 +20,7 @@ public class MixOutputToGeneralTestEventsConverter extends OutputToGeneralTestEv
     MixOutputToGeneralTestEventsConverter(@NotNull String testFrameworkName, @NotNull TestConsoleProperties consoleProperties) {
         super(testFrameworkName, consoleProperties);
 
-        splitter = new OutputEventSplitter(consoleProperties.isEditable()) {
+        splitter = new OutputEventSplitter() {
             @Override
             public void onTextAvailable(@NotNull String text, @NotNull Key outputType) {
                 processConsistentText(text, outputType);


### PR DESCRIPTION
Constructor argument does not have to same meaning as OutputLineSplitter.