### PR TITLE
Don't highlight Quote or Sigil as normal text if part of documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -306,6 +306,9 @@
     * Don't resolve primary Find Usages element.
       The primary element passed to `FindUsageHandler` is now already resolved, so resolving it again for call definitions finds usages of `def`, `defmacro`, etc.
     * Since the element passed to `FindUsagesProvider#canFindUsageFor`, definers can no longer be excluded, so remove that check.
+* [#2449](https://github.com/KronicDeth/intellij-elixir/pull/2449) - [@KronicDeth](https://github.com/KronicDeth)
+  * Don't highlight `Quote` or `Sigil` as normal text if part of documentation.
+    Since the annotators will run in arbitrary order, the `Textual` annotator has to avoid annotating the same nodes as the `ModuleAttribute` annotator or the colors can get interleaved.
 
 ## v12.0.1
 

--- a/resources/META-INF/changelog.html
+++ b/resources/META-INF/changelog.html
@@ -65,6 +65,8 @@
           <li>Since the element passed to <code>FindUsagesProvider#canFindUsageFor</code>, definers can no longer be excluded, so remove that check.</li>
         </ul>
       </li>
+      <li>Don't highlight <code>Quote</code> or <code>Sigil</code> as normal text if part of documentation.<br>
+        Since the annotators will run in arbitrary order, the <code>Textual</code> annotator has to avoid annotating the same nodes as the <code>ModuleAttribute</code> annotator or the colors can get interleaved.</li>
     </ul>
   </li>
 </ul>

--- a/src/org/elixir_lang/annotator/ModuleAttribute.kt
+++ b/src/org/elixir_lang/annotator/ModuleAttribute.kt
@@ -156,46 +156,12 @@ class ModuleAttribute : Annotator, DumbAware {
                                     .create()
                         }
                     }
-                    is Heredoc -> {
-                        val heredocLineList = greatGrandChild.heredocLineList
-
-                        for (bodied in heredocLineList) {
-                            val body = bodied.body
-                            highlightFragments(
-                                    body,
-                                    holder
-                            )
-                        }
-                    }
-                    is Line -> {
-                        val body = greatGrandChild.body
-                        highlightFragments(
-                                body,
-                                holder
-                        )
-                    }
+                    is Quote ->
+                        Textual.highlightQuote(holder, greatGrandChild, ElixirSyntaxHighlighter.DOCUMENTATION_TEXT)
+                    is Sigil ->
+                        Textual.highlightSigil(holder, greatGrandChild, ElixirSyntaxHighlighter.DOCUMENTATION_TEXT)
                 }
             }
-        }
-    }
-
-    /**
-     * Highlights fragment ASTNodes under `body` that have fragment type from `fragmented.getFragmentType()`.
-     *
-     * @param body              contains fragments
-     * @param annotationHolder  the container which receives annotations created by the plugin.
-     */
-    private fun highlightFragments(body: Body,
-                                   annotationHolder: AnnotationHolder) {
-        val bodyNode = body.node
-        val fragmentNodes = bodyNode.getChildren(
-                TokenSet.create(ElixirTypes.FRAGMENT)
-        )
-        for (fragmentNode in fragmentNodes) {
-            Highlighter.highlight(annotationHolder,
-                    fragmentNode.textRange,
-                    ElixirSyntaxHighlighter.DOCUMENTATION_TEXT
-            )
         }
     }
 

--- a/src/org/elixir_lang/annotator/Textual.kt
+++ b/src/org/elixir_lang/annotator/Textual.kt
@@ -2,32 +2,17 @@ package org.elixir_lang.annotator
 
 import com.intellij.lang.annotation.AnnotationHolder
 import com.intellij.lang.annotation.Annotator
-import com.intellij.lang.annotation.HighlightSeverity
 import com.intellij.openapi.editor.colors.TextAttributesKey
 import com.intellij.openapi.project.DumbAware
 import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiRecursiveElementVisitor
 import com.intellij.psi.tree.TokenSet
 import org.elixir_lang.ElixirSyntaxHighlighter
 import org.elixir_lang.ElixirSyntaxHighlighter.Companion.SIGIL
 import org.elixir_lang.ElixirSyntaxHighlighter.Companion.SIGIL_BY_NAME
-import org.elixir_lang.eex.Language
-import org.elixir_lang.errorreport.Logger
 import org.elixir_lang.psi.*
