### PR TITLE
Stop look for qualifier at curly braces for %{}

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -253,6 +253,8 @@
 ### Bug Fixes
 * [#2345](https://github.com/KronicDeth/intellij-elixir/pull/2345) - [@KronicDeth](https://github.com/KronicDeth)
   * Override `Override org.elixir_lang.*.configuration.Factory.getId` to fix deprecation warning about the default implementation being accidentally localizable when it shouldn't be.  The Elixir plugin didn't localize these name using message bundles, so this wasn't an actual risk, but overriding is the only way to silence the error.
+* [#2346](https://github.com/KronicDeth/intellij-elixir/pull/2346) - [@KronicDeth](https://github.com/KronicDeth)
+  * Stop look for qualifier at curly braces for `%{Alias}`.
 
 ## v12.0.0
 

--- a/resources/META-INF/changelog.html
+++ b/resources/META-INF/changelog.html
@@ -6,6 +6,7 @@
     <p>Bug Fixes</p>
     <ul dir="auto">
       <li>Override <code>Override org.elixir_lang.*.configuration.Factory.getId</code> to fix deprecation warning about the default implementation being accidentally localizable when it shouldn't be.  The Elixir plugin didn't localize these name using message bundles, so this wasn't an actual risk, but overriding is the only way to silence the error.</li>
+      <li>Stop look for qualifier at curly braces for <code>%{Alias}</code></li>
     </ul>
   </li>
 </ul>

--- a/src/org/elixir_lang/psi/impl/QualifiableAliasImpl.kt
+++ b/src/org/elixir_lang/psi/impl/QualifiableAliasImpl.kt
@@ -136,7 +136,7 @@ object QualifiableAliasImpl {
             is Operation,
             is QuotableKeywordPair,
             // containers
-            is ElixirContainerAssociationOperation, is ElixirList, is ElixirStructOperation, is ElixirTuple,
+            is ElixirAssociationsBase, is ElixirContainerAssociationOperation, is ElixirList, is ElixirStructOperation, is ElixirTuple,
             // Top of file
             is ElixirFile,
             // Top of expression inside of interpolation


### PR DESCRIPTION
Fixes #2344

# Changelog
## Bug Fixes
* Stop look for qualifier at curly braces for `%{Alias}`