### PR TITLE
Use absolute path for IEx Mix Run/Debug configuration.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -206,6 +206,8 @@
 ### Bug Fixes
 * [#1589](https://github.com/KronicDeth/intellij-elixir/pull/1589) - [@KronicDeth](https://github.com/KronicDeth)
   * Don't error on `runtume` in mix deps.  `guardian` is too common of a dependency and too many users have the version with the typo installed.
+* [#1569](https://github.com/KronicDeth/intellij-elixir/pull/1569) - [@chitacan](https://github.com/chitacan)
+  * Fix IEx Mix Run/Debug Configuration for `asdf` by using absolute path to `mix`.
 
 ## v11.1.0
 ### Enhancements

--- a/resources/META-INF/changelog.html
+++ b/resources/META-INF/changelog.html
@@ -17,6 +17,9 @@
         Don't error on <code>runtume</code> in mix deps.  <code>guardian</code> is too common of a dependency and too
         many users have the version with the typo installed.
       </li>
+      <li>
+        Fix IEx Mix Run/Debug Configuration for <code>asdf</code> by using absolute path to <code>mix</code>.
+      </li>
     </ul>
   </li>
 </ul>

--- a/src/org/elixir_lang/iex/Mix.kt
+++ b/src/org/elixir_lang/iex/Mix.kt
@@ -2,6 +2,7 @@ package org.elixir_lang.iex
 
 import com.intellij.execution.configurations.GeneralCommandLine
 import com.intellij.openapi.projectRoots.Sdk
+import org.elixir_lang.jps.sdk_type.Elixir
 
 object Mix {
     fun commandLine(
@@ -13,12 +14,13 @@ object Mix {
     ): GeneralCommandLine {
         val commandLine = org.elixir_lang.IEx.commandLine(environment, workingDirectory, elixirSdk, erlArgumentList)
         commandLine.addParameters(iexArgumentList)
-        addMix(commandLine)
+        addMix(commandLine, elixirSdk)
 
         return commandLine
     }
 
-    private fun addMix(commandLine: GeneralCommandLine) {
-        commandLine.addParameters("-S", "mix")
+    private fun addMix(commandLine: GeneralCommandLine, sdk: Sdk) {
+        val mixPath = Elixir.mixPath(sdk.homePath)
+        commandLine.addParameters("-S", mixPath)
     }
 }


### PR DESCRIPTION
Hi, I changed the mix path on IEx Mix Run/Debug configuration to use absolute path instead of relative path, which was causing issues with asdf. The change is similar to what's already in  [Mix.kt](https://github.com/KronicDeth/intellij-elixir/blob/b80bba9ae0a576770f992b97800ea14d937f7547/src/org/elixir_lang/Mix.kt#L31-L34)

Fixes:

With [asdf](https://github.com/asdf-vm/asdf), launching IEx Mix Run/Debug Configuration will load `~/.asdf/shims/mix` and throw following error.

```
** (SyntaxError) /Users/chitacan/.asdf/shims/mix:11: syntax error before: '.'
    (elixir) lib/code.ex:813: Code.require_file/2
```