### PR TITLE
Put ENTRANCE and Initiali Visited Element in __module__.Resolver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -309,6 +309,8 @@
 * [#2449](https://github.com/KronicDeth/intellij-elixir/pull/2449) - [@KronicDeth](https://github.com/KronicDeth)
   * Don't highlight `Quote` or `Sigil` as normal text if part of documentation.
     Since the annotators will run in arbitrary order, the `Textual` annotator has to avoid annotating the same nodes as the `ModuleAttribute` annotator or the colors can get interleaved.
+* [#2450](https://github.com/KronicDeth/intellij-elixir/pull/2450) - [@KronicDeth](https://github.com/KronicDeth)
+  * Put `ENTRANCE` and Initial Visited Element in `__module__.Resolver`.
 
 ## v12.0.1
 

--- a/resources/META-INF/changelog.html
+++ b/resources/META-INF/changelog.html
@@ -67,6 +67,7 @@
       </li>
       <li>Don't highlight <code>Quote</code> or <code>Sigil</code> as normal text if part of documentation.<br>
         Since the annotators will run in arbitrary order, the <code>Textual</code> annotator has to avoid annotating the same nodes as the <code>ModuleAttribute</code> annotator or the colors can get interleaved.</li>
+      <li>Put <code>ENTRANCE</code> and Initial Visited Element in <code>__module__.Resolver</code>.</li>
     </ul>
   </li>
 </ul>

--- a/src/org/elixir_lang/psi/__module__/Resolver.kt
+++ b/src/org/elixir_lang/psi/__module__/Resolver.kt
@@ -5,6 +5,8 @@ import com.intellij.psi.ResolveState
 import com.intellij.psi.impl.source.resolve.ResolveCache
 import com.intellij.psi.util.PsiTreeUtil
 import org.elixir_lang.psi.call.Call
+import org.elixir_lang.psi.impl.ElixirPsiImplUtil.ENTRANCE
+import org.elixir_lang.psi.putInitialVisitedElement
 
 object Resolver : ResolveCache.PolyVariantResolver<Reference> {
     override fun resolve(reference: Reference, incompleteCode: Boolean): Array<ResolveResult> =
@@ -17,7 +19,7 @@ object Resolver : ResolveCache.PolyVariantResolver<Reference> {
                 processor,
                 call,
                 call.containingFile,
-                ResolveState.initial()
+                ResolveState.initial().put(ENTRANCE, call).putInitialVisitedElement(call)
         )
 
         return processor.resolveResults


### PR DESCRIPTION
Fixes #2442

# Changelog
## Bug Fixes
* Put `ENTRANCE` and Initial Visited Element in `__module__.Resolver`.