### PR TITLE
Fix capitalization of Docs @moduledoc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -250,11 +250,14 @@
 * [#1880](https://github.com/KronicDeth/intellij-elixir/pull/1880) - [@KronicDeth](https://github.com/KronicDeth)
   * Fix matching `unquote(ATOM)` call definitions to compiled function by using the argument to`unquote` when calculating the name of the call definition clause if possible.
     Needed to match anonymous function names that are `unquote`d because they contain `/` to separate the outer function name from the anonymous function naming convention.
-* Don't use `Docs` signature for `MacroNameArity` that is an operator or `unquote`d
-  The signatures for operators and `unquote`d don't produce valid code that can be parsed.
-*  Don't use signatures for `__struct__` functions.
-   The signatures for the `__struct__` functions are like `%Module{}`, but that's not parseable, so bypass the signatures with a specialized `SignatureOverride` decompiler that matches the actual code in `defstruct`.
-* Don't indent empty lines from `Docs` for `@moduledoc` and `@doc` to match the formatter output. 
+  * Don't use `Docs` signature for `MacroNameArity` that is an operator or `unquote`d
+    The signatures for operators and `unquote`d don't produce valid code that can be parsed.
+  *  Don't use signatures for `__struct__` functions.
+     The signatures for the `__struct__` functions are like `%Module{}`, but that's not parseable, so bypass the signatures with a specialized `SignatureOverride` decompiler that matches the actual code in `defstruct`.
+  * Don't indent empty lines from `Docs` for `@moduledoc` and `@doc` to match the formatter output. 
+* [#1881](https://github.com/KronicDeth/intellij-elixir/pull/1881) - [@KronicDeth](https://github.com/KronicDeth)
+  * Fix capitalization of `Docs` `@moduledoc`
+    `@moduleDoc` -> `@moduledoc`
 
 ## v11.9.0
 

--- a/resources/META-INF/changelog.html
+++ b/resources/META-INF/changelog.html
@@ -81,6 +81,10 @@
         Don't indent empty lines from <code>Docs</code> for <code>@moduledoc</code> and <code>@doc</code> to match the
         formatter output.
       </li>
+      <li>
+        Fix capitalization of <code>Docs</code> <code>@moduledoc</code><br>
+        <code>@moduleDoc</code> -&gt; <code>@moduledoc</code>
+      </li>
     </ul>
   </li>
 </ul>

--- a/src/org/elixir_lang/beam/Decompiler.java
+++ b/src/org/elixir_lang/beam/Decompiler.java
@@ -72,7 +72,7 @@ public class Decompiler implements BinaryFileDecompiler {
                                 : null;
 
                         if (moduleDocs != null){
-                            decompiled.append("  @moduleDoc \"\"\"\n");
+                            decompiled.append("  @moduledoc \"\"\"\n");
                             String indentedModuleDocs = Arrays.stream(moduleDocs.split("\n"))
                                     .map(line -> {
                                         if (line.isEmpty()) {

--- a/testData/org/elixir_lang/beam/decompiler/Docs/Elixir.Kernel.SpecialForms.ex
+++ b/testData/org/elixir_lang/beam/decompiler/Docs/Elixir.Kernel.SpecialForms.ex
@@ -1,6 +1,6 @@
 # Source code recreated from a .beam file by IntelliJ Elixir
 defmodule Kernel.SpecialForms do
-  @moduleDoc """
+  @moduledoc """
   Special forms are the basic building blocks of Elixir, and therefore
   cannot be overridden by the developer.
 

--- a/testData/org/elixir_lang/beam/decompiler/Docs/Elixir.Kernel.ex
+++ b/testData/org/elixir_lang/beam/decompiler/Docs/Elixir.Kernel.ex
@@ -1,6 +1,6 @@
 # Source code recreated from a .beam file by IntelliJ Elixir
 defmodule Kernel do
-  @moduleDoc """
+  @moduledoc """
   `Kernel` is Elixir's default environment.
 
   It mainly consists of:

--- a/tests/org/elixir_lang/beam/DecompilerTest.java
+++ b/tests/org/elixir_lang/beam/DecompilerTest.java
@@ -35,7 +35,7 @@ public class DecompilerTest extends LightCodeInsightTestCase {
 
         assertEquals("# Source code recreated from a .beam file by IntelliJ Elixir\n" +
                         "defmodule Bitwise do\n" +
-                        "  @moduleDoc \"\"\"\n" +
+                        "  @moduledoc \"\"\"\n" +
                         "  A set of functions that perform calculations on bits.\n" +
                         "\n" +
                         "  All bitwise functions work only on integers; otherwise an\n" +


### PR DESCRIPTION
# Changelog
## Bug Fixes
* Fix capitalization of `Docs` `@moduledoc`
  `@moduleDoc` -> `@moduledoc`