### PR TITLE
Protect ExUnit configuration Producer from ElixirFile without VirtualFile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -292,6 +292,8 @@
 * [#2441](https://github.com/KronicDeth/intellij-elixir/pull/2441) - [@KronicDeth](https://github.com/KronicDeth)
   * Render `OtpErlangExternalFun` correctly as remote captures (`&Mod.fun/arity`).
     Fixes decompiling `Ecto.Changeset.validate_number`.
+* [#2445](https://github.com/KronicDeth/intellij-elixir/pull/2445) - [@KronicDeth](https://github.com/KronicDeth)
+  * Protect ExUnit configuration `Producer` from `ElixirFile` without `VirtualFile`.
 
 ## v12.0.1
 

--- a/resources/META-INF/changelog.html
+++ b/resources/META-INF/changelog.html
@@ -51,6 +51,7 @@
       <li>Restore colors for char lists and strings lost with the PSI changes in <a href="https://github.com/KronicDeth/intellij-elixir/commit/e71b247aacaff389358ca5441c32512cdafd6af9">e71b247</a>.</li>
       <li>Render <code>OtpErlangExternalFun</code> correctly as remote captures (<code>&amp;Mod.fun/arity</code>).<br>
         Fixes decompiling <code>Ecto.Changeset.validate_number</code>.</li>
+      <li>Protect ExUnit configuration <code>Producer</code> from <code>ElixirFile</code> without <code>VirtualFile</code>.</li>
     </ul>
   </li>
 </ul>

--- a/src/org/elixir_lang/exunit/configuration/Producer.kt
+++ b/src/org/elixir_lang/exunit/configuration/Producer.kt
@@ -135,7 +135,7 @@ private fun setupConfigurationFromContextImpl(configuration: Configuration,
                 }
             }
             is ElixirFile -> {
-                if (psiElement.virtualFile.path.endsWith(SUFFIX)) {
+                if (psiElement.virtualFile?.path?.endsWith(SUFFIX) == true) {
                     val basePath = psiElement.project.basePath
                     val workingDirectory = workingDirectory(psiElement, basePath)
                     val lineNumber = lineNumber(psiElement)
@@ -152,7 +152,7 @@ private fun setupConfigurationFromContextImpl(configuration: Configuration,
             else -> {
                 val containingFile = psiElement.containingFile
 
-                if (containingFile is ElixirFile && containingFile.virtualFile.path.endsWith(SUFFIX)) {
+                if (containingFile is ElixirFile && containingFile.virtualFile?.path?.endsWith(SUFFIX) == true) {
                     val basePath = psiElement.project.basePath
                     val workingDirectory = workingDirectory(psiElement, basePath)
                     val lineNumber = lineNumber(psiElement)


### PR DESCRIPTION
Fixes #2384

# Changelog
## Bug Fixes
* Protect ExUnit configuration `Producer` from `ElixirFile` without `VirtualFile`.