### PR TITLE
Add guards to CallDefinitionClause.time/1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -531,6 +531,11 @@
     `unquote_splicing` is being used to splat arguments or fields of a struct into the type.  The arguments to `unquote_splicing` are normal calls or variables, not types.
 * [#2201](https://github.com/KronicDeth/intellij-elixir/pull/2201) - [@KronicDeth](https://github.com/KronicDeth)
   * Implement `call_definition_clause.Variants#executeOnCallback`
+* [#2204](https://github.com/KronicDeth/intellij-elixir/pull/2201) - [@KronicDeth](https://github.com/KronicDeth)
+  * `CallDefinitionClause.time/1`
+    * Mark guards as runtime.
+    * Mark anything unknown as runtime too.
+    * Log unknown calls.
 
 ## v11.13.0
 

--- a/resources/META-INF/changelog.html
+++ b/resources/META-INF/changelog.html
@@ -385,6 +385,13 @@
         arguments to <code>unquote_splicing</code> are normal calls or variables, not types.
       </li>
       <li>Implement <code>call_definition_clause.Variants#executeOnCallback</code></li>
+      <li><code>CallDefinitionClause.time/1</code>
+        <ul dir="auto">
+          <li>Mark guards as runtime.</li>
+          <li>Mark anything unknown as runtime too.</li>
+          <li>Log unknown calls.</li>
+        </ul>
+      </li>
     </ul>
   </li>
 </ul>


### PR DESCRIPTION
Fixes #2009

# Changelog
## Bug Fixes
* `CallDefinitionClause.time/1`
  * Mark guards as runtime.
  * Mark anything unknown as runtime too.
  * Log unknown calls.