### PR TITLE
fix word in description.html (goland)

### DIFF
--- a/resources/META-INF/description.html
+++ b/resources/META-INF/description.html
@@ -13,7 +13,7 @@ Elixir support for JetBrains IDEs
   <li>IntelliJ IDEA</li>
   <li>AppCode</li>
   <li>CLion</li>
-  <li>Gogland</li>
+  <li>Goland</li>
   <li>PhpStorm</li>
   <li>PyCharm</li>
   <li>Rubymine</li>


### PR DESCRIPTION
fix golang IDE name in description.
readme was fixed  https://github.com/KronicDeth/intellij-elixir/pull/999, but description is not.