### PR TITLE
Fix "Unknown Elixir version" in settings

### DIFF
--- a/src/org/elixir_lang/sdk/ProcessOutput.java
+++ b/src/org/elixir_lang/sdk/ProcessOutput.java
@@ -92,7 +92,7 @@ public class ProcessOutput {
 
   @NotNull
   public static com.intellij.execution.process.ProcessOutput execute(@NotNull GeneralCommandLine cmd, int timeout) throws ExecutionException {
-    CapturingProcessHandler processHandler = new CapturingProcessHandler(cmd.createProcess());
+    CapturingProcessHandler processHandler = new CapturingProcessHandler(cmd);
     return timeout < 0 ? processHandler.runProcess() : processHandler.runProcess(timeout);
   }
 


### PR DESCRIPTION
When I setup the Elixir SDK, I get Unknown Elixir version.
The idea.log says:

> java.lang.IllegalArgumentException: Must specify non-empty 'commandLine' parameter
> 	at com.intellij.execution.process.BaseProcessHandler.<init>(BaseProcessHandler.java:34)
> 	at com.intellij.execution.process.BaseOSProcessHandler.<init>(BaseOSProcessHandler.java:32)
> 	at com.intellij.execution.process.OSProcessHandler.<init>(OSProcessHandler.java:151)
> 	at com.intellij.execution.process.CapturingProcessHandler.<init>(CapturingProcessHandler.java:35)
> 	at com.intellij.execution.process.CapturingProcessHandler.<init>(CapturingProcessHandler.java:28)
> 	at org.elixir_lang.sdk.ProcessOutput.execute(ProcessOutput.java:95)
> 	at org.elixir_lang.sdk.ProcessOutput.getProcessOutput(ProcessOutput.java:85)
> 	at org.elixir_lang.sdk.ProcessOutput.transformStdoutLine(ProcessOutput.java:61)
> 	at org.elixir_lang.sdk.elixir.Type.detectSdkVersion(Type.java:470)

This is similar to this issue: https://github.com/ignatov/intellij-erlang/issues/728
which was resolved here:
https://github.com/ignatov/intellij-erlang/commit/9b82c755379257b19adfae14be3318526db5574c
So I guess that this fix works here too.