### PR TITLE
Stop highlighting types when `unquote_splicing/1` is reached

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -364,6 +364,8 @@
   * Walk the true and false (else) branch of if in Modules or Quote
   * Port `preferred` and `expand` system from `Callables` to `Modules`.
   * Update CI build dependencies
+* [#2199](https://github.com/KronicDeth/intellij-elixir/pull/2199) - [@KronicDeth](https://github.com/KronicDeth)
+  * Regression test for [#2198](https://github.com/KronicDeth/intellij-elixir/issues/2198).
 
 ### Bug Fixes
 * [#2074](https://github.com/KronicDeth/intellij-elixir/pull/2074) - [@Thau](https://github.com/Thau)
@@ -522,6 +524,9 @@
     Stops invalid binding test from erroring when resolving it.
   * Turn off `tailrec` because it doesn't work correctly for `ElixirAccessExpression`
   * Stop searching for qualifier when `ElixirUnqualifiedNoParenthesesManyArgumentsCall`.
+* [#2199](https://github.com/KronicDeth/intellij-elixir/pull/2199) - [@KronicDeth](https://github.com/KronicDeth)
+  * Stop highlighting types when `unquote_splicing/1` is reached.
+    `unquote_splicing` is being used to splat arguments or fields of a struct into the type.  The arguments to `unquote_splicing` are normal calls or variables, not types.
 
 ## v11.13.0
 

--- a/resources/META-INF/changelog.html
+++ b/resources/META-INF/changelog.html
@@ -1,7 +1,19 @@
 <html>
 <body>
-<h1>v11.14.0</h1>
+<h1>v12.0.0</h1>
 <ul>
+  <li>
+    <p>Breaking Changes</p>
+    <ul>
+      <li>Drop support for Elixir &lt;= 1.6.<br>
+        Continuing support for Elixir &lt;= 1.6 required special handling of the language level to support differences
+        in precedence and operators.  Removing the language level tracking allows dropping the <code>Level</code> and
+        <code>FilePropertyPusher</code> classes and all their usages, including in the parser grammar and the special
+        <code>ifVersion</code> external rule.  It also eliminates the need for tests to setup the SDK since it was only
+        needed to get the appropriate Level.  This makes the tests run in 45 seconds instead of 7 minutes.
+      </li>
+    </ul>
+  </li>
   <li>
     <p>Enhancements</p>
     <ul>
@@ -164,6 +176,7 @@
       <li>Stop <code>prependQualifiers</code> at top of file</li>
       <li>Walk the false and true (else) branch of unless in Modules or Quote</li>
       <li>Walk the true and false (else) branch of if in Modules or Quote</li>
+      <li>Regression test for <a href="https://github.com/KronicDeth/intellij-elixir/issues/2198">#2198</a></li>
     </ul>
   </li>
   <li>
@@ -365,6 +378,11 @@
         Stops invalid binding test from erroring when resolving it.</li>
       <li>Turn off <code>tailrec</code> because it doesn't work correctly for <code>ElixirAccessExpression</code></li>
       <li>Stop searching for qualifier when <code>ElixirUnqualifiedNoParenthesesManyArgumentsCall</code>.</li>
+      <li>
+        Stop highlighting types when <code>unquote_splicing/1</code> is reached.<br>
+        <code>unquote_splicing</code> is being used to splat arguments or fields of a struct into the type.  The
+        arguments to <code>unquote_splicing</code> are normal calls or variables, not types.
+      </li>
     </ul>
   </li>
 </ul>

--- a/src/org/elixir_lang/annotator/ModuleAttribute.kt
+++ b/src/org/elixir_lang/annotator/ModuleAttribute.kt
@@ -15,7 +15,9 @@ import org.elixir_lang.psi.*
 import org.elixir_lang.psi.CallDefinitionClause.`is`
 import org.elixir_lang.psi.call.Call
 import org.elixir_lang.psi.call.name.Function
+import org.elixir_lang.psi.call.name.Function.UNQUOTE_SPLICING
 import org.elixir_lang.psi.call.name.Module
+import org.elixir_lang.psi.call.name.Module.KERNEL
 import org.elixir_lang.psi.impl.identifierName
 import org.elixir_lang.psi.impl.stripAccessExpression
 import org.elixir_lang.psi.operation.*
@@ -1022,12 +1024,16 @@ class ModuleAttribute : Annotator, DumbAware {
                 )
             }
             psiElement is UnqualifiedParenthesesCall<*> -> {
-                highlightTypesAndTypeParameterUsages(
-                        psiElement,
-                        typeParameterNameSet,
-                        annotationHolder,
-                        typeTextAttributesKey
-                )
+                // `unquote_splicing` is being used to splat arguments or fields of a struct into the type.
+                // The arguments to `unquote_splicing` are normal calls or variables, not types.
+                if (!psiElement.isCalling(KERNEL, UNQUOTE_SPLICING, 1)) {
+                    highlightTypesAndTypeParameterUsages(
+                            psiElement,
+                            typeParameterNameSet,
+                            annotationHolder,
+                            typeTextAttributesKey
+                    )
+                }
             }
             else -> {
                 if (!( /* Occurs in the case of typing a {@code @type name ::} above a {@code @doc <HEREDOC>} and the

--- a/src/org/elixir_lang/psi/call/name/Function.java
+++ b/src/org/elixir_lang/psi/call/name/Function.java
@@ -34,6 +34,7 @@ public class Function {
     public static final String TRY = "try";
     public static final String UNLESS = "unless";
     public static final String UNQUOTE = "unquote";
+    public static final String UNQUOTE_SPLICING = "unquote_splicing";
     public static final String USE = "use";
     public static final String VAR_BANG = "var!";
     public static final String __MODULE__ = "__MODULE__";

--- a/testData/org/elixir_lang/annotator/module_attribute/issue_2198.ex
+++ b/testData/org/elixir_lang/annotator/module_attribute/issue_2198.ex
@@ -1,0 +1,16 @@
+defmodule Schema do
+  alias Schema
+
+  defmacro def_schema(fields) do
+    quote bind_quoted: [fields: fields] do
+      defstruct Keyword.keys(fields)
+
+      @type t :: %__MODULE__{
+                   unquote_splicing(Enum.map(fields, &Schema.spec_field/1))
+                 }
+    end
+  end
+
+  def spec_field(_) do
+  end
+end

--- a/tests/org/elixir_lang/annotator/ModuleAttributeTest.java
+++ b/tests/org/elixir_lang/annotator/ModuleAttributeTest.java
@@ -69,6 +69,11 @@ public class ModuleAttributeTest extends PlatformTestCase {
         myFixture.checkHighlighting(false, false, true);
     }
 
+    public void testIssue2198() {
+        myFixture.configureByFile("issue_2198.ex");
+        myFixture.checkHighlighting(false, false, false);
+    }
+
     public void testMatch() {
         myFixture.configureByFile("match.ex");
         myFixture.checkHighlighting(false, false, true);


### PR DESCRIPTION
Fixes #2198

# Changelog
## Enhancements
* Regression test  for #2198.

## Bug Fixes
* Stop highlighting types when `unquote_splicing/1` is reached.
 `unquote_splicing` is being used to splat arguments or fields of a struct into the type.  The arguments to `unquote_splicing` are normal calls or variables, not types.