### PR TITLE
fix: Alternative call shape for put_event with suite_finished

### DIFF
--- a/resources/exunit/1.6.0/team_city_ex_unit_formatting.ex
+++ b/resources/exunit/1.6.0/team_city_ex_unit_formatting.ex
@@ -43,6 +43,7 @@ defmodule TeamCityExUnitFormatting do
     state
   end
 
+  def put_event(state = %__MODULE__{}, {:suite_finished, _opts}), do: state
   def put_event(state = %__MODULE__{}, {:suite_finished, _run_us, _load_us}), do: state
 
   def put_event(state = %__MODULE__{}, {:suite_started, opts}) do


### PR DESCRIPTION
Using Elixir 1.12 and ExUnit, a test run ends in this warning:

```
warning: TeamCityExUnitFormatting does not know how to process event ({:suite_finished, %{async: 64164, load: nil, run: 121385}}).  Please report this message to https://github.com/KronicDeth/intellij-elixir/issues/new.
  /tmp/intellij_elixir/exunit/1.6.0/team_city_ex_unit_formatting.ex:210: TeamCityExUnitFormatting.put_event/2
  /tmp/intellij_elixir/exunit/1.6.0/team_city_ex_unit_formatter.ex:11: TeamCityExUnitFormatter.handle_cast/2
  (stdlib 3.15.2) gen_server.erl:695: :gen_server.try_dispatch/4
  (stdlib 3.15.2) gen_server.erl:771: :gen_server.handle_msg/6
  (stdlib 3.15.2) proc_lib.erl:226: :proc_lib.init_p_do_apply/3
```

Looks to me like the function call might have changed, so I've added another clause to take that into account, while keeping the previous one for compatibility with previous versions.

Solves #2045, #2016, and #1949