### PR TITLE
Fix Icon issue for IntelliJ 2020.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,7 @@
 name: Test
 
 on:
-  push:
+  pull_request:
     branches-ignore:
       - master
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -215,6 +215,8 @@
   * Treat `.leex` files as `.eex` files, so same features apply to both.
 * [#1735](https://github.com/KronicDeth/intellij-elixir/pull/1735) - [@KronciDeth](https://github.com/KronicDeth)
   * Switch build to GitHub Actions.
+* [#1738](https://github.com/KronicDeth/intellij-elixir/pull/1738) - [@Koziolek](https://github.com/Koziolek)
+  * Update build to IntelliJ IDEA 2020.1
 
 ### Bug Fixes
 * [#1646](https://github.com/KronicDeth/intellij-elixir/pull/1646) - [@seanwash](https://github.com/seanwash)
@@ -225,6 +227,12 @@
   * Update `README.md` about information for Goland IDE since has been released for awhile and no longer only an EAP.
 * [#1735](https://github.com/KronicDeth/intellij-elixir/pull/1735) - [@KronciDeth](https://github.com/KronicDeth)
   * Restore canary [builds being published to JetBrains Marketplace](https://plugins.jetbrains.com/plugin/7522-elixir/versions).
+* [#1738](https://github.com/KronicDeth/intellij-elixir/pull/1738) - [@Koziolek](https://github.com/Koziolek)
+  * JetBrains IDEs 2020.1 compatibility
+    * Change obsolete references to `AllocIcons` in `Icons` to new ones in `AlllIcons` that are recommended in documentation.
+    * Update to `@NotNull` annotation on `PsiElementVisitor`
+      * `DepGatherer`
+      * `QuotableImpl.quote`
 
 ## v11.5.0
 ### Enhancements

--- a/build.gradle
+++ b/build.gradle
@@ -60,7 +60,9 @@ allprojects {
   intellij {
     def intellij_erlang_version
 
-    if (ideaVersion.startsWith("2019.2")) {
+    if (ideaVersion.startsWith("2020.1")) {
+      intellij_erlang_version = "0.11.1059"
+    } else if (ideaVersion.startsWith("2019.2")) {
       intellij_erlang_version = "0.11.1008"
     } else if (ideaVersion.startsWith("2019.1")) {
       intellij_erlang_version = "0.11.1004"

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,8 +2,8 @@
 # https://www.jetbrains.com/intellij-repository/releases
 # https://www.jetbrains.com/intellij-repository/snapshots
 
-baseVersion = 11.6.0
-ideaVersion = 2019.2.2
+baseVersion = 11.6.1
+ideaVersion = 2020.1
 javaVersion = 1.8
 javaTargetVersion = 1.8
 sources = true

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 # https://www.jetbrains.com/intellij-repository/releases
 # https://www.jetbrains.com/intellij-repository/snapshots
 
-baseVersion = 11.6.1
+baseVersion = 11.6.0
 ideaVersion = 2020.1
 javaVersion = 1.8
 javaTargetVersion = 1.8

--- a/resources/META-INF/changelog.html
+++ b/resources/META-INF/changelog.html
@@ -7,6 +7,7 @@
     <ul>
       <li>Treat <code>.leex</code> files as <code>.eex</code> files, so same features apply to both.</li>
       <li>Switch build to GitHub Actions</li>
+      <li>Update build to IntelliJ IDEA 2020.1</li>
     </ul>
   </li>
   <li>
@@ -29,6 +30,20 @@
         <a href="https://plugins.jetbrains.com/plugin/7522-elixir/versions">
           builds being published to JetBrains Marketplace
         </a>.
+      </li>
+      <li>JetBrains IDEs 2020.1 compatibility
+        <ul>
+          <li>
+            Change obsolete references to <code>AllocIcons</code> in <code>Icons</code> to new ones in
+            <code>AlllIcons</code> that are recommended in documentation.
+          </li>
+          <li>Update to <code>@NotNull</code> annotation on <code>PsiElementVisitor</code>
+            <ul>
+              <li><code>DepGatherer</code></li>
+              <li><code>QuotableImpl.quote</code></li>
+            </ul>
+          </li>
+        </ul>
       </li>
     </ul>
   </li>

--- a/src/org/elixir_lang/Icons.kt
+++ b/src/org/elixir_lang/Icons.kt
@@ -28,7 +28,7 @@ object Icons {
         @JvmField
         val COMPILE = AllIcons.Actions.Compile
         @JvmField
-        val RUN = AllIcons.General.Run
+        val RUN = AllIcons.RunConfigurations.TestState.Run
 
         @JvmStatic
         fun from(time: Timed.Time): Icon {
@@ -77,7 +77,7 @@ object Icons {
     @JvmField
     val CALL_DEFINITION_CLAUSE: Icon = RowIconFactory.create(CALL_DEFINITION, PlatformIcons.PACKAGE_LOCAL_ICON)
     @JvmField
-    val DELEGATION: Icon = RowIconFactory.create(AllIcons.General.Run, PlatformIcons.PACKAGE_LOCAL_ICON)
+    val DELEGATION: Icon = RowIconFactory.create(AllIcons.RunConfigurations.TestState.Run, PlatformIcons.PACKAGE_LOCAL_ICON)
     @JvmField
     val EXCEPTION = PlatformIcons.EXCEPTION_CLASS_ICON
     @JvmField
@@ -108,7 +108,7 @@ object Icons {
 
     // it is the unknown that is only a question mark
     @JvmField
-    val UNKNOWN = AllIcons.RunConfigurations.Unknown
+    val UNKNOWN =  AllIcons.Actions.Help
 
     @JvmField
     val VARIABLE = AllIcons.Nodes.Variable

--- a/src/org/elixir_lang/debugger/StackFrame.kt
+++ b/src/org/elixir_lang/debugger/StackFrame.kt
@@ -60,7 +60,7 @@ class StackFrame(private val process: Process, private val pid: OtpErlangPid, pr
         val title = "$elixirModuleName.${traceElement.function}/${traceElement.arguments.size}$lineSuffix"
 
         component.append(title, SimpleTextAttributes.REGULAR_ATTRIBUTES)
-        component.setIcon(AllIcons.Debugger.StackFrame)
+        component.setIcon(AllIcons.Debugger.Frame)
     }
 
     override fun computeChildren(node: XCompositeNode) {

--- a/src/org/elixir_lang/mix/DepGatherer.kt
+++ b/src/org/elixir_lang/mix/DepGatherer.kt
@@ -19,7 +19,7 @@ import org.elixir_lang.psi.impl.keywordValue
 import org.elixir_lang.psi.impl.stripAccessExpression
 
 class DepGatherer : DepGatherer() {
-    override fun visitFile(file: PsiFile?) {
+    override fun visitFile(file: PsiFile) {
         if (file is ElixirFile) {
             runReadAction {
                 file.acceptChildren(this)
@@ -27,7 +27,7 @@ class DepGatherer : DepGatherer() {
         }
     }
 
-    override fun visitElement(element: PsiElement?) {
+    override fun visitElement(element: PsiElement) {
         if (element is Call && org.elixir_lang.structure_view.element.modular.Module.`is`(element)) {
             val childCalls = element.macroChildCalls()
 

--- a/src/org/elixir_lang/mix/project/DirectoryConfigurator.kt
+++ b/src/org/elixir_lang/mix/project/DirectoryConfigurator.kt
@@ -17,7 +17,7 @@ import com.intellij.openapi.roots.ModuleRootModificationUtil
 import com.intellij.openapi.util.Ref
 import com.intellij.openapi.util.io.FileUtil
 import com.intellij.openapi.vfs.VirtualFile
-//import com.intellij.platform.PlatformProjectOpenProcessor.runDirectoryProjectConfigurators
+import com.intellij.platform.PlatformProjectOpenProcessor.Companion.runDirectoryProjectConfigurators
 import com.intellij.platform.ProjectBaseDirectory
 import com.intellij.projectImport.ProjectAttachProcessor
 import com.intellij.util.PlatformUtils
@@ -102,7 +102,7 @@ class DirectoryConfigurator : com.intellij.platform.DirectoryProjectConfigurator
 
             projectManager.newProject(otpApp.name, otpApp.root.path, false, false)?.let { project ->
                 ProjectBaseDirectory.getInstance(project).baseDir = otpApp.root
-//                runDirectoryProjectConfigurators(otpApp.root, project)
+                runDirectoryProjectConfigurators(Paths.get(otpApp.root.path), project, false)
 
                 saveSettings(project)
 

--- a/src/org/elixir_lang/mix/project/DirectoryConfigurator.kt
+++ b/src/org/elixir_lang/mix/project/DirectoryConfigurator.kt
@@ -17,7 +17,7 @@ import com.intellij.openapi.roots.ModuleRootModificationUtil
 import com.intellij.openapi.util.Ref
 import com.intellij.openapi.util.io.FileUtil
 import com.intellij.openapi.vfs.VirtualFile
-import com.intellij.platform.PlatformProjectOpenProcessor.runDirectoryProjectConfigurators
+//import com.intellij.platform.PlatformProjectOpenProcessor.runDirectoryProjectConfigurators
 import com.intellij.platform.ProjectBaseDirectory
 import com.intellij.projectImport.ProjectAttachProcessor
 import com.intellij.util.PlatformUtils
@@ -37,7 +37,7 @@ class DirectoryConfigurator : com.intellij.platform.DirectoryProjectConfigurator
         var foundOtpApps: List<OtpApp> = emptyList()
 
         ProgressManager.getInstance().run(object : Task.Modal(project, "Scanning Mix Projects", true) {
-            override fun run(indicator: com.intellij.openapi.progress.ProgressIndicator) {
+            override fun run(indicator: ProgressIndicator) {
                 foundOtpApps = org.elixir_lang.mix.Project.findOtpApps(baseDir, indicator)
             }
         })
@@ -102,7 +102,7 @@ class DirectoryConfigurator : com.intellij.platform.DirectoryProjectConfigurator
 
             projectManager.newProject(otpApp.name, otpApp.root.path, false, false)?.let { project ->
                 ProjectBaseDirectory.getInstance(project).baseDir = otpApp.root
-                runDirectoryProjectConfigurators(otpApp.root, project)
+//                runDirectoryProjectConfigurators(otpApp.root, project)
 
                 saveSettings(project)
 

--- a/src/org/elixir_lang/psi/impl/QuotableImpl.kt
+++ b/src/org/elixir_lang/psi/impl/QuotableImpl.kt
@@ -1370,7 +1370,7 @@ object QuotableImpl {
 
         file.acceptChildren(
                 object : PsiElementVisitor() {
-                    override fun visitElement(element: PsiElement?) {
+                    override fun visitElement(element: PsiElement) {
                         if (element is Quotable) {
                             visitQuotable((element as Quotable?)!!)
                         } else if (element != null && !element.isUnquoted()) {

--- a/src/org/elixir_lang/rebar3/DepGatherer.kt
+++ b/src/org/elixir_lang/rebar3/DepGatherer.kt
@@ -9,7 +9,7 @@ import org.elixir_lang.package_manager.DepGatherer
 import org.intellij.erlang.psi.*
 
 class DepGatherer : DepGatherer() {
-    override fun visitFile(file: PsiFile?) {
+    override fun visitFile(file: PsiFile) {
         if (file is ErlangFile) {
             runReadAction {
                 file.acceptChildren(this)


### PR DESCRIPTION
Change old references to new that are recommended by documentation. 



Happy Easter Eggs

# Changelog
## Enhancements
* Update build to IntelliJ IDEA 2020.1

## Bug Fixes
* JetBrains IDEs 2020.1 compatibility
  * Change obsolete references to `AllocIcons` in `Icons` to new ones in `AlllIcons` that are recommended in documentation.
  * Update to `@NotNull` annotation on `PsiElementVisitor`
    * `DepGatherer`
    * `QuotableImpl.quote`