### PR TITLE
Take resolveInScope only if at least one valid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -540,6 +540,9 @@
   * Check if `Call` `isValid` before using `containingFile` for `locationString`.
 * [#2208](https://github.com/KronicDeth/intellij-elixir/pull/2208) - [@KronicDeth](https://github.com/KronicDeth)
   * Check if `project` is not dumb in `nameArityInAnyModule`.
+* [#2209](https://github.com/KronicDeth/intellij-elixir/pull/2209) - [@KronicDeth](https://github.com/KronicDeth)
+  * Take `resolveInScope` only if at least one valid
+    Checking only for an empty collection allowed any prefixes in the scope to override exact matches in anywhere indexed, which meant that `Ecto` in `defmodule Ecto.Adapter do` resolved to itself instead of the exact `defmodule Ecto do`.
 
 ## v11.13.0
 

--- a/gen/org/elixir_lang/psi/scope/variable/MultiResolve.kt
+++ b/gen/org/elixir_lang/psi/scope/variable/MultiResolve.kt
@@ -114,7 +114,7 @@ class MultiResolve(private val name: String, private val incompleteCode: Boolean
                 val resolveState = ResolveState.initial().put(ENTRANCE, entrance).putInitialVisitedElement(entrance)
 
                 resolveInScope(name, incompleteCode, entrance, resolveState)
-                        .takeIf(Collection<ResolveResult>::isNotEmpty)
+                        .takeIf { set -> set.any(ResolveResult::isValidResult) }
                         ?: nameInAnyQuote(entrance, name, incompleteCode)
             }
 

--- a/resources/META-INF/changelog.html
+++ b/resources/META-INF/changelog.html
@@ -397,6 +397,12 @@
         <code>locationString</code>.
       </li>
       <li>Check if <code>project</code> is not dumb in <code>nameArityInAnyModule</code>.</li>
+      <li>
+        Take <code>resolveInScope</code> only if at least one valid<br>
+        Checking only for an empty collection allowed any prefixes in the scope to override exact matches in anywhere
+        indexed, which meant that <code>Ecto</code> in <code>defmodule Ecto.Adapter do</code> resolved to itself instead
+        of the exact <code>defmodule Ecto do</code>.
+      </li>
     </ul>
   </li>
 </ul>

--- a/src/org/elixir_lang/reference/resolver/Callable.kt
+++ b/src/org/elixir_lang/reference/resolver/Callable.kt
@@ -86,7 +86,7 @@ object Callable : ResolveCache.PolyVariantResolver<org.elixir_lang.reference.Cal
 
     private fun resolve(element: Call, name: String, resolvedPrimaryArity: Arity, incompleteCode: Boolean) =
         resolveInScope(element, name, resolvedPrimaryArity, incompleteCode)
-                .takeIf(Collection<ResolveResult>::isNotEmpty)
+                .takeIf { set -> set.any(ResolveResult::isValidResult) }
                 ?: nameArityInAnyModule(element, name, resolvedPrimaryArity, incompleteCode)
 
     private fun resolveInScope(element: Call,

--- a/src/org/elixir_lang/reference/resolver/Module.kt
+++ b/src/org/elixir_lang/reference/resolver/Module.kt
@@ -71,7 +71,7 @@ object Module : ResolveCache.PolyVariantResolver<org.elixir_lang.reference.Modul
 
     private fun resolveAll(element: PsiElement, name: String, incompleteCode: Boolean) =
             resolveInScope(element, name, incompleteCode)
-                    .takeIf(Collection<ResolveResult>::isNotEmpty)
+                    .takeIf { set -> set.any(ResolveResult::isValidResult) }
                     ?: multiResolveProject(element, name)
 
     private fun resolveInScope(element: PsiElement, name: String, incompleteCode: Boolean) =


### PR DESCRIPTION
# Changelog
## Bug Fixes
* Take `resolveInScope` only if at least one valid
  Checking only for an empty collection allowed any prefixes in the scope to override exact matches in anywhere indexed, which meant that `Ecto` in `defmodule Ecto.Adapter do` resolved to itself instead of the exact `defmodule Ecto do`.