### PR TITLE
Don't require Alias qualifier to be a PsiNamedElement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -271,6 +271,9 @@
   * Implement `beam.FileEditor#getFile` to fix `DeprecatedMethodException` as the default implementation is now deprecated and requires an explicit implementation.
   * Use `TabbedPaneWrapper.AsJBTabs` instead of `JBTabbedPane` for "BEAM Chunks" tabs.
     I'm not sure why `JBTabbedPane` stopped showing its labels sometime in the 2020.X IDE version series, but by debugging when "BEAM Chunks" name was retrieved I found that the bottom tabs used `TabbedPaneWrapper.asJBTabs`.  Using that, the labels reappeared.
+* [#2000](https://github.com/KronicDeth/intellij-elixir/pull/2000) - [@KronicDeth](https://github.com/KronicDeth)
+  * Don't require Alias qualifier to be a `PsiNamedElement`.
+    It can be an `ElixirAtom` and getting the reference will still work.
 
 ### Enhancements
 * [#1988](https://github.com/KronicDeth/intellij-elixir/pull/1988) - [@KronicDeth](https://github.com/KronicDeth)

--- a/gen/org/elixir_lang/psi/scope/module/Variants.kt
+++ b/gen/org/elixir_lang/psi/scope/module/Variants.kt
@@ -101,9 +101,7 @@ class Variants(private val entrance: PsiElement) : Module() {
                                 .qualifier()
                                 // if there is a qualifier, then it is only modules nested under `qualifier`'s alias or it's fully
                                 // qualified name if unaliased that are valid variants because the completions are after a `.`
-                                ?.let { qualifier ->
-                                    filteredLookupElements(qualifier as PsiNamedElement)
-                                }
+                                ?.let { qualifier -> filteredLookupElements(qualifier) }
                         ?:
                         // if there is no qualifier then all aliases in the file and all project names are valid
                         unfilteredLookupElements(entrance)
@@ -174,7 +172,7 @@ class Variants(private val entrance: PsiElement) : Module() {
         /**
          * Any modules nested under `qualifier`
          */
-        private fun filteredLookupElements(qualifier: PsiNamedElement): Collection<LookupElement> =
+        private fun filteredLookupElements(qualifier: PsiElement): Collection<LookupElement> =
                 qualifier
                         .reference
                         ?.let { qualifierReference ->

--- a/resources/META-INF/changelog.html
+++ b/resources/META-INF/changelog.html
@@ -89,6 +89,10 @@ end
         but by debugging when "BEAM Chunks" name was retrieved I found that the bottom tabs used
         <code>TabbedPaneWrapper.asJBTabs</code>.  Using that, the labels reappeared.
       </li>
+      <li>
+        Don't require Alias qualifier to be a <code>PsiNamedElement</code><br>
+        It can be an <code>ElixirAtom</code> and getting the reference will still work.
+      </li>
     </ul>
   </li>
   <li>


### PR DESCRIPTION
Fixes #1998

# Changelog
## Bug Fixes
* Don't require Alias qualifier to be a `PsiNamedElement`
  It can be an `ElixirAtom` and getting the reference will still work.