### PR TITLE
Check if Call isValid before using containingFile for locationString

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -536,6 +536,8 @@
     * Mark guards as runtime.
     * Mark anything unknown as runtime too.
     * Log unknown calls.
+* [#2207](https://github.com/KronicDeth/intellij-elixir/pull/2207) - [@KronicDeth](https://github.com/KronicDeth)
+  * Check if `Call` `isValid` before using `containingFile` for `locationString`.
 
 ## v11.13.0
 

--- a/resources/META-INF/changelog.html
+++ b/resources/META-INF/changelog.html
@@ -392,6 +392,10 @@
           <li>Log unknown calls.</li>
         </ul>
       </li>
+      <li>
+        Check if <code>Call</code> <code>isValid</code> before using <code>containingFile</code> for
+        <code>locationString</code>.
+      </li>
     </ul>
   </li>
 </ul>

--- a/src/org/elixir_lang/psi/impl/PresentationImpl.kt
+++ b/src/org/elixir_lang/psi/impl/PresentationImpl.kt
@@ -93,13 +93,18 @@ object PresentationImpl {
     }
 }
 
-fun Call.locationString(): String = this.containingFile!!.locationString(this.project)
+fun Call.locationString(): String =
+    if (isValid) {
+        containingFile?.locationString(this.project) ?: "?"
+    } else {
+        "?"
+    }
 
 fun PsiFile.locationString(project: Project): String {
     val originalFile = originalFile
 
     return when (originalFile) {
-        is BeamFileImpl -> originalFile.virtualFile?.locationString(project)?.let { "$it.decompiled.ex" }
+        is BeamFileImpl -> originalFile.virtualFile.locationString(project).let { "$it.decompiled.ex" }
         else -> virtualFile?.locationString(project)
     } ?: name
 }


### PR DESCRIPTION
Fixes #2011

# Changelog
## Bug Fixes
* Check if `Call` `isValid` before using `containingFile` for `locationString`.