### PR TITLE
Plugin updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ jobs:
     - stage: Test
       language: elixir
       elixir: 1.7.4
-      env: IDEA_VERSION="2019.2"
+      env: IDEA_VERSION="2019.2.2"
       otp_release: 20.1
       services:
         - xvfb

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id 'org.jetbrains.intellij' version "0.4.7"
+  id 'org.jetbrains.intellij' version "0.4.10"
   id "org.jetbrains.kotlin.jvm" version "1.3.10"
   id 'de.undercouch.download' version "3.4.3"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
   id 'org.jetbrains.intellij' version "0.4.10"
   id "org.jetbrains.kotlin.jvm" version "1.3.50"
-  id 'de.undercouch.download' version "3.4.3"
+  id 'de.undercouch.download' version "4.0.0"
 }
 
 ext {

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
   id 'org.jetbrains.intellij' version "0.4.10"
-  id "org.jetbrains.kotlin.jvm" version "1.3.10"
+  id "org.jetbrains.kotlin.jvm" version "1.3.50"
   id 'de.undercouch.download' version "3.4.3"
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@
 # https://www.jetbrains.com/intellij-repository/snapshots
 
 baseVersion = 11.0.1
-ideaVersion = 2019.2
+ideaVersion = 2019.2.2
 javaVersion = 1.8
 javaTargetVersion = 1.8
 sources = true


### PR DESCRIPTION
# Changelog
## Enhancements
* Update gradle plugins
  * `gradle-intellij-plugin` (`org.jetbrains.intellij`) to `0.4.10`
  * `org.jetbrains.kotlin.jvm` to `1.3.50`
  * `de.undercrouch.download` to `4.0.0`
* Update IDEA version in builds
  * `2019.2` -> `2019.2.2`

## Bug Fixes
* Update gradle intellij plugin to fix `runIde` on newer macOS.