### PR TITLE
Don't return null left or right infix operands in `Infix.primaryArguments`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,10 +18,10 @@ jobs:
       - name: Set up Elixir
         uses: actions/setup-elixir@v1
         with:
-          otp-version: 22.2
-          elixir-version: 1.7.4
+          otp-version: 23.1
+          elixir-version: 1.11.2
       - name: Export OTP_RELEASE
-        run: echo "OTP_RELEASE=22.2" >> $GITHUB_ENV
+        run: echo "OTP_RELEASE=23.1" >> $GITHUB_ENV
       - name: Export ERLANG_SDK_HOME
         run: echo "ERLANG_SDK_HOME=`erl -eval 'io:format("~s", [code:root_dir()]).' -noshell -run init stop`" >> $GITHUB_ENV
       - name: Grant execute permission for gradlew
@@ -40,10 +40,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 1.8
+      - name: Set up JDK 11
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 11
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Build with Gradle

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
           otp-version: 23.1
           elixir-version: 1.11.2
       - name: Export OTP_RELEASE
-        run: echo "OTP_RELEASE=22.2" >> $GITHUB_ENV
+        run: echo "OTP_RELEASE=23.1" >> $GITHUB_ENV
       - name: Export ERLANG_SDK_HOME
         run: echo "ERLANG_SDK_HOME=`erl -eval 'io:format("~s", [code:root_dir()]).' -noshell -run init stop`" >> $GITHUB_ENV
       - name: Grant execute permission for gradlew

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -241,6 +241,8 @@
       * `recv_marker_clear`
       * `recv_marker_clear`
       * `recv_marker_user `
+* [#1899](https://github.com/KronicDeth/intellij-elixir/pull/1899) - [@KronicDeth](https://github.com/KronicDeth)
+  * Log `PsiElement` if `Call#finalArguments` contain a `null`.
   
 ### Bug Fixes
 * [#1893](https://github.com/KronicDeth/intellij-elixir/pull/1893) - [@KronicDeth](https://github.com/KronicDeth)
@@ -249,6 +251,9 @@
 * [#1897](https://github.com/KronicDeth/intellij-elixir/pull/1897) - [@KronicDeth](https://github.com/KronicDeth)
   * Compare max opcode in to file to max opcode number, not ordinal.
     Opcodes are 1-based, but the ordinal of the Kotlin `Enum`s are 0-based, so the comparison was off-by-1 when a file had the max opcode and would be incorrectly marked as too new.
+* [#1899](https://github.com/KronicDeth/intellij-elixir/pull/1899) - [@KronicDeth](https://github.com/KronicDeth)
+  * Don't return null left or right infix operands in `primaryArguments`
+    `operation.infix.Normalized.leftOperand` and `.rightOperand` ensures that `PsiErrorElement` is not returned: they can return `null` when there is no left or right operand.  `Infix.primaryArguments` was not taking this into account and so could return a `null` as one of the `primaryArguments`, which broke `Call.finalArguments`.
 
 ## v11.9.2
 

--- a/resources/META-INF/changelog.html
+++ b/resources/META-INF/changelog.html
@@ -21,6 +21,7 @@
           </li>
         </ul>
       </li>
+      <li>Log <code>PsiElement</code> if <code>Call#finalArguments</code> contain a <code>null</code>.</li>
     </ul>
   </li>
   <li>
@@ -42,6 +43,13 @@
         Compare max opcode in to file to max opcode number, not ordinal.<br>
         Opcodes are 1-based, but the ordinal of the Kotlin <code>Enum</code>s are 0-based, so the comparison was
         off-by-1 when a file had the max opcode and would be incorrectly marked as too new.
+      </li>
+      <li>
+        Don't return null left or right infix operands in <code>primaryArguments</code><br>
+        <code>operation.infix.Normalized.leftOperand</code> and <code>.rightOperand</code> ensures that
+        <code>PsiErrorElement</code> is not returned: they can return <code>null</code> when there is no left or right
+        operand.  <code>Infix.primaryArguments</code> was not taking this into account and so could return a
+        <code>null</code> as one of the <code>primaryArguments</code>, which broke <code>Call.finalArguments</code>.
       </li>
     </ul>
   </li>

--- a/src/org/elixir_lang/psi/impl/call/CallImpl.kt
+++ b/src/org/elixir_lang/psi/impl/call/CallImpl.kt
@@ -501,13 +501,25 @@ object CallImpl {
 
     @Contract(pure = true)
     @JvmStatic
-    fun primaryArguments(infix: Infix): Array<PsiElement?> {
+    fun primaryArguments(infix: Infix): Array<PsiElement> {
         val children = infix.children
         val operatorIndex = Normalized.operatorIndex(children)
         val leftOperand = org.elixir_lang.psi.operation.infix.Normalized.leftOperand(children, operatorIndex)
         val rightOperand = org.elixir_lang.psi.operation.infix.Normalized.rightOperand(children, operatorIndex)
 
-        return arrayOf(leftOperand, rightOperand)
+        return if (leftOperand != null) {
+            if (rightOperand != null) {
+                arrayOf<PsiElement>(leftOperand, rightOperand)
+            } else {
+                arrayOf<PsiElement>(leftOperand)
+            }
+        } else {
+            if (rightOperand != null) {
+                arrayOf<PsiElement>(rightOperand)
+            } else {
+                emptyArray()
+            }
+        }
     }
 
     @Contract(pure = true)

--- a/src/org/elixir_lang/psi/impl/call/CallImpl.kt
+++ b/src/org/elixir_lang/psi/impl/call/CallImpl.kt
@@ -7,6 +7,7 @@ import com.intellij.psi.PsiReference
 import com.intellij.psi.tree.TokenSet
 import com.intellij.psi.util.CachedValueProvider
 import com.intellij.psi.util.CachedValuesManager
+import org.elixir_lang.errorreport.Logger
 import org.elixir_lang.mix.project.computeReadAction
 import org.elixir_lang.psi.*
 import org.elixir_lang.psi.call.Call
@@ -117,7 +118,12 @@ private fun Call.computeCallableReference(): PsiReference =
  *
  * @return [Call.primaryArguments]
  */
-fun Call.finalArguments(): Array<PsiElement>? = (secondaryArguments() ?: primaryArguments())?.map { it!! }?.toTypedArray()
+fun Call.finalArguments(): Array<PsiElement>? = try {
+        (secondaryArguments() ?: primaryArguments())?.map { it!! }?.toTypedArray()
+} catch (e: NullPointerException) {
+    Logger.error(this.javaClass, "NullPointerException getting Call.finalArguments()", this);
+    null
+}
 
 fun Call.getReference(): PsiReference? =
         CachedValuesManager.getCachedValue(this) {


### PR DESCRIPTION
Fixes #1876

# Changelog
## Enhancements
* Log `PsiElement` if `Call#finalArguments` contain a `null`.

## Bug Fixes
* Don't return null left or right infix operands in `primaryArguments`
   `operation.infix.Normalized.leftOperand` and `.rightOperand` ensures that `PsiErrorElement` is not returned: they can return `null` when there is no left or right operand.  `Infix.primaryArguments` was not taking this into account and so could return a `null` as one of the `primaryArguments`, which broke `Call.finalArguments`.