### PR TITLE
Protect against IndexOutOfBounds from highlighterIterator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -261,7 +261,6 @@
     * Regenerate Parser for newer GrammarParser version.
     * Port elixir-lang/elixir@1e4e05ef78b3105065f0a313bd0e1e78b2aa973e
 
-
 ### Bug Fixes
 * [#1844](https://github.com/KronicDeth/intellij-elixir/pull/1844) - [@KronicDeth](https://github.com/KronicDeth)
   * Fix deprecation warnings for IntelliJ IDEA 2020.2
@@ -342,8 +341,8 @@
   * Heredoc with escapable newlines (#1843)
     Heredocs allow the final newline to be escaped so you can write a heredoc in the code, but have no newlines in the string term at runtime.
   * Fix terminators docs to show closing version and not opening version
-
-
+* [#1866](https://github.com/KronicDeth/intellij-elixir/pull/1866) - [@KronicDeth](https://github.com/KronicDeth)
+  * Protect against `IndexOutOfBounds` from `highlighterIterator` in `QuoteHandler`.
 
 ## v11.8.1
 ### Bug Fixes

--- a/resources/META-INF/changelog.html
+++ b/resources/META-INF/changelog.html
@@ -128,6 +128,10 @@
           <li>Convert <code>beam.assembly.ParserDefinition</code> to Kotlin</li>
         </ul>
       </li>
+      <li>
+        Protect against <code>IndexOutOfBounds</code> from <code>highlighterIterator</code> in
+        <code>QuoteHandler</code>.
+      </li>
     </ul>
   </li>
 </ul>

--- a/src/org/elixir_lang/QuoteHandler.java
+++ b/src/org/elixir_lang/QuoteHandler.java
@@ -125,12 +125,22 @@ public class QuoteHandler implements MultiCharQuoteHandler {
      */
     @Override
     public boolean isClosingQuote(HighlighterIterator highlighterIterator, int offset) {
-        boolean isClosingQuote = false;
+        IElementType tokenType;
 
-        if (CLOSING_QUOTES.contains(highlighterIterator.getTokenType())) {
+        try {
+            tokenType = highlighterIterator.getTokenType();
+        } catch (IndexOutOfBoundsException e) {
+            tokenType = null;
+        }
+
+        boolean isClosingQuote;
+
+        if (CLOSING_QUOTES.contains(tokenType)) {
             int start = highlighterIterator.getStart();
             int end = highlighterIterator.getEnd();
             isClosingQuote = end - start >= 1 && offset == end - 1;
+        } else {
+            isClosingQuote = false;
         }
 
         return isClosingQuote;
@@ -143,11 +153,21 @@ public class QuoteHandler implements MultiCharQuoteHandler {
 
     @Override
     public boolean isOpeningQuote(HighlighterIterator highlighterIterator, int offset) {
-        boolean isOpeningQuote = false;
+        IElementType tokenType;
 
-        if (OPENING_QUOTES.contains(highlighterIterator.getTokenType())){
+        try {
+            tokenType = highlighterIterator.getTokenType();
+        } catch (IndexOutOfBoundsException e) {
+            tokenType = null;
+        }
+
+        boolean isOpeningQuote;
+
+        if (OPENING_QUOTES.contains(tokenType)){
             int start = highlighterIterator.getStart();
             isOpeningQuote = offset == start;
+        } else {
+            isOpeningQuote = false;
         }
 
         return isOpeningQuote;


### PR DESCRIPTION
Fixes #1865

# Changelog
## Bug Fixes
* Protect against `IndexOutOfBounds` from `highlighterIterator` in `QuoteHandler`.