### PR TITLE
Adds Run icon in gutter next to ExUnit tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -221,6 +221,8 @@
 ### Enhancements
 * [#1792](https://github.com/KronicDeth/intellij-elixir/pull/1792) - [@marcindawidziuk](https://github.com/marcindawidziuk)
   * Quick documentation (F1/Ctrl+Q)
+* [#1807](https://github.com/KronicDeth/intellij-elixir/pull/1807) - [@niknetniko](https://github.com/niknetniko)
+  * Run Icons in gutter next to ExUnit tests.  The icon changes to the state of the test: green for passing and red for failing. 
 
 ### Bug Fixes
 * [#1788](https://github.com/KronicDeth/intellij-elixir/pull/1788) - [@KronicDeth](https://github.com/KronicDeth)

--- a/resources/META-INF/changelog.html
+++ b/resources/META-INF/changelog.html
@@ -6,6 +6,10 @@
     <p>Enhancements</p>
     <ul>
       <li>Quick documentation (F1/Ctrl+Q)</li>
+      <li>
+        Run Icons in gutter next to ExUnit tests.  The icon changes to the state of the test: green for passing and
+        red for failing.
+      </li>
     </ul>
   </li>
   <li>

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -174,6 +174,9 @@
     <lang.formatter language="EEx" implementationClass="com.intellij.psi.templateLanguages.SimpleTemplateLanguageFormattingModelBuilder"/>
     <langCodeStyleSettingsProvider implementation="org.elixir_lang.formatter.settings.LanguageCodeStyleSettingsProvider"/>
 
+    <!-- test -->
+    <runLineMarkerContributor language="Elixir" implementationClass="org.elixir_lang.exunit.ExUnitLineMarkerProvider"/>
+
     <lang.parserDefinition language="Elixir" implementationClass="org.elixir_lang.ElixirParserDefinition"/>
     <lang.psiStructureViewFactory language="Elixir" implementationClass="org.elixir_lang.structure_view.Factory"/>
     <lang.quoteHandler language="Elixir" implementationClass="org.elixir_lang.QuoteHandler"/>

--- a/src/org/elixir_lang/exunit/TestLineMarkerProvider.kt
+++ b/src/org/elixir_lang/exunit/TestLineMarkerProvider.kt
@@ -1,0 +1,75 @@
+package org.elixir_lang.exunit
+
+import com.intellij.execution.TestStateStorage
+import com.intellij.execution.lineMarker.RunLineMarkerContributor
+import com.intellij.openapi.roots.ProjectRootManager
+import com.intellij.psi.PsiElement
+import com.intellij.psi.impl.source.tree.LeafPsiElement
+import org.codehaus.plexus.interpolation.os.Os
+import org.elixir_lang.exunit.configuration.SUFFIX
+import org.elixir_lang.exunit.configuration.lineNumber
+import org.elixir_lang.mix.TestFinder
+import org.elixir_lang.psi.ElixirFile
+import org.elixir_lang.psi.ElixirUnmatchedQualifiedParenthesesCall
+import org.elixir_lang.psi.call.Call
+import org.elixir_lang.psi.operation.Match
+
+/**
+ * Provides the gutter "run" icons for tests.
+ */
+class ExUnitLineMarkerProvider: RunLineMarkerContributor() {
+
+    override fun getInfo(element: PsiElement): Info? {
+
+        // Speed things up by only looking at files inside the test directory.
+        if (!isUnderTestSources(element)) {
+            return null
+        }
+
+        if (!TestFinder.isTestElement(element) || element !is LeafPsiElement) {
+            return null
+        }
+        
+        val parent = element.parent?.parent
+        
+        if (parent !is Call) {
+            return null
+        }
+        
+        // Assignment
+        if (parent.parent is Match) {
+            return null
+        }
+        
+        val functionElement = parent.firstChild
+        
+        if (functionElement != element.parent) {
+            return null
+        }
+        
+        val isClass = when (parent.functionName()) {
+            "test" -> false
+            "describe" -> true
+            "defmodule" -> true
+            "doctest" -> false
+            else -> null
+        } ?: return null
+
+        val number = lineNumber(element)
+        var url = "file://${element.containingFile.virtualFile.path}:${number}"
+        if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+            // In Elixir, the drive letter is lowercase for some reason.
+            val location = "file://".length
+            url = url.replaceRange(location, location + 1, url[location].toLowerCase().toString())
+        }
+        val state = TestStateStorage.getInstance(element.project)?.getState(url)
+        return withExecutorActions(getTestStateIcon(state, isClass))
+    }
+}
+
+fun isUnderTestSources(clazz: PsiElement): Boolean {
+    val psiFile = clazz.containingFile
+    val vFile = psiFile.virtualFile ?: return false
+    val isTest = psiFile is ElixirFile && psiFile.virtualFile.path.endsWith(SUFFIX)
+    return ProjectRootManager.getInstance(clazz.project).fileIndex.isInTestSourceContent(vFile) and isTest
+}

--- a/src/org/elixir_lang/exunit/configuration/Producer.kt
+++ b/src/org/elixir_lang/exunit/configuration/Producer.kt
@@ -28,7 +28,7 @@ class MixExUnitRunConfigurationProducer :
             } == true
 }
 
-private const val SUFFIX = "_test.exs"
+const val SUFFIX = "_test.exs"
 private const val UNKNOWN_LINE = -1
 
 private fun configurationName(file: PsiFileSystemItem,
@@ -71,7 +71,7 @@ private fun isConfigurationFromContextImpl(configuration: Configuration, psiElem
             contextConfiguration.workingDirectory == configuration.workingDirectory
 }
 
-private fun lineNumber(psiElement: PsiElement): Int {
+fun lineNumber(psiElement: PsiElement): Int {
     val containingFile = psiElement.containingFile
     val documentLineNumber = PsiDocumentManager
             .getInstance(containingFile.project)


### PR DESCRIPTION
- This PR adds the "run" icons in the gutter for tests:
![image](https://user-images.githubusercontent.com/1756811/89186921-c7af7280-d59c-11ea-9d1a-b9c57a938e58.png)

- There are also some small clean-ups in related code.

For the run icons:

- They use the existing run actions, same as when you right-click.
- They only appear of the file is a test file (suffix _test.exs and in a map marked as tests in the project structure)
- I have no idea how one should write a test for this stuff, so I didn't (I'm fairly new to Intellij SDK stuff)
- I hardcoded "test", "describe", "doctest" and "defmodule". I don't know if it would be better to dynamically determine these, but that would be fairly hard I think.

I have been using this some time in a personal fork and it seems to work pretty well.

Fixes #688.