### PR TITLE
Target Java 1.8 for JPS compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -244,6 +244,9 @@
 * [1878](https://github.com/KronicDeth/intellij-elixir/pull/1878) - [@KronicDeth](https://github.com/KronicDeth)
   * Fix missed references to `DepsWatcher` as project component
     `DepsWatcher` was converted to a Project Listener in #1844 to support installing the plugin from the Marketplace without reloading, but some references to `DepsWatcher` were still trying to get its instance for project using `project.getComponent()`, which would now return `null`.
+* [#1879](https://github.com/KronicDeth/intellij-elixir/pull/1879) - [@KronicDeth](https://github.com/KronicDeth)
+  * Target Java 1.8 for JPS compatibility.
+    JPS (JetBrains Project System) is the API used to allow External Builders, like `mix` to build projects.
 
 ## v11.9.0
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,8 +4,10 @@
 
 baseVersion = 11.9.1
 ideaVersion = 2020.2.2
-javaVersion = 1.9
-javaTargetVersion = 1.9
+# MUST stay at 1.8 for JPS (Build/Compile Project) compatibility even if JRE/JBR is newer
+javaVersion = 1.8
+# MUST stay at 1.8 for JPS (Build/Compile Project) compatibility even if JRE/JBR is newer
+javaTargetVersion = 1.8
 sources = true
 elixirVersion = 1.11.2
 publishChannels = canary

--- a/resources/META-INF/changelog.html
+++ b/resources/META-INF/changelog.html
@@ -58,6 +58,8 @@
         <code>DepsWatcher</code> were still trying to get its instance for project using
         <code>project.getComponent()</code>, which would now return <code>null</code>.
       </li>
+      <li>Target Java 1.8 for JPS compatibility<br>
+        JPS (JetBrains Project System) is the API used to allow External Builders, like <code>mix</code> to build projects.</li>
     </ul>
   </li>
 </ul>


### PR DESCRIPTION
Fixes #1879

# Changelog
## Bug Fixes
* Target Java 1.8 for JPS compatibility
  JPS (JetBrains Project System) is the API used to allow External Builders, like `mix` to build projects.