### PR TITLE
Fix associating HTML as DataTemplateLanguage for *.html.leex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -226,6 +226,17 @@
   * [Enhancements](#enhancements-61)
   * [Bug Fixes](#bug-fixes-67)
 
+## v11.10.0
+
+### Enhancements
+* [#1893](https://github.com/KronicDeth/intellij-elixir/pull/1893) - [@KronicDeth](https://github.com/KronicDeth)
+  * Simplify `onlyTemplateDateFileType`
+  
+### Bug Fixes
+* [#1893](https://github.com/KronicDeth/intellij-elixir/pull/1893) - [@KronicDeth](https://github.com/KronicDeth)
+  * Use `VirtualFile#fileType` instead of EEx Type::INSTANCE when looking up extensions.
+    Since LEEx file `Type` is a subclass of EEx's file `Type`, it calls `templateDataFileTypeSet` in EEx's `Type`, but `templateDataFileTypeSet` uses `INSTANCE` from EEx.  By using the `VirtualFile#fileType` instead, it will properly be EEx or LEEx based on the actual file extension and then it can be used to strip that off and find the DataTemplateLanguage, such as `HTMLLanguage` for `.html.leex`.
+
 ## v11.9.2
 
 ### Bug Fixes

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 # https://www.jetbrains.com/intellij-repository/releases
 # https://www.jetbrains.com/intellij-repository/snapshots
 
-baseVersion = 11.9.2
+baseVersion = 11.9.3
 ideaVersion = 2020.2.2
 # MUST stay at 1.8 for JPS (Build/Compile Project) compatibility even if JRE/JBR is newer
 javaVersion = 1.8

--- a/resources/META-INF/changelog.html
+++ b/resources/META-INF/changelog.html
@@ -1,5 +1,31 @@
 <html>
 <body>
+<h1>v11.10.0</h1>
+<ul>
+  <li>
+    <p>Enhancements</p>
+    <ul>
+      <li>Simplify <code>onlyTemplateDateFileType</code></li>
+    </ul>
+  </li>
+  <li>
+    <p>Bug Fixes</p>
+    <ul>
+      <li>
+        <p>
+          Use <code>VirtualFile#fileType</code> instead of EEx Type::INSTANCE when looking up extensions.
+        </p>
+        <p>
+          Since LEEx file <code>Type</code> is a subclass of EEx's file <code>Type</code>, it calls
+          <code>templateDataFileTypeSet</code> in EEx's <code>Type</code>, but <code>templateDataFileTypeSet</code> uses
+          <code>INSTANCE</code> from EEx.  By using the <code>VirtualFile#fileType</code> instead, it will properly be
+          EEx or LEEx based on the actual file extension and then it can be used to strip that off and find the
+          DataTemplateLanguage, such as <code>HTMLLanguage</code> for <code>.html.leex</code>.
+        </p>
+      </li>
+    </ul>
+  </li>
+</ul>
 <h1>v11.9.2</h1>
 <ul>
   <li>

--- a/src/org/elixir_lang/eex/file/Type.kt
+++ b/src/org/elixir_lang/eex/file/Type.kt
@@ -42,21 +42,17 @@ open class Type protected constructor(lang: Language? = org.elixir_lang.eex.Lang
         }
 
         @JvmStatic
-        fun onlyTemplateDataFileType(virtualFile: VirtualFile): Optional<FileType> {
-            val typeSet = templateDataFileTypeSet(virtualFile)
-            val optionalType: Optional<FileType>
-            optionalType = if (typeSet.size == 1) {
-                val type = Iterables.getOnlyElement(typeSet)
-                if (type === FileTypes.UNKNOWN) {
-                    Optional.empty()
-                } else {
-                    Optional.of(type)
-                }
-            } else {
-                Optional.empty()
-            }
-            return optionalType
-        }
+        fun onlyTemplateDataFileType(virtualFile: VirtualFile): Optional<FileType> =
+                templateDataFileTypeSet(virtualFile)
+                        .singleOrNull()
+                        ?.let { type ->
+                            if (type === FileTypes.UNKNOWN) {
+                                null
+                            } else {
+                                Optional.of(type)
+                            }
+                        }
+                        ?: Optional.empty()
     }
 
     init {

--- a/src/org/elixir_lang/eex/file/Type.kt
+++ b/src/org/elixir_lang/eex/file/Type.kt
@@ -29,7 +29,7 @@ open class Type protected constructor(lang: Language? = org.elixir_lang.eex.Lang
             val pathLength = path.length
             val fileTypeManager = FileTypeManager.getInstance()
             return fileTypeManager
-                    .getAssociations(INSTANCE)
+                    .getAssociations(virtualFile.fileType)
                     .stream()
                     .filter { obj: FileNameMatcher? -> ExtensionFileNameMatcher::class.java.isInstance(obj) }
                     .map { obj: FileNameMatcher? -> ExtensionFileNameMatcher::class.java.cast(obj) }


### PR DESCRIPTION
# Changelog
## Enhancements
* Simplify `onlyTemplateDateFileType`

## Bug Fixes
* Use `VirtualFile#fileType` instead of EEx Type::INSTANCE when looking up extensions.

  Since LEEx file `Type` is a subclass of EEx's file `Type`, it calls `templateDataFileTypeSet` in EEx's `Type`, but `templateDataFileTypeSet` uses `INSTANCE` from EEx.  By using the `VirtualFile#fileType` instead, it will properly be EEx or LEEx based on the actual file extension and then it can be used to strip that off and find the DataTemplateLanguage, such as `HTMLLanguage` for `.html.leex`.