### PR TITLE
Fix missed references to DepsWatcher as project component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -241,6 +241,9 @@
       The docs from the `Docs` chunk may contain interpolation in the code samples or `#{` in regex examples, but these should not be treated as an interpolation start as the `Docs` format does not support interpolation.  Anything that looks like interpolation in the docs text was actually escaped in the original docs, so also escape it here by using `S"""`, which turns off interpolation.
     * Log an error if `Code` function can't be matched to decompiled source.
       Unlike the old `InvalidMirrorException`, this won't be an exception and the binary <-> decompile will still work for the other functions/macros in the file, so it will be a more graceful degradation.
+* [1878](https://github.com/KronicDeth/intellij-elixir/pull/1878) - [@KronicDeth](https://github.com/KronicDeth)
+  * Fix missed references to `DepsWatcher` as project component
+    `DepsWatcher` was converted to a Project Listener in #1844 to support installing the plugin from the Marketplace without reloading, but some references to `DepsWatcher` were still trying to get its instance for project using `project.getComponent()`, which would now return `null`.
 
 ## v11.9.0
 

--- a/resources/META-INF/changelog.html
+++ b/resources/META-INF/changelog.html
@@ -50,6 +50,14 @@
           </li>
         </ul>
       </li>
+      <li>
+        Fix missed references to <code>DepsWatcher</code> as project component<br>
+        <code>DepsWatcher</code> was converted to a Project Listener in
+        <a href="https://github.com/KronicDeth/intellij-elixir/pull/1844">#1844</a>
+        to support installing the plugin from the Marketplace without reloading, but some references to
+        <code>DepsWatcher</code> were still trying to get its instance for project using
+        <code>project.getComponent()</code>, which would now return <code>null</code>.
+      </li>
     </ul>
   </li>
 </ul>

--- a/src/org/elixir_lang/DepsWatcher.kt
+++ b/src/org/elixir_lang/DepsWatcher.kt
@@ -106,7 +106,7 @@ class DepsWatcher(val project: Project) : BulkFileListener {
             if (fileName == "_build" && isModuleContentRoot(parent, project)) {
                 ProgressManager.getInstance().run(object : Task.Backgroundable(project, "Syncing Libraries in _build", true) {
                     override fun run(indicator: ProgressIndicator) {
-                        syncLibraries(project, indicator)
+                        syncLibraries(indicator)
                     }
                 })
             } else {
@@ -114,7 +114,7 @@ class DepsWatcher(val project: Project) : BulkFileListener {
                     if (parent.name == "_build" && isModuleContentRoot(grandParent, project)) {
                         ProgressManager.getInstance().run(object : Task.Backgroundable(project, "Syncing Libraries in _build/$fileName", true) {
                             override fun run(indicator: ProgressIndicator) {
-                                syncLibraries(project, indicator)
+                                syncLibraries(indicator)
                             }
                         })
                     } else {
@@ -122,7 +122,7 @@ class DepsWatcher(val project: Project) : BulkFileListener {
                             if (fileName in arrayOf("consolidated", "lib") && grandParent.name == "_build" && isModuleContentRoot(greatGrandParent, project)) {
                                 ProgressManager.getInstance().run(object : Task.Backgroundable(project, "Syncing Libraries in _build/${parent.name}/$fileName", true) {
                                     override fun run(indicator: ProgressIndicator) {
-                                        syncLibraries(project, indicator)
+                                        syncLibraries(indicator)
                                     }
                                 })
                             } else if (fileName in SOURCE_NAMES && grandParent.name == "deps" && isModuleContentRoot(greatGrandParent, project)) {
@@ -168,7 +168,7 @@ class DepsWatcher(val project: Project) : BulkFileListener {
         }
     }
 
-    fun syncLibraries(project: Project, progressIndicator: ProgressIndicator) {
+    fun syncLibraries(progressIndicator: ProgressIndicator) {
         ProjectRootManager
                 .getInstance(project)
                 .contentRootsFromAllModules

--- a/src/org/elixir_lang/mix/Project.kt
+++ b/src/org/elixir_lang/mix/Project.kt
@@ -87,7 +87,7 @@ object Project {
 
                 ProgressManager.getInstance().run(object : Task.Modal(project, "Scanning dependencies for Libraries", true) {
                     override fun run(indicator: ProgressIndicator) {
-                        project.getComponent(DepsWatcher::class.java).syncLibraries(project, indicator)
+                        DepsWatcher(project).syncLibraries(indicator)
                     }
                 })
             }

--- a/src/org/elixir_lang/mix/Watcher.kt
+++ b/src/org/elixir_lang/mix/Watcher.kt
@@ -129,7 +129,7 @@ class Watcher(private val project: Project) : BulkFileListener {
         if (externalPaths.isNotEmpty()) {
             val libraryTable = LibraryTablesRegistrar.getInstance().getLibraryTable(project)
 
-            project.getComponent(DepsWatcher::class.java).syncLibraries(externalPaths, libraryTable, progressIndicator)
+            DepsWatcher(project).syncLibraries(externalPaths, libraryTable, progressIndicator)
         }
     }
 }

--- a/src/org/elixir_lang/mix/project/DirectoryConfigurator.kt
+++ b/src/org/elixir_lang/mix/project/DirectoryConfigurator.kt
@@ -63,7 +63,7 @@ class DirectoryConfigurator : com.intellij.platform.DirectoryProjectConfigurator
 
             ProgressManager.getInstance().run(object : Task.Modal(project, "Scanning dependencies for Libraries", true) {
                 override fun run(indicator: ProgressIndicator) {
-                    project.getComponent(DepsWatcher::class.java).syncLibraries(project, indicator)
+                    DepsWatcher(project).syncLibraries(indicator)
                 }
             })
         }


### PR DESCRIPTION
Fixes #1871

# Changelog
## Bug Fixes
* Fix missed references to `DepsWatcher` as project component
  `DepsWatcher` was converted to a Project Listener in #1844 to support installing the plugin from the Marketplace without reloading, but some references to `DepsWatcher` were still trying to get its instance for project using `project.getComponent()`, which would now return `null`.