### PR TITLE
Only require at least instead of exact number of children

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -215,6 +215,8 @@
 ### Bug Fixes
 * [#1762](https://github.com/KronicDeth/intellij-elixir/pull/1762) - [@KronicDeth](https://github.com/KronicDeth)
   * Support diffs in pattern matching added in Elixir `1.10.0` in the ExUnit formatter.  Ports [elixir-lang/elixir@98c6bba436cc4833363295e5fedd3f819504d79d](https://github.com/elixir-lang/elixir/commit/98c6bba436cc4833363295e5fedd3f819504d79d).
+* [#1773](https://github.com/KronicDeth/intellij-elixir/pull/1773) - [@KronicDeth](https://github.com/KronicDeth)
+  * Only require at least the number of children to safely get a specific child instead of exact number to allow getting prefix children when there are grammatical errors.
 
 ## v11.6.0
 ### Enhancements

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 # https://www.jetbrains.com/intellij-repository/releases
 # https://www.jetbrains.com/intellij-repository/snapshots
 
-baseVersion = 11.6.0
+baseVersion = 11.6.1
 ideaVersion = 2020.1
 javaVersion = 1.8
 javaTargetVersion = 1.8

--- a/resources/META-INF/changelog.html
+++ b/resources/META-INF/changelog.html
@@ -11,6 +11,10 @@
           elixir-lang/elixir@<tt>98c6bba</tt>
         </a>.
       </li>
+      <li>
+        Only require at least the number of children to safely get a specific child instead of exact number to allow
+        getting prefix children when there are grammatical errors.
+      </li>
     </ul>
   </li>
 </ul>

--- a/src/org/elixir_lang/psi/impl/QuotableKeywordPairImpl.kt
+++ b/src/org/elixir_lang/psi/impl/QuotableKeywordPairImpl.kt
@@ -33,7 +33,7 @@ object QuotableKeywordPairImpl {
     fun getKeywordValue(keywordPair: ElixirKeywordPair): Quotable {
         val children = keywordPair.children
 
-        assert(children.size == 2)
+        assert(children.size >= 2)
 
         return children[1] as Quotable
     }

--- a/src/org/elixir_lang/psi/impl/QuotableKeywordPairImpl.kt
+++ b/src/org/elixir_lang/psi/impl/QuotableKeywordPairImpl.kt
@@ -42,7 +42,7 @@ object QuotableKeywordPairImpl {
     fun getKeywordValue(noParenthesesKeywordPair: ElixirNoParenthesesKeywordPair): Quotable {
         val children = noParenthesesKeywordPair.children
 
-        assert(children.size == 2)
+        assert(children.size >= 2)
 
         return children[1] as Quotable
     }

--- a/src/org/elixir_lang/reference/module/UnaliasedName.kt
+++ b/src/org/elixir_lang/reference/module/UnaliasedName.kt
@@ -32,7 +32,7 @@ object UnaliasedName {
                 is ElixirAccessExpression -> {
                     val children = element.children
 
-                    assert(children.size == 1)
+                    assert(children.size >= 1)
 
                     down(children[0])
                 }


### PR DESCRIPTION
Fixes #1611

# Changelog
## Bug Fixes
* Only require at least the number of children to safely get a specific child instead of exact number to allow getting prefix children when there are grammatical errors.