### PR TITLE
Update IntelliJ IDEA version to 2021.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,232 +2,594 @@
 
 ## Table of Contents
 
+* [v11.11.0](#v11110)
+   * [Enhancements](#enhancements)
+   * [Bug Fixes](#bug-fixes)
 * [v11.10.0](#v11100)
-  * [Enhancements](#enhancements)
-  * [Bug Fixes](#bug-fixes)
+   * [Enhancements](#enhancements-1)
+   * [Bug Fixes](#bug-fixes-1)
 * [v11.9.2](#v1192)
-  * [Bug Fixes](#bug-fixes-1)
+   * [Bug Fixes](#bug-fixes-2)
 * [v11.9.1](#v1191)
-  * [Bug Fixes](#bug-fixes-2)
+   * [Bug Fixes](#bug-fixes-3)
 * [v11.9.0](#v1190)
-  * [Enhancements](#enhancements-1)
-  * [Bug Fixes](#bug-fixes-3)
+   * [Enhancements](#enhancements-2)
+   * [Bug Fixes](#bug-fixes-4)
 * [v11.8.1](#v1181)
-  * [Bug Fixes](#bug-fixes-4)
+   * [Bug Fixes](#bug-fixes-5)
 * [v11.8.0](#v1180)
-  * [Enhancements](#enhancements-2)
-  * [Bug Fixes](#bug-fixes-5)
+   * [Enhancements](#enhancements-3)
+   * [Bug Fixes](#bug-fixes-6)
 * [v11.7.0](#v1170)
-  * [Enhancements](#enhancements-3)
-  * [Bug Fixes](#bug-fixes-6)
+   * [Enhancements](#enhancements-4)
+   * [Bug Fixes](#bug-fixes-7)
 * [v11.6.1](#v1161)
-  * [Bug Fixes](#bug-fixes-7)
+   * [Bug Fixes](#bug-fixes-8)
 * [v11.6.0](#v1160)
-  * [Enhancements](#enhancements-4)
-  * [Bug Fixes](#bug-fixes-8)
+   * [Enhancements](#enhancements-5)
+   * [Bug Fixes](#bug-fixes-9)
 * [v11.5.0](#v1150)
-  * [Enhancements](#enhancements-5)
-  * [Bug Fixes](#bug-fixes-9)
+   * [Enhancements](#enhancements-6)
+   * [Bug Fixes](#bug-fixes-10)
 * [v11.4.0](#v1140)
-  * [Enhancements](#enhancements-6)
+   * [Enhancements](#enhancements-7)
 * [v11.3.0](#v1130)
-  * [Enhancements](#enhancements-7)
-  * [Bug Fixes](#bug-fixes-10)
+   * [Enhancements](#enhancements-8)
+   * [Bug Fixes](#bug-fixes-11)
 * [v11.2.0](#v1120)
-  * [Enhancements](#enhancements-8)
-  * [Bug Fixes](#bug-fixes-11)
+   * [Enhancements](#enhancements-9)
+   * [Bug Fixes](#bug-fixes-12)
 * [v11.1.0](#v1110)
-  * [Enhancements](#enhancements-9)
-  * [Bug Fixes](#bug-fixes-12)
+   * [Enhancements](#enhancements-10)
+   * [Bug Fixes](#bug-fixes-13)
 * [v11.0.1](#v1101)
-  * [Bug Fixes](#bug-fixes-13)
+   * [Bug Fixes](#bug-fixes-14)
 * [v11.0.0](#v1100)
-  * [Enhancements](#enhancements-10)
-  * [Bug Fixes](#bug-fixes-14)
-  * [Incompatible Changes](#incompatible-changes)
+   * [Enhancements](#enhancements-11)
+   * [Bug Fixes](#bug-fixes-15)
+   * [Incompatible Changes](#incompatible-changes)
 * [v10.6.0](#v1060)
-  * [Enhancements](#enhancements-11)
-  * [Bug Fixes](#bug-fixes-15)
+   * [Enhancements](#enhancements-12)
+   * [Bug Fixes](#bug-fixes-16)
 * [v10.5.1](#v1051)
-  * [Bug Fixes](#bug-fixes-16)
+   * [Bug Fixes](#bug-fixes-17)
 * [v10.5.0](#v1050)
-  * [Enhancements](#enhancements-12)
-  * [Bug Fixes](#bug-fixes-17)
+   * [Enhancements](#enhancements-13)
+   * [Bug Fixes](#bug-fixes-18)
 * [v10.4.0](#v1040)
-  * [Enhancements](#enhancements-13)
-  * [Bug Fixes](#bug-fixes-18)
+   * [Enhancements](#enhancements-14)
+   * [Bug Fixes](#bug-fixes-19)
 * [v10.3.0](#v1030)
-  * [Enhancements](#enhancements-14)
-  * [Bug Fixes](#bug-fixes-19)
+   * [Enhancements](#enhancements-15)
+   * [Bug Fixes](#bug-fixes-20)
 * [v10.2.0](#v1020)
-  * [Enhancements](#enhancements-15)
-  * [Bug Fixes](#bug-fixes-20)
+   * [Enhancements](#enhancements-16)
+   * [Bug Fixes](#bug-fixes-21)
 * [v10.1.0](#v1010)
-  * [Enhancements](#enhancements-16)
-  * [Bug Fixes](#bug-fixes-21)
+   * [Enhancements](#enhancements-17)
+   * [Bug Fixes](#bug-fixes-22)
 * [v10.0.1](#v1001)
-  * [Bug Fixes](#bug-fixes-22)
+   * [Bug Fixes](#bug-fixes-23)
 * [v10.0.0](#v1000)
-  * [Enhancements](#enhancements-17)
-  * [Bug Fixes](#bug-fixes-23)
-  * [Incompatible Changes](#incompatible-changes-1)
+   * [Enhancements](#enhancements-18)
+   * [Bug Fixes](#bug-fixes-24)
+   * [Incompatible Changes](#incompatible-changes-1)
 * [v9.0.0](#v900)
-  * [Enhancements](#enhancements-18)
-  * [Bug Fixes](#bug-fixes-24)
-  * [Incompatible Changs](#incompatible-changs)
+   * [Enhancements](#enhancements-19)
+   * [Bug Fixes](#bug-fixes-25)
+   * [Incompatible Changs](#incompatible-changs)
 * [v8.1.0](#v810)
-  * [Enhancements](#enhancements-19)
-  * [Bug Fixes](#bug-fixes-25)
+   * [Enhancements](#enhancements-20)
+   * [Bug Fixes](#bug-fixes-26)
 * [v8.0.0](#v800)
-  * [Enhancements](#enhancements-20)
-  * [Bug Fixes](#bug-fixes-26)
-  * [Incompatible Changes](#incompatible-changes-2)
+   * [Enhancements](#enhancements-21)
+   * [Bug Fixes](#bug-fixes-27)
+   * [Incompatible Changes](#incompatible-changes-2)
 * [v7.5.0](#v750)
-  * [Enhancements](#enhancements-21)
-  * [Bug Fixes](#bug-fixes-27)
+   * [Enhancements](#enhancements-22)
+   * [Bug Fixes](#bug-fixes-28)
 * [v7.4.0](#v740)
-  * [Enhancements](#enhancements-22)
-  * [Bug Fixes](#bug-fixes-28)
+   * [Enhancements](#enhancements-23)
+   * [Bug Fixes](#bug-fixes-29)
 * [v7.3.0](#v730)
-  * [Enhancements](#enhancements-23)
-  * [Bug Fixes](#bug-fixes-29)
+   * [Enhancements](#enhancements-24)
+   * [Bug Fixes](#bug-fixes-30)
 * [v7.2.1](#v721)
-  * [Bug Fixes](#bug-fixes-30)
+   * [Bug Fixes](#bug-fixes-31)
 * [v7.2.0](#v720)
-  * [Enhancements](#enhancements-24)
-  * [Bug Fixes](#bug-fixes-31)
+   * [Enhancements](#enhancements-25)
+   * [Bug Fixes](#bug-fixes-32)
 * [v7.1.0](#v710)
-  * [Enhancements](#enhancements-25)
-  * [Bug Fixes](#bug-fixes-32)
+   * [Enhancements](#enhancements-26)
+   * [Bug Fixes](#bug-fixes-33)
 * [v7.0.0](#v700)
-  * [Enhancements](#enhancements-26)
-  * [Bug Fixes](#bug-fixes-33)
+   * [Enhancements](#enhancements-27)
+   * [Bug Fixes](#bug-fixes-34)
 * [Incompatible Changes](#incompatible-changes-3)
 * [v6.7.0](#v670)
-  * [Enhancements](#enhancements-27)
-  * [Bug Fixes](#bug-fixes-34)
+   * [Enhancements](#enhancements-28)
+   * [Bug Fixes](#bug-fixes-35)
 * [v6.6.0](#v660)
-  * [Enhancements](#enhancements-28)
-  * [Bug Fixes](#bug-fixes-35)
+   * [Enhancements](#enhancements-29)
+   * [Bug Fixes](#bug-fixes-36)
 * [v6.5.1](#v651)
-  * [Bug Fixes](#bug-fixes-36)
+   * [Bug Fixes](#bug-fixes-37)
 * [v6.5.0](#v650)
-  * [Enhancements](#enhancements-29)
-  * [Bug Fixes](#bug-fixes-37)
+   * [Enhancements](#enhancements-30)
+   * [Bug Fixes](#bug-fixes-38)
 * [v6.4.0](#v640)
-  * [Enhancements](#enhancements-30)
-  * [Bug Fixes](#bug-fixes-38)
+   * [Enhancements](#enhancements-31)
+   * [Bug Fixes](#bug-fixes-39)
 * [v6.3.0](#v630)
-  * [Enhancements](#enhancements-31)
-  * [Bug Fixes](#bug-fixes-39)
+   * [Enhancements](#enhancements-32)
+   * [Bug Fixes](#bug-fixes-40)
 * [v6.2.0](#v620)
-  * [Enhancements](#enhancements-32)
-  * [Bug Fixes](#bug-fixes-40)
+   * [Enhancements](#enhancements-33)
+   * [Bug Fixes](#bug-fixes-41)
 * [v6.1.1](#v611)
-  * [Bug Fixes](#bug-fixes-41)
+   * [Bug Fixes](#bug-fixes-42)
 * [v6.1.0](#v610)
-  * [Enhancements](#enhancements-33)
-  * [Bug Fixes](#bug-fixes-42)
+   * [Enhancements](#enhancements-34)
+   * [Bug Fixes](#bug-fixes-43)
 * [v6.0.0](#v600)
-  * [Enhancements](#enhancements-34)
-  * [Bug Fixes](#bug-fixes-43)
-  * [Incompatible Changes](#incompatible-changes-4)
+   * [Enhancements](#enhancements-35)
+   * [Bug Fixes](#bug-fixes-44)
+   * [Incompatible Changes](#incompatible-changes-4)
 * [v5.1.0](#v510)
-  * [Enhancements](#enhancements-35)
-  * [Bug Fixes](#bug-fixes-44)
+   * [Enhancements](#enhancements-36)
+   * [Bug Fixes](#bug-fixes-45)
 * [v5.0.0](#v500)
-  * [Enhancements](#enhancements-36)
-  * [Bug Fixes](#bug-fixes-45)
-  * [Incompatible Changes](#incompatible-changes-5)
+   * [Enhancements](#enhancements-37)
+   * [Bug Fixes](#bug-fixes-46)
+   * [Incompatible Changes](#incompatible-changes-5)
 * [v4.7.0](#v470)
-  * [Enhancements](#enhancements-37)
-  * [Bug Fixes](#bug-fixes-46)
+   * [Enhancements](#enhancements-38)
+   * [Bug Fixes](#bug-fixes-47)
 * [v4.6.0](#v460)
-  * [Enhancements](#enhancements-38)
-  * [Bug Fixes](#bug-fixes-47)
+   * [Enhancements](#enhancements-39)
+   * [Bug Fixes](#bug-fixes-48)
 * [v4.5.0](#v450)
-  * [Enhancements](#enhancements-39)
+   * [Enhancements](#enhancements-40)
 * [v4.4.0](#v440)
-  * [Enhancements](#enhancements-40)
-  * [Bug Fixes](#bug-fixes-48)
+   * [Enhancements](#enhancements-41)
+   * [Bug Fixes](#bug-fixes-49)
 * [v4.3.0](#v430)
-  * [Enhancements](#enhancements-41)
-  * [Bug Fixes](#bug-fixes-49)
+   * [Enhancements](#enhancements-42)
+   * [Bug Fixes](#bug-fixes-50)
 * [v4.2.0](#v420)
-  * [Enhancements](#enhancements-42)
-  * [Bug Fixes](#bug-fixes-50)
+   * [Enhancements](#enhancements-43)
+   * [Bug Fixes](#bug-fixes-51)
 * [v4.1.0](#v410)
-  * [Enhancements](#enhancements-43)
-  * [Bug Fixes](#bug-fixes-51)
+   * [Enhancements](#enhancements-44)
+   * [Bug Fixes](#bug-fixes-52)
 * [v4.0.0](#v400)
-  * [Enhancements](#enhancements-44)
-  * [Bug Fixes](#bug-fixes-52)
-  * [Incompatible Changes](#incompatible-changes-6)
+   * [Enhancements](#enhancements-45)
+   * [Bug Fixes](#bug-fixes-53)
+   * [Incompatible Changes](#incompatible-changes-6)
 * [v3.0.1](#v301)
-  * [Bug Fixes](#bug-fixes-53)
+   * [Bug Fixes](#bug-fixes-54)
 * [v3.0.0](#v300)
-  * [Enhancements](#enhancements-45)
-  * [Bug Fixes](#bug-fixes-54)
-  * [Incompatible Changes](#incompatible-changes-7)
+   * [Enhancements](#enhancements-46)
+   * [Bug Fixes](#bug-fixes-55)
+   * [Incompatible Changes](#incompatible-changes-7)
 * [v2.2.0](#v220)
-  * [Enhancement](#enhancement)
-  * [Bug Fixes](#bug-fixes-55)
+   * [Enhancement](#enhancement)
+   * [Bug Fixes](#bug-fixes-56)
 * [v2.1.0](#v210)
-  * [Enhancement](#enhancement-1)
-  * [Bug Fixes](#bug-fixes-56)
+   * [Enhancement](#enhancement-1)
+   * [Bug Fixes](#bug-fixes-57)
 * [v2.0.0](#v200)
-  * [Enhancements](#enhancements-46)
-  * [Bug Fixes](#bug-fixes-57)
-  * [Incompatible Changes](#incompatible-changes-8)
+   * [Enhancements](#enhancements-47)
+   * [Bug Fixes](#bug-fixes-58)
+   * [Incompatible Changes](#incompatible-changes-8)
 * [v1.2.1](#v121)
-  * [Enhancements](#enhancements-47)
-  * [Bug Fixes](#bug-fixes-58)
+   * [Enhancements](#enhancements-48)
+   * [Bug Fixes](#bug-fixes-59)
 * [v1.2.0](#v120)
-  * [Enhancements](#enhancements-48)
-  * [Bug Fixes](#bug-fixes-59)
+   * [Enhancements](#enhancements-49)
+   * [Bug Fixes](#bug-fixes-60)
 * [v1.1.0](#v110)
-  * [Enhancements](#enhancements-49)
+   * [Enhancements](#enhancements-50)
 * [v1.0.0](#v100)
-  * [Enhancements](#enhancements-50)
-  * [Bug Fixes](#bug-fixes-60)
-  * [Incompatible Fixes](#incompatible-fixes)
+   * [Enhancements](#enhancements-51)
+   * [Bug Fixes](#bug-fixes-61)
+   * [Incompatible Fixes](#incompatible-fixes)
 * [v0.3.5](#v035)
-  * [Enhancements](#enhancements-51)
-  * [Bug Fixes](#bug-fixes-61)
+   * [Enhancements](#enhancements-52)
+   * [Bug Fixes](#bug-fixes-62)
 * [v0.3.4](#v034)
-  * [Enhancements](#enhancements-52)
+   * [Enhancements](#enhancements-53)
 * [v0.3.3](#v033)
-  * [Enhancements](#enhancements-53)
+   * [Enhancements](#enhancements-54)
 * [v0.3.2](#v032)
-  * [Bug Fixes](#bug-fixes-62)
+   * [Bug Fixes](#bug-fixes-63)
 * [v0.3.1](#v031)
-  * [Enhancements](#enhancements-54)
+   * [Enhancements](#enhancements-55)
 * [v0.3.0](#v030)
-  * [Enhancements](#enhancements-55)
-  * [Incompatible Changes](#incompatible-changes-9)
+   * [Enhancements](#enhancements-56)
+   * [Incompatible Changes](#incompatible-changes-9)
 * [v0.2.1](#v021)
-  * [Enhancements](#enhancements-56)
-  * [Bug Fixes](#bug-fixes-63)
+   * [Enhancements](#enhancements-57)
+   * [Bug Fixes](#bug-fixes-64)
 * [v0.2.0](#v020)
-  * [Enhancements](#enhancements-57)
-  * [Incompatible Changes](#incompatible-changes-10)
+   * [Enhancements](#enhancements-58)
+   * [Incompatible Changes](#incompatible-changes-10)
 * [v0.1.4](#v014)
-  * [Enhancements](#enhancements-58)
-  * [Bug Fixes](#bug-fixes-64)
+   * [Enhancements](#enhancements-59)
+   * [Bug Fixes](#bug-fixes-65)
 * [v0.1.3](#v013)
-  * [Bug Fixes](#bug-fixes-65)
+   * [Bug Fixes](#bug-fixes-66)
 * [v0.1.2](#v012)
-  * [Enhancements](#enhancements-59)
+   * [Enhancements](#enhancements-60)
 * [v0.1.1](#v011)
-  * [Bug Fixes](#bug-fixes-66)
+   * [Bug Fixes](#bug-fixes-67)
 * [v0.1.0](#v010)
-  * [Enhancements](#enhancements-60)
-  * [Bug Fixes](#bug-fixes-67)
+   * [Enhancements](#enhancements-61)
+   * [Bug Fixes](#bug-fixes-68)
 * [v0.0.3](#v003)
-  * [Enhancements](#enhancements-61)
+   * [Enhancements](#enhancements-62)
 * [v0.0.2](#v002)
-  * [Enhancements](#enhancements-62)
-  * [Bug Fixes](#bug-fixes-68)
+   * [Enhancements](#enhancements-63)
+   * [Bug Fixes](#bug-fixes-69)
+
+## v11.11.0
+
+### Enhancements
+* [#1948](https://github.com/KronicDeth/intellij-elixir/pull/1948) - [@KronicDeth](https://github.com/KronicDeth)
+  * Reference Resolution
+    * Allow any Alias in a chain to have references.
+      This allows going to the declaration of `Phoenix`, `Phoenix.LiveView`, or `Phoenix.LiveView.Socket` depending on whether you're on the `Phoenix`, `LiveView`, or `Socket` Alias, respectively, in the chain.
+      * Allow any Alias in Qualified Alias to be resolved
+        This allows going to the declaration of Phoenix, Phoenix.LiveView, or Phoenix.LiveView.Socket depending on whether you're
+        on the Phoenix, LiveView, or Socket Alias, respectively, in the chain.
+      * Update DocumentationProvider to work with improved Alias resolution
+  
+        Without these changes the DocumentationProvider double-resolves and so ends up showing the docs for `def` and `defmodule`, instead of the call definition clause or module, respectively.
+    * Reimplement Module references
+      Instead of references for only the outermost QualifiableAlias, there is a reference for each right-most Alias at a given position, so instead of there only be a reference to `App.Context.Schema` in `App.Context.Schema`, there is now a reference to `App` in the `App` prefix, a reference to `App.Context` in `Context` in `App.Context`, and a reference to `App.Context.Schema` in `Schema` in `App.Context.Schema`.  Not only is this more useful, being able to jump to parent namespaces, but it fixed some of the capability issues with Go To Definition in the 2020 line of IDEs.  This approach of using `getRangeInElement` to target the range of the right-most Alias, while the element was still the parent that contained, but did not go beyond the Alias, was tried after having references only on `Alias`es and not `QualifiedAlias`es did not fix completion issues.  It was the while debugging Go To Declaration actions and noticing they were sensitive to the range in element AND the [docs for PsiReference#getRangeInElement](https://github.com/JetBrains/intellij-community/blob/f66e9644fa683fba22f4ce9e30c037720f745989/platform/core-api/src/com/intellij/psi/PsiReference.java#L49-L62) that I realized that the Go To Declaration and Completion has a hidden requirement that References for things that behave like namespaces have to work this way.
+      * Use `ModularName` index for Module Variants
+        Have a smaller index to iterate and remove need for the `isAlias` check.
+    * Limit Elixir Module resolution to same JetBrains Project Module
+      * Change the `GlobalSearchScope` from `allProject` to `moduleWithDependenciesAndLibrariesScope` for faster searching on multi-module projects.
+        * Set `includeTests` based whether the referring element is in a test directory.
+      * Use `StubIndex#processElements` instead of home grown `forEachNavigationElement` as `processElements` is more efficient.
+    * Favor Module `ResolveResults` under same `Module` content roots
+      This should favor deps sources in the same module.
+    * Iterate `function` body in `unquote(function())` when iterating call definition clauses in `quote`
+      Treats it `function` body the same as a `__using__` body.
+    * Standardized preferred `ResolveResult` filters between Callables and Modules
+  
+      1. Prefer valid results as long as it doesn't leave no results.
+      2. Prefer results in the same module as long as it doesn't leave no results.
+  
+      In Go To Declaration also:
+  
+      3. Prefer results in source (that aren't decompiled) as long as it doesn't leave no results.
+    * Use the second argument to `use` to determine which function is called with apply/3
+  
+      This pattern is used in Phoenix `__using__`, so this lets to differentiate whether `Plug.Conn.assign/3` or `Phoenix.LiveSocket.assign/3` is resolved in a Controller, LiveComponent, or LiveView.
+    * In LEEx Templates
+      * Resolve function calls in `*.html.leex` templates to functions defined in the corresponding LiveComponent/View module.
+      * Assigns
+        * Resolve assigns in LEEx templates to the keyword key in `assign/3` calls in `update/2` in the LiveComponent or LiveView
+          Had to add back in a `TargetElementEvaluator`, so that the `UnqualifiedNoArgumentCall` (`name`) that is the identifier in an assign (`@name`) was not counted as valid target for Find Usages / Go To Declaration by itself.
+        * Search for assigns in all call definitions in view module
+          Expand from just `update` to any call definition to cover helper functions and other callbacks. Don't stop on the first valid match because with helper functions and multiple callbacks, the last write isn't obvious.
+        * Resolve assigns set with `assign/3`
+        * Look for `assign` calls in `|>` pipelines
+        * Resolve assigns set with `assign_new/3`
+        * Resolve @live_action to where it is assigned Phoenix.LiveView.Channel.assign_action/2
+        * Find assigns in maps for assign/2
+          Since assign/2 accepts either a keyword list or a map, check in both types.
+        * Resolve @myself to where it is set in `render_pending_components`
+        * Resolve assigns in macros with do blocks like `case` and `if`
+        * Find assigns in `live_component` calls
+          If an assign can't be found in the body of a LiveComponent module, then it maybe passed through from the `live_component` call itself, so look for any references to the view module (the LiveComponent) and if it is a `live_component` call, then look at those assigns to try to resolve the assign name.
+        * Resolve assigns to `live_modal` calls
+          `live_modal` is not built into `phoenix_live_view`, but it is generated by `phx.gen.live`, so most projects will have it.  This allows `return_to`, which is used use in `live_modal`, to be resolved.
+        * Resolve `@socket` to last socket variable or call in view module.
+        * Resolve `@flash` to `put_flash/3` calls.
+        * Resolve `@inner_content` to `Phoenix.LiveView.Utils.to_rendered/2` setting the assign with `put_in`
+      * Resolve aliases in `.leex` templates
+        Generalize the `.leex` and `use` walking from call definition clauses to any scope processor lambda, so it can be used to resolve uses of `Routes` in `.leex` templates.
+    * Resolve Types
+      * Have separate references specifically for Types.
+      * Resolve to both types declared with `@type`, `@typep`, or `@opaque`; and named type parameters.
+      * Process declarations for `@type`, `@typep`, and `@opaque`.
+      * Count `@callback` as declaring a Type
+      * Resolve type `t` for `defprotocol` to where it is defined in `Protocol.__protocol__`
+        Unfortunately, this ties all protocol's `t` to the same element, so Find Usage finds all protocol's types instead of just a specific module's type, but this works for projects that have source, but not yet compiled.
+        * Favor protocol-specific decompiled `@type t` when available.
+      * Resolve type variable to the keyword key in guards.
+      * `__MODULE__`
+    * Favor source over decompiled per name instead of overall for `ResolveResultOrderedSet`
+      This allows the `Routes` alias to be resolved to the both the `MyAppWeb.Router.Helpers` in `alias MyAppWeb.Router.Helpers, as: Routes` in the source of `MyAppWeb`, but also the decompiled `MyAppWeb.Router.Helpers`, which is necessary as `MyAppWeb.Router.Helpers` is produced on compile from `router.ex`.
+    * Resolve references through `defdelegate` calls.
+    * Resolve `code_reloading?` in MyApp.Endpoint
+  
+      The generated `MyApp.Endpoint` for `mix phx.new` has a section to enable code-reloading at compile time:
+  
+      ```elixir
+      # Code reloading can be explicitly enabled under the
+      # :code_reloader configuration of your endpoint.
+      if code_reloading? do
+        socket("/phoenix/live_reload/socket", Phoenix.LiveReloader.Socket)
+        plug(Phoenix.LiveReloader)
+        plug(Phoenix.CodeReloader)
+      end
+      ```
+  
+      Previously, `code_reloading?` variable would not resolve because psi.scope.Variable ignored `use` calls, not `use` calls are entered and the `var!(code_reloading?)` is found in `Phoenix.Endpoint.config/1` by way of the `unquote(config(opts))` call in the `quote` block in `__using__(opts)`.
+    * Resolve qualified calls with unknown resolvable qualifier using only relative identifier and arity.
+    * `@spec`
+      * Resolve `@spec` to `defdelegate` calls.
+      * Resolve @specs to the definitions if the definitions are in a for comprehension
+    * `Ecto`
+      * `Query`
+        * Resolve reference variables in `Ecto.Query`
+          * Reference variables are introduced in as the left operand of `in` passed to `from/2` and the `join:` keyword in `from/2`.
+          * `join/3-5`
+          * Resolve bindings in `select/2-3`.
+          * Resolve reference variables in `where/2,3` binding.
+            Also add support for resolving `a` in `[{^assoc, a}]` binding.
+          * Resolve `bindings` in `group_by/2-3`.
+          * Resolve `bindings` and `expressions` in `order_by/2-3`.
+          * Resolve `bindings` in `having/2-3`.
+          * Add `select_merge` to declaring `Ecto.Query` macros.
+          * Add `distinct/2-3` as a declaring `Ecto.Query` macro.
+        * Resolve `field` calls in Ecto `schema` blocks
+  
+          How `field` works in `schema` for `Ecto.Schema`
+          1. `use Ecto.Schema`
+          2. `Ecto.Schema.__using__`
+          3. `import Ecto.Schema, only: [schema: 2, embedded_schema: 1]``
+  
+          Note that only the outer DSLs, schema and embedded_schema are available even though field/2 is defined in Ecto.Schema.
+  
+          So when you call `schema ... do`
+          1. `defmacro schema(source, [do: block])`
+          2. `schema(__CALLER__, source, true, :id, block)`
+          3. `defp schema(caller, source, meta?, type, block)`
+          4. There's a big `prelude = quote do` quote block
+  
+          At the end of prelude there is
+  
+          ```elixir
+          try do
+            import Ecto.Schema
+            unquote(block)
+          after
+            :ok
+          end
+          ```
+  
+          Hey! An `import Ecto.Schema`, but `prelude` is just floating as a variable.  At the end of  `defp schema(caller, source, meta?, type, block)` is
+  
+          ```elixir
+          quote do
+            unquote(prelude)
+            unquote(postlude)
+          end
+          ```
+  
+          So to statically analyze an `Ecto.Schema` module.
+  
+          1. Resolve `schema/2` to `defmacro schema` by walking the `use`, `__using__`, `quote`, and `import`.
+          2. Inside the `schema/2` (or macros in general if you want to get fancy 💅 and support more DSLs),
+          3. Go into the body of the macro.  If there's a call, resolve it
+          4. Go into the called function
+          5. Look for a `quote` block at the end (the same as my current `__using__` support)
+          6. If there's a `Call` inside an `unquote` see if you can resolve it to a variable in addition to a call definition (which is already supported for Phoenix).
+          7. If it's a variable, check it's value.  If it's a `quote`, use the quote block handling
+          8. In the quote block handling add support for `try`
+          9. Walk the `try` and see the `import`, walk the `import` to find `Ecto.Schema.field/2`
+        * `API`
+          *  Resolve `Ecto.Query.API` functions in `Ecto.Query`
+            * `from(order_by: ...)`
+            * `from(select: ...)`
+              * `from(select: tuple())`
+            * `from(where: ...)`
+            * `group_by/2-3`
+            * `having/2-3`
+            * `select/2-3` `expr` argument
+            * `where`
+          * Resolve `Ecto.Query.API.fragment` to arity interval `0..`.
+          * Resolve `fragment` nested in other `Ecto.Query.API` call like `type`.
+          * Walk `rightOperand` of `join(..., ... in ..., ...)` for `Ecto.Query.API` usages like `fragment`.
+    * Resolve module attributes defined in `use` `__using__` `quote` block
+      * Change `org.elixir_lang.reference.resolver.ModuleAttribute` to use `PsiScopeProcessor` for non-`@for` and non-`@protocol` instead of custom logic.
+      * Don't descend into a `use` if the `ENTRANCE` is an ancestor since that means the `Alias` on the `use` is probably being resolved.
+      * `AtUnqualifiedNoParenthesesCall.processDeclarations` will call `processor.execute` when it isn't a type spec.
+      * The `UseScopeSelector` for `AtUnqualifiedNoParenthesesCallImpl` has been changed to `SELF_AND_FOLLOWING_SIBLINGS` since the module attribute is used that way.  The previous `SELF` value was when the `UseScopeSelector` only applied to variables.
+  * "Elixir References" inspection for finding unresolved or invalid references.
+    * `visitAtNonNumericOperation`
+      Helps "Elixir References" find unresolved assigns.
+  * Strip `AccessExpression`s from `Qualified` qualifiers automatically
+  * Documentation
+    * Show `deprecated`, `impl`, and `spec`, and actual heads in documentation for source functions
+    * Merge `Documentation` across multiple arities when arity of lookup is ambiguous.
+  * Find variables defined in EEx element
+    Finds variables defined in EEx PsiElement by creating them the same as a StabBody, which means that the siblings are checked backwards from the last parent.  This fixes resolving the `f` from `f = form_for ...` in `*input f ...` in LiveView FormComponent templates.
+  * Highlight named parameters in types.
+  * Decompilation
+    * Fake built-in types by decompiling in `:erlang.beam`
+      For type reference resolution of built-in types to work, they need to be defined somewhere.  IntelliJ Erlang does this by looping usages back on themselves, but this leads to Find Usages not working for built-in types since each usage is a distinct declaration.  By instead defining the types in decompiled `:erlang.beam` (even though they aren't actually defined there), there is a shared location for all reference to point to and then check for Find Usages.
+    * Decompile types from EEP-48 documentation.
+  * Descend into body of `unless` in `quote` for `treeWalkUp`.
+  * Descend into `for` when looking for call definition clauses.
+  * `QuoteMacro.treeWalkUp` into `if`
+    `unless` was already walked, but not `if`.  Fixes resolving `Repo.preload/2`, which is defined inside an `if` in `use Ecto.Repo`'s `__using__`.
+  * Add `defguard` and `defguardp` to CallDefinitionClause.`is`.
+  * Don't generate a reference for `Elixir`
+    `Elixir` is not declared anywhere. It is the namespace of all Aliases.
+  * Refactor how sibling sequences are walked
+    Port filtering out comments, white space and end of expressions from `siblingExpression`.
+  * Reimplement `fullyQualifiedName`
+  
+    Eliminate the specialization for `ElixirAlias` AND `QualifiableAlias` as which was picked as based on the static casted type. `fullyQualifiedName` will include the following:
+    * Convert `__MODULE__` to the enclosing modular canonical name
+    * Combine an ElixirAlias with its qualifier
+      * If in a `ElixirMultipleAliases` will combine the qualifier (`qualifier.{...}`) outside the `{}` with the relative name inside `...{relative, ...}`.
+  * EEx
+    * `viewFile` for `.eex` files used in same directory as `.ex` using `EEx.function_from_file`.
+    * Resolve function calls to those defined by `EEx.function_from_file/3-5`.
+    * Find view modules for templates under the `templates` directory.
+  * Walk `quote` macros for sibling call definitions
+  * Always fallback to name/arity in any module if callable not resolved in scope
+  * Resolve uses of aliased name produced by `alias __MODULE__`
+
+### Bug Fixes
+* [#1948](https://github.com/KronicDeth/intellij-elixir/pull/1948) - [@KronicDeth](https://github.com/KronicDeth)
+  * Fix Ctrl+Click/Cmd+B/Go To Declaration for Aliases.
+  * Don't index non-canonical names.
+    The non-canonical name for a nested `defmodule` is the Alias given to that `defmodule` call.  While that name should be resolvable within the parent modular, it should not be indexed because the index is for the global scope.
+  
+    Prevents `defmodule Enum` in
+  
+    ```elixir
+    defmodule ExJsonSchema.Validator.Error do
+      ...
+      defmodule Enum do
+        ...
+      end
+      ...
+    end
+    ```
+  
+    from being indexed as `Enum`, which hides the decompiled version from the standard library because source references are favored over decompiled versions when resolving references.
+  * Reference Resolution
+    * Only favor same file Module resolutions if they are valid
+      Invalid same file results can occur for prefix matches, but if only prefix matches are available, then a whole project search should occur instead of only when there are no same file `ResolveResult` of either validity.
+    * Include library sources in `Module#multiResolveProject` `GlobalSearchScope`
+       Ensures that library sources can be returned, which are favored over decompiled libraries, so that `__using__` macros can be followed.
+    * Protect from `Module` reference element not having a `VirtualFile` when checking if a test file.
+    * Fix `QualifiableAliasImpl#fullyQualifiedName`
+      * Include qualifier of `MultipleAliases`
+        In an `alias` line like `alias Myapp.MyContext.{Schema1, Schema2}`, `Schema1` would think its `fullyQualifiedName` was only `Schema1`, when it should included the `fullyQualifiedName` of the qualifier, `MyApp.MyContext` too. This leads to the correct `Schema1` fully-qualified name of `MyApp.MyContext.Schema1`.  This fix makes references to `Schema1` resolve to both the `alias` and the `defmodule`.
+      * Include qualifier of `MultipleAliases` for deep aliases
+        In an `alias` line like `alias Myapp.MyContext.{NestedContext1.Schema1, NestedContext2.Schema2}`, `Schema1` would think its `fullyQualifiedName` was only `NestedContext1.Schema1`, when it should included the `fullyQualifiedName` of the qualifier, `MyApp.MyContext` too.  This leads to the correct `Schema1` fully-qualified name of `MyApp.MyContext.NestedContext.Schema1`.  This fix makes references to `Schema1` resolve to both the `alias` and the `defmodule`.
+    * In LEEx Templates
+      * Don't check for implicit imports at top of template file if there is a view file
+        The implicit imports should come last, after the view file has been processed.
+      * Ignore call definition clauses expressions that can't contain an assign
+        * Atom keywords (`false`, `true`, `nil`)
+        * Maps
+        * Structs
+        * Keyword lists
+        * Strings and charlists
+      * Don't follow variables for assigns
+        For now, don't follow variables to look for assigns.
+      * Fix finding assigns in `|> case do ... end`
+        `None` calls were ignored, but when `case` is used in a pipeline it is a `None` since it has no literal arguments and only resolved arguments, so it was being ignored.
+      * Ignore Lists and Aliases when resolving assigns
+      * Fix resolve assigns in `if`s
+        Only looked in `stab` of the `doBlock`, but the `else` is in the `blockList`.
+    * Don't use the same path for actual aliases and defmodules when resolving aliases
+      Prevents a case of an exact match and its namespace both being marked as valid (exact matches).
+    * Types
+      * Don't generate references for map key optionality (`required/1` and `optional/1`)
+      * Don't create a reference to `...` in lists in type specs.
+      * Look above `ElixirStabBody` for `ancestorTypeSpec`.
+      * Generate `Callable` reference for `unquote` in typespec instead of `Type` reference.
+    * Allow modular names to resolve to multiple modulars
+      Fix `:systemd.ready()` not resolving because `:systemd` only exists as a decompiled file from source because it is Erlang and there is no preference given to different MIX_ENVs.  All MIX_ENV `defmodule :systemd` are returned for the `:systemd` and all of them are checked for `ready/0`.
+    * Fix resolving qualified calls that are defined through use
+  
+      Resolving qualified calls only used `Modular.callDefinitionClauseCallFoldWhile`, which ignores all non call definition, which means it ignored the `use`, but switching to use `org.elixir_lang.psi.scope.call_definition_clause.MultiResolve` `PsiScopeProcessor` used for unqualified calls, but starting on the modular call of the qualifier, all the `use` handling that works for unqualified calls also works for qualified calls now.
+  
+      This fixes resolving `MyAppWeb.Endpoint.config_change(changed, removed)` in `MyApp.Application.config_change/3` because `use Phoenix.Endpoint, otp_app: :my_app` in `MyAppWeb.Endpoint` is now walked for qualified calls.
+    * Fix resolving variables to parameters that are both pattern matched and defaulted
+  
+      In functions like
+  
+      ```elixir
+      def f(%Struct{} = s \\ %Struct{}) do
+        s
+      end
+      ```
+  
+      `s` in the body would not resolve to the `s` parameter because the default parameter had to be `PsiNamedElement`, that is a variable directly. Instead, recurse on any operand before the `\\` to support pattern matching too.
+    * Use `keepProcessing()` in `MultiResolve.addToResolveResults` instead of specific return values
+  
+      Fixes `def` in `def default_host_flag, do: "--host` resolving as an invalid match to `default_host_flag` instead of search the implicit imports for `defmacro def`.
+    * The `nameIdentifier` for a `defdelegate` is the first argument, not the `as:`
+      The `as:` is the name in the `to:` module only.
+    * Fix `defdelegate` `MultiResolve`
+      1. I had flipped the head name and `as` name for checking for a name match
+      2. I only counted the `defdelegate` as matching if the `as` name as found in `to` module, but if the head alone is prefixed by the name then the head should be a ResolveResult element even if the `to` or `as` can't be found
+      3. Inside the `to`, I only checked if the children were call definition clauses, but this meant that all the `for` handling was ignored, so start a new `resolveResults()` for each modular.
+    * Fix `toModulars` not returning all modulars
+      `fullyResolve` only touched the first modular.
+    * Favor complete valid results over incomplete invalid earlier bindings for variables.
+    * Ecto
+      * Don't generate reference for `assoc/2` pseudo-function in `join(..., _ in assoc(_, _))`
+    * Fix unaliasing multiple aliases
+      `UnaliasName` still assumed that `fullyQualifiedName` included the qualifier, but it is just the lexical qualifier now.
+    * Check for `MULTIPLE_ALIASES_QUALIFIER` in `ResolveState` for prefix matches.
+      Fixes resolving `SSH.Key` to `Foo.SSH.Key` when the alias is `alias Foo.{SSH, ...}`.
+    * Ignore type variables in type restrictions when resolving normal variables.
+    * Fix `withSelf` for `childExpressions` `siblingExpressions` call
+      While refactoring the walk, I copied the call for siblings, which shouldn't included self.  Children should include self, or the first expression is missed which showed up as `Repo.transaction` not being found because `transaction` is the first `def` inside an `if` in `Ecto.Repo.__using__`'s `quote` block.
+    * Don't try to resolve keys/fields of a capture.
+    * Don't generate reference for `assoc` in `*join*: .. in assoc(..., ...)`.
+      Already worked for `join/3` calls, extend to keyword syntax too.
+    * Fix resolving references to `Modulars` when resolved is in BEAM file
+      The check to see if the resolved was a modular only worked for source elements because it checked if it was a `Call`, but decompiled modules in BEAM files are `ModuleImpls`.
+    * Fix logic error when ignored pinned variables as declaration sites
+  
+      The logic was supposed to be that
+  
+      * If it is pinned, keep searching
+      * If it is not pinned, check the operation as a Call
+  
+      ... but, the code was `operatorText != "^" && execute(match as Call, state)` which meant that if the `operatorText` was `"^"`, then the whole expression was `false`, which meant `keepProcessing` was `false`, so any pin stopped the processing for other unpinned parameters after the pin in addition to processing in the outer scope of the pin.
+    * Prefer source only for target candidates for Go To Declaration and not all ResolveResults.
+      Ensures that functions only defined in decompiled Modules can be found because the Module's ResolveResults include the decompiled Module in addition to the source ones.
+    * Don't prefer source over decompiled in `ResolveResultOrderedSet`
+      Preference is now handled in `Resolver`, so that source preference only happens on Go To Declaration and not for `multiResolve` because that needs decompiled Modulars for compile-time `for` loops that are too complex to infer.
+    * Use primary arity instead of final for resolving Callables
+  
+      Fixes `unquote` in `def unquote(...)() do` not resolving.
+  * Filter out decompiled private functions from completions
+    If they are only available as decompiled functions, it is unlikely we have the source available to make them public, which was the reasoning to allow private functions at all.
+  * Decompiling
+    * Include module name for "No decompiled source function" errors
+    * Unquote `and` when not and/2
+      Fixes decompiling `:hipe_arm_encode`.
+    * `unquote` `false` when decompiling.
+      Fixes decompiling `:thrift_json_parser`. Add `true` to the `Unquote` list too since it would have the same issue.
+    * Unquote `in` when not `in/2`
+      Fix decompiling `:digraph_utils`
+    * Use `containingFile.originalFile` for `resolve.Module.multiResolveProject`
+      Ensures `VirtualFile` is available for decompiled files.
+  * Performance
+    * Don't use `.navigationElement` for `Variants`
+  
+      Using `navigationElement` forces parsing of the decompiled source, which isn't necessary whe only showing the lookup string.
+    * Remove `ModuleOwner` interface
+      * `BeamFileImpl` is known to have only 1 module in it, so it makes the code more complicated to make it act like source files.
+      * Don't use `getChildrenByType`, as it causes the decompiled source to be parsed, which is slow and unnecessary since all the metadata for modules is available from the binary format.
+    * Get project from parent in decompiled Module and CallDefinition
+      Not doing this causes an unnecessary parsing of the decompiled source.
+  * Fix infinite recursion in `ElixirVisitor#visitLiteralSigilLine`
+  * Show more scope for keyword key Go To Definition
+    * Always show the keyword pair, instead of just the keyword key, so that the value being assigned to the key can be seen before Go To.
+    * Show the location at the path relative to the content root and the line number as `live_modal` may be used more than once in the same file.
+  * Put `entrance` as initial visited in `module.Variants`.
+  * Check if `PsiElement` has been visited before walking `quote` and `__using__`
+  * Don't mark qualified calls as unresolved in "Elixir References" inspection
+    I don't have a good approach for resolving struct fields or map keys for now, don't mark them as unresolved as it clutters finding unresolved calls I expect to work.
+  * Don't assume `PsiFile#virtualFile` is `NotNull` in `PsiElement.moduleWithDependentsScope`.
+  * Don't assume `PsiFile#virtualFile` is `NotNull` in `AtNonNumericOperation.computeReference()`.
+  * `putInitialVisitedElement` in `variable.MultiResolve`
+    Fixes resolving variables through `use` statements for variables in the body of `defmodule` blocks.
+  * Log when `VISITED_ELEMENT_SET` is `null` instead of erroring.
+  * Fix `resolvePrimaryArity` for `|> case do`
+    `resolvedPrimaryArity` did not add both the doBlock's arity and the arity from the `|>` at the same time.  If the pipe was there, the `do` was ignored because the pre-existing `resolvePrimaryArity` was not used if the normal primary arity of the call was zero, which is the case for `|> case do`.
+  * Find module for elements in libraries
+    Elements in libraries don't have a `Module` from `ModuleUtil.findModuleForPsiElement`, so scan the element's project's module's content roots for the closest `Module` for libraries.
+  * `prependQualifiers` when typing an alias on a new line in the body of a function.
+  * Don't descend into `quote` blocks if the call being resolved is given to an `unquote` in the `quote` block.
 
 ## v11.10.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -437,6 +437,14 @@
   * Walk `quote` macros for sibling call definitions
   * Always fallback to name/arity in any module if callable not resolved in scope
   * Resolve uses of aliased name produced by `alias __MODULE__`
+* [#1967](https://github.com/KronicDeth/intellij-elixir/pull/1967) - [@KronicDeth](https://github.com/KronicDeth)
+  * Updates
+    * IntelliJ IDEA build version to 2021.1.2
+      * Update `ParsingTestCase` to latest APIs.
+    * Gradle plugins
+      * intellij 1.0
+      * kotlin.jvm 1.5.10 
+  * Configure `runPluginVerifier`
 
 ### Bug Fixes
 * [#1948](https://github.com/KronicDeth/intellij-elixir/pull/1948) - [@KronicDeth](https://github.com/KronicDeth)
@@ -590,6 +598,10 @@
     Elements in libraries don't have a `Module` from `ModuleUtil.findModuleForPsiElement`, so scan the element's project's module's content roots for the closest `Module` for libraries.
   * `prependQualifiers` when typing an alias on a new line in the body of a function.
   * Don't descend into `quote` blocks if the call being resolved is given to an `unquote` in the `quote` block.
+* [#1967](https://github.com/KronicDeth/intellij-elixir/pull/1967) - [@KronicDeth](https://github.com/KronicDeth)
+  * `updateSinceUntilBuild` to prevent breaking in future IDEs.
+  * Check if modules loaded before using `findModuleForPsiElement`.
+  * Use `BasePlatformTestCase` instead of `LightCodeInsightTestCase` because `LightCodeInsightTestCase` is deprecated.
 
 ## v11.10.0
 

--- a/build.gradle
+++ b/build.gradle
@@ -105,6 +105,10 @@ allprojects {
     token System.getenv("JET_BRAINS_MARKETPLACE_TOKEN")
     channels publishChannels
   }
+
+  runPluginVerifier {
+    ideVersions = ["2021.1.2"]
+  }
 }
 
 apply plugin: "kotlin"

--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,9 @@ allprojects {
   intellij {
     def intellij_erlang_version
 
-    if (ideaVersion.startsWith("2020.2")) {
+    if (ideaVersion.startsWith("2021.1.2")) {
+      intellij_erlang_version = "0.11.1108"
+    } else if (ideaVersion.startsWith("2020.2")) {
       intellij_erlang_version = "0.11.1068"
     } else if (ideaVersion.startsWith("2020.1")) {
       intellij_erlang_version = "0.11.1059"

--- a/build.gradle
+++ b/build.gradle
@@ -88,7 +88,6 @@ allprojects {
     pluginName 'intellij-elixir'
     version ideaVersion
     downloadSources Boolean.valueOf(sources)
-    updateSinceUntilBuild = false
   }
 
   patchPluginXml {

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
-  id 'org.jetbrains.intellij' version "0.6.3"
-  id "org.jetbrains.kotlin.jvm" version "1.3.70"
+  id 'org.jetbrains.intellij' version "1.0"
+  id "org.jetbrains.kotlin.jvm" version "1.5.10"
   id 'de.undercouch.download' version "4.1.1"
 }
 
@@ -49,45 +49,15 @@ sourceSets {
 allprojects {
   apply plugin: 'org.jetbrains.intellij'
   intellij {
-    def intellij_erlang_version
-
-    if (ideaVersion.startsWith("2021.1.2")) {
-      intellij_erlang_version = "0.11.1108"
-    } else if (ideaVersion.startsWith("2020.2")) {
-      intellij_erlang_version = "0.11.1068"
-    } else if (ideaVersion.startsWith("2020.1")) {
-      intellij_erlang_version = "0.11.1059"
-    } else if (ideaVersion.startsWith("2019.2")) {
-      intellij_erlang_version = "0.11.1008"
-    } else if (ideaVersion.startsWith("2019.1")) {
-      intellij_erlang_version = "0.11.1004"
-    } else if (ideaVersion.startsWith("2018.3")) {
-      intellij_erlang_version = "0.11.1000"
-    } else if (ideaVersion.startsWith("2018.2")) {
-      intellij_erlang_version = "0.11.985"
-    } else if (ideaVersion.startsWith("2018.1")) {
-      intellij_erlang_version = "0.11.976"
-    } else if (ideaVersion.startsWith("2017.3")) {
-      intellij_erlang_version = "0.10.966"
-    } else if (ideaVersion.startsWith("2017.2")) {
-      intellij_erlang_version = "0.9.958"
-    } else if (ideaVersion.startsWith("2017.1.")) {
-      intellij_erlang_version = "0.9.939"
-    } else if (ideaVersion.startsWith("2016.3.")) {
-      intellij_erlang_version = "0.9.912"
-    } else {
-      throw new IllegalArgumentException("ideaVersion is not a recognized MAJOR.MINOR for IntelliJ Erlang compatibility")
-    }
-
     plugins = [// needed for jps builder
                "java",
-               "org.jetbrains.erlang:${intellij_erlang_version}",
+               "org.jetbrains.erlang:0.11.1108",
                // always have IdeaVIM installed in sandbox
-               "IdeaVIM:0.56",
+               "IdeaVIM:0.67",
                "PsiViewer:3.28.93"]
-    pluginName 'intellij-elixir'
-    version ideaVersion
-    downloadSources Boolean.valueOf(sources)
+    pluginName.set('intellij-elixir')
+    version.set(ideaVersion)
+    downloadSources.set(Boolean.valueOf(sources))
   }
 
   patchPluginXml {
@@ -96,14 +66,18 @@ allprojects {
       stripTag(stripTag(file(path).text, "html"), "body")
     }
 
-    changeNotes bodyInnerHTML("resources/META-INF/changelog.html")
-    pluginDescription bodyInnerHTML("resources/META-INF/description.html")
+    changeNotes.set(bodyInnerHTML("resources/META-INF/changelog.html"))
+    pluginDescription.set(bodyInnerHTML("resources/META-INF/description.html"))
   }
 
   publishPlugin {
-    distributionFile System.getenv("ASSET_PATH")
-    token System.getenv("JET_BRAINS_MARKETPLACE_TOKEN")
-    channels publishChannels
+    distributionFile = provider {
+      System.getenv("ASSET_PATH")
+    }
+    token = provider {
+      System.getenv("JET_BRAINS_MARKETPLACE_TOKEN")
+    }
+    channels = publishChannels.split(',').toList()
   }
 
   runPluginVerifier {
@@ -117,7 +91,7 @@ apply plugin: "kotlin"
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
   //noinspection GrUnresolvedAccess
   kotlinOptions {
-    apiVersion = "1.2"
+    apiVersion = "1.3"
     jvmTarget = "1.8"
   }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@
 # https://www.jetbrains.com/intellij-repository/snapshots
 
 baseVersion = 11.11.0
-ideaVersion = 2020.2.2
+ideaVersion = 2021.1.2
 # MUST stay at 1.8 for JPS (Build/Compile Project) compatibility even if JRE/JBR is newer
 javaVersion = 1.8
 # MUST stay at 1.8 for JPS (Build/Compile Project) compatibility even if JRE/JBR is newer

--- a/resources/META-INF/changelog.html
+++ b/resources/META-INF/changelog.html
@@ -1,5 +1,970 @@
 <html>
 <body>
+<h1>v11.11.0</h1>
+<ul>
+  <li>
+    <p>Enhancements</p>
+    <ul>
+      <li>
+        <p>Reference Resolution</p>
+        <ul>
+          <li>
+            <p>
+              Allow any Alias in a chain to have references.<br>
+              This allows going to the declaration of <code>Phoenix</code>, <code>Phoenix.LiveView</code>, or
+              <code>Phoenix.LiveView.Socket</code> depending on whether you're on the <code>Phoenix</code>,
+              <code>LiveView</code>, or <code>Socket</code> Alias, respectively, in the chain.
+            </p>
+            <ul>
+              <li>
+                <p>
+                  Allow any Alias in Qualified Alias to be resolved<br>
+                  This allows going to the declaration of Phoenix, Phoenix.LiveView, or Phoenix.LiveView.Socket
+                  depending on whether you're<br>
+                  on the Phoenix, LiveView, or Socket Alias, respectively, in the chain.
+                </p>
+              </li>
+              <li>
+                <p>Update DocumentationProvider to work with improved Alias resolution</p>
+                <p>
+                  Without these changes the DocumentationProvider double-resolves and so ends up showing the docs for
+                  <code>def</code> and <code>defmodule</code>, instead of the call definition clause or module,
+                  respectively.
+                </p>
+              </li>
+            </ul>
+          </li>
+          <li>
+            <p>
+              Reimplement Module references<br>
+              Instead of references for only the outermost QualifiableAlias, there is a reference for each right-most
+              Alias at a given position, so instead of there only be a reference to <code>App.Context.Schema</code> in
+              <code>App.Context.Schema</code>, there is now a reference to <code>App</code> in the <code>App</code>
+              prefix, a reference to <code>App.Context</code> in <code>Context</code> in <code>App.Context</code>, and a
+              reference to <code>App.Context.Schema</code> in <code>Schema</code> in <code>App.Context.Schema</code>.
+              Not only is this more useful, being able to jump to parent namespaces, but it fixed some of the capability
+              issues with Go To Definition in the 2020 line of IDEs.  This approach of using
+              <code>getRangeInElement</code> to target the range of the right-most Alias, while the element was still
+              the parent that contained, but did not go beyond the Alias, was tried after having references only on
+              <code>Alias</code>es and not <code>QualifiedAlias</code>es did not fix completion issues.  It was the
+              while debugging Go To Declaration actions and noticing they were sensitive to the range in element AND the
+              <a href="https://github.com/JetBrains/intellij-community/blob/f66e9644fa683fba22f4ce9e30c037720f745989/platform/core-api/src/com/intellij/psi/PsiReference.java#L49-L62">
+                docs for PsiReference#getRangeInElement
+              </a> that I realized that the Go To Declaration and Completion has a hidden requirement that References
+              for things that behave like namespaces have to work this way.
+            </p>
+            <ul>
+              <li>Use <code>ModularName</code> index for Module Variants<br>
+                Have a smaller index to iterate and remove need for the <code>isAlias</code> check.</li>
+            </ul>
+          </li>
+          <li>
+            <p>Limit Elixir Module resolution to same JetBrains Project Module</p>
+            <ul>
+              <li>
+                Change the <code>GlobalSearchScope</code> from <code>allProject</code> to
+                <code>moduleWithDependenciesAndLibrariesScope</code> for faster searching on multi-module projects.
+                <ul>
+                  <li>Set <code>includeTests</code> based whether the referring element is in a test directory.</li>
+                </ul>
+              </li>
+              <li>
+                Use <code>StubIndex#processElements</code> instead of home grown <code>forEachNavigationElement</code> as
+                <code>processElements</code> is more efficient.
+              </li>
+            </ul>
+          </li>
+          <li>
+            <p>Favor Module <code>ResolveResults</code> under same <code>Module</code> content roots<br>
+              This should favor deps sources in the same module.</p>
+          </li>
+          <li>
+            <p>
+              Iterate <code>function</code> body in <code>unquote(function())</code> when iterating call definition
+              clauses in <code>quote</code><br>
+              Treats it <code>function</code> body the same as a <code>__using__</code> body.
+            </p>
+          </li>
+          <li>
+            <p>Standardized preferred <code>ResolveResult</code> filters between Callables and Modules</p>
+            <ol>
+              <li>Prefer valid results as long as it doesn't leave no results.</li>
+              <li>Prefer results in the same module as long as it doesn't leave no results.</li>
+            </ol>
+            <p>In Go To Declaration also:</p>
+            <ol start="3">
+              <li>Prefer results in source (that aren't decompiled) as long as it doesn't leave no results.</li>
+            </ol>
+          </li>
+          <li>
+            <p>Use the second argument to <code>use</code> to determine which function is called with apply/3</p>
+            <p>
+              This pattern is used in Phoenix <code>__using__</code>, so this lets to differentiate whether
+              <code>Plug.Conn.assign/3</code> or <code>Phoenix.LiveSocket.assign/3</code> is resolved in a Controller,
+              LiveComponent, or LiveView.
+            </p>
+          </li>
+          <li>
+            <p>In LEEx Templates</p>
+            <ul>
+              <li>
+                Resolve function calls in <code>*.html.leex</code> templates to functions defined in the corresponding
+                LiveComponent/View module.
+              </li>
+              <li>Assigns
+                <ul>
+                  <li>
+                    Resolve assigns in LEEx templates to the keyword key in <code>assign/3</code> calls in
+                    <code>update/2</code> in the LiveComponent or LiveView<br>
+                    Had to add back in a <code>TargetElementEvaluator</code>, so that the
+                    <code>UnqualifiedNoArgumentCall</code> (<code>name</code>) that is the identifier in an assign
+                    (<code>@name</code>) was not counted as valid target for Find Usages / Go To Declaration by itself.
+                  </li>
+                  <li>
+                    Search for assigns in all call definitions in view module<br>
+                    Expand from just <code>update</code> to any call definition to cover helper functions and other
+                    callbacks. Don't stop on the first valid match because with helper functions and multiple callbacks,
+                    the last write isn't obvious.
+                  </li>
+                  <li>Resolve assigns set with <code>assign/3</code></li>
+                  <li>Look for <code>assign</code> calls in <code>|&gt;</code> pipelines</li>
+                  <li>Resolve assigns set with <code>assign_new/3</code></li>
+                  <li>Resolve @live_action to where it is assigned Phoenix.LiveView.Channel.assign_action/2</li>
+                  <li>Find assigns in maps for assign/2<br>
+                    Since assign/2 accepts either a keyword list or a map, check in both types.</li>
+                  <li>Resolve <code>@myself</code> to where it is set in <code>render_pending_components</code></li>
+                  <li>Resolve assigns in macros with do blocks like <code>case</code> and <code>if</code></li>
+                  <li>
+                    Find assigns in <code>live_component</code> calls<br>
+                    If an assign can't be found in the body of a LiveComponent module, then it maybe passed through from
+                    the <code>live_component</code> call itself, so look for any references to the view module
+                    (the LiveComponent) and if it is a <code>live_component</code> call, then look at those assigns to
+                    try to resolve the assign name.
+                  </li>
+                  <li>
+                    Resolve assigns to <code>live_modal</code> calls<br>
+                    <code>live_modal</code> is not built into <code>phoenix_live_view</code>, but it is generated by
+                    <code>phx.gen.live</code>, so most projects will have it.&nbsp; This allows <code>return_to</code>,
+                    which is used use in <code>live_modal</code>, to be resolved.
+                  </li>
+                  <li>Resolve <code>@socket</code> to last socket variable or call in view module.</li>
+                  <li>Resolve <code>@flash</code> to <code>put_flash/3</code> calls.</li>
+                  <li>
+                    Resolve <code>@inner_content</code> to <code>Phoenix.LiveView.Utils.to_rendered/2</code> setting the
+                    assign with <code>put_in</code>
+                  </li>
+                </ul>
+              </li>
+              <li>
+                Resolve aliases in <code>.leex</code> templates<br>
+                Generalize the <code>.leex</code> and <code>use</code> walking from call definition clauses to any scope
+                processor lambda, so it can be used to resolve uses of <code>Routes</code> in <code>.leex</code>
+                templates.
+              </li>
+            </ul>
+          </li>
+          <li>
+            <p>Resolve Types</p>
+            <ul>
+              <li>Have separate references specifically for Types.</li>
+              <li>
+                Resolve to both types declared with <code>@type</code>, <code>@typep</code>, or <code>@opaque</code>;
+                and named type parameters.
+              </li>
+              <li>Process declarations for <code>@type</code>, <code>@typep</code>, and <code>@opaque</code>.</li>
+              <li>Count <code>@callback</code> as declaring a Type</li>
+              <li>
+                Resolve type <code>t</code> for <code>defprotocol</code> to where it is defined in
+                <code>Protocol.__protocol__</code><br>
+                Unfortunately, this ties all protocol's <code>t</code> to the same element, so Find Usage finds all
+                protocol's types instead of just a specific module's type, but this works for projects that have source,
+                but not yet compiled.
+                <ul>
+                  <li>Favor protocol-specific decompiled <code>@type t</code> when available.</li>
+                </ul>
+              </li>
+              <li>Resolve type variable to the keyword key in guards.</li>
+              <li><code>__MODULE__</code></li>
+            </ul>
+          </li>
+          <li>
+            <p>
+              Favor source over decompiled per name instead of overall for <code>ResolveResultOrderedSet</code><br>
+              This allows the <code>Routes</code> alias to be resolved to the both the
+              <code>MyAppWeb.Router.Helpers</code> in <code>alias MyAppWeb.Router.Helpers, as: Routes</code> in the
+              source of <code>MyAppWeb</code>, but also the decompiled <code>MyAppWeb.Router.Helpers</code>, which is
+              necessary as <code>MyAppWeb.Router.Helpers</code> is produced on compile from <code>router.ex</code>.
+            </p>
+          </li>
+          <li>
+            <p>Resolve references through <code>defdelegate</code> calls.</p>
+          </li>
+          <li>
+            <p>Resolve <code>code_reloading?</code> in MyApp.Endpoint</p>
+            <p>The generated <code>MyApp.Endpoint</code> for <code>mix phx.new</code> has a section to enable code-reloading at compile time:</p>
+            <div class="highlight highlight-source-elixir position-relative"><pre><span class="pl-c"><span class="pl-c">#</span> Code reloading can be explicitly enabled under the</span>
+<span class="pl-c"><span class="pl-c">#</span> :code_reloader configuration of your endpoint.</span>
+<span class="pl-k">if</span> code_reloading? <span class="pl-k">do</span>
+  <span class="pl-en">socket</span>(<span class="pl-s"><span class="pl-pds">"</span>/phoenix/live_reload/socket<span class="pl-pds">"</span></span>, <span class="pl-en">Phoenix</span>.<span class="pl-en">LiveReloader</span>.<span class="pl-en">Socket</span>)
+  <span class="pl-en">plug</span>(<span class="pl-en">Phoenix</span>.<span class="pl-en">LiveReloader</span>)
+  <span class="pl-en">plug</span>(<span class="pl-en">Phoenix</span>.<span class="pl-en">CodeReloader</span>)
+<span class="pl-k">end</span></pre><div class="zeroclipboard-container position-absolute right-0 top-0">
+              <clipboard-copy aria-label="Copy" class="ClipboardButton btn js-clipboard-copy m-2 p-0 tooltipped-no-delay" data-copy-feedback="Copied!" data-tooltip-direction="w" value="# Code reloading can be explicitly enabled under the
+# :code_reloader configuration of your endpoint.
+if code_reloading? do
+  socket(&quot;/phoenix/live_reload/socket&quot;, Phoenix.LiveReloader.Socket)
+  plug(Phoenix.LiveReloader)
+  plug(Phoenix.CodeReloader)
+end
+" tabindex="0" role="button">
+                <svg aria-hidden="true" viewBox="0 0 16 16" version="1.1" data-view-component="true" height="16" width="16" class="octicon octicon-clippy js-clipboard-clippy-icon m-2">
+                  <path fill-rule="evenodd" d="M5.75 1a.75.75 0 00-.75.75v3c0 .414.336.75.75.75h4.5a.75.75 0 00.75-.75v-3a.75.75 0 00-.75-.75h-4.5zm.75 3V2.5h3V4h-3zm-2.874-.467a.75.75 0 00-.752-1.298A1.75 1.75 0 002 3.75v9.5c0 .966.784 1.75 1.75 1.75h8.5A1.75 1.75 0 0014 13.25v-9.5a1.75 1.75 0 00-.874-1.515.75.75 0 10-.752 1.298.25.25 0 01.126.217v9.5a.25.25 0 01-.25.25h-8.5a.25.25 0 01-.25-.25v-9.5a.25.25 0 01.126-.217z"></path>
+                </svg>
+                <svg aria-hidden="true" viewBox="0 0 16 16" version="1.1" data-view-component="true" height="16" width="16" class="octicon octicon-check js-clipboard-check-icon color-text-success d-none m-2">
+                  <path fill-rule="evenodd" d="M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z"></path>
+                </svg>
+              </clipboard-copy>
+            </div></div>
+            <p>
+              Previously, <code>code_reloading?</code> variable would not resolve because psi.scope.Variable ignored
+              <code>use</code> calls, not <code>use</code> calls are entered and the <code>var!(code_reloading?)</code>
+              is found in <code>Phoenix.Endpoint.config/1</code> by way of the <code>unquote(config(opts))</code> call
+              in the <code>quote</code> block in <code>__using__(opts)</code>.
+            </p>
+          </li>
+          <li>
+            <p>Resolve qualified calls with unknown resolvable qualifier using only relative identifier and arity.</p>
+          </li>
+          <li>
+            <p><code>@spec</code></p>
+            <ul>
+              <li>Resolve <code>@spec</code> to <code>defdelegate</code> calls.</li>
+              <li>Resolve <code>@specs</code> to the definitions if the definitions are in a for comprehension</li>
+            </ul>
+          </li>
+          <li>
+            <p><code>Ecto</code></p>
+            <ul>
+              <li><code>Query</code>
+                <ul>
+                  <li>
+                    <p>Resolve reference variables in <code>Ecto.Query</code></p>
+                    <ul>
+                      <li>
+                        Reference variables are introduced in as the left operand of <code>in</code> passed to
+                        <code>from/2</code> and the <code>join:</code> keyword in <code>from/2</code>.
+                      </li>
+                      <li><code>join/3-5</code></li>
+                      <li>Resolve bindings in <code>select/2-3</code>.</li>
+                      <li>Resolve reference variables in <code>where/2,3</code> binding.<br>
+                        Also add support for resolving <code>a</code> in <code>[{^assoc, a}]</code> binding.</li>
+                      <li>Resolve <code>bindings</code> in <code>group_by/2-3</code>.</li>
+                      <li>Resolve <code>bindings</code> and <code>expressions</code> in <code>order_by/2-3</code>.</li>
+                      <li>Resolve <code>bindings</code> in <code>having/2-3</code>.</li>
+                      <li>Add <code>select_merge</code> to declaring <code>Ecto.Query</code> macros.</li>
+                      <li>Add <code>distinct/2-3</code> as a declaring <code>Ecto.Query</code> macro.</li>
+                    </ul>
+                  </li>
+                  <li>
+                    <p>Resolve <code>field</code> calls in Ecto <code>schema</code> blocks</p>
+                    <p>How <code>field</code> works in <code>schema</code> for <code>Ecto.Schema</code></p>
+                    <ol>
+                      <li><code>use Ecto.Schema</code></li>
+                      <li><code>Ecto.Schema.__using__</code></li>
+                      <li>`import Ecto.Schema, only: [schema: 2, embedded_schema: 1]``</li>
+                    </ol>
+                    <p>
+                      Note that only the outer DSLs, schema and embedded_schema are available even though field/2 is
+                      defined in Ecto.Schema.
+                    </p>
+                    <p>So when you call <code>schema ... do</code></p>
+                    <ol>
+                      <li><code>defmacro schema(source, [do: block])</code></li>
+                      <li><code>schema(__CALLER__, source, true, :id, block)</code></li>
+                      <li><code>defp schema(caller, source, meta?, type, block)</code></li>
+                      <li>There's a big <code>prelude = quote do</code> quote block</li>
+                    </ol>
+                    <p>At the end of prelude there is</p>
+                    <div class="highlight highlight-source-elixir position-relative"><pre><span class="pl-k">try</span> <span class="pl-k">do</span>
+  <span class="pl-k">import</span> <span class="pl-en">Ecto</span>.<span class="pl-en">Schema</span>
+  <span class="pl-en">unquote</span>(block)
+<span class="pl-k">after</span>
+  <span class="pl-c1">:ok</span>
+<span class="pl-k">end</span></pre><div class="zeroclipboard-container position-absolute right-0 top-0">
+                      <clipboard-copy aria-label="Copy" class="ClipboardButton btn js-clipboard-copy m-2 p-0 tooltipped-no-delay" data-copy-feedback="Copied!" data-tooltip-direction="w" value="try do
+  import Ecto.Schema
+  unquote(block)
+after
+  :ok
+end
+" tabindex="0" role="button">
+                        <svg aria-hidden="true" viewBox="0 0 16 16" version="1.1" data-view-component="true" height="16" width="16" class="octicon octicon-clippy js-clipboard-clippy-icon m-2">
+                          <path fill-rule="evenodd" d="M5.75 1a.75.75 0 00-.75.75v3c0 .414.336.75.75.75h4.5a.75.75 0 00.75-.75v-3a.75.75 0 00-.75-.75h-4.5zm.75 3V2.5h3V4h-3zm-2.874-.467a.75.75 0 00-.752-1.298A1.75 1.75 0 002 3.75v9.5c0 .966.784 1.75 1.75 1.75h8.5A1.75 1.75 0 0014 13.25v-9.5a1.75 1.75 0 00-.874-1.515.75.75 0 10-.752 1.298.25.25 0 01.126.217v9.5a.25.25 0 01-.25.25h-8.5a.25.25 0 01-.25-.25v-9.5a.25.25 0 01.126-.217z"></path>
+                        </svg>
+                        <svg aria-hidden="true" viewBox="0 0 16 16" version="1.1" data-view-component="true" height="16" width="16" class="octicon octicon-check js-clipboard-check-icon color-text-success d-none m-2">
+                          <path fill-rule="evenodd" d="M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z"></path>
+                        </svg>
+                      </clipboard-copy>
+                    </div></div>
+                    <p>
+                      Hey! An <code>import Ecto.Schema</code>, but <code>prelude</code> is just floating as a variable.&nbsp;
+                      At the end of&nbsp; <code>defp schema(caller, source, meta?, type, block)</code> is
+                    </p>
+                    <div class="highlight highlight-source-elixir position-relative"><pre><span class="pl-k">quote</span> <span class="pl-k">do</span>
+  <span class="pl-en">unquote</span>(prelude)
+  <span class="pl-en">unquote</span>(postlude)
+<span class="pl-k">end</span></pre><div class="zeroclipboard-container position-absolute right-0 top-0">
+                      <clipboard-copy aria-label="Copy" class="ClipboardButton btn js-clipboard-copy m-2 p-0 tooltipped-no-delay" data-copy-feedback="Copied!" data-tooltip-direction="w" value="quote do
+  unquote(prelude)
+  unquote(postlude)
+end
+" tabindex="0" role="button">
+                        <svg aria-hidden="true" viewBox="0 0 16 16" version="1.1" data-view-component="true" height="16" width="16" class="octicon octicon-clippy js-clipboard-clippy-icon m-2">
+                          <path fill-rule="evenodd" d="M5.75 1a.75.75 0 00-.75.75v3c0 .414.336.75.75.75h4.5a.75.75 0 00.75-.75v-3a.75.75 0 00-.75-.75h-4.5zm.75 3V2.5h3V4h-3zm-2.874-.467a.75.75 0 00-.752-1.298A1.75 1.75 0 002 3.75v9.5c0 .966.784 1.75 1.75 1.75h8.5A1.75 1.75 0 0014 13.25v-9.5a1.75 1.75 0 00-.874-1.515.75.75 0 10-.752 1.298.25.25 0 01.126.217v9.5a.25.25 0 01-.25.25h-8.5a.25.25 0 01-.25-.25v-9.5a.25.25 0 01.126-.217z"></path>
+                        </svg>
+                        <svg aria-hidden="true" viewBox="0 0 16 16" version="1.1" data-view-component="true" height="16" width="16" class="octicon octicon-check js-clipboard-check-icon color-text-success d-none m-2">
+                          <path fill-rule="evenodd" d="M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z"></path>
+                        </svg>
+                      </clipboard-copy>
+                    </div></div>
+                    <p>So to statically analyze an <code>Ecto.Schema</code> module.</p>
+                    <ol>
+                      <li>
+                        Resolve <code>schema/2</code> to <code>defmacro schema</code> by walking the <code>use</code>,
+                        <code>__using__</code>, <code>quote</code>, and <code>import</code>.
+                      </li>
+                      <li>
+                        Inside the <code>schema/2</code> (or macros in general if you want to get fancy 💅 and support
+                        more DSLs),
+                      </li>
+                      <li>Go into the body of the macro.&nbsp; If there's a call, resolve it</li>
+                      <li>Go into the called function</li>
+                      <li>
+                        Look for a <code>quote</code> block at the end (the same as my current <code>__using__</code>
+                        support)
+                      </li>
+                      <li>
+                        If there's a <code>Call</code> inside an <code>unquote</code> see if you can resolve it to a
+                        variable in addition to a call definition (which is already supported for Phoenix).
+                      </li>
+                      <li>
+                        If it's a variable, check it's value.&nbsp; If it's a <code>quote</code>, use the quote block
+                        handling
+                      </li>
+                      <li>In the quote block handling add support for <code>try</code></li>
+                      <li>
+                        Walk the <code>try</code> and see the <code>import</code>, walk the <code>import</code> to find
+                        <code>Ecto.Schema.field/2</code>
+                      </li>
+                    </ol>
+                  </li>
+                  <li>
+                    <p><code>API</code></p>
+                    <ul>
+                      <li>Resolve <code>Ecto.Query.API</code> functions in <code>Ecto.Query</code></li>
+                      <li><code>from(order_by: ...)</code></li>
+                      <li><code>from(select: ...)</code>
+                        <ul>
+                          <li><code>from(select: tuple())</code></li>
+                        </ul>
+                      </li>
+                      <li><code>from(where: ...)</code></li>
+                      <li><code>group_by/2-3</code></li>
+                      <li><code>having/2-3</code></li>
+                      <li><code>select/2-3</code> <code>expr</code> argument</li>
+                      <li><code>where</code></li>
+                      <li>Resolve <code>Ecto.Query.API.fragment</code> to arity interval <code>0..</code>.</li>
+                      <li>
+                        Resolve <code>fragment</code> nested in other <code>Ecto.Query.API</code> call like
+                        <code>type</code>.
+                      </li>
+                      <li>
+                        Walk <code>rightOperand</code> of <code>join(..., ... in ..., ...)</code> for
+                        <code>Ecto.Query.API</code> usages like <code>fragment</code>.
+                      </li>
+                    </ul>
+                  </li>
+                </ul>
+              </li>
+            </ul>
+          </li>
+          <li>
+            <p>Resolve module attributes defined in <code>use</code> <code>__using__</code> <code>quote</code> block</p>
+            <ul>
+              <li>
+                Change <code>org.elixir_lang.reference.resolver.ModuleAttribute</code> to use
+                <code>PsiScopeProcessor</code> for non-<code>@for</code> and non-<code>@protocol</code> instead of
+                custom logic.
+              </li>
+              <li>
+                Don't descend into a <code>use</code> if the <code>ENTRANCE</code> is an ancestor since that means the
+                <code>Alias</code> on the <code>use</code> is probably being resolved.
+              </li>
+              <li>
+                <code>AtUnqualifiedNoParenthesesCall.processDeclarations</code> will call <code>processor.execute</code>
+                when it isn't a type spec.
+              </li>
+              <li>
+                The <code>UseScopeSelector</code> for <code>AtUnqualifiedNoParenthesesCallImpl</code> has been changed
+                to <code>SELF_AND_FOLLOWING_SIBLINGS</code> since the module attribute is used that way.&nbsp; The previous
+                <code>SELF</code> value was when the <code>UseScopeSelector</code> only applied to variables.
+              </li>
+            </ul>
+          </li>
+        </ul>
+      </li>
+      <li>
+        <p>"Elixir References" inspection for finding unresolved or invalid references.</p>
+        <ul>
+          <li><code>visitAtNonNumericOperation</code><br>
+            Helps "Elixir References" find unresolved assigns.</li>
+        </ul>
+      </li>
+      <li>
+        <p>Strip <code>AccessExpression</code>s from <code>Qualified</code> qualifiers automatically</p>
+      </li>
+      <li>
+        <p>Documentation</p>
+        <ul>
+          <li>
+            Show <code>deprecated</code>, <code>impl</code>, and <code>spec</code>, and actual heads in documentation
+            for source functions
+          </li>
+          <li>Merge <code>Documentation</code> across multiple arities when arity of lookup is ambiguous.</li>
+        </ul>
+      </li>
+      <li>
+        <p>
+          Find variables defined in EEx element<br>
+          Finds variables defined in EEx PsiElement by creating them the same as a StabBody, which means that the
+          siblings are checked backwards from the last parent.&nbsp; This fixes resolving the <code>f</code> from
+          <code>f = form_for ...</code> in <code>*input f ...</code> in LiveView FormComponent templates.
+        </p>
+      </li>
+      <li>
+        <p>Highlight named parameters in types.</p>
+      </li>
+      <li>
+        <p>Decompilation</p>
+        <ul>
+          <li>
+            Fake built-in types by decompiling in <code>:erlang.beam</code><br>
+            For type reference resolution of built-in types to work, they need to be defined somewhere.&nbsp; IntelliJ Erlang
+            does this by looping usages back on themselves, but this leads to Find Usages not working for built-in types
+            since each usage is a distinct declaration.&nbsp; By instead defining the types in decompiled
+            <code>:erlang.beam</code> (even though they aren't actually defined there), there is a shared location for
+            all reference to point to and then check for Find Usages.
+          </li>
+          <li>Decompile types from EEP-48 documentation.</li>
+        </ul>
+      </li>
+      <li>
+        <p>Descend into body of <code>unless</code> in <code>quote</code> for <code>treeWalkUp</code>.</p>
+      </li>
+      <li>
+        <p>Descend into <code>for</code> when looking for call definition clauses.</p>
+      </li>
+      <li>
+        <p>
+          <code>QuoteMacro.treeWalkUp</code> into <code>if</code><br>
+          <code>unless</code> was already walked, but not <code>if</code>.&nbsp; Fixes resolving <code>Repo.preload/2</code>,
+          which is defined inside an <code>if</code> in <code>use Ecto.Repo</code>'s <code>__using__</code>.
+        </p>
+      </li>
+      <li>
+        <p>Add <code>defguard</code> and <code>defguardp</code> to CallDefinitionClause.<code>is</code>.</p>
+      </li>
+      <li>
+        <p>Don't generate a reference for <code>Elixir</code><br>
+          <code>Elixir</code> is not declared anywhere. It is the namespace of all Aliases.</p>
+      </li>
+      <li>
+        <p>Refactor how sibling sequences are walked<br>
+          Port filtering out comments, white space and end of expressions from <code>siblingExpression</code>.</p>
+      </li>
+      <li>
+        <p>Reimplement <code>fullyQualifiedName</code></p>
+        <p>
+          Eliminate the specialization for <code>ElixirAlias</code> AND <code>QualifiableAlias</code> as which was
+          picked as based on the static casted type. <code>fullyQualifiedName</code> will include the following:
+        </p>
+        <ul>
+          <li>Convert <code>__MODULE__</code> to the enclosing modular canonical name</li>
+          <li>Combine an ElixirAlias with its qualifier
+            <ul>
+              <li>
+                If in a <code>ElixirMultipleAliases</code> will combine the qualifier (<code>qualifier.{...}</code>)
+                outside the <code>{}</code> with the relative name inside <code>...{relative, ...}</code>.
+              </li>
+            </ul>
+          </li>
+        </ul>
+      </li>
+      <li>
+        <p>EEx</p>
+        <ul>
+          <li>
+            <code>viewFile</code> for <code>.eex</code> files used in same directory as <code>.ex</code> using
+            <code>EEx.function_from_file</code>.
+          </li>
+          <li>Resolve function calls to those defined by <code>EEx.function_from_file/3-5</code>.</li>
+          <li>Find view modules for templates under the <code>templates</code> directory.</li>
+        </ul>
+      </li>
+      <li>
+        <p>Walk <code>quote</code> macros for sibling call definitions</p>
+      </li>
+      <li>
+        <p>Always fallback to name/arity in any module if callable not resolved in scope</p>
+      </li>
+      <li>
+        <p>Resolve uses of aliased name produced by <code>alias __MODULE__</code></p>
+      </li>
+    </ul>
+  </li>
+  <li>
+    <p>Bug Fixes</p>
+    <ul>
+      <li>
+        <p>Fix Ctrl+Click/Cmd+B/Go To Declaration for Aliases.</p>
+      </li>
+      <li>
+        <p>Don't index non-canonical names.<br>
+          The non-canonical name for a nested <code>defmodule</code> is the Alias given to that <code>defmodule</code> call.  While that name should be resolvable within the parent modular, it should not be indexed because the index is for the global scope.</p>
+        <p>Prevents <code>defmodule Enum</code> in</p>
+        <div class="highlight highlight-source-elixir position-relative"><pre><span class="pl-k">defmodule</span> <span class="pl-e">ExJsonSchema</span>.<span class="pl-e">Validator</span>.<span class="pl-en">Error</span> <span class="pl-k">do</span>
+  <span class="pl-k">..</span>.
+  <span class="pl-k">defmodule</span> <span class="pl-en">Enum</span> <span class="pl-k">do</span>
+    <span class="pl-k">..</span>.
+  <span class="pl-k">end</span>
+  <span class="pl-k">..</span>.
+<span class="pl-k">end</span></pre><div class="zeroclipboard-container position-absolute right-0 top-0">
+          <clipboard-copy aria-label="Copy" class="ClipboardButton btn js-clipboard-copy m-2 p-0 tooltipped-no-delay" data-copy-feedback="Copied!" data-tooltip-direction="w" value="defmodule ExJsonSchema.Validator.Error do
+  ...
+  defmodule Enum do
+    ...
+  end
+  ...
+end
+" tabindex="0" role="button">
+            <svg aria-hidden="true" viewBox="0 0 16 16" version="1.1" data-view-component="true" height="16" width="16" class="octicon octicon-clippy js-clipboard-clippy-icon m-2">
+              <path fill-rule="evenodd" d="M5.75 1a.75.75 0 00-.75.75v3c0 .414.336.75.75.75h4.5a.75.75 0 00.75-.75v-3a.75.75 0 00-.75-.75h-4.5zm.75 3V2.5h3V4h-3zm-2.874-.467a.75.75 0 00-.752-1.298A1.75 1.75 0 002 3.75v9.5c0 .966.784 1.75 1.75 1.75h8.5A1.75 1.75 0 0014 13.25v-9.5a1.75 1.75 0 00-.874-1.515.75.75 0 10-.752 1.298.25.25 0 01.126.217v9.5a.25.25 0 01-.25.25h-8.5a.25.25 0 01-.25-.25v-9.5a.25.25 0 01.126-.217z"></path>
+            </svg>
+            <svg aria-hidden="true" viewBox="0 0 16 16" version="1.1" data-view-component="true" height="16" width="16" class="octicon octicon-check js-clipboard-check-icon color-text-success d-none m-2">
+              <path fill-rule="evenodd" d="M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z"></path>
+            </svg>
+          </clipboard-copy>
+        </div></div>
+        <p>
+          from being indexed as <code>Enum</code>, which hides the decompiled version from the standard library because
+          source references are favored over decompiled versions when resolving references.
+        </p>
+      </li>
+      <li>
+        <p>Reference Resolution</p>
+        <ul>
+          <li>
+            <p>
+              Only favor same file Module resolutions if they are valid<br>
+              Invalid same file results can occur for prefix matches, but if only prefix matches are available, then a
+              whole project search should occur instead of only when there are no same file <code>ResolveResult</code>
+              of either validity.
+            </p>
+          </li>
+          <li>
+            <p>
+              Include library sources in <code>Module#multiResolveProject</code> <code>GlobalSearchScope</code><br>
+              Ensures that library sources can be returned, which are favored over decompiled libraries, so that
+              <code>__using__</code> macros can be followed.
+            </p>
+          </li>
+          <li>
+            <p>
+              Protect from <code>Module</code> reference element not having a <code>VirtualFile</code> when checking if
+              a test file.
+            </p>
+          </li>
+          <li>
+            <p>Fix <code>QualifiableAliasImpl#fullyQualifiedName</code></p>
+            <ul>
+              <li>
+                Include qualifier of <code>MultipleAliases</code><br>
+                In an <code>alias</code> line like <code>alias Myapp.MyContext.{Schema1, Schema2}</code>,
+                <code>Schema1</code> would think its <code>fullyQualifiedName</code> was only <code>Schema1</code>, when
+                it should included the <code>fullyQualifiedName</code> of the qualifier, <code>MyApp.MyContext</code>
+                too. This leads to the correct <code>Schema1</code> fully-qualified name of
+                <code>MyApp.MyContext.Schema1</code>.&nbsp; This fix makes references to <code>Schema1</code> resolve to
+                both the <code>alias</code> and the <code>defmodule</code>.
+              </li>
+              <li>
+                Include qualifier of <code>MultipleAliases</code> for deep aliases<br>
+                In an <code>alias</code> line like
+                <code>alias Myapp.MyContext.{NestedContext1.Schema1, NestedContext2.Schema2}</code>,
+                <code>Schema1</code> would think its <code>fullyQualifiedName</code> was only
+                <code>NestedContext1.Schema1</code>, when it should included the <code>fullyQualifiedName</code> of the
+                qualifier, <code>MyApp.MyContext</code> too.&nbsp; This leads to the correct <code>Schema1</code>
+                fully-qualified name of <code>MyApp.MyContext.NestedContext.Schema1</code>.&nbsp; This fix makes
+                references to <code>Schema1</code> resolve to both the <code>alias</code> and the
+                <code>defmodule</code>.
+              </li>
+            </ul>
+          </li>
+          <li>
+            <p>In LEEx Templates</p>
+            <ul>
+              <li>Don't check for implicit imports at top of template file if there is a view file<br>
+                The implicit imports should come last, after the view file has been processed.</li>
+              <li>Ignore call definition clauses expressions that can't contain an assign
+                <ul>
+                  <li>Atom keywords (<code>false</code>, <code>true</code>, <code>nil</code>)</li>
+                  <li>Maps</li>
+                  <li>Structs</li>
+                  <li>Keyword lists</li>
+                  <li>Strings and charlists</li>
+                </ul>
+              </li>
+              <li>Don't follow variables for assigns<br>
+                For now, don't follow variables to look for assigns.</li>
+              <li>
+                Fix finding assigns in <code>|&gt; case do ... end</code><br>
+                <code>None</code> calls were ignored, but when <code>case</code> is used in a pipeline it is a
+                <code>None</code> since it has no literal arguments and only resolved arguments, so it was being
+                ignored.
+              </li>
+              <li>Ignore Lists and Aliases when resolving assigns</li>
+              <li>
+                Fix resolve assigns in <code>if</code>s<br>
+                Only looked in <code>stab</code> of the <code>doBlock</code>, but the <code>else</code> is in the
+                <code>blockList</code>.
+              </li>
+            </ul>
+          </li>
+          <li>
+            <p>Don't use the same path for actual aliases and defmodules when resolving aliases<br>
+              Prevents a case of an exact match and its namespace both being marked as valid (exact matches).</p>
+          </li>
+          <li>
+            <p>Types</p>
+            <ul>
+              <li>
+                Don't generate references for map key optionality (<code>required/1</code> and <code>optional/1</code>)
+              </li>
+              <li>Don't create a reference to <code>...</code> in lists in type specs.</li>
+              <li>Look above <code>ElixirStabBody</code> for <code>ancestorTypeSpec</code>.</li>
+              <li>
+                Generate <code>Callable</code> reference for <code>unquote</code> in typespec instead of
+                <code>Type</code> reference.
+              </li>
+            </ul>
+          </li>
+          <li>
+            <p>
+              Allow modular names to resolve to multiple modulars<br>
+              Fix <code>:systemd.ready()</code> not resolving because <code>:systemd</code> only exists as a decompiled
+              file from source because it is Erlang and there is no preference given to different MIX_ENVs.&nbsp; All
+              MIX_ENV <code>defmodule :systemd</code> are returned for the <code>:systemd</code> and all of them are
+              checked for <code>ready/0</code>.
+            </p>
+          </li>
+          <li>
+            <p>Fix resolving qualified calls that are defined through use</p>
+            <p>
+              Resolving qualified calls only used <code>Modular.callDefinitionClauseCallFoldWhile</code>, which ignores
+              all non call definition, which means it ignored the <code>use</code>, but switching to use
+              <code>org.elixir_lang.psi.scope.call_definition_clause.MultiResolve</code> <code>PsiScopeProcessor</code>
+              used for unqualified calls, but starting on the modular call of the qualifier, all the <code>use</code>
+              handling that works for unqualified calls also works for qualified calls now.
+            </p>
+            <p>
+              This fixes resolving <code>MyAppWeb.Endpoint.config_change(changed, removed)</code> in
+              <code>MyApp.Application.config_change/3</code> because
+              <code>use Phoenix.Endpoint, otp_app: :my_app</code> in <code>MyAppWeb.Endpoint</code> is now walked for
+              qualified calls.
+            </p>
+          </li>
+          <li>
+            <p>Fix resolving variables to parameters that are both pattern matched and defaulted</p>
+            <p>In functions like</p>
+            <div class="highlight highlight-source-elixir position-relative"><pre><span class="pl-k">def</span> <span class="pl-en">f</span>(%<span class="pl-en">Struct</span>{} <span class="pl-k">=</span> s <span class="pl-k">\\</span> %<span class="pl-en">Struct</span>{}) <span class="pl-k">do</span>
+  s
+<span class="pl-k">end</span></pre><div class="zeroclipboard-container position-absolute right-0 top-0">
+              <clipboard-copy aria-label="Copy" class="ClipboardButton btn js-clipboard-copy m-2 p-0 tooltipped-no-delay" data-copy-feedback="Copied!" data-tooltip-direction="w" value="def f(%Struct{} = s \\ %Struct{}) do
+  s
+end
+" tabindex="0" role="button">
+                <svg aria-hidden="true" viewBox="0 0 16 16" version="1.1" data-view-component="true" height="16" width="16" class="octicon octicon-clippy js-clipboard-clippy-icon m-2">
+                  <path fill-rule="evenodd" d="M5.75 1a.75.75 0 00-.75.75v3c0 .414.336.75.75.75h4.5a.75.75 0 00.75-.75v-3a.75.75 0 00-.75-.75h-4.5zm.75 3V2.5h3V4h-3zm-2.874-.467a.75.75 0 00-.752-1.298A1.75 1.75 0 002 3.75v9.5c0 .966.784 1.75 1.75 1.75h8.5A1.75 1.75 0 0014 13.25v-9.5a1.75 1.75 0 00-.874-1.515.75.75 0 10-.752 1.298.25.25 0 01.126.217v9.5a.25.25 0 01-.25.25h-8.5a.25.25 0 01-.25-.25v-9.5a.25.25 0 01.126-.217z"></path>
+                </svg>
+                <svg aria-hidden="true" viewBox="0 0 16 16" version="1.1" data-view-component="true" height="16" width="16" class="octicon octicon-check js-clipboard-check-icon color-text-success d-none m-2">
+                  <path fill-rule="evenodd" d="M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z"></path>
+                </svg>
+              </clipboard-copy>
+            </div></div>
+            <p>
+              <code>s</code> in the body would not resolve to the <code>s</code> parameter because the default
+              parameter had to be <code>PsiNamedElement</code>, that is a variable directly. Instead, recurse on any
+              operand before the <code>\\</code> to support pattern matching too.
+            </p>
+          </li>
+          <li>
+            <p>
+              Use <code>keepProcessing()</code> in <code>MultiResolve.addToResolveResults</code> instead of specific
+              return values
+            </p>
+            <p>
+              Fixes <code>def</code> in <code>def default_host_flag, do: "--host</code> resolving as an invalid match to
+              <code>default_host_flag</code> instead of search the implicit imports for <code>defmacro def</code>.
+            </p>
+          </li>
+          <li>
+            <p>
+              The <code>nameIdentifier</code> for a <code>defdelegate</code> is the first argument, not the
+              <code>as:</code><br>
+              The <code>as:</code> is the name in the <code>to:</code> module only.
+            </p>
+          </li>
+          <li>
+            <p>Fix <code>defdelegate</code> <code>MultiResolve</code></p>
+            <ol>
+              <li>I had flipped the head name and <code>as</code> name for checking for a name match</li>
+              <li>
+                I only counted the <code>defdelegate</code> as matching if the <code>as</code> name as found in
+                <code>to</code> module, but if the head alone is prefixed by the name then the head should be a
+                ResolveResult element even if the <code>to</code> or <code>as</code> can't be found
+              </li>
+              <li>
+                Inside the <code>to</code>, I only checked if the children were call definition clauses, but this meant
+                that all the <code>for</code> handling was ignored, so start a new <code>resolveResults()</code> for
+                each modular.
+              </li>
+            </ol>
+          </li>
+          <li>
+            <p>Fix <code>toModulars</code> not returning all modulars<br>
+              <code>fullyResolve</code> only touched the first modular.</p>
+          </li>
+          <li>
+            <p>Favor complete valid results over incomplete invalid earlier bindings for variables.</p>
+          </li>
+          <li>
+            <p>Ecto</p>
+            <ul>
+              <li>
+                Don't generate reference for <code>assoc/2</code> pseudo-function in
+                <code>join(..., _ in assoc(_, _))</code>
+              </li>
+            </ul>
+          </li>
+          <li>
+            <p>
+              Fix unaliasing multiple aliases<br>
+              <code>UnaliasName</code> still assumed that <code>fullyQualifiedName</code> included the qualifier, but it
+              is just the lexical qualifier now.
+            </p>
+          </li>
+          <li>
+            <p>
+              Check for <code>MULTIPLE_ALIASES_QUALIFIER</code> in <code>ResolveState</code> for prefix matches.<br>
+              Fixes resolving <code>SSH.Key</code> to <code>Foo.SSH.Key</code> when the alias is
+              <code>alias Foo.{SSH, ...}</code>.
+            </p>
+          </li>
+          <li>
+            <p>Ignore type variables in type restrictions when resolving normal variables.</p>
+          </li>
+          <li>
+            <p>
+              Fix <code>withSelf</code> for <code>childExpressions</code> <code>siblingExpressions</code> call<br>
+              While refactoring the walk, I copied the call for siblings, which shouldn't included self.&nbsp; Children
+              should include self, or the first expression is missed which showed up as <code>Repo.transaction</code>
+              not being found because <code>transaction</code> is the first <code>def</code> inside an <code>if</code>
+              in <code>Ecto.Repo.__using__</code>'s <code>quote</code> block.
+            </p>
+          </li>
+          <li>
+            <p>Don't try to resolve keys/fields of a capture.</p>
+          </li>
+          <li>
+            <p>Don't generate reference for <code>assoc</code> in <code>*join*: .. in assoc(..., ...)</code>.<br>
+              Already worked for <code>join/3</code> calls, extend to keyword syntax too.</p>
+          </li>
+          <li>
+            <p>
+              Fix resolving references to <code>Modulars</code> when resolved is in BEAM file<br>
+              The check to see if the resolved was a modular only worked for source elements because it checked if it
+              was a <code>Call</code>, but decompiled modules in BEAM files are <code>ModuleImpls</code>.
+            </p>
+          </li>
+          <li>
+            <p>Fix logic error when ignored pinned variables as declaration sites</p>
+            <p>The logic was supposed to be that</p>
+            <ul>
+              <li>If it is pinned, keep searching</li>
+              <li>If it is not pinned, check the operation as a Call</li>
+            </ul>
+            <p>
+              ... but, the code was <code>operatorText != "^" &amp;&amp; execute(match as Call, state)</code> which
+              meant that if the <code>operatorText</code> was <code>"^"</code>, then the whole expression was
+              <code>false</code>, which meant <code>keepProcessing</code> was <code>false</code>, so any pin stopped the
+              processing for other unpinned parameters after the pin in addition to processing in the outer scope of the
+              pin.
+            </p>
+          </li>
+          <li>
+            <p>
+              Prefer source only for target candidates for Go To Declaration and not all ResolveResults.<br>
+              Ensures that functions only defined in decompiled Modules can be found because the Module's ResolveResults
+              include the decompiled Module in addition to the source ones.
+            </p>
+          </li>
+          <li>
+            <p>
+              Don't prefer source over decompiled in <code>ResolveResultOrderedSet</code><br>
+              Preference is now handled in <code>Resolver</code>, so that source preference only happens on
+              Go To Declaration and not for <code>multiResolve</code> because that needs decompiled Modulars for
+              compile-time <code>for</code> loops that are too complex to infer.
+            </p>
+          </li>
+          <li>
+            <p>Use primary arity instead of final for resolving Callables</p>
+            <p>Fixes <code>unquote</code> in <code>def unquote(...)() do</code> not resolving.</p>
+          </li>
+        </ul>
+      </li>
+      <li>
+        <p>
+          Filter out decompiled private functions from completions<br>
+          If they are only available as decompiled functions, it is unlikely we have the source available to make them
+          public, which was the reasoning to allow private functions at all.
+        </p>
+      </li>
+      <li>
+        <p>Decompiling</p>
+        <ul>
+          <li>Include module name for "No decompiled source function" errors</li>
+          <li>Unquote <code>and</code> when not and/2<br>
+            Fixes decompiling <code>:hipe_arm_encode</code>.</li>
+          <li>
+            <code>unquote</code> <code>false</code> when decompiling.<br>
+            Fixes decompiling <code>:thrift_json_parser</code>. Add <code>true</code> to the <code>Unquote</code> list
+            too since it would have the same issue.
+          </li>
+          <li>Unquote <code>in</code> when not <code>in/2</code><br>
+            Fix decompiling <code>:digraph_utils</code></li>
+          <li>Use <code>containingFile.originalFile</code> for <code>resolve.Module.multiResolveProject</code><br>
+            Ensures <code>VirtualFile</code> is available for decompiled files.</li>
+        </ul>
+      </li>
+      <li>
+        <p>Performance</p>
+        <ul>
+          <li>
+            <p>Don't use <code>.navigationElement</code> for <code>Variants</code></p>
+            <p>
+              Using <code>navigationElement</code> forces parsing of the decompiled source, which isn't necessary whe
+              only showing the lookup string.
+            </p>
+          </li>
+          <li>
+            <p>Remove <code>ModuleOwner</code> interface</p>
+            <ul>
+              <li>
+                <code>BeamFileImpl</code> is known to have only 1 module in it, so it makes the code more complicated to
+                make it act like source files.
+              </li>
+              <li>
+                Don't use <code>getChildrenByType</code>, as it causes the decompiled source to be parsed, which is slow
+                and unnecessary since all the metadata for modules is available from the binary format.
+              </li>
+            </ul>
+          </li>
+          <li>
+            <p>Get project from parent in decompiled Module and CallDefinition<br>
+              Not doing this causes an unnecessary parsing of the decompiled source.</p>
+          </li>
+        </ul>
+      </li>
+      <li>
+        <p>Fix infinite recursion in <code>ElixirVisitor#visitLiteralSigilLine</code></p>
+      </li>
+      <li>
+        <p>Show more scope for keyword key Go To Definition</p>
+        <ul>
+          <li>
+            Always show the keyword pair, instead of just the keyword key, so that the value being assigned to the key
+            can be seen before Go To.
+          </li>
+          <li>
+            Show the location at the path relative to the content root and the line number as <code>live_modal</code>
+            may be used more than once in the same file.
+          </li>
+        </ul>
+      </li>
+      <li>
+        <p>Put <code>entrance</code> as initial visited in <code>module.Variants</code>.</p>
+      </li>
+      <li>
+        <p>
+          Check if <code>PsiElement</code> has been visited before walking <code>quote</code> and <code>__using__</code>
+        </p>
+      </li>
+      <li>
+        <p>
+          Don't mark qualified calls as unresolved in "Elixir References" inspection<br>
+          I don't have a good approach for resolving struct fields or map keys for now, don't mark them as unresolved as
+          it clutters finding unresolved calls I expect to work.
+        </p>
+      </li>
+      <li>
+        <p>
+          Don't assume <code>PsiFile#virtualFile</code> is <code>NotNull</code> in
+          <code>PsiElement.moduleWithDependentsScope</code>.
+        </p>
+      </li>
+      <li>
+        <p>
+          Don't assume <code>PsiFile#virtualFile</code> is <code>NotNull</code> in
+          <code>AtNonNumericOperation.computeReference()</code>.
+        </p>
+      </li>
+      <li>
+        <p>
+          <code>putInitialVisitedElement</code> in <code>variable.MultiResolve</code><br>
+          Fixes resolving variables through <code>use</code> statements for variables in the body of
+          <code>defmodule</code> blocks.
+        </p>
+      </li>
+      <li>
+        <p>Log when <code>VISITED_ELEMENT_SET</code> is <code>null</code> instead of erroring.</p>
+      </li>
+      <li>
+        <p>
+          Fix <code>resolvePrimaryArity</code> for <code>|&gt; case do</code><br>
+          <code>resolvedPrimaryArity</code> did not add both the doBlock's arity and the arity from the
+          <code>|&gt;</code> at the same time.&nbsp; If the pipe was there, the <code>do</code> was ignored because the
+          pre-existing <code>resolvePrimaryArity</code> was not used if the normal primary arity of the call was zero,
+          which is the case for <code>|&gt; case do</code>.
+        </p>
+      </li>
+      <li>
+        <p>
+          Find module for elements in libraries<br>
+          Elements in libraries don't have a <code>Module</code> from <code>ModuleUtil.findModuleForPsiElement</code>,
+          so scan the element's project's module's content roots for the closest <code>Module</code> for libraries.
+        </p>
+      </li>
+      <li>
+        <p><code>prependQualifiers</code> when typing an alias on a new line in the body of a function.</p>
+      </li>
+      <li>
+        <p>
+          Don't descend into <code>quote</code> blocks if the call being resolved is given to an <code>unquote</code> in
+          the <code>quote</code> block.
+        </p>
+      </li>
+    </ul>
+  </li>
+</ul>
 <h1>v11.10.0</h1>
 <ul>
   <li>

--- a/resources/META-INF/changelog.html
+++ b/resources/META-INF/changelog.html
@@ -520,6 +520,22 @@ end
       <li>
         <p>Resolve uses of aliased name produced by <code>alias __MODULE__</code></p>
       </li>
+      <li>Updates
+        <ul>
+          <li>IntelliJ IDEA build version to 2021.1.2
+            <ul>
+              <li>Update <code>ParsingTestCase</code> to latest APIs.</li>
+            </ul>
+          </li>
+          <li>Gradle plugins
+            <ul>
+              <li>intellij 1.0</li>
+              <li>kotlin.jvm 1.5.10</li>
+            </ul>
+          </li>
+        </ul>
+      </li>
+      <li>Configure <code>runPluginVerifier</code></li>
     </ul>
   </li>
   <li>
@@ -962,6 +978,9 @@ end
           the <code>quote</code> block.
         </p>
       </li>
+      <li><code>updateSinceUntilBuild</code> to prevent breaking in future IDEs.</li>
+      <li>Check if modules loaded before using <code>findModuleForPsiElement</code>.</li>
+      <li>Use <code>BasePlatformTestCase</code> instead of <code>LightCodeInsightTestCase</code> because <code>LightCodeInsightTestCase</code> is deprecated.</li>
     </ul>
   </li>
 </ul>

--- a/src/org/elixir_lang/UsageTypeProvider.kt
+++ b/src/org/elixir_lang/UsageTypeProvider.kt
@@ -23,7 +23,7 @@ class UsageTypeProvider : com.intellij.usages.impl.rules.UsageTypeProviderEx {
                 else -> null
             }
 
-    override fun getUsageType(element: PsiElement?): UsageType? = getUsageType(element, emptyArray())
+    override fun getUsageType(element: PsiElement): UsageType? = getUsageType(element, emptyArray())
 
     private fun getUsageType(targets: Array<out UsageTarget>): UsageType? =
             targets.map { getUsageType(it) }.fold(null as UsageType?) { acc, targetUsageType ->

--- a/src/org/elixir_lang/beam/psi/BeamFileImpl.kt
+++ b/src/org/elixir_lang/beam/psi/BeamFileImpl.kt
@@ -78,7 +78,7 @@ class BeamFileImpl private constructor(private val fileViewProvider: FileViewPro
      */
     override fun setName(@NonNls name: String): PsiElement = throw IncorrectOperationException(CAN_NOT_MODIFY_MESSAGE)
 
-    override fun processChildren(processor: PsiElementProcessor<PsiFileSystemItem>): Boolean = true
+    override fun processChildren(processor: PsiElementProcessor<in PsiFileSystemItem>): Boolean = true
 
     /**
      * Returns the directory containing the file.

--- a/src/org/elixir_lang/beam/psi/stubs/ModuleElementType.java
+++ b/src/org/elixir_lang/beam/psi/stubs/ModuleElementType.java
@@ -20,7 +20,7 @@ import static org.elixir_lang.psi.stub.type.Named.indexStubbic;
  *   {@link org.elixir_lang.beam.psi.BeamFileImpl#buildFileStub(byte[], String)}.
  * @param <P> The PSI element that should be returned by {@link #createPsi(StubElement)} in subclasses
  */
-public abstract class ModuleElementType<S extends StubElement & Stubbic, P extends PsiElement>
+public abstract class ModuleElementType<S extends StubElement<?> & Stubbic, P extends PsiElement>
         extends ModuleStubElementType<S, P> {
     /**
      * @throws IllegalArgumentException stubs should never be created from {@link LighterAST} and

--- a/src/org/elixir_lang/beam/psi/stubs/ModuleStubElementType.java
+++ b/src/org/elixir_lang/beam/psi/stubs/ModuleStubElementType.java
@@ -8,7 +8,7 @@ import org.elixir_lang.ElixirLanguage;
 import org.jetbrains.annotations.NonNls;
 import org.jetbrains.annotations.NotNull;
 
-public abstract class ModuleStubElementType<S extends StubElement, P extends PsiElement>
+public abstract class ModuleStubElementType<S extends StubElement<?>, P extends PsiElement>
         extends ILightStubElementType<S, P> implements ICompositeElementType {
     protected ModuleStubElementType(@NotNull @NonNls String debugName) {
         super(debugName, ElixirLanguage.INSTANCE);
@@ -18,7 +18,7 @@ public abstract class ModuleStubElementType<S extends StubElement, P extends Psi
     public abstract P createPsi(@NotNull ASTNode node);
 
     @Override
-    public S createStub(@NotNull P psi, StubElement parentStub) {
+    public S createStub(@NotNull P psi, StubElement<?> parentStub) {
         final String message = "Should not be called. Element=" + psi +
                 "; class" + psi.getClass() +
                 "; file=" + (psi.isValid() ? psi.getContainingFile() : "-");

--- a/src/org/elixir_lang/beam/psi/stubs/ModuleStubElementTypes.java
+++ b/src/org/elixir_lang/beam/psi/stubs/ModuleStubElementTypes.java
@@ -22,7 +22,7 @@ import static org.elixir_lang.psi.stub.call.Deserialized.writeGuarded;
 
 // See com.intellij.psi.impl.java.stubs.JavaStubElementTypes
 public interface ModuleStubElementTypes {
-    ModuleElementType CALL_DEFINITION = new ModuleElementType<CallDefinitionStub, CallDefinition>("CallDefinition") {
+    ModuleElementType<CallDefinitionStub<?>, CallDefinition> CALL_DEFINITION = new ModuleElementType<CallDefinitionStub<?>, CallDefinition>("CallDefinition") {
         @NotNull
         @Override
         public ASTNode createCompositeNode() {
@@ -31,17 +31,17 @@ public interface ModuleStubElementTypes {
 
         @Override
         public CallDefinition createPsi(@NotNull CallDefinitionStub stub) {
-            return new CallDefinitionImpl(stub);
+            return new CallDefinitionImpl<>(stub);
         }
 
         @NotNull
         @Override
-        public CallDefinitionStub deserialize(@NotNull StubInputStream stubInputStream,
-                                              @NotNull StubElement parentStub) throws IOException {
+        public CallDefinitionStub<?> deserialize(@NotNull StubInputStream stubInputStream,
+                                                 @NotNull StubElement parentStub) throws IOException {
             Deserialized deserialized = Deserialized.deserialize(stubInputStream);
             int callDefinitionClauseArity = deserializeCallDefinitionClauseArity(stubInputStream);
 
-            return new CallDefinitionStubImpl((ModuleStub) parentStub, deserialized, callDefinitionClauseArity);
+            return new CallDefinitionStubImpl((ModuleStub<?>) parentStub, deserialized, callDefinitionClauseArity);
         }
 
         int deserializeCallDefinitionClauseArity(@NotNull StubInputStream stubInputStream) throws IOException {
@@ -62,7 +62,7 @@ public interface ModuleStubElementTypes {
     /**
      * See {@link com.intellij.psi.impl.java.stubs.JavaStubElementTypes#CLASS}
      */
-    ModuleElementType MODULE = new ModuleElementType<ModuleStub, Module>("Module") {
+    ModuleElementType<ModuleStub<?>, Module> MODULE = new ModuleElementType<ModuleStub<?>, Module>("Module") {
         @NotNull
         @Override
         public ASTNode createCompositeNode() {
@@ -76,8 +76,8 @@ public interface ModuleStubElementTypes {
 
         @NotNull
         @Override
-        public ModuleStub deserialize(@NotNull StubInputStream stubInputStream,
-                                      @NotNull StubElement parentStub) throws IOException {
+        public ModuleStub<?> deserialize(@NotNull StubInputStream stubInputStream,
+                                         @NotNull StubElement parentStub) throws IOException {
             Deserialized deserialized = Deserialized.deserialize(stubInputStream);
 
             return new ModuleStubImpl(parentStub, deserialized);

--- a/src/org/elixir_lang/errorreport/Submitter.kt
+++ b/src/org/elixir_lang/errorreport/Submitter.kt
@@ -37,7 +37,7 @@ class Submitter : ErrorReportSubmitter() {
     override fun submit(events: Array<IdeaLoggingEvent>,
                         additionalInfo: String?,
                         parentComponent: Component,
-                        consumer: Consumer<SubmittedReportInfo>): Boolean {
+                        consumer: Consumer<in SubmittedReportInfo>): Boolean {
         val project = project(parentComponent)
         val throwableList = events.mapNotNull { event -> event.throwable }
         val attachmentList = events.map { event -> event.data }.filterIsInstance<AbstractMessage>().flatMap { it.includedAttachments }
@@ -97,7 +97,7 @@ class Submitter : ErrorReportSubmitter() {
 
         private fun successCallback(
                 project: Project?,
-                consumer: Consumer<SubmittedReportInfo>
+                consumer: Consumer<in SubmittedReportInfo>
         ): Consumer<Boolean> {
             return Consumer {
                 val url: String? = null

--- a/src/org/elixir_lang/file/LevelPropertyPusher.java
+++ b/src/org/elixir_lang/file/LevelPropertyPusher.java
@@ -10,6 +10,7 @@ import com.intellij.openapi.module.Module;
 import com.intellij.openapi.module.ModuleManager;
 import com.intellij.openapi.module.ModuleType;
 import com.intellij.openapi.module.ModuleUtilCore;
+import com.intellij.openapi.module.impl.ModuleManagerEx;
 import com.intellij.openapi.progress.ProgressIndicator;
 import com.intellij.openapi.project.DumbModeTask;
 import com.intellij.openapi.project.DumbService;
@@ -139,7 +140,12 @@ public class LevelPropertyPusher implements FilePropertyPusher<Level> {
         if (virtualFile == null) {
             level = level(project);
         } else {
-            Module module = ModuleUtilCore.findModuleForFile(virtualFile, project);
+            ModuleManager manager = ModuleManager.getInstance(project);
+            Module module = null;
+
+            if (!(manager instanceof ModuleManagerEx) || ((ModuleManagerEx)manager).areModulesLoaded()) {
+                module = ModuleUtilCore.findModuleForFile(virtualFile, project);
+            }
 
             if (module != null) {
                 level = level(module);

--- a/src/org/elixir_lang/mix/project/DirectoryConfigurator.kt
+++ b/src/org/elixir_lang/mix/project/DirectoryConfigurator.kt
@@ -101,7 +101,7 @@ class DirectoryConfigurator : com.intellij.platform.DirectoryProjectConfigurator
             val projectManager = ProjectManagerEx.getInstanceEx()
 
             projectManager.newProject(otpApp.name, otpApp.root.path, false, false)?.let { project ->
-                ProjectBaseDirectory.getInstance(project).baseDir = otpApp.root
+                ProjectBaseDirectory.getInstance(project).setBaseDir(otpApp.root)
                 runDirectoryProjectConfigurators(Paths.get(otpApp.root.path), project, false)
 
                 saveSettings(project)

--- a/src/org/elixir_lang/psi/impl/PresentationImpl.kt
+++ b/src/org/elixir_lang/psi/impl/PresentationImpl.kt
@@ -116,6 +116,3 @@ private fun VirtualFile.locationString(project: Project): String {
         path
     }
 }
-
-private fun root(project: Project, module: Module?): String =
-    module?.moduleFilePath?.let { File(it).parent } ?: project.basePath!!

--- a/src/org/elixir_lang/sdk/elixir/Type.kt
+++ b/src/org/elixir_lang/sdk/elixir/Type.kt
@@ -6,7 +6,9 @@ import com.intellij.openapi.application.ModalityState
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.fileChooser.FileChooserDescriptor
 import com.intellij.openapi.module.Module
+import com.intellij.openapi.module.ModuleManager
 import com.intellij.openapi.module.ModuleUtilCore
+import com.intellij.openapi.module.impl.ModuleManagerEx
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.project.ProjectBundle
 import com.intellij.openapi.projectRoots.*
@@ -497,8 +499,19 @@ ELIXIR_SDK_HOME
            ProjectFileIndex.SERVICE.getInstance(Project) returns {@code null}, so check that the ProjectFileIndex is
            available first */
             return if (ProjectFileIndex.SERVICE.getInstance(project) != null) {
-                ModuleUtilCore.findModuleForPsiElement(psiElement)?.let { module -> mostSpecificSdk(module) }
-                        ?: mostSpecificSdk(project)
+                val manager = ModuleManager.getInstance(project)
+
+                val module = if (manager !is ModuleManagerEx || manager.areModulesLoaded()) {
+                    ModuleUtilCore.findModuleForPsiElement(psiElement)
+                } else {
+                    null
+                }
+
+                if (module != null) {
+                    mostSpecificSdk(module)
+                } else {
+                    mostSpecificSdk(project)
+                }
             } else {
                 mostSpecificSdk(project)
             }

--- a/tests/org/elixir_lang/beam/DecompilerTest.java
+++ b/tests/org/elixir_lang/beam/DecompilerTest.java
@@ -5,19 +5,19 @@ import com.google.common.io.Files;
 import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.openapi.vfs.newvfs.impl.VfsRootAccess;
-import com.intellij.testFramework.LightCodeInsightTestCase;
+import com.intellij.testFramework.fixtures.BasePlatformTestCase;
 
 import java.io.File;
 import java.io.IOException;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
-public class DecompilerTest extends LightCodeInsightTestCase {
+public class DecompilerTest extends BasePlatformTestCase {
     /*
      * Tests
      */
 
-    public void testIssue575() throws IOException, OtpErlangDecodeException {
+    public void testIssue575() {
         String ebinDirectory = ebinDirectory();
 
         VfsRootAccess.allowRootAccess(ebinDirectory);

--- a/tests/org/elixir_lang/parser_definition/ParsingTestCase.java
+++ b/tests/org/elixir_lang/parser_definition/ParsingTestCase.java
@@ -10,9 +10,8 @@ import com.intellij.openapi.editor.impl.EditorFactoryImpl;
 import com.intellij.openapi.extensions.DefaultPluginDescriptor;
 import com.intellij.openapi.extensions.ExtensionPoint;
 import com.intellij.openapi.extensions.ExtensionsArea;
+import com.intellij.openapi.extensions.ProjectExtensionPointName;
 import com.intellij.openapi.extensions.impl.ExtensionsAreaImpl;
-import com.intellij.openapi.fileTypes.FileTypeRegistry;
-import com.intellij.openapi.fileTypes.MockFileTypeManager;
 import com.intellij.openapi.module.ModuleManager;
 import com.intellij.openapi.progress.ProgressManager;
 import com.intellij.openapi.progress.impl.ProgressManagerImpl;
@@ -226,12 +225,11 @@ public abstract class ParsingTestCase extends com.intellij.testFramework.Parsing
     private void registerProjectFileIndex(MessageBus messageBus)
             throws ClassNotFoundException, NoSuchMethodException, InstantiationException, IllegalAccessException,
             InvocationTargetException {
-        DirectoryIndex directoryIndex = registerDirectoryIndex(messageBus);
-        FileTypeRegistry fileTypeRegistry = new MockFileTypeManager();
+        registerDirectoryIndex(messageBus);
 
         myProject.registerService(
                 ProjectFileIndex.class,
-                new ProjectFileIndexImpl(myProject, directoryIndex, fileTypeRegistry)
+                new ProjectFileIndexImpl(myProject)
         );
     }
 
@@ -351,7 +349,11 @@ public abstract class ParsingTestCase extends com.intellij.testFramework.Parsing
 
         ExtensionsArea area = myProject.getExtensionArea();
         //noinspection UnstableApiUsage
-        registerExtensionPoint((ExtensionsAreaImpl) area, ProjectExtension.EP_NAME, ProjectExtension.class);
+        registerExtensionPoint(
+                (ExtensionsAreaImpl) area,
+                new ProjectExtensionPointName<>("com.intellij.projectExtension"),
+                ProjectExtension.class
+        );
 
         //noinspection UnstableApiUsage
         applicationExtensionArea.registerPoint(FilePropertyPusher.EP_NAME.getName(), FilePropertyPusher.class, new DefaultPluginDescriptor(getClass().getName() + "." + getName()));


### PR DESCRIPTION
# Changelog
## Enhancements
* Updates
  * IntelliJ IDEA build version to 2021.1.2
    * Update `ParsingTestCase` to latest APIs.
  * Gradle plugins
    * intellij 1.0
    * kotlin.jvm 1.5.10 
* Configure `runPluginVerifier`

## Bug Fixes
* `updateSinceUntilBuild` to prevent breaking in future IDEs.
* Check if modules loaded before using `findModuleForPsiElement`.
* Use `BasePlatformTestCase` instead of `LightCodeInsightTestCase` because `LightCodeInsightTestCase` is deprecated.