### PR TITLE
Add missing mix deps options to non-path influencing lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -251,6 +251,14 @@
 * [#1993](https://github.com/KronicDeth/intellij-elixir/pull/1993) - [@KronicDeth](https://github.com/KronicDeth)
   * Log element in psi.scope.Type instead of using `TODO()`
     Error will still be reported, but there will be enough information to triage and since `true` is returned now it won't stop the type resolving from working.
+* [#1994](https://github.com/KronicDeth/intellij-elixir/pull/1994) - [@KronicDeth](https://github.com/KronicDeth)    
+  * Add missing mix deps options to non-path influencing list:
+    * env
+    * manager
+    * repo
+    * sparse
+    * submodules
+    * system_env
 
 ### Enhancements
 * [#1988](https://github.com/KronicDeth/intellij-elixir/pull/1988) - [@KronicDeth](https://github.com/KronicDeth)

--- a/resources/META-INF/changelog.html
+++ b/resources/META-INF/changelog.html
@@ -55,6 +55,17 @@ end
         Error will still be reported, but there will be enough information to triage and since <code>true</code> is
         returned now it won't stop the type resolving from working.
       </li>
+      <li>
+        Add missing mix deps options to non-path influencing list:
+        <ul>
+          <li>env</li>
+          <li>manager</li>
+          <li>repo</li>
+          <li>sparse</li>
+          <li>submodules</li>
+          <li>system_env</li>
+        </ul>
+      </li>
     </ul>
   </li>
   <li>

--- a/src/org/elixir_lang/mix/Dep.kt
+++ b/src/org/elixir_lang/mix/Dep.kt
@@ -46,7 +46,9 @@ data class Dep(val application: String, val path: String, val type: Type = Type.
                                 val key = keywordPair.keywordKey.text
 
                                 when (key) {
-                                    "app", "branch", "commit", "compile", "git", "github", "hex", "only", "optional", "organization", "override", "ref", "runtime", GUARDIAN_RUNTIME_TYPO, "tag", "targets" -> acc
+                                    "app", "branch", "commit", "compile", "env", "git", "github", "hex", "manager",
+                                    "only", "optional", "organization", "override", "ref", "repo", "runtime",
+                                    GUARDIAN_RUNTIME_TYPO, "sparse", "submodules", "system_env", "tag", "targets" -> acc
                                     "in_umbrella" -> acc.copy(path = "apps/$name", type = Type.MODULE)
                                     "path" -> putPath(acc, keywordPair.keywordValue)
                                     else -> {


### PR DESCRIPTION
Fixes #1498
Fixes #1983

# Changelog
## Bug Fixes
* Add missing mix deps options to non-path influencing lists:
  * env
  * manager
  * repo
  * sparse
  * submodules
  * system_env