### PR TITLE
Fix BEAM Chunks tab labels not displaying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Table of Contents
 
-* [v11.11.1](#v11111)
+* [v11.12.0](#v11120)
   * [Bug Fixes](#bug-fixes)
   * [Enhancements](#enhancements)
 * [v11.11.0](#v11110)
@@ -235,7 +235,7 @@
   * [Enhancements](#enhancements-64)
   * [Bug Fixes](#bug-fixes-70)
 
-## v11.11.1
+## v11.12.0
 
 ### Bug Fixes
 * [#1988](https://github.com/KronicDeth/intellij-elixir/pull/1988) - [@KronicDeth](https://github.com/KronicDeth)
@@ -267,6 +267,10 @@
 * [#1997](https://github.com/KronicDeth/intellij-elixir/pull/1997) - [@KronicDeth](https://github.com/KronicDeth)
   * Return `null` `Chunk` instead of throwing `IOException` when read incomplete.
     Incomplete reads happen often due to incomplete writes to the file system being read in. As such, they shouldn't generate error reports and instead should be silently ignored.
+* [#1999](https://github.com/KronicDeth/intellij-elixir/pull/1999) - [@KronicDeth](https://github.com/KronicDeth)
+  * Implement `beam.FileEditor#getFile` to fix `DeprecatedMethodException` as the default implementation is now deprecated and requires an explicit implementation.
+  * Use `TabbedPaneWrapper.AsJBTabs` instead of `JBTabbedPane` for "BEAM Chunks" tabs.
+    I'm not sure why `JBTabbedPane` stopped showing its labels sometime in the 2020.X IDE version series, but by debugging when "BEAM Chunks" name was retrieved I found that the bottom tabs used `TabbedPaneWrapper.asJBTabs`.  Using that, the labels reappeared.
 
 ### Enhancements
 * [#1988](https://github.com/KronicDeth/intellij-elixir/pull/1988) - [@KronicDeth](https://github.com/KronicDeth)

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 # https://www.jetbrains.com/intellij-repository/releases
 # https://www.jetbrains.com/intellij-repository/snapshots
 
-baseVersion = 11.11.1
+baseVersion = 11.12.0
 ideaVersion = 2021.1.2
 # MUST stay at 1.8 for JPS (Build/Compile Project) compatibility even if JRE/JBR is newer
 javaVersion = 1.8

--- a/resources/META-INF/changelog.html
+++ b/resources/META-INF/changelog.html
@@ -79,6 +79,16 @@ end
         Incomplete reads happen often due to incomplete writes to the file system being read in. As such, they shouldn't
         generate error reports and instead should be silently ignored.
       </li>
+      <li>
+        Implement <code>beam.FileEditor#getFile</code> to fix <code>DeprecatedMethodException</code> as the default
+        implementation is now deprecated and requires an explicit implementation.
+      </li>
+      <li>
+        Use <code>TabbedPaneWrapper.AsJBTabs</code> instead of <code>JBTabbedPane</code> for "BEAM Chunks" tabs.<br>
+        I'm not sure why <code>JBTabbedPane</code> stopped showing its labels sometime in the 2020.X IDE version series,
+        but by debugging when "BEAM Chunks" name was retrieved I found that the bottom tabs used
+        <code>TabbedPaneWrapper.asJBTabs</code>.  Using that, the labels reappeared.
+      </li>
     </ul>
   </li>
   <li>

--- a/src/org/elixir_lang/beam/FileEditor.kt
+++ b/src/org/elixir_lang/beam/FileEditor.kt
@@ -44,6 +44,7 @@ class FileEditor(
     }
 
     override fun getCurrentLocation(): FileEditorLocation? = null
+    override fun getFile(): VirtualFile = virtualFile
     override fun getName(): String = "BEAM Chunks"
     override fun getPreferredFocusedComponent(): JComponent? = rootTabbedPane
     override fun isModified(): Boolean = false

--- a/src/org/elixir_lang/beam/FileEditor.kt
+++ b/src/org/elixir_lang/beam/FileEditor.kt
@@ -1,6 +1,7 @@
 package org.elixir_lang.beam
 
 import com.intellij.codeHighlighting.BackgroundEditorHighlighter
+import com.intellij.openapi.actionSystem.IdeActions
 import com.intellij.openapi.fileEditor.FileEditor
 import com.intellij.openapi.fileEditor.FileEditorLocation
 import com.intellij.openapi.fileEditor.FileEditorState
@@ -8,16 +9,14 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.Disposer
 import com.intellij.openapi.util.UserDataHolderBase
 import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.ui.PrevNextActionsDescriptor
+import com.intellij.ui.TabbedPaneWrapper
 import com.intellij.ui.components.JBScrollPane
-import com.intellij.ui.components.JBTabbedPane
 import org.elixir_lang.beam.chunk.Chunk
 import org.elixir_lang.beam.chunk.Table
 import org.elixir_lang.beam.chunk.lines.TabbedPane
 import java.beans.PropertyChangeListener
-import javax.swing.Icon
-import javax.swing.JComponent
-import javax.swing.JPanel
-import javax.swing.JTabbedPane
+import javax.swing.*
 
 class FileEditor(
         private val virtualFile: VirtualFile,
@@ -26,13 +25,14 @@ class FileEditor(
     private var isActive: Boolean = false
 
     // GUI
-    private lateinit var rootTabbedPane: JBTabbedPane
+    private lateinit var rootTabbedPane: TabbedPaneWrapper
     override fun addPropertyChangeListener(listener: PropertyChangeListener) {}
     override fun removePropertyChangeListener(listener: PropertyChangeListener) {}
 
     override fun getBackgroundHighlighter(): BackgroundEditorHighlighter? = null
     override fun getComponent(): JComponent {
-        rootTabbedPane = JBTabbedPane(JTabbedPane.TOP, JTabbedPane.SCROLL_TAB_LAYOUT)
+        val descriptor = PrevNextActionsDescriptor(IdeActions.ACTION_NEXT_EDITOR_TAB, IdeActions.ACTION_PREVIOUS_EDITOR_TAB)
+        rootTabbedPane = TabbedPaneWrapper.AsJBTabs(project, SwingConstants.TOP, descriptor, this)
 
         Cache.from(virtualFile)?.let { cache ->
             cache.chunkCollection().forEach { chunk ->
@@ -40,13 +40,13 @@ class FileEditor(
             }
         }
 
-        return rootTabbedPane
+        return rootTabbedPane.component
     }
 
     override fun getCurrentLocation(): FileEditorLocation? = null
     override fun getFile(): VirtualFile = virtualFile
     override fun getName(): String = "BEAM Chunks"
-    override fun getPreferredFocusedComponent(): JComponent? = rootTabbedPane
+    override fun getPreferredFocusedComponent(): JComponent? = rootTabbedPane.component
     override fun isModified(): Boolean = false
     override fun isValid() = true
 
@@ -68,12 +68,8 @@ class FileEditor(
 
     override fun setState(state: FileEditorState) {}
 
-    private fun addTab(tabbedPane: JBTabbedPane, cache: Cache, chunk: Chunk) {
+    private fun addTab(tabbedPaneWrapper: TabbedPaneWrapper, cache: Cache, chunk: Chunk) {
         val typeID = chunk.typeID
-        val icon: Icon? = when (typeID) {
-            Chunk.TypeID.CODE.toString() -> org.elixir_lang.beam.assembly.Icons.LANGUAGE
-            else -> null
-        }
         val component: JComponent = when (typeID) {
             Chunk.TypeID.ATOM.toString(), Chunk.TypeID.ATU8.toString() ->
                 JBScrollPane(Table(org.elixir_lang.beam.chunk.atoms.Model(cache.atoms)))
@@ -82,15 +78,15 @@ class FileEditor(
             Chunk.TypeID.CINF.toString() ->
                 JBScrollPane(Table(org.elixir_lang.beam.chunk.keyword.Model(cache.compileInfo)))
             Chunk.TypeID.CODE.toString() ->
-                org.elixir_lang.beam.chunk.code.Component(cache, project, tabbedPane)
+                org.elixir_lang.beam.chunk.code.Component(cache, project, tabbedPaneWrapper)
             Chunk.TypeID.DBGI.toString() ->
-                org.elixir_lang.beam.chunk.debug_info.term.component(cache.debugInfo, project, tabbedPane)
+                org.elixir_lang.beam.chunk.debug_info.term.component(cache.debugInfo, project, tabbedPaneWrapper)
             Chunk.TypeID.EXDC.toString() ->
                 org.elixir_lang.beam.chunk.elixir_documentation.component(
                         cache.elixirDocumentation,
                         project,
                         cache.atoms?.moduleName(),
-                        tabbedPane
+                        tabbedPaneWrapper
                 )
             Chunk.TypeID.EXPT.toString() ->
                 JBScrollPane(Table(org.elixir_lang.beam.chunk.call_definitions.Model(cache.exports)))
@@ -110,6 +106,6 @@ class FileEditor(
                 JBScrollPane(JPanel())
         }
 
-        tabbedPane.addTab(typeID, icon, component)
+        tabbedPaneWrapper.addTab(typeID, component)
     }
 }

--- a/src/org/elixir_lang/beam/chunk/code/Component.kt
+++ b/src/org/elixir_lang/beam/chunk/code/Component.kt
@@ -3,7 +3,8 @@ package org.elixir_lang.beam.chunk.code
 import com.intellij.openapi.editor.Document
 import com.intellij.openapi.editor.EditorFactory
 import com.intellij.openapi.project.Project
-import com.intellij.ui.components.JBTabbedPane
+import com.intellij.ui.TabbedPaneWrapper
+import com.intellij.ui.tabs.impl.JBEditorTabs
 import com.intellij.util.ui.components.BorderLayoutPanel
 import org.elixir_lang.beam.Cache
 import org.elixir_lang.beam.assembly.Controls
@@ -12,14 +13,14 @@ import javax.swing.JComponent
 import javax.swing.event.ChangeEvent
 import javax.swing.event.ChangeListener
 
-class Component(private val cache: Cache, private val project: Project, tabbedPane: JBTabbedPane) :
+class Component(private val cache: Cache, private val project: Project, tabbedPane: TabbedPaneWrapper) :
         BorderLayoutPanel(), ChangeListener {
     init {
         tabbedPane.addChangeListener(this)
     }
 
     override fun stateChanged(changeEvent: ChangeEvent) {
-        if (changeEvent.source.let { it as JBTabbedPane }.selectedComponent == this) {
+        if (changeEvent.source.let { it as JBEditorTabs }.selectedInfo?.component == parent) {
             ensureChildrenAdded()
         }
     }

--- a/src/org/elixir_lang/beam/chunk/debug_info/term/Model.kt
+++ b/src/org/elixir_lang/beam/chunk/debug_info/term/Model.kt
@@ -2,8 +2,8 @@ package org.elixir_lang.beam.chunk.debug_info.term
 
 import com.ericsson.otp.erlang.OtpErlangObject
 import com.intellij.openapi.project.Project
+import com.intellij.ui.TabbedPaneWrapper
 import com.intellij.ui.components.JBScrollPane
-import com.intellij.ui.components.JBTabbedPane
 import org.elixir_lang.beam.chunk.DebugInfo
 import org.elixir_lang.beam.chunk.Table
 import org.elixir_lang.beam.chunk.debug_info.Term
@@ -12,7 +12,7 @@ import javax.swing.JComponent
 import javax.swing.JPanel
 import javax.swing.table.AbstractTableModel
 
-fun component(debugInfo: DebugInfo?, project: Project, tabbedPane: JBTabbedPane): JComponent =
+fun component(debugInfo: DebugInfo?, project: Project, tabbedPane: TabbedPaneWrapper): JComponent =
     when (debugInfo) {
         is org.elixir_lang.beam.chunk.debug_info.v1.elixir_erl.V1 ->
             org.elixir_lang.beam.chunk.debug_info.v1.elixir_erl.v1.Component(debugInfo, project, tabbedPane)

--- a/src/org/elixir_lang/beam/chunk/debug_info/v1/elixir_erl/v1/Component.kt
+++ b/src/org/elixir_lang/beam/chunk/debug_info/v1/elixir_erl/v1/Component.kt
@@ -1,8 +1,9 @@
 package org.elixir_lang.beam.chunk.debug_info.v1.elixir_erl.v1
 
 import com.intellij.openapi.project.Project
+import com.intellij.ui.TabbedPaneWrapper
 import com.intellij.ui.components.JBScrollPane
-import com.intellij.ui.components.JBTabbedPane
+import com.intellij.ui.tabs.impl.JBEditorTabs
 import org.elixir_lang.beam.chunk.debug_info.v1.elixir_erl.V1
 import java.awt.GridBagConstraints
 import java.awt.GridBagConstraints.BOTH
@@ -12,13 +13,13 @@ import javax.swing.JPanel
 import javax.swing.event.ChangeEvent
 import javax.swing.event.ChangeListener
 
-class Component(private val debugInfo: V1, private val project: Project, tabbedPane: JBTabbedPane) : JPanel(GridBagLayout()), ChangeListener {
+class Component(private val debugInfo: V1, private val project: Project, tabbedPane: TabbedPaneWrapper) : JPanel(GridBagLayout()), ChangeListener {
     init {
         tabbedPane.addChangeListener(this)
     }
 
     override fun stateChanged(changeEvent: ChangeEvent) {
-        if (changeEvent.source.let { it as JBTabbedPane }.selectedComponent == this) {
+        if (changeEvent.source.let { it as JBEditorTabs }.selectedInfo?.component == parent) {
             ensureChildrenAdded()
         }
     }

--- a/src/org/elixir_lang/beam/chunk/debug_info/v1/erl_abstract_code/abstract_code_compiler_options/Component.kt
+++ b/src/org/elixir_lang/beam/chunk/debug_info/v1/erl_abstract_code/abstract_code_compiler_options/Component.kt
@@ -1,7 +1,8 @@
 package org.elixir_lang.beam.chunk.debug_info.v1.erl_abstract_code.abstract_code_compiler_options
 
 import com.intellij.openapi.project.Project
-import com.intellij.ui.components.JBTabbedPane
+import com.intellij.ui.TabbedPaneWrapper
+import com.intellij.ui.tabs.impl.JBEditorTabs
 import org.elixir_lang.beam.chunk.debug_info.v1.erl_abstract_code.AbstractCodeCompileOptions
 import org.elixir_lang.beam.chunk.debug_info.v1.erl_abstract_code.abstract_code_compiler_options.abstract_code.Splitter
 import javax.swing.JPanel
@@ -12,7 +13,7 @@ import javax.swing.event.ChangeListener
 class Component(
         private val debugInfo: AbstractCodeCompileOptions,
         private val project: Project,
-        tabbedPane: JBTabbedPane
+        tabbedPane: TabbedPaneWrapper
 ):
         JTabbedPane(JTabbedPane.TOP, JTabbedPane.WRAP_TAB_LAYOUT), ChangeListener {
 
@@ -21,7 +22,7 @@ class Component(
     }
 
     override fun stateChanged(changeEvent: ChangeEvent) {
-        if (changeEvent.source.let { it as JBTabbedPane }.selectedComponent == this) {
+        if (changeEvent.source.let { it as JBEditorTabs }.selectedInfo?.component == parent) {
             ensureChildrenAdded()
         }
     }

--- a/src/org/elixir_lang/beam/chunk/elixir_documentation/Splitter.kt
+++ b/src/org/elixir_lang/beam/chunk/elixir_documentation/Splitter.kt
@@ -2,8 +2,9 @@ package org.elixir_lang.beam.chunk.elixir_documentation
 
 import com.intellij.openapi.project.Project
 import com.intellij.ui.OnePixelSplitter
+import com.intellij.ui.TabbedPaneWrapper
 import com.intellij.ui.components.JBScrollPane
-import com.intellij.ui.components.JBTabbedPane
+import com.intellij.ui.tabs.impl.JBEditorTabs
 import org.elixir_lang.beam.chunk.ElixirDocumentation
 import javax.swing.event.ChangeEvent
 import javax.swing.event.ChangeListener
@@ -12,14 +13,14 @@ class Splitter(
         private val elixirDocumentation: ElixirDocumentation,
         private val project: Project,
         private val moduleName: String?,
-        tabbedPane: JBTabbedPane
+        tabbedPane: TabbedPaneWrapper
 ): OnePixelSplitter(false), ChangeListener {
     init {
         tabbedPane.addChangeListener(this)
     }
 
     override fun stateChanged(changeEvent: ChangeEvent) {
-        if (changeEvent.source.let { it as JBTabbedPane }.selectedComponent == this) {
+        if (changeEvent.source.let { it as JBEditorTabs }.selectedInfo?.component == parent) {
             ensureChildrenAdded()
         }
     }

--- a/src/org/elixir_lang/beam/chunk/elixir_documentation/namespace.kt
+++ b/src/org/elixir_lang/beam/chunk/elixir_documentation/namespace.kt
@@ -1,8 +1,8 @@
 package org.elixir_lang.beam.chunk.elixir_documentation
 
 import com.intellij.openapi.project.Project
+import com.intellij.ui.TabbedPaneWrapper
 import com.intellij.ui.components.JBScrollPane
-import com.intellij.ui.components.JBTabbedPane
 import org.elixir_lang.beam.chunk.ElixirDocumentation
 import javax.swing.JComponent
 import javax.swing.JPanel
@@ -11,7 +11,7 @@ fun component(
         elixirDocumentation: ElixirDocumentation?,
         project: Project,
         moduleName: String?,
-        tabbedPane: JBTabbedPane
+        tabbedPane: TabbedPaneWrapper
 ): JComponent =
         if (elixirDocumentation != null) {
             Splitter(elixirDocumentation, project, moduleName, tabbedPane)


### PR DESCRIPTION
Fixes #1918

# Changelog
## Bug Fixes
* Implement `beam.FileEditor#getFile` to fix `DeprecatedMethodException` as the default implementation is now deprecated and requires an explicit implementation.
* Use `TabbedPaneWrapper.AsJBTabs` instead of `JBTabbedPane` for "BEAM Chunks" tabs.
  I'm not sure why `JBTabbedPane` stopped showing its labels sometime in the 2020.X IDE version series, but by debugging when "BEAM Chunks" name was retrieved I found that the bottom tabs used `TabbedPaneWrapper.asJBTabs`.  Using that, the labels reappeared.