### PR TITLE
Use default formatter for EEx files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -224,6 +224,8 @@
     Previously, unchecking Show Method Separator would still show the method separator if it was the module attributes (such as `@doc` and `@spec`) associated with the call definition (`def`, `defp`, `defmacro`, or `defmacrop`) and only disabled the ones directly above the call definition.  This is fixed by checking if method separators are enabled in `getLineMarkerInfo(PsiElement)` instead of the specialized `getLineMarkerInfo(Call)`, so that the check happens for both module attributes and call definitions.
 * [#1786](https://github.com/KronicDeth/intellij-elixir/pull/1786) - [@odk211](https://github.com/odk211)
   * Remove "Unresolved module attribute" error annotation because module attributes cannot be resolved through `use` yet, so current annotation is a false positive in those cases.
+* [#1801](https://github.com/KronicDeth/intellij-elixir/pull/1801) - [@niknetniko](https://github.com/niknetniko)
+  * Use `SimpleTemplateLanguageFormattingModelBuilder` for EEx files, so that the `TemplateDataLanguage` (i.e. `html` when the extension is `.html.eex`) formatter is used instead of the Elixir formatter.
 
 ## v11.7.0
 ### Enhancements

--- a/resources/META-INF/changelog.html
+++ b/resources/META-INF/changelog.html
@@ -20,6 +20,11 @@
         Remove "Unresolved module attribute" error annotation because module attributes cannot be resolved through
         <code>use</code> yet, so current annotation is a false positive in those cases.
       </li>
+      <li>
+        Use <code>SimpleTemplateLanguageFormattingModelBuilder</code> for EEx files, so that the
+        <code>TemplateDataLanguage</code> (i.e. <code>html</code> when the extension is <code>.html.eex</code>)
+        formatter is used instead of the Elixir formatter.
+      </li>
     </ul>
   </li>
 </ul>

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -171,6 +171,7 @@
     <!-- formatting -->
     <codeStyleSettingsProvider implementation="org.elixir_lang.formatter.settings.CodeStyleSettingsProvider"/>
     <lang.formatter language="Elixir" implementationClass="org.elixir_lang.formatting.ModelBuilder"/>
+    <lang.formatter language="EEx" implementationClass="com.intellij.psi.templateLanguages.SimpleTemplateLanguageFormattingModelBuilder"/>
     <langCodeStyleSettingsProvider implementation="org.elixir_lang.formatter.settings.LanguageCodeStyleSettingsProvider"/>
 
     <lang.parserDefinition language="Elixir" implementationClass="org.elixir_lang.ElixirParserDefinition"/>


### PR DESCRIPTION
This PR provides basic support for formatting EEx files.
By basic, I mean that the underlying language is formatted, but the Elixir constructs are not taken into account.

For example, following snippet of HTML:
```eex
<html>
<body>
<div>
  <%= if true do %>
    <p>Hallo</p>
    <% end %>
  <p>Test</p>
</div></body></html>
```

will be formatted as:

```eex
<html>
<body>
<div>
    <%= if true do %>
    <p>Hallo</p>
    <% end %>
    <p>Test</p>
</div>
</body>
</html>
```

As you can see, the content inside the `if` was not intented. I haven't found an easy way to support this, short of writing a much more complex formatter. As such, I think enabling this will not result in perfect formatting, but it is better then the current situation. Relevant issue is #1594.