### PR TITLE
Double escape \ in debugger file paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -224,6 +224,8 @@
 * [#1822](https://github.com/KronicDeth/intellij-elixir/pull/1822) - [@KronicDeth](https://github.com/KronicDeth)
   * Vendor JInterface 1.11 to support `BIG_CREATION` when debugging.
     The JInterface on Maven Central has stopped being updated because [the OTP Team didn't actually maintain it](https://bugs.erlang.org/browse/ERL-928?focusedCommentId=16521&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-16521), that was Basho, and Basho is gone now.  This version of JInterface, 1.11, is from Erlang 23.0.4 from Homebrew, but with the formula edited (`brew edit erlang`) to add `--with-java` and then built with `brew install erlang --build-from-source`.
+* [#1823](https://github.com/KronicDeth/intellij-elixir/pull/1823) - [@KronicDeth](https://github.com/KronicDeth)
+  * On Windows, the `file.path` to the debugger server files has `\`, but they aren't escaped.  Therefore, replace them with escaped version, `\\` to fix debugging on Windows, but leave Linux and macOS unaffected.
 
 ## v11.8.0
 ### Enhancements

--- a/resources/META-INF/changelog.html
+++ b/resources/META-INF/changelog.html
@@ -14,6 +14,11 @@
         Homebrew, but with the formula edited (<code>brew edit erlang</code>) to add <code>--with-java</code> and then
         built with <code>brew install erlang --build-from-source</code>.
       </li>
+      <li>
+        On Windows, the <code>file.path</code> to the debugger server files has <code>\</code>, but they aren't escaped.
+        Therefore, replace them with escaped version, <code>\\</code> to fix debugging on Windows, but leave Linux and
+        macOS unaffected.
+      </li>
     </ul>
   </li>
 </ul>

--- a/src/org/elixir_lang/debugger/Modules.kt
+++ b/src/org/elixir_lang/debugger/Modules.kt
@@ -32,7 +32,7 @@ object Modules {
     fun erlArgumentList(mix: Boolean = false): List<String> =
             listOf("-eval", "application:ensure_all_started(elixir)") +
                     copy(mix).flatMap { file ->
-                        listOf("-eval", "'Elixir.Code':require_file(<<\"${file.path}\">>)")
+                        listOf("-eval", "'Elixir.Code':require_file(<<\"${file.path.replace("\\", "\\\\")}\">>)")
                     } + if (mix) {
                 emptyList()
             } else {


### PR DESCRIPTION
Fixes #1347

# Changelog
## Bug Fixes
* On Windows, the `file.path` to the debugger server files has `\`, but they aren't escaped.  Therefore, replace them with escaped version, `\\` to fix debugging on Windows, but leave Linux and macOS unaffected.