### PR TITLE
Get ProjectImportProvider builder in doGetBuilder instead of constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -235,6 +235,20 @@
       * `QuotableImpl.quote`
 * [#1745](https://github.com/KronicDeth/intellij-elixir/pull/1745) - [@KronciDeth](https://github.com/KronicDeth)
   * Fix tests for IDEA 2020.1.
+* [#1753](https://github.com/KronicDeth/intellij-elixir/pull/1753) - [@KronciDeth](https://github.com/KronicDeth)
+  * Get `ProjectImportProvider` builder in `doGetBuilder` instead of constructor.
+  
+    Fixes use of deprecated constructor dependency injection that is incompatible with dynamic, injectable plugins in 2020.1.
+  
+    ```
+    com.intellij.diagnostic.PluginException: getComponentAdapterOfType is
+    used to get org.elixir_lang.mix.project._import.Builder(
+      requestorClass=org.elixir_lang.mix.project._import.Provider,
+      requestorConstructor=protected org.elixir_lang.mix.project._import.Provider(org.elixir_lang.mix.project._import.Builder)
+    ).
+    
+    Probably constructor should be marked as NonInjectable. [Plugin: org.elixir_lang]
+    ```
 
 ## v11.5.0
 ### Enhancements

--- a/resources/META-INF/changelog.html
+++ b/resources/META-INF/changelog.html
@@ -46,6 +46,18 @@
         </ul>
       </li>
       <li>Fix tests for IDEA 2020.1.</li>
+      <li>
+        <p>Get <code>ProjectImportProvider</code> builder in <code>doGetBuilder</code> instead of constructor.</p>
+        <p>Fixes use of deprecated constructor dependency injection that is incompatible with dynamic, injectable plugins in 2020.1.</p>
+        <pre><code>com.intellij.diagnostic.PluginException: getComponentAdapterOfType is
+used to get org.elixir_lang.mix.project._import.Builder(
+  requestorClass=org.elixir_lang.mix.project._import.Provider,
+  requestorConstructor=protected org.elixir_lang.mix.project._import.Provider(org.elixir_lang.mix.project._import.Builder)
+).
+
+Probably constructor should be marked as NonInjectable. [Plugin: org.elixir_lang]
+</code></pre>
+      </li>
     </ul>
   </li>
 </ul>

--- a/src/org/elixir_lang/mix/project/_import/Provider.java
+++ b/src/org/elixir_lang/mix/project/_import/Provider.java
@@ -4,6 +4,7 @@ import com.intellij.ide.util.projectWizard.ModuleWizardStep;
 import com.intellij.ide.util.projectWizard.ProjectJdkForModuleStep;
 import com.intellij.ide.util.projectWizard.WizardContext;
 import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.projectImport.ProjectImportBuilder;
 import com.intellij.projectImport.ProjectImportProvider;
 import org.elixir_lang.mix.project._import.step.Root;
 import org.elixir_lang.mix.project._import.step.SelectOtpApps;
@@ -11,14 +12,7 @@ import org.elixir_lang.sdk.elixir.Type;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-/**
- * Created by zyuyou on 15/7/1.
- */
 public class Provider extends ProjectImportProvider {
-  protected Provider(@NotNull Builder builder) {
-    super(builder);
-  }
-
   @Override
   public ModuleWizardStep[] createSteps(@NotNull WizardContext context){
     return new ModuleWizardStep[]{
@@ -26,6 +20,11 @@ public class Provider extends ProjectImportProvider {
         new Root(context),
         new SelectOtpApps(context)
     };
+  }
+
+  @Override
+  protected ProjectImportBuilder doGetBuilder() {
+    return ProjectImportBuilder.EXTENSIONS_POINT_NAME.findExtensionOrFail(Builder.class);
   }
 
   @Override


### PR DESCRIPTION
Fixes #1634

# Changelog
## Bug Fixes
* Get `ProjectImportProvider` builder in `doGetBuilder` instead of constructor.

  Fixes use of deprecated constructor dependency injection that is incompatible with dynamic, injectable plugins in 2020.1.

  ```
  com.intellij.diagnostic.PluginException: getComponentAdapterOfType is
  used to get org.elixir_lang.mix.project._import.Builder(
    requestorClass=org.elixir_lang.mix.project._import.Provider,
    requestorConstructor=protected org.elixir_lang.mix.project._import.Provider(org.elixir_lang.mix.project._import.Builder)
  ).
  
  Probably constructor should be marked as NonInjectable. [Plugin: org.elixir_lang]
  ```