### PR TITLE
Any.isDecompiled for CallDefinitionHead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -274,6 +274,8 @@
 * [#2000](https://github.com/KronicDeth/intellij-elixir/pull/2000) - [@KronicDeth](https://github.com/KronicDeth)
   * Don't require Alias qualifier to be a `PsiNamedElement`.
     It can be an `ElixirAtom` and getting the reference will still work.
+* [#2001](https://github.com/KronicDeth/intellij-elixir/pull/2000) - [@KronicDeth](https://github.com/KronicDeth)
+  * `Any.isDecompiled` for `CallDefinitionHead`.
 
 ### Enhancements
 * [#1988](https://github.com/KronicDeth/intellij-elixir/pull/1988) - [@KronicDeth](https://github.com/KronicDeth)

--- a/resources/META-INF/changelog.html
+++ b/resources/META-INF/changelog.html
@@ -93,6 +93,7 @@ end
         Don't require Alias qualifier to be a <code>PsiNamedElement</code><br>
         It can be an <code>ElixirAtom</code> and getting the reference will still work.
       </li>
+      <li><code>Any.isDecompiled</code> for <code>CallDefinitionHead</code>.</li>
     </ul>
   </li>
   <li>

--- a/src/org/elixir_lang/navigation/SourcePreferredItems.kt
+++ b/src/org/elixir_lang/navigation/SourcePreferredItems.kt
@@ -184,6 +184,7 @@ private fun Any.isDecompiled(): Boolean =
     when (this) {
         is CallDefinition -> isDecompiled()
         is CallDefinitionClause -> isDecompiled()
+        is CallDefinitionHead -> isDecompiled()
         is Module -> isDecompiled()
         is PsiElement -> isDecompiled()
         is PsiElementResolveResult -> isDecompiled()
@@ -192,6 +193,7 @@ private fun Any.isDecompiled(): Boolean =
 
 private fun CallDefinition.isDecompiled(): Boolean = modular.isDecompiled()
 private fun CallDefinitionClause.isDecompiled(): Boolean = callDefinition.isDecompiled()
+private fun CallDefinitionHead.isDecompiled(): Boolean = callDefinition.isDecompiled()
 
 private fun Modular.isDecompiled(): Boolean =
         when (this) {


### PR DESCRIPTION
Fixes #1901

# Changelog
## Bug Fixes
* `Any.isDecompiled` for `CallDefinitionHead`.