### PR TITLE
Add OTP 22 and 23 opcodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -208,6 +208,14 @@
   * Don't error on `runtume` in mix deps.  `guardian` is too common of a dependency and too many users have the version with the typo installed.
 * [#1569](https://github.com/KronicDeth/intellij-elixir/pull/1569) - [@chitacan](https://github.com/chitacan)
   * Fix IEx Mix Run/Debug Configuration for `asdf` by using absolute path to `mix`.
+* [#1595](https://github.com/KronicDeth/intellij-elixir/pull/1595) - [@KronicDeth](https://github.com/KronicDeth)
+  * Add OTP 22 and 23 opcodes to Code BEAM Chunk Viewer
+    * `put_tuple/2`
+    * `bs_get_tail/3`
+    * `bs_start_match3/4`
+    * `bs_get_position/3`
+    * `bs_set_position/2`
+    * `swap/2`
 
 ## v11.1.0
 ### Enhancements

--- a/resources/META-INF/changelog.html
+++ b/resources/META-INF/changelog.html
@@ -20,6 +20,16 @@
       <li>
         Fix IEx Mix Run/Debug Configuration for <code>asdf</code> by using absolute path to <code>mix</code>.
       </li>
+      <li>Add OTP 22 and 23 opcodes to Code BEAM Chunk Viewer
+        <ul>
+          <li><code>put_tuple/2</code></li>
+          <li><code>bs_get_tail/3</code></li>
+          <li><code>bs_start_match3/4</code></li>
+          <li><code>bs_get_position/3</code></li>
+          <li><code>bs_set_position/2</code></li>
+          <li><code>swap/2</code></li>
+        </ul>
+      </li>
     </ul>
   </li>
 </ul>

--- a/src/org/elixir_lang/beam/chunk/code/operation/Code.kt
+++ b/src/org/elixir_lang/beam/chunk/code/operation/Code.kt
@@ -380,7 +380,7 @@ enum class Code(val number: Int, val function: String, val arguments: Array<Argu
     SET_TUPLE_ELEMENT(
             67,
             "set_tuple_element",
-            arrayOf(Argument("new_element"), TUPLE, Argument("position"))
+            arrayOf(Argument("new_element"), TUPLE, POSITION)
     ),
 
     //
@@ -769,7 +769,36 @@ enum class Code(val number: Int, val function: String, val arguments: Array<Argu
     // @spec get_tl  Source Tail
     // @doc  Get the tail (or cdr) part of a list (a cons cell) from Source and
     //       put it into the register Tail.
-    GET_TL(163, "get_tl", arrayOf(SOURCE, Argument("tail")));
+    GET_TL(163, "get_tl", arrayOf(SOURCE, Argument("tail"))),
+
+    // OTP 22
+
+    // @spec put_tuple2  Destination Elements
+    // @doc  Build a tuple with the elements in the list Elements and put it
+    //       put into register Destination.
+    PUT_TUPLE2(164, "put_tuple2", arrayOf(DESTINATION, Argument("elements"))),
+
+    // @spec bs_get_tail Ctx Dst Live
+    // @doc  Sets Dst to the tail of Ctx at the current position
+    BS_GET_TAIL(165, "bs_get_tail", arrayOf(CONTEXT, DESTINATION, LIVE_X_REGISTER_COUNT)),
+
+    // @spec bs_start_match3 Fail Bin Live Dst
+    // @doc  Starts a binary match sequence
+    BS_START_MATCH3(166, "bs_start_match3", arrayOf(FAIL_LABEL, Argument("binary"), LIVE_X_REGISTER_COUNT, POSITION)),
+
+    // @spec bs_get_position Ctx Dst Live
+    // @doc  Sets Dst to the current position of Ctx
+    BS_GET_POSITION(167, "bs_get_position", arrayOf(CONTEXT, DESTINATION, LIVE_X_REGISTER_COUNT)),
+
+    // @spec bs_set_positon Ctx Pos
+    // @doc  Sets the current position of Ctx to Pos
+    BS_SET_POSITION(168, "bs_set_position", arrayOf(CONTEXT, POSITION)),
+
+    // OTP 23
+
+    // @spec swap Register1 Register2
+    // @doc  Swaps the contents of two registers.
+    SWAP(169, "swap", arrayOf(Argument("register1"), Argument("register2")));
 
     fun arity() = arguments.size
 }

--- a/src/org/elixir_lang/beam/chunk/code/operation/code/Argument.kt
+++ b/src/org/elixir_lang/beam/chunk/code/operation/code/Argument.kt
@@ -124,6 +124,7 @@ data class Argument(val name: String, val supportedOptions: Code.Options = Code.
 }
 
 val ARITY = Argument("arity", Options(Inline(integers = true, literals = false)))
+val CONTEXT = Argument("context")
 val DESTINATION = Argument("destination")
 val DEALLOCATE_WORDS_OF_STACK = Argument("deallocate_words_of_stack", Options(Inline(integers = true)))
 val FAIL_LABEL = Argument("fail_label", Options(Inline(labels = true)))
@@ -132,6 +133,7 @@ val IMPORT = Argument("import", Options(Inline(imports = true, integers = true, 
 val LABEL_ARGUMENT = Argument("label", Options(Inline(labels = true)))
 val LIVE_X_REGISTER_COUNT = Argument("live_x_register_count", Options(Inline(integers = true, literals = false)))
 val MATCH_STATE = Argument("match_state")
+val POSITION = Argument("position")
 val SIZE = Argument("size")
 val SOURCE = Argument("source", Options(Inline(atoms = true, integers = false, literals = true)))
 val TUPLE = Argument("tuple")


### PR DESCRIPTION
Fixes #1593

# Changelog
## Enhancements
* Add OTP 22 and 23 opcodes to Code BEAM Chunk Viewer
  * `put_tuple/2`
  * `bs_get_tail/3`
  * `bs_start_match3/4`
  * `bs_get_position/3`
  * `bs_set_position/2`
  * `swap/2`