### PR TITLE
Variants (completion) of defdelegate defined functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -372,6 +372,13 @@
   * Decompiler
     * Don't require `MacroNameArity` for `accept`, but use `NameArity` only because no decompiler cares about the macro.
   * Tests for Code.Identifier and String.Tokenizer
+* [#2226](https://github.com/KronicDeth/intellij-elixir/pull/2226) - [@KronicDeth](https://github.com/KronicDeth)
+  * Structure View for `EEx.function_from_(file|string)`
+  * Variants (completion) for functions declared by special macros.
+    * Functions defined by `EEx.function_from_(file|string)`
+    * `exception/1` and `message/1` defined by `defexception`
+    * `*_text/0` and `*_template(assigns)` functions defined by `Mix.Generator.embed_text` and `Mix.Generator.embed_template`.
+
 
 ### Bug Fixes
 * [#2074](https://github.com/KronicDeth/intellij-elixir/pull/2074) - [@Thau](https://github.com/Thau)
@@ -571,6 +578,10 @@
     When converting to an extension function I left `parent` in place because the argument is called `parent`, but since it is an extension function that value because `this.parent` when it really should have been `this`.  Using `this.parent` meant it would ask for the parent's children and keep looping back to `this`.
   * Don't use `tailrec` in function with any body-recursion.
     It causes issues with `ElixirAccessExpression` recursion sometimes.
+* [#2226](https://github.com/KronicDeth/intellij-elixir/pull/2226) - [@KronicDeth](https://github.com/KronicDeth)
+  * Implement completion for functions declared with `defdelegate`.
+  * Fix `LookupElementPresentation.putItemPresentation` `addTailText`.
+    Only append suffix of `presentableText` if it is prefixed by `itemText`.
 
 ## v11.13.0
 

--- a/gen/org/elixir_lang/psi/scope/call_definition_clause/MultiResolve.kt
+++ b/gen/org/elixir_lang/psi/scope/call_definition_clause/MultiResolve.kt
@@ -99,16 +99,17 @@ private constructor(
 
     override fun executeOnEExFunctionFrom(element: Call, state: ResolveState): Boolean =
             element.finalArguments()?.let { arguments ->
-                when (element.functionName()) {
-                    FUNCTION_FROM_FILE_ARITY_RANGE.name -> {
                         arguments[1].stripAccessExpression().let { it as? ElixirAtom }?.node?.lastChildNode?.text?.let { name ->
                             if (this.name != null && name.startsWith(this.name)) {
                                 val arity = if (arguments.size >= 4) {
                                     // function_from_file(kind, name, file, args)
                                     // function_from_file(kind, name, file, args, options)
+                                    // function_from_string(kind, name, template, args)
+                                    // function_from_string(kind, name, template, args, options)
                                     arguments[3].stripAccessExpression().let { it as? ElixirList }?.children?.size
                                 } else {
                                     // function_from_file(kind, name, file) where args defaults to `[]`
+                                    // function_from_string(kind, name, template) where args defaults to `[]`
                                     0
                                 }
 
@@ -119,10 +120,6 @@ private constructor(
                                 true
                             }
                         } ?: true
-                    }
-                    FUNCTION_FROM_STRING_ARITY_RANGE.name -> TODO()
-                    else -> true
-                }
             } ?: true
 
     override fun executeOnException(element: Call, state: ResolveState): Boolean =

--- a/gen/org/elixir_lang/psi/scope/call_definition_clause/Variants.kt
+++ b/gen/org/elixir_lang/psi/scope/call_definition_clause/Variants.kt
@@ -6,16 +6,17 @@ import com.intellij.openapi.util.Key
 import com.intellij.psi.PsiElement
 import com.intellij.psi.ResolveState
 import com.intellij.psi.util.PsiTreeUtil
+import org.elixir_lang.EEx
+import org.elixir_lang.EEx.FUNCTION_FROM_FILE_ARITY_RANGE
+import org.elixir_lang.EEx.FUNCTION_FROM_STRING_ARITY_RANGE
 import org.elixir_lang.annotator.Parameter
-import org.elixir_lang.psi.AtUnqualifiedNoParenthesesCall
-import org.elixir_lang.psi.ElixirIdentifier
+import org.elixir_lang.psi.*
 import org.elixir_lang.psi.call.Call
 import org.elixir_lang.psi.call.Named
 import org.elixir_lang.psi.impl.ElixirPsiImplUtil.ENTRANCE
 import org.elixir_lang.psi.impl.call.finalArguments
+import org.elixir_lang.psi.impl.stripAccessExpression
 import org.elixir_lang.psi.scope.CallDefinitionClause
-import org.elixir_lang.psi.putInitialVisitedElement
-import org.elixir_lang.psi.putVisitedElement
 import org.elixir_lang.structure_view.element.CallDefinitionHead
 import org.elixir_lang.structure_view.element.Callback
 import java.util.*
@@ -97,7 +98,20 @@ class Variants : CallDefinitionClause() {
     }
 
     override fun executeOnEExFunctionFrom(element: Call, state: ResolveState): Boolean {
-        TODO()
+        element.finalArguments()?.let { arguments ->
+            arguments[1].stripAccessExpression().let { it as? ElixirAtom }?.node?.lastChildNode?.text?.let { name ->
+                lookupElementByPsiElement.computeIfAbsent(element) { element ->
+                    LookupElementBuilder.createWithSmartPointer(
+                            name,
+                            element
+                    ).withRenderer(
+                            org.elixir_lang.code_insight.lookup.element_renderer.EExFunctionFrom(name)
+                    )
+                }
+            }
+       }
+
+        return true
     }
 
     override fun executeOnException(element: Call, state: ResolveState): Boolean {

--- a/gen/org/elixir_lang/psi/scope/call_definition_clause/Variants.kt
+++ b/gen/org/elixir_lang/psi/scope/call_definition_clause/Variants.kt
@@ -12,9 +12,11 @@ import org.elixir_lang.psi.ElixirIdentifier
 import org.elixir_lang.psi.call.Call
 import org.elixir_lang.psi.call.Named
 import org.elixir_lang.psi.impl.ElixirPsiImplUtil.ENTRANCE
+import org.elixir_lang.psi.impl.call.finalArguments
 import org.elixir_lang.psi.scope.CallDefinitionClause
 import org.elixir_lang.psi.putInitialVisitedElement
 import org.elixir_lang.psi.putVisitedElement
+import org.elixir_lang.structure_view.element.CallDefinitionHead
 import org.elixir_lang.structure_view.element.Callback
 import java.util.*
 
@@ -74,7 +76,24 @@ class Variants : CallDefinitionClause() {
             }
 
     override fun executeOnDelegation(element: Call, state: ResolveState): Boolean {
-        TODO()
+        element.finalArguments()?.takeIf { it.size == 2 }?.let { arguments ->
+            val head = arguments[0]
+
+            CallDefinitionHead.nameArityInterval(head, state)?.let { headNameArityInterval ->
+                val headName = headNameArityInterval.name
+
+                lookupElementByPsiElement.computeIfAbsent(head) { head ->
+                    LookupElementBuilder.createWithSmartPointer(
+                            headName,
+                            element
+                    ).withRenderer(
+                            org.elixir_lang.code_insight.lookup.element_renderer.Delegation(headName)
+                    )
+                }
+            }
+        }
+
+        return true
     }
 
     override fun executeOnEExFunctionFrom(element: Call, state: ResolveState): Boolean {

--- a/resources/META-INF/changelog.html
+++ b/resources/META-INF/changelog.html
@@ -187,6 +187,17 @@
         </ul>
       </li>
       <li>Tests for Code.Identifier and String.Tokenizer</li>
+      <li>Structure View for <code>EEx.function_from_(file|string)</code></li>
+      <li>Variants (completion) for functions declared by special macros.
+        <ul>
+          <li>Functions defined by <code>EEx.function_from_(file|string)</code></li>
+          <li><code>exception/1</code> and <code>message/1</code> defined by <code>defexception</code></li>
+          <li>
+            <code>*_text/0</code> and <code>*_template(assigns)</code> functions defined by
+            <code>Mix.Generator.embed_text</code> and <code>Mix.Generator.embed_template</code>.
+          </li>
+        </ul>
+      </li>
     </ul>
   </li>
   <li>
@@ -461,6 +472,9 @@
         Don't use <code>tailrec</code> in function with any body-recursion.<br>
         It causes issues with <code>ElixirAccessExpression</code> recursion sometimes.
       </li>
+      <li>Implement completion for functions declared with <code>defdelegate</code>.</li>
+      <li>Fix <code>LookupElementPresentation.putItemPresentation</code> <code>addTailText</code>.<br>
+        Only append suffix of <code>presentableText</code> if it is prefixed by <code>itemText</code>.</li>
     </ul>
   </li>
 </ul>

--- a/src/org/elixir_lang/code_insight/lookup/element_renderer/Delegation.kt
+++ b/src/org/elixir_lang/code_insight/lookup/element_renderer/Delegation.kt
@@ -1,0 +1,17 @@
+package org.elixir_lang.code_insight.lookup.element_renderer
+
+import com.intellij.codeInsight.lookup.LookupElement
+import com.intellij.codeInsight.lookup.LookupElementPresentation
+import com.intellij.codeInsight.lookup.LookupElementRenderer
+import org.elixir_lang.psi.call.Call
+
+class Delegation(val name: String) : LookupElementRenderer<LookupElement>() {
+    override fun renderElement(element: LookupElement, lookupElementPresentation: LookupElementPresentation) {
+        lookupElementPresentation.itemText = name
+        lookupElementPresentation.isItemTextBold = true
+
+        element.psiElement?.let { it as? Call }?.let { org.elixir_lang.structure_view.element.Delegation.fromCall(it) }?.presentation?.let { itemPresentation ->
+            lookupElementPresentation.putItemPresentation(itemPresentation)
+        }
+    }
+}

--- a/src/org/elixir_lang/code_insight/lookup/element_renderer/EExFunctionFrom.kt
+++ b/src/org/elixir_lang/code_insight/lookup/element_renderer/EExFunctionFrom.kt
@@ -1,0 +1,21 @@
+package org.elixir_lang.code_insight.lookup.element_renderer
+
+import com.intellij.codeInsight.lookup.LookupElement
+import com.intellij.codeInsight.lookup.LookupElementPresentation
+import com.intellij.codeInsight.lookup.LookupElementRenderer
+import org.elixir_lang.psi.call.Call
+
+class EExFunctionFrom(val name: String) : LookupElementRenderer<LookupElement>() {
+    override fun renderElement(element: LookupElement, lookupElementPresentation: LookupElementPresentation) {
+        lookupElementPresentation.itemText = name
+        lookupElementPresentation.isItemTextBold = true
+
+        val eexFunctionFrom = element.psiElement?.let { it as? Call }?.let { org.elixir_lang.structure_view.element.EExFunctionFrom.fromCall(it) }
+
+        if (eexFunctionFrom != null) {
+            val itemPresentation = eexFunctionFrom.children.first().presentation
+
+            lookupElementPresentation.putItemPresentation(itemPresentation)
+        }
+    }
+}

--- a/src/org/elixir_lang/code_insight/lookup/element_renderer/LookupElementPresentationExt.kt
+++ b/src/org/elixir_lang/code_insight/lookup/element_renderer/LookupElementPresentationExt.kt
@@ -7,11 +7,8 @@ fun LookupElementPresentation.putItemPresentation(itemPresentation: ItemPresenta
     this.icon = itemPresentation.getIcon(true)
 
     itemPresentation.presentableText?.let { presentableText ->
-        val nameLength = itemText!!.length
-        val presentableTextLength = presentableText.length
-
-        if (nameLength <= presentableTextLength) {
-            appendTailText(presentableText.substring(nameLength), true)
+        if (presentableText.startsWith(itemText!!)) {
+            appendTailText(presentableText.removePrefix(itemText!!), true)
         }
     }
 

--- a/src/org/elixir_lang/code_insight/lookup/element_renderer/exception/CallDefinitionClause.kt
+++ b/src/org/elixir_lang/code_insight/lookup/element_renderer/exception/CallDefinitionClause.kt
@@ -1,0 +1,23 @@
+package org.elixir_lang.code_insight.lookup.element_renderer.exception
+
+import com.intellij.codeInsight.lookup.LookupElement
+import com.intellij.codeInsight.lookup.LookupElementPresentation
+import com.intellij.codeInsight.lookup.LookupElementRenderer
+import org.elixir_lang.NameArity
+import org.elixir_lang.Visibility
+import org.elixir_lang.code_insight.lookup.element_renderer.putItemPresentation
+import org.elixir_lang.psi.CallDefinitionClause
+import org.elixir_lang.psi.Exception.EXCEPTION
+import org.elixir_lang.psi.Exception.MESSAGE
+
+class CallDefinitionClause(val nameArity: NameArity) : LookupElementRenderer<LookupElement>() {
+    override fun renderElement(element: LookupElement, lookupElementPresentation: LookupElementPresentation) {
+        lookupElementPresentation.itemText = nameArity.name
+
+        when (nameArity) {
+            EXCEPTION -> lookupElementPresentation.appendTailText("(message)", true)
+            MESSAGE -> lookupElementPresentation.appendTailText("(exception)", true)
+            else -> Unit
+        }
+    }
+}

--- a/src/org/elixir_lang/code_insight/lookup/element_renderer/mix/generator/EmbedTemplate.kt
+++ b/src/org/elixir_lang/code_insight/lookup/element_renderer/mix/generator/EmbedTemplate.kt
@@ -1,0 +1,18 @@
+package org.elixir_lang.code_insight.lookup.element_renderer.mix.generator
+
+import com.intellij.codeInsight.lookup.LookupElement
+import com.intellij.codeInsight.lookup.LookupElementPresentation
+import com.intellij.codeInsight.lookup.LookupElementRenderer
+import org.elixir_lang.NameArity
+import org.elixir_lang.Visibility
+import org.elixir_lang.code_insight.lookup.element_renderer.putItemPresentation
+import org.elixir_lang.psi.CallDefinitionClause
+import org.elixir_lang.psi.Exception.EXCEPTION
+import org.elixir_lang.psi.Exception.MESSAGE
+
+class EmbedTemplate(val name: String) : LookupElementRenderer<LookupElement>() {
+    override fun renderElement(element: LookupElement, lookupElementPresentation: LookupElementPresentation) {
+        lookupElementPresentation.itemText = name
+        lookupElementPresentation.appendTailText("(assigns)", true)
+    }
+}

--- a/src/org/elixir_lang/code_insight/lookup/element_renderer/mix/generator/EmbedText.kt
+++ b/src/org/elixir_lang/code_insight/lookup/element_renderer/mix/generator/EmbedText.kt
@@ -1,0 +1,18 @@
+package org.elixir_lang.code_insight.lookup.element_renderer.mix.generator
+
+import com.intellij.codeInsight.lookup.LookupElement
+import com.intellij.codeInsight.lookup.LookupElementPresentation
+import com.intellij.codeInsight.lookup.LookupElementRenderer
+import org.elixir_lang.NameArity
+import org.elixir_lang.Visibility
+import org.elixir_lang.code_insight.lookup.element_renderer.putItemPresentation
+import org.elixir_lang.psi.CallDefinitionClause
+import org.elixir_lang.psi.Exception.EXCEPTION
+import org.elixir_lang.psi.Exception.MESSAGE
+
+class EmbedText(val name: String) : LookupElementRenderer<LookupElement>() {
+    override fun renderElement(element: LookupElement, lookupElementPresentation: LookupElementPresentation) {
+        lookupElementPresentation.itemText = name
+        lookupElementPresentation.appendTailText("()", true)
+    }
+}

--- a/src/org/elixir_lang/psi/Exception.kt
+++ b/src/org/elixir_lang/psi/Exception.kt
@@ -7,9 +7,12 @@ import org.elixir_lang.psi.call.name.Function
 import org.elixir_lang.psi.call.name.Module
 
 object Exception {
+    val EXCEPTION = NameArity("exception", 1)
+    val MESSAGE = NameArity("message", 1)
+
     val NAME_ARITY_LIST = listOf(
-            NameArity("exception", 1),
-            NameArity("message", 1)
+            EXCEPTION,
+            MESSAGE
     )
 
     @JvmStatic

--- a/src/org/elixir_lang/structure_view/element/Delegation.kt
+++ b/src/org/elixir_lang/structure_view/element/Delegation.kt
@@ -15,6 +15,7 @@ import org.elixir_lang.psi.call.name.Module
 import org.elixir_lang.psi.impl.call.finalArguments
 import org.elixir_lang.psi.impl.call.keywordArgument
 import org.elixir_lang.psi.impl.stripAccessExpression
+import org.elixir_lang.structure_view.element.CallDefinitionClause.Companion.enclosingModular
 import org.elixir_lang.structure_view.element.modular.Modular
 import java.util.*
 
@@ -122,6 +123,11 @@ class Delegation(private val modular: Modular, call: Call) : Element<Call?>(call
 
         @JvmStatic
         fun `is`(call: Call): Boolean = call.isCalling(Module.KERNEL, Function.DEFDELEGATE, 2)
+
+        fun fromCall(call: Call): org.elixir_lang.structure_view.element.Delegation? =
+                enclosingModular(call)?.let { modular ->
+                    Delegation(modular, call)
+                }
 
         fun nameIdentifier(call: Call): PsiElement? =
             call.finalArguments()?.get(0)?.let { it as? Call }?.functionNameElement()

--- a/src/org/elixir_lang/structure_view/element/EExFunctionFrom.kt
+++ b/src/org/elixir_lang/structure_view/element/EExFunctionFrom.kt
@@ -1,0 +1,88 @@
+package org.elixir_lang.structure_view.element
+
+import com.intellij.ide.structureView.StructureViewTreeElement
+import com.intellij.ide.util.treeView.smartTree.TreeElement
+import com.intellij.navigation.ItemPresentation
+import com.intellij.navigation.NavigationItem
+import org.elixir_lang.Visibility
+import org.elixir_lang.navigation.item_presentation.NameArity
+import org.elixir_lang.navigation.item_presentation.Parent
+import org.elixir_lang.psi.ElixirAtom
+import org.elixir_lang.psi.ElixirList
+import org.elixir_lang.psi.call.Call
+import org.elixir_lang.psi.call.name.Function.DEF
+import org.elixir_lang.psi.call.name.Function.DEFP
+import org.elixir_lang.psi.impl.call.finalArguments
+import org.elixir_lang.psi.impl.stripAccessExpression
+import org.elixir_lang.structure_view.element.CallDefinitionClause.Companion.enclosingModular
+import org.elixir_lang.structure_view.element.modular.Modular
+
+class EExFunctionFrom(val modular: Modular, val call: Call) : StructureViewTreeElement, Visible, NavigationItem {
+    override fun navigate(requestFocus: Boolean) {
+        if (canNavigate()) {
+            call.navigate(requestFocus)
+        }
+    }
+
+    override fun canNavigate(): Boolean = true
+    override fun canNavigateToSource(): Boolean = true
+
+    override fun getName(): String = "$declaredName/$arity"
+
+    override fun getValue(): Any = call
+
+    override fun getPresentation(): ItemPresentation {
+        val parent = modular.presentation as Parent
+        val location = parent.locatedPresentableText
+
+        return NameArity(
+                location,
+                false,
+                Timed.Time.RUN,
+                visibility(),
+                false,
+                false,
+                declaredName,
+                arity
+        )
+    }
+
+    override fun getChildren(): Array<TreeElement> = arrayOf(EExFunctionFromHead(this))
+
+    private val declaredName: String by lazy {
+        call.finalArguments()?.get(1)?.stripAccessExpression()?.let { it as? ElixirAtom }?.node?.lastChildNode?.text ?: "unknown_name"
+    }
+
+    private val arity: Int by lazy {
+        call.finalArguments()?.let { arguments ->
+            if (arguments.size >= 4) {
+                // function_from_file(kind, name, file, args)
+                // function_from_file(kind, name, file, args, options)
+                // function_from_string(kind, name, template, args)
+                // function_from_string(kind, name, template, args, options)
+                arguments[3].stripAccessExpression().let { it as? ElixirList }?.children?.size
+            } else {
+                // function_from_file(kind, name, file) where args defaults to `[]`
+                // function_from_string(kind, name, template) where args defaults to `[]`
+                0
+            }
+        } ?: 0
+    }
+
+    override fun visibility(): Visibility? =
+            call.finalArguments()?.get(0)?.stripAccessExpression()?.let { it as? ElixirAtom }?.node?.lastChildNode?.text?.let { macro ->
+                when (macro) {
+                    DEF -> Visibility.PUBLIC
+                    DEFP -> Visibility.PRIVATE
+                    else -> null
+                }
+            }
+
+
+    companion object {
+        fun fromCall(call: Call): EExFunctionFrom? =
+                enclosingModular(call)?.let { modular ->
+                    EExFunctionFrom(modular, call)
+                }
+    }
+}

--- a/src/org/elixir_lang/structure_view/element/EExFunctionFromHead.kt
+++ b/src/org/elixir_lang/structure_view/element/EExFunctionFromHead.kt
@@ -1,0 +1,21 @@
+package org.elixir_lang.structure_view.element
+
+import com.intellij.ide.util.treeView.smartTree.TreeElement
+import com.intellij.navigation.ItemPresentation
+import org.elixir_lang.Visibility
+import org.elixir_lang.navigation.item_presentation.NameArity
+import org.elixir_lang.navigation.item_presentation.Parent
+import org.elixir_lang.psi.call.Call
+import org.elixir_lang.structure_view.element.modular.Modular
+
+class EExFunctionFromHead(private val eexFunctionFrom: EExFunctionFrom) : Element<Call>(eexFunctionFrom.call), Presentable, Visible {
+    override fun getPresentation(): ItemPresentation =
+            org.elixir_lang.navigation.item_presentation.CallDefinitionHead(
+                    eexFunctionFrom.presentation as NameArity,
+                    eexFunctionFrom.visibility()!!,
+                    navigationItem
+            )
+
+    override fun getChildren(): Array<TreeElement> = emptyArray()
+    override fun visibility(): Visibility? = eexFunctionFrom.visibility()
+}

--- a/testData/org/elixir_lang/code_insight/completion/contributor/call_definition_clause/defdelegate.ex
+++ b/testData/org/elixir_lang/code_insight/completion/contributor/call_definition_clause/defdelegate.ex
@@ -1,0 +1,8 @@
+defmodule Defdelegate do
+  defdelegate source(), to: Source
+  defdelegate source_as(), to: Source, as: :source
+
+  def usage do
+    s<caret>
+  end
+end

--- a/testData/org/elixir_lang/code_insight/completion/contributor/call_definition_clause/eex.ex
+++ b/testData/org/elixir_lang/code_insight/completion/contributor/call_definition_clause/eex.ex
@@ -1,0 +1,275 @@
+# Source code recreated from a .beam file by IntelliJ Elixir
+defmodule EEx do
+  @moduledoc ~S"""
+  EEx stands for Embedded Elixir. It allows you to embed
+  Elixir code inside a string in a robust way.
+
+      iex> EEx.eval_string("foo <%= bar %>", bar: "baz")
+      "foo baz"
+
+  ## API
+
+  This module provides 3 main APIs for you to use:
+
+    1. Evaluate a string (`eval_string/3`) or a file (`eval_file/3`)
+       directly. This is the simplest API to use but also the
+       slowest, since the code is evaluated and not compiled before.
+
+    2. Define a function from a string (`function_from_string/5`)
+       or a file (`function_from_file/5`). This allows you to embed
+       the template as a function inside a module which will then
+       be compiled. This is the preferred API if you have access
+       to the template at compilation time.
+
+    3. Compile a string (`compile_string/2`) or a file (`compile_file/2`)
+       into Elixir syntax tree. This is the API used by both functions
+       above and is available to you if you want to provide your own
+       ways of handling the compiled template.
+
+  ## Options
+
+  All functions in this module accept EEx-related options.
+  They are:
+
+    * `:file` - the file to be used in the template. Defaults to the given
+      file the template is read from or to "nofile" when compiling from a string.
+    * `:line` - the line to be used as the template start. Defaults to 1.
+    * `:indentation` - (since v1.11.0) an integer added to the column after every
+      new line. Defaults to 0.
+    * `:engine` - the EEx engine to be used for compilation.
+    * `:trim` - if true, trims whitespace left/right of quotation tags up until
+      newlines. At least one newline is retained. Defaults to false.
+
+  ## Engine
+
+  EEx has the concept of engines which allows you to modify or
+  transform the code extracted from the given string or file.
+
+  By default, `EEx` uses the `EEx.SmartEngine` that provides some
+  conveniences on top of the simple `EEx.Engine`.
+
+  ### Tags
+
+  `EEx.SmartEngine` supports the following tags:
+
+      <% Elixir expression - inline with output %>
+      <%= Elixir expression - replace with result %>
+      <%% EEx quotation - returns the contents inside %>
+      <%# Comments - they are discarded from source %>
+
+  All expressions that output something to the template
+  **must** use the equals sign (`=`). Since everything in
+  Elixir is an expression, there are no exceptions for this rule.
+  For example, while some template languages would special-case
+  `if` clauses, they are treated the same in EEx and
+  also require `=` in order to have their result printed:
+
+      <%= if true do %>
+        It is obviously true
+      <% else %>
+        This will never appear
+      <% end %>
+
+  To escape an EEx expression in EEx use `<%% content %>`. For example:
+
+      <%%= x + 3 %>
+
+  will be rendered as `<%= x + 3 %>`.
+
+  Note that different engines may have different rules
+  for each tag. Other tags may be added in future versions.
+
+  ### Macros
+
+  `EEx.SmartEngine` also adds some macros to your template.
+  An example is the `@` macro which allows easy data access
+  in a template:
+
+      iex> EEx.eval_string("<%= @foo %>", assigns: [foo: 1])
+      "1"
+
+  In other words, `<%= @foo %>` translates to:
+
+      <%= {:ok, v} = Access.fetch(assigns, :foo); v %>
+
+  The `assigns` extension is useful when the number of variables
+  required by the template is not specified at compilation time.
+
+  """
+
+  # Macros
+
+  defmacro function_from_file(x0, x1, x2) do
+    super(x0, x1, x2, [], [])
+  end
+
+  defmacro function_from_file(x0, x1, x2, x3) do
+    super(x0, x1, x2, x3, [])
+  end
+
+  @doc ~S"""
+  Generates a function definition from the file contents.
+
+  The kind (`:def` or `:defp`) must be given, the
+  function name, its arguments and the compilation options.
+
+  This function is useful in case you have templates but
+  you want to precompile inside a module for speed.
+
+  ## Examples
+
+      # sample.eex
+      <%= a + b %>
+
+      # sample.ex
+      defmodule Sample do
+        require EEx
+        EEx.function_from_file(:def, :sample, "sample.eex", [:a, :b])
+      end
+
+      # iex
+      Sample.sample(1, 2)
+      #=> "3"
+
+
+  """
+  defmacro function_from_file(kind, name, file, args, options) do
+    {:__block__, [], [{:=, [], [{:args, [line: 162], EEx}, args]}, {:=, [], [{:file, [line: 162], EEx}, file]}, {:=, [], [{:kind, [line: 162], EEx}, kind]}, {:=, [], [{:name, [line: 162], EEx}, name]}, {:=, [], [{:options, [line: 162], EEx}, options]}, {:__block__, [], [{:=, [], [{:info, [], EEx}, {{:".", [], [{:__aliases__, [alias: false], [:"Keyword"]}, :merge]}, [], [{:options, [], EEx}, [file: {:file, [], EEx}, line: 1]]}]}, {:=, [], [{:args, [], EEx}, {{:".", [], [{:__aliases__, [alias: false], [:"Enum"]}, :map]}, [], [{:args, [], EEx}, {:fn, [], [{:"->", [], [[{:arg, [], EEx}], {:"{}", [], [{:arg, [], EEx}, [line: 1], nil]}]}]}]}]}, {:=, [], [{:compiled, [], EEx}, {{:".", [], [{:__aliases__, [alias: false], [:"EEx"]}, :compile_file]}, [], [{:file, [], EEx}, {:info, [], EEx}]}]}, {:@, [context: EEx, import: Kernel], [{:external_resource, [context: EEx], [{:file, [], EEx}]}]}, {:@, [context: EEx, import: Kernel], [{:file, [context: EEx], [{:file, [], EEx}]}]}, {:case, [], [{:kind, [], EEx}, [do: [{:"->", [], [[:def], {:def, [context: EEx, import: Kernel], [{{:unquote, [], [{:name, [], EEx}]}, [context: EEx], [{:unquote_splicing, [], [{:args, [], EEx}]}]}, [do: {:unquote, [], [{:compiled, [], EEx}]}]]}]}, {:"->", [], [[:defp], {:defp, [context: EEx, import: Kernel], [{{:unquote, [], [{:name, [], EEx}]}, [context: EEx], [{:unquote_splicing, [], [{:args, [], EEx}]}]}, [do: {:unquote, [], [{:compiled, [], EEx}]}]]}]}]]]}]}]}
+  end
+
+  defmacro function_from_string(x0, x1, x2) do
+    super(x0, x1, x2, [], [])
+  end
+
+  defmacro function_from_string(x0, x1, x2, x3) do
+    super(x0, x1, x2, x3, [])
+  end
+
+  @doc ~S"""
+  Generates a function definition from the string.
+
+  The kind (`:def` or `:defp`) must be given, the
+  function name, its arguments and the compilation options.
+
+  ## Examples
+
+      iex> defmodule Sample do
+      ...>   require EEx
+      ...>   EEx.function_from_string(:def, :sample, "<%= a + b %>", [:a, :b])
+      ...> end
+      iex> Sample.sample(1, 2)
+      "3"
+
+
+  """
+  defmacro function_from_string(kind, name, source, args, options) do
+    {:__block__, [], [{:=, [], [{:args, [line: 124], EEx}, args]}, {:=, [], [{:kind, [line: 124], EEx}, kind]}, {:=, [], [{:name, [line: 124], EEx}, name]}, {:=, [], [{:options, [line: 124], EEx}, options]}, {:=, [], [{:source, [line: 124], EEx}, source]}, {:__block__, [], [{:=, [], [{:info, [], EEx}, {{:".", [], [{:__aliases__, [alias: false], [:"Keyword"]}, :merge]}, [], [[file: {{:".", [], [{:__ENV__, [], EEx}, :file]}, [no_parens: true], []}, line: {{:".", [], [{:__ENV__, [], EEx}, :line]}, [no_parens: true], []}], {:options, [], EEx}]}]}, {:=, [], [{:args, [], EEx}, {{:".", [], [{:__aliases__, [alias: false], [:"Enum"]}, :map]}, [], [{:args, [], EEx}, {:fn, [], [{:"->", [], [[{:arg, [], EEx}], {:"{}", [], [{:arg, [], EEx}, [line: {{:".", [], [Access, :get]}, [], [{:info, [], EEx}, :line]}], nil]}]}]}]}]}, {:=, [], [{:compiled, [], EEx}, {{:".", [], [{:__aliases__, [alias: false], [:"EEx"]}, :compile_string]}, [], [{:source, [], EEx}, {:info, [], EEx}]}]}, {:case, [], [{:kind, [], EEx}, [do: [{:"->", [], [[:def], {:def, [context: EEx, import: Kernel], [{{:unquote, [], [{:name, [], EEx}]}, [context: EEx], [{:unquote_splicing, [], [{:args, [], EEx}]}]}, [do: {:unquote, [], [{:compiled, [], EEx}]}]]}]}, {:"->", [], [[:defp], {:defp, [context: EEx, import: Kernel], [{{:unquote, [], [{:name, [], EEx}]}, [context: EEx], [{:unquote_splicing, [], [{:args, [], EEx}]}]}, [do: {:unquote, [], [{:compiled, [], EEx}]}]]}]}]]]}]}]}
+  end
+
+  # Functions
+
+  def __info__(p0) do
+    # body not decompiled
+  end
+
+  def compile_file(x0) do
+    super(x0, [])
+  end
+
+  @doc ~S"""
+  Gets a `filename` and generate a quoted expression
+  that can be evaluated by Elixir or compiled to a function.
+
+  """
+  def compile_file(filename, options) do
+    (
+      options = Keyword.merge(options, file: filename, line: 1)
+      compile_string(File.read!(filename), options)
+      )
+  end
+
+  def compile_string(x0) do
+    super(x0, [])
+  end
+
+  @doc ~S"""
+  Gets a string `source` and generate a quoted expression
+  that can be evaluated by Elixir or compiled to a function.
+
+  """
+  def compile_string(source, options) do
+    EEx.Compiler.compile(source, options)
+  end
+
+  def eval_file(x0) do
+    super(x0, [], [])
+  end
+
+  def eval_file(x0, x1) do
+    super(x0, x1, [])
+  end
+
+  @doc ~S"""
+  Gets a `filename` and evaluate the values using the `bindings`.
+
+  ## Examples
+
+      # sample.eex
+      foo <%= bar %>
+
+      # iex
+      EEx.eval_file("sample.eex", bar: "baz")
+      #=> "foo baz"
+
+
+  """
+  def eval_file(filename, bindings, options) do
+    (
+      options = Keyword.put(options, :file, filename)
+      compiled = compile_file(filename, options)
+      do_eval(compiled, bindings, options)
+      )
+  end
+
+  def eval_string(x0) do
+    super(x0, [], [])
+  end
+
+  def eval_string(x0, x1) do
+    super(x0, x1, [])
+  end
+
+  @doc ~S"""
+  Gets a string `source` and evaluate the values using the `bindings`.
+
+  ## Examples
+
+      iex> EEx.eval_string("foo <%= bar %>", bar: "baz")
+      "foo baz"
+
+
+  """
+  def eval_string(source, bindings, options) do
+    (
+      compiled = compile_string(source, options)
+      do_eval(compiled, bindings, options)
+      )
+  end
+
+  def module_info() do
+    # body not decompiled
+  end
+
+  def module_info(p0) do
+    # body not decompiled
+  end
+
+  # Private Functions
+
+  defp do_eval(compiled, bindings, options) do
+    (
+      {result, _} = Code.eval_quoted(compiled, bindings, options)
+      result
+      )
+  end
+end

--- a/testData/org/elixir_lang/code_insight/completion/contributor/call_definition_clause/eex_function.ex
+++ b/testData/org/elixir_lang/code_insight/completion/contributor/call_definition_clause/eex_function.ex
@@ -1,0 +1,10 @@
+defmodule EExFunction do
+  require EEx
+
+  EEx.function_from_file(:def, :function_from_file_sample, "sample.eex", [:a, :b])
+  EEx.function_from_string(:def, :function_from_string_sample, "<%= a + b %>", [:a, :b])
+
+  def usage do
+    f<caret>
+  end
+end

--- a/testData/org/elixir_lang/code_insight/completion/contributor/call_definition_clause/exception.ex
+++ b/testData/org/elixir_lang/code_insight/completion/contributor/call_definition_clause/exception.ex
@@ -1,0 +1,7 @@
+defmodule MyException do
+  defexception [:message]
+
+  def extra do
+    e<caret>
+  end
+end

--- a/testData/org/elixir_lang/code_insight/completion/contributor/call_definition_clause/mix_generator.ex
+++ b/testData/org/elixir_lang/code_insight/completion/contributor/call_definition_clause/mix_generator.ex
@@ -1,0 +1,240 @@
+# Source code recreated from a .beam file by IntelliJ Elixir
+defmodule Mix.Generator do
+  @moduledoc ~S"""
+  Conveniences for working with paths and generating content.
+
+  """
+
+  # Macros
+
+  @doc ~S"""
+  Embeds a template given by `contents` into the current module.
+
+  It will define a private function with the `name` followed by
+  `_template` that expects assigns as arguments.
+
+  This function must be invoked passing a keyword list.
+  Each key in the keyword list can be accessed in the
+  template using the `@` macro.
+
+  For more information, check `EEx.SmartEngine`.
+
+  ## Examples
+
+      defmodule Mix.Tasks.MyTask do
+        require Mix.Generator
+        Mix.Generator.embed_template(:log, "Log: <%= @log %>")
+      end
+
+
+  """
+  defmacro embed_template(name, contents) do
+    {:__block__, [], [{:=, [], [{:contents, [line: 181], Mix.Generator}, contents]}, {:=, [], [{:name, [line: 181], Mix.Generator}, name]}, {:__block__, [], [{:=, [], [{:contents, [], Mix.Generator}, {:case, [], [{:contents, [], Mix.Generator}, [do: [{:"->", [], [[[from_file: {:file, [], Mix.Generator}]], {:__block__, [], [{:@, [context: Mix.Generator, import: Kernel], [{:file, [context: Mix.Generator], [{:file, [], Mix.Generator}]}]}, {{:".", [], [{:__aliases__, [alias: false], [:"File"]}, :read!]}, [], [{:file, [], Mix.Generator}]}]}]}, {:"->", [], [[{:when, [], [{:c, [], Mix.Generator}, {:is_binary, [context: Mix.Generator, import: Kernel], [{:c, [], Mix.Generator}]}]}], {:__block__, [], [{:@, [context: Mix.Generator, import: Kernel], [{:file, [context: Mix.Generator], [{{{:".", [], [{:__ENV__, [], Mix.Generator}, :file]}, [no_parens: true], []}, {:+, [context: Mix.Generator, import: Kernel], [{{:".", [], [{:__ENV__, [], Mix.Generator}, :line]}, [no_parens: true], []}, 1]}}]}]}, {:c, [], Mix.Generator}]}]}, {:"->", [], [[{:_, [], Mix.Generator}], {:raise, [context: Mix.Generator, import: Kernel], [{:__aliases__, [alias: false], [:"ArgumentError"]}, "expected string or from_file: file"]}]}]]]}]}, {:require, [context: Mix.Generator], [{:__aliases__, [alias: false], [:"EEx"]}]}, {:=, [], [{:source, [], Mix.Generator}, {:<>, [context: Mix.Generator, import: Kernel], ["<% _ = assigns %>", {:contents, [], Mix.Generator}]}]}, {{:".", [], [{:__aliases__, [alias: false], [:"EEx"]}, :function_from_string]}, [], [:defp, {{:".", [], [:erlang, :binary_to_atom]}, [], [{:"<<>>", [], [{:::, [], [{{:".", [], [Kernel, :to_string]}, [], [{:name, [], Mix.Generator}]}, {:binary, [], Mix.Generator}]}, "_template"]}, :utf8]}, {:source, [], Mix.Generator}, [:assigns]]}]}]}
+  end
+
+  @doc ~S"""
+  Embeds a text given by `contents` into the current module.
+
+  It will define a private function with the `name` followed by
+  `_text` that expects no arguments.
+
+  ## Examples
+
+      defmodule Mix.Tasks.MyTask do
+        require Mix.Generator
+        Mix.Generator.embed_text(:error, "There was an error!")
+      end
+
+
+  """
+  defmacro embed_text(name, contents) do
+    {:__block__, [], [{:=, [], [{:contents, [line: 218], Mix.Generator}, contents]}, {:=, [], [{:name, [line: 218], Mix.Generator}, name]}, {:__block__, [], [{:=, [], [{:contents, [], Mix.Generator}, {:case, [], [{:contents, [], Mix.Generator}, [do: [{:"->", [], [[[from_file: {:f, [], Mix.Generator}]], {{:".", [], [{:__aliases__, [alias: false], [:"File"]}, :read!]}, [], [{:f, [], Mix.Generator}]}]}, {:"->", [], [[{:when, [], [{:c, [], Mix.Generator}, {:is_binary, [context: Mix.Generator, import: Kernel], [{:c, [], Mix.Generator}]}]}], {:c, [], Mix.Generator}]}, {:"->", [], [[{:_, [], Mix.Generator}], {:raise, [context: Mix.Generator, import: Kernel], [{:__aliases__, [alias: false], [:"ArgumentError"]}, "expected string or from_file: file"]}]}]]]}]}, {:defp, [context: Mix.Generator, import: Kernel], [{{:unquote, [], [{{:".", [], [:erlang, :binary_to_atom]}, [], [{:"<<>>", [], [{:::, [], [{{:".", [], [Kernel, :to_string]}, [], [{:name, [], Mix.Generator}]}, {:binary, [], Mix.Generator}]}, "_text"]}, :utf8]}]}, [context: Mix.Generator], []}, [do: {:unquote, [], [{:contents, [], Mix.Generator}]}]]}]}]}
+  end
+
+  # Functions
+
+  def __info__(p0) do
+    # body not decompiled
+  end
+
+  def copy_file(x0, x1) do
+    super(x0, x1, [])
+  end
+
+  @doc ~S"""
+  Copies `source` to `target`.
+
+  If `target` already exists and the contents are not the same,
+  it asks for user confirmation.
+
+  ## Options
+
+    * `:force` - forces copying without a shell prompt
+    * `:quiet` - does not log command output
+
+  ## Examples
+
+      iex> Mix.Generator.copy_file("source/gitignore", ".gitignore")
+      * creating .gitignore
+      true
+
+
+  """
+  def copy_file(source, target, options) do
+    create_file(target, File.read!(source), options)
+  end
+
+  def copy_template(x0, x1, x2) do
+    super(x0, x1, x2, [])
+  end
+
+  @doc ~S"""
+  Evaluates and copy templates at `source` to `target`.
+
+  The template in `source` is evaluated with the given `assigns`.
+
+  If `target` already exists and the contents are not the same,
+  it asks for user confirmation.
+
+  ## Options
+
+    * `:force` - forces copying without a shell prompt
+    * `:quiet` - does not log command output
+
+  ## Examples
+
+      iex> assigns = [project_path: "/Users/joe/newproject"]
+      iex> Mix.Generator.copy_template("source/gitignore", ".gitignore", assigns)
+      * creating .gitignore
+      true
+
+
+  """
+  def copy_template(source, target, assigns, options) do
+    create_file(target, EEx.eval_file(source, assigns: assigns), options)
+  end
+
+  def create_directory(x0) do
+    super(x0, [])
+  end
+
+  @doc ~S"""
+  Creates a directory if one does not exist yet.
+
+  This function does nothing if the given directory already exists; in this
+  case, it still logs the directory creation.
+
+  ## Options
+
+    * `:quiet` - does not log command output
+
+  ## Examples
+
+      iex> Mix.Generator.create_directory("path/to/dir")
+      * creating path/to/dir
+      true
+
+
+  """
+  def create_directory(path, options) do
+    (
+      log(:green, "creating", Path.relative_to_cwd(path), options)
+      File.mkdir_p!(path)
+      true
+      )
+  end
+
+  def create_file(x0, x1) do
+    super(x0, x1, [])
+  end
+
+  @doc ~S"""
+  Creates a file with the given contents.
+
+  If the file already exists and the contents are not the same,
+  it asks for user confirmation.
+
+  ## Options
+
+    * `:force` - forces creation without a shell prompt
+    * `:quiet` - does not log command output
+
+  ## Examples
+
+      iex> Mix.Generator.create_file(".gitignore", "_build\ndeps\n")
+      * creating .gitignore
+      true
+
+
+  """
+  def create_file(path, contents, opts) do
+    (
+      log(:green, :creating, Path.relative_to_cwd(path), opts)
+      if(opts[:force] || x) do
+        false
+      else
+        File.mkdir_p!(Path.dirname(path))
+        File.write!(path, contents)
+        true
+      end
+      )
+  end
+
+  def module_info() do
+    # body not decompiled
+  end
+
+  def module_info(p0) do
+    # body not decompiled
+  end
+
+  @doc ~S"""
+  Prompts the user to overwrite the file if it exists.
+
+  Returns false if the file exists and the user forbade
+  to override it. Returns true otherwise.
+
+  """
+  def overwrite?(path) do
+    if(File.exists?(path)) do
+      true
+    else
+      full = Path.expand(path)
+      Mix.shell().yes?(<<Path.relative_to_cwd(full)::binary(), " already exists, overwrite?"::binary()>>)
+    end
+  end
+
+  @doc ~S"""
+  Prompts the user to overwrite the file if it exists.
+
+  The contents are compared to avoid asking the user to
+  override if the contents did not change. Returns false
+  if the file exists and the content is the same or the
+  user forbade to override it. Returns true otherwise.
+
+  """
+  def overwrite?(path, contents) do
+    case(File.read(path)) do
+      {:ok, binary} ->
+        case(binary == :erlang.iolist_to_binary(contents)) do
+          false ->
+            full = Path.expand(path)
+            Mix.shell().yes?(<<Path.relative_to_cwd(full)::binary(), " already exists, overwrite?"::binary()>>)
+          true ->
+            false
+        end
+      _ ->
+        true
+    end
+  end
+
+  # Private Functions
+
+  defp log(color, command, message, opts) do
+    if(opts[:quiet]) do
+      Mix.shell().info([color, <<"* "::binary(), String.Chars.to_string(command)::binary(), " "::binary()>>, :reset, message])
+    else
+      nil
+    end
+  end
+end

--- a/testData/org/elixir_lang/code_insight/completion/contributor/call_definition_clause/mix_generator_embed.ex
+++ b/testData/org/elixir_lang/code_insight/completion/contributor/call_definition_clause/mix_generator_embed.ex
@@ -1,0 +1,10 @@
+defmodule MixGeneratorEmbed do
+  require Mix.Generator
+
+  Mix.Generator.embed_template(:log, "Log: <%= @log %>")
+  Mix.Generator.embed_text(:error, "There was an error!")
+
+  def usage do
+    e<caret>
+  end
+end

--- a/testData/org/elixir_lang/code_insight/completion/contributor/call_definition_clause/to.ex
+++ b/testData/org/elixir_lang/code_insight/completion/contributor/call_definition_clause/to.ex
@@ -1,0 +1,5 @@
+defmodule To do
+  def source do
+
+  end
+end

--- a/tests/org/elixir_lang/code_insight/completion/contributor/CallDefinitionClauseTest.java
+++ b/tests/org/elixir_lang/code_insight/completion/contributor/CallDefinitionClauseTest.java
@@ -78,22 +78,45 @@ public class CallDefinitionClauseTest extends LightPlatformCodeInsightFixtureTes
         assertCompletion("usage", strings);
         assertEquals("Wrong number of completions", 3, strings.size());
 
-        LookupElement[] lookuoEelements = myFixture.getLookupElements();
+        LookupElement[] lookupElements = myFixture.getLookupElements();
 
         LookupElementPresentation lookupElementPresentation = new LookupElementPresentation();
-        lookuoEelements[0].renderElement(lookupElementPresentation);
+        lookupElements[0].renderElement(lookupElementPresentation);
         assertEquals("source", lookupElementPresentation.getItemText());
         assertEquals(" (defdelegate.ex defmodule Defdelegate)", lookupElementPresentation.getTailText());
 
         lookupElementPresentation = new LookupElementPresentation();
-        lookuoEelements[1].renderElement(lookupElementPresentation);
+        lookupElements[1].renderElement(lookupElementPresentation);
         assertEquals("source_as", lookupElementPresentation.getItemText());
         assertEquals(" (defdelegate.ex defmodule Defdelegate)", lookupElementPresentation.getTailText());
 
         lookupElementPresentation = new LookupElementPresentation();
-        lookuoEelements[2].renderElement(lookupElementPresentation);
+        lookupElements[2].renderElement(lookupElementPresentation);
         assertEquals("usage", lookupElementPresentation.getItemText());
         assertEquals(" (defdelegate.ex defmodule Defdelegate)", lookupElementPresentation.getTailText());
+    }
+
+    public void testExecuteOnEExFunctionFrom() {
+        myFixture.configureByFiles("eex_function.ex", "eex.ex");
+        myFixture.complete(CompletionType.BASIC, 1);
+
+        List<String> strings = myFixture.getLookupElementStrings();
+        assertNotNull("Completion lookup not shown", strings);
+        assertCompletion("function_from_file_sample", strings);
+        assertCompletion("function_from_string_sample", strings);
+        assertEquals("Wrong number of completions", 2, strings.size());
+
+        LookupElement[] lookupElements = myFixture.getLookupElements();
+
+        LookupElementPresentation lookupElementPresentation = new LookupElementPresentation();
+        lookupElements[0].renderElement(lookupElementPresentation);
+        assertEquals("function_from_file_sample", lookupElementPresentation.getItemText());
+        assertEquals(" (eex_function.ex defmodule EExFunction)", lookupElementPresentation.getTailText());
+
+        lookupElementPresentation = new LookupElementPresentation();
+        lookupElements[1].renderElement(lookupElementPresentation);
+        assertEquals("function_from_string_sample", lookupElementPresentation.getItemText());
+        assertEquals(" (eex_function.ex defmodule EExFunction)", lookupElementPresentation.getTailText());
     }
 
     /*

--- a/tests/org/elixir_lang/code_insight/completion/contributor/CallDefinitionClauseTest.java
+++ b/tests/org/elixir_lang/code_insight/completion/contributor/CallDefinitionClauseTest.java
@@ -119,6 +119,35 @@ public class CallDefinitionClauseTest extends LightPlatformCodeInsightFixtureTes
         assertEquals(" (eex_function.ex defmodule EExFunction)", lookupElementPresentation.getTailText());
     }
 
+    public void testExecuteOnException() {
+        myFixture.configureByFile("exception.ex");
+        myFixture.complete(CompletionType.BASIC, 1);
+
+        List<String> strings = myFixture.getLookupElementStrings();
+        assertNotNull("Completion lookup not shown", strings);
+        assertCompletion("extra", strings);
+        assertCompletion("exception", strings);
+        assertCompletion("message", strings);
+        assertEquals("Wrong number of completions", 3, strings.size());
+
+        LookupElement[] lookupElements = myFixture.getLookupElements();
+
+        LookupElementPresentation lookupElementPresentation = new LookupElementPresentation();
+        lookupElements[0].renderElement(lookupElementPresentation);
+        assertEquals("exception", lookupElementPresentation.getItemText());
+        assertEquals("(message)", lookupElementPresentation.getTailText());
+
+        lookupElementPresentation = new LookupElementPresentation();
+        lookupElements[1].renderElement(lookupElementPresentation);
+        assertEquals("extra", lookupElementPresentation.getItemText());
+        assertEquals(" (exception.ex defmodule MyException)", lookupElementPresentation.getTailText());
+
+        lookupElementPresentation = new LookupElementPresentation();
+        lookupElements[2].renderElement(lookupElementPresentation);
+        assertEquals("message", lookupElementPresentation.getItemText());
+        assertEquals("(exception)", lookupElementPresentation.getTailText());
+    }
+
     /*
      * Protected Instance Methods
      */

--- a/tests/org/elixir_lang/code_insight/completion/contributor/CallDefinitionClauseTest.java
+++ b/tests/org/elixir_lang/code_insight/completion/contributor/CallDefinitionClauseTest.java
@@ -1,8 +1,11 @@
 package org.elixir_lang.code_insight.completion.contributor;
 
 import com.intellij.codeInsight.completion.CompletionType;
+import com.intellij.codeInsight.lookup.LookupElement;
+import com.intellij.codeInsight.lookup.LookupElementPresentation;
 import com.intellij.testFramework.fixtures.LightPlatformCodeInsightFixtureTestCase;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 
@@ -62,6 +65,35 @@ public class CallDefinitionClauseTest extends LightPlatformCodeInsightFixtureTes
         assertCompletion("private_function", strings);
         assertCompletion("Nested", strings);
         assertEquals("Wrong number of completions", 5, strings.size());
+    }
+
+    public void testIssue2122() {
+        myFixture.configureByFiles("defdelegate.ex", "to.ex");
+        myFixture.complete(CompletionType.BASIC, 1);
+
+        List<String> strings = myFixture.getLookupElementStrings();
+        assertNotNull("Completion lookup not shown", strings);
+        assertCompletion("source", strings);
+        assertCompletion("source_as", strings);
+        assertCompletion("usage", strings);
+        assertEquals("Wrong number of completions", 3, strings.size());
+
+        LookupElement[] lookuoEelements = myFixture.getLookupElements();
+
+        LookupElementPresentation lookupElementPresentation = new LookupElementPresentation();
+        lookuoEelements[0].renderElement(lookupElementPresentation);
+        assertEquals("source", lookupElementPresentation.getItemText());
+        assertEquals(" (defdelegate.ex defmodule Defdelegate)", lookupElementPresentation.getTailText());
+
+        lookupElementPresentation = new LookupElementPresentation();
+        lookuoEelements[1].renderElement(lookupElementPresentation);
+        assertEquals("source_as", lookupElementPresentation.getItemText());
+        assertEquals(" (defdelegate.ex defmodule Defdelegate)", lookupElementPresentation.getTailText());
+
+        lookupElementPresentation = new LookupElementPresentation();
+        lookuoEelements[2].renderElement(lookupElementPresentation);
+        assertEquals("usage", lookupElementPresentation.getItemText());
+        assertEquals(" (defdelegate.ex defmodule Defdelegate)", lookupElementPresentation.getTailText());
     }
 
     /*

--- a/tests/org/elixir_lang/code_insight/completion/contributor/CallDefinitionClauseTest.java
+++ b/tests/org/elixir_lang/code_insight/completion/contributor/CallDefinitionClauseTest.java
@@ -148,6 +148,35 @@ public class CallDefinitionClauseTest extends LightPlatformCodeInsightFixtureTes
         assertEquals("(exception)", lookupElementPresentation.getTailText());
     }
 
+    public void testExecuteOnMixGeneratorEmbed() {
+        myFixture.configureByFiles("mix_generator_embed.ex", "mix_generator.ex");
+        myFixture.complete(CompletionType.BASIC, 1);
+
+        List<String> strings = myFixture.getLookupElementStrings();
+        assertNotNull("Completion lookup not shown", strings);
+        assertCompletion("error_text", strings);
+        assertCompletion("log_template", strings);
+        assertCompletion("usage", strings);
+        assertEquals("Wrong number of completions", 3, strings.size());
+
+        LookupElement[] lookupElements = myFixture.getLookupElements();
+
+        LookupElementPresentation lookupElementPresentation = new LookupElementPresentation();
+        lookupElements[0].renderElement(lookupElementPresentation);
+        assertEquals("error_text", lookupElementPresentation.getItemText());
+        assertEquals("()", lookupElementPresentation.getTailText());
+
+        lookupElementPresentation = new LookupElementPresentation();
+        lookupElements[1].renderElement(lookupElementPresentation);
+        assertEquals("usage", lookupElementPresentation.getItemText());
+        assertEquals(" (mix_generator_embed.ex defmodule MixGeneratorEmbed)", lookupElementPresentation.getTailText());
+
+        lookupElementPresentation = new LookupElementPresentation();
+        lookupElements[2].renderElement(lookupElementPresentation);
+        assertEquals("log_template", lookupElementPresentation.getItemText());
+        assertEquals("(assigns)", lookupElementPresentation.getTailText());
+    }
+
     /*
      * Protected Instance Methods
      */


### PR DESCRIPTION
Fixes #2122

# Changelog

## Enhancements
* Structure View for `EEx.function_from_(file|string)`
* Variants (completion) for functions declared by special macros.
  * Functions defined by `EEx.function_from_(file|string)`
  * `exception/1` and `message/1` defined by `defexception`
  * `*_text/0` and `*_template(assigns)` functions defined by `Mix.Generator.embed_text` and `Mix.Generator.embed_template`.
  
## Bug Fixes
* Implement completion for functions declared with `defdelegate`.
* Fix `LookupElementPresentation.putItemPresentation` `addTailText`.
  Only append suffix of `presentableText` if it is prefixed by `itemText`.  