-import org.elixir_lang.psi.CallDefinitionClause.`is`
-import org.elixir_lang.psi.call.Call
-import org.elixir_lang.psi.call.name.Function
-import org.elixir_lang.psi.call.name.Function.UNQUOTE_SPLICING
-import org.elixir_lang.psi.call.name.Module
-import org.elixir_lang.psi.call.name.Module.KERNEL
 import org.elixir_lang.psi.impl.identifierName
-import org.elixir_lang.psi.impl.stripAccessExpression
 import org.elixir_lang.psi.operation.*
-import org.elixir_lang.reference.ModuleAttribute.Companion.isCallbackName
 import org.elixir_lang.reference.ModuleAttribute.Companion.isDocumentationName
-import org.elixir_lang.reference.ModuleAttribute.Companion.isSpecificationName
-import org.elixir_lang.reference.ModuleAttribute.Companion.isTypeName
-import org.elixir_lang.structure_view.element.CallDefinitionHead.Companion.stripAllOuterParentheses
 
 /**
  * Annotates quotes and sigils
@@ -46,70 +31,96 @@ class Textual : Annotator, DumbAware {
             element.accept(
                     object : ElixirVisitor() {
                         override fun visitQuote(quote: Quote) {
-                            val node = quote.node
-                            val textAttributesKey = if (quote.isCharList) {
-                                ElixirSyntaxHighlighter.CHAR_LIST
-                            } else {
-                                ElixirSyntaxHighlighter.STRING
-                            }
+                            if (!isDocumentationText(quote)) {
+                                val textAttributesKey = if (quote.isCharList) {
+                                    ElixirSyntaxHighlighter.CHAR_LIST
+                                } else {
+                                    ElixirSyntaxHighlighter.STRING
+                                }
 
-                            Highlighter.highlight(holder, node.firstChildNode, textAttributesKey)
-
-                            visitChildren(quote, textAttributesKey)
-
-                            Highlighter.highlight(holder, node.lastChildNode, textAttributesKey)
-                        }
-
-
-                        private fun visitHeredoc(heredoc: Heredoc, textAttributesKey: TextAttributesKey) {
-                            heredoc.heredocLineList.forEach { heredocLine ->
-                                visitBodied(heredocLine, textAttributesKey)
-                            }
-                        }
-
-                        private fun visitBodied(bodied: Bodied, textAttributesKey: TextAttributesKey) {
-                            visitBody(bodied.body, textAttributesKey)
-                        }
-
-                        private fun visitBody(body: Body, textAttributesKey: TextAttributesKey) {
-                            body.node.getChildren(TokenSet.create(ElixirTypes.FRAGMENT, ElixirTypes.LINE_TERMINATOR, ElixirTypes.HEREDOC_TERMINATOR)).forEach { fragment ->
-                                Highlighter.highlight(holder, fragment, textAttributesKey)
-                            }
-                            body.node.getChildren(TokenSet.create(ElixirTypes.ESCAPED_LINE_TERMINATOR, ElixirTypes.ESCAPED_HEREDOC_TERMINATOR)).forEach { escapedTerminator ->
-                                Highlighter.highlight(holder, escapedTerminator, ElixirSyntaxHighlighter.VALID_ESCAPE_SEQUENCE)
+                                highlightQuote(holder, quote, textAttributesKey)
                             }
                         }
 
                         override fun visitSigil(sigil: Sigil) {
-                            val node = sigil.node
-                            val tilde = node.firstChildNode
-                            val sigilName = tilde.treeNext
-                            val textAttributesKey = textAttributesKey(sigilName.text)
-                            val promoter = sigilName.treeNext
+                            if (!isDocumentationText(sigil)) {
+                                val textAttributesKey = textAttributesKey(sigil.sigilName())
 
-                            Highlighter.highlight(holder, tilde, textAttributesKey)
-                            Highlighter.highlight(holder, sigilName, textAttributesKey)
-                            Highlighter.highlight(holder, promoter, textAttributesKey)
-
-                            visitChildren(sigil, textAttributesKey)
-
-                            val sigilModifiers = node.lastChildNode
-                            val terminator = sigilModifiers.treePrev
-
-                            Highlighter.highlight(holder, terminator, textAttributesKey)
-                            Highlighter.highlight(holder, sigilModifiers, textAttributesKey)
+                                highlightSigil(holder, sigil, textAttributesKey)
+                            }
                         }
 
-                        private fun textAttributesKey(sigilName: String): TextAttributesKey =
-                            SIGIL_BY_NAME[sigilName.first()] ?: SIGIL
+                        private fun isDocumentationText(parent: Parent): Boolean =
+                            parent
+                                    .parent?.let { it as? ElixirAccessExpression }
+                                    ?.parent?.let { it as? ElixirNoParenthesesOneArgument }
+                                    ?.parent?.let { it as? AtUnqualifiedNoParenthesesCall<*> }
+                                    ?.atIdentifier
+                                    ?.identifierName()?.let { isDocumentationName(it) }
+                                    ?: false
 
-                        private fun visitChildren(parent: PsiElement, textAttributesKey: TextAttributesKey) =
-                                when (parent) {
-                                    is Heredoc -> visitHeredoc(parent, textAttributesKey)
-                                    is Line -> visitBodied(parent, textAttributesKey)
-                                    else -> Unit
-                                }
+                        private fun textAttributesKey(sigilName: Char): TextAttributesKey =
+                            SIGIL_BY_NAME[sigilName] ?: SIGIL
                     }
             )
         }
+
+    companion object {
+        fun highlightQuote(holder: AnnotationHolder, quote: Quote, textAttributesKey: TextAttributesKey) {
+            val node = quote.node
+
+            Highlighter.highlight(holder, node.firstChildNode, textAttributesKey)
+
+            highlightChildren(holder, quote, textAttributesKey)
+
+            Highlighter.highlight(holder, node.lastChildNode, textAttributesKey)
+        }
+
+        fun highlightSigil(holder: AnnotationHolder, sigil: Sigil, textAttributesKey: TextAttributesKey) {
+            val node = sigil.node
+
+            val tilde = node.firstChildNode
+            Highlighter.highlight(holder, tilde, textAttributesKey)
+
+            val sigilName = tilde.treeNext
+            Highlighter.highlight(holder, sigilName, textAttributesKey)
+
+            val promoter = sigilName.treeNext
+            Highlighter.highlight(holder, promoter, textAttributesKey)
+
+            highlightChildren(holder, sigil, textAttributesKey)
+
+            val sigilModifiers = node.lastChildNode
+            val terminator = sigilModifiers.treePrev
+
+            Highlighter.highlight(holder, terminator, textAttributesKey)
+            Highlighter.highlight(holder, sigilModifiers, textAttributesKey)
+        }
+
+        private fun highlightChildren(holder: AnnotationHolder, parent: PsiElement, textAttributesKey: TextAttributesKey) =
+                when (parent) {
+                    is Heredoc -> highlightHeredoc(holder, parent, textAttributesKey)
+                    is Line -> highlightBodied(holder, parent, textAttributesKey)
+                    else -> Unit
+                }
+
+        private fun highlightHeredoc(holder: AnnotationHolder, heredoc: Heredoc, textAttributesKey: TextAttributesKey) {
+            heredoc.heredocLineList.forEach { heredocLine ->
+                highlightBodied(holder, heredocLine, textAttributesKey)
+            }
+        }
+
+        private fun highlightBodied(holder: AnnotationHolder, bodied: Bodied, textAttributesKey: TextAttributesKey) {
+            highlightBody(holder, bodied.body, textAttributesKey)
+        }
+
+        private fun highlightBody(holder: AnnotationHolder, body: Body, textAttributesKey: TextAttributesKey) {
+            body.node.getChildren(TokenSet.create(ElixirTypes.FRAGMENT, ElixirTypes.LINE_TERMINATOR, ElixirTypes.HEREDOC_TERMINATOR)).forEach { fragment ->
+                Highlighter.highlight(holder, fragment, textAttributesKey)
+            }
+            body.node.getChildren(TokenSet.create(ElixirTypes.ESCAPED_LINE_TERMINATOR, ElixirTypes.ESCAPED_HEREDOC_TERMINATOR)).forEach { escapedTerminator ->
+                Highlighter.highlight(holder, escapedTerminator, ElixirSyntaxHighlighter.VALID_ESCAPE_SEQUENCE)
+            }
+        }
+    }
 }


### PR DESCRIPTION
# Changelog
## Bug Fixes
* Don't highlight `Quote` or `Sigil` as normal text if part of documentation.
  Since the annotators will run in arbitrary order, the `Textual` annotator has to avoid annotating the same nodes as the `ModuleAttribute` annotator or the colors can get interleaved.