### PR TITLE
Log element in psi.scope.Type instead of TODO()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -238,8 +238,6 @@
 ## v11.11.1
 
 ### Bug Fixes
-* [#1990](https://github.com/KronicDeth/intellij-elixir/pull/1990) - [@KronicDeth](https://github.com/KronicDeth)
-  * Convert MissingSDK errors for Dialyzer into Notifications.
 * [#1988](https://github.com/KronicDeth/intellij-elixir/pull/1988) - [@KronicDeth](https://github.com/KronicDeth)
   * Only descend into modular children of modular for Module scope.  Prevents recursion loops on use calls.
   * Don't search for unquoted variable value variable is value for `do:`.
@@ -248,6 +246,11 @@
   * Walk case in `__using__` to find quote in any clause.  Fixes resolving test macro from `use PowerAssert`
   * Resolve functions declared in `quote`'s scope when `block` injected with `unquote(block)`.
     Fixes resolving `field`, `timestamps`, and `index` in `schema` for `use Yacto.Schema` as it makes the `block` see the `import Yacto.Schema` above `unquote(block)` in the `quote` in `schema(..., do: block)`.
+* [#1990](https://github.com/KronicDeth/intellij-elixir/pull/1990) - [@KronicDeth](https://github.com/KronicDeth)
+  * Convert MissingSDK errors for Dialyzer into Notifications.
+* [#1993](https://github.com/KronicDeth/intellij-elixir/pull/1993) - [@KronicDeth](https://github.com/KronicDeth)
+  * Log element in psi.scope.Type instead of using `TODO()`
+    Error will still be reported, but there will be enough information to triage and since `true` is returned now it won't stop the type resolving from working.
 
 ### Enhancements
 * [#1988](https://github.com/KronicDeth/intellij-elixir/pull/1988) - [@KronicDeth](https://github.com/KronicDeth)

--- a/gen/org/elixir_lang/psi/scope/Type.kt
+++ b/gen/org/elixir_lang/psi/scope/Type.kt
@@ -10,6 +10,7 @@ import com.intellij.psi.stubs.StubIndex
 import com.intellij.psi.util.isAncestor
 import com.intellij.psi.util.siblings
 import org.elixir_lang.beam.psi.impl.ModuleImpl
+import org.elixir_lang.debugger.node.ok_error.OKError
 import org.elixir_lang.errorreport.Logger
 import org.elixir_lang.psi.*
 import org.elixir_lang.psi.call.Call
@@ -45,7 +46,9 @@ abstract class Type : PsiScopeProcessor {
                 is ElixirAtom, is ElixirFile, is ElixirList, is ElixirParentheticalStab, is ElixirTuple,
                 is WholeNumber -> false
                 else -> {
-                    TODO("Not yet implemented")
+                    error("Don't know how process element as type", element)
+
+                    true
                 }
             }
 
@@ -182,6 +185,12 @@ abstract class Type : PsiScopeProcessor {
                 true
             }
         } ?: true
+
+    companion object {
+        fun error(title: String, element: PsiElement) {
+            Logger.error(Type::class.java, title, element)
+        }
+    }
 }
 
 internal tailrec fun PsiElement.ancestorTypeSpec(): AtUnqualifiedNoParenthesesCall<*>? =

--- a/resources/META-INF/changelog.html
+++ b/resources/META-INF/changelog.html
@@ -50,6 +50,11 @@ end
         </ul>
       </li>
       <li>Convert MissingSDK errors for Dialyzer into Notifications.</li>
+      <li>
+        Log element in psi.scope.Type instead of using <code>TODO()</code><br>
+        Error will still be reported, but there will be enough information to triage and since <code>true</code> is
+        returned now it won't stop the type resolving from working.
+      </li>
     </ul>
   </li>
   <li>


### PR DESCRIPTION
Fixes #1979

# Changelog
## Bug Fixes
* Log element in psi.scope.Type instead of using `TODO()`
  Error will still be reported, but there will be enough information to triage and since `true` is returned now it won't stop the type resolving from working.