### PR TITLE
Fix resolving Erlang modules aliased with as

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -276,6 +276,8 @@
 * [#2448](https://github.com/KronicDeth/intellij-elixir/pull/2448) - [@KronicDeth](https://github.com/KronicDeth)
   * Regression test for #2386
     Issue #2386 had the same root cause (OtpExternalFun not being decompiled correctly) as Issue #2410, so Issue #2386 was fixed by Pull Request #2441, but since @alexxero was nice enough to upload the `.beam` file for Issue #2386, I might as well add it as a regression test too.
+* [#2453](https://github.com/KronicDeth/intellij-elixir/pull/2453) - [@KronicDeth](https://github.com/KronicDeth)
+  * Regression test for #2446
 
 ### Bug Fixes
 * [#2397](https://github.com/KronicDeth/intellij-elixir/pull/2397) - [@KronicDeth](https://github.com/KronicDeth)
@@ -313,6 +315,10 @@
   * Put `ENTRANCE` and Initial Visited Element in `__module__.Resolver`.
 * [#2452](https://github.com/KronicDeth/intellij-elixir/pull/2452) - [@KronicDeth](https://github.com/KronicDeth)
   * Keep searching when resolving type parameters if bitstring is encountered. 
+* [#2453](https://github.com/KronicDeth/intellij-elixir/pull/2453) - [@KronicDeth](https://github.com/KronicDeth)
+  * Fix `UnaliasedName.unaliasedName` for atoms.
+  * Restore `ElixirAtom#getName`
+    Lost when parser was regenerated when Elixir <= 1.6 support was dropped in [679a9689cfe097018b9baa4e894d4550a84d7aac](https://github.com/KronicDeth/intellij-elixir/commit/679a9689cfe097018b9baa4e894d4550a84d7aac).
 
 ## v12.0.1
 

--- a/gen/org/elixir_lang/psi/ElixirAtom.java
+++ b/gen/org/elixir_lang/psi/ElixirAtom.java
@@ -18,6 +18,8 @@ public interface ElixirAtom extends NavigatablePsiElement, PsiNamedElement, Quot
 
   @NotNull OtpErlangObject quote();
 
+  @Nullable String getName();
+
   @NotNull PsiElement setName(@NotNull String newName);
 
 }

--- a/gen/org/elixir_lang/psi/impl/ElixirAtomImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirAtomImpl.java
@@ -46,6 +46,11 @@ public class ElixirAtomImpl extends ASTWrapperPsiElement implements ElixirAtom {
   }
 
   @Override
+  public @Nullable String getName() {
+    return ElixirPsiImplUtil.getName(this);
+  }
+
+  @Override
   public @NotNull PsiElement setName(@NotNull String newName) {
     return ElixirPsiImplUtil.setName(this, newName);
   }

--- a/resources/META-INF/changelog.html
+++ b/resources/META-INF/changelog.html
@@ -29,6 +29,7 @@
       <li>Regression test for<a href="https://github.com/KronicDeth/intellij-elixir/issues/2386">#2386</a><br>
         Issue <a href="https://github.com/KronicDeth/intellij-elixir/issues/2386">#2386</a> had the same root cause (OtpExternalFun not being decompiled correctly) as Issue <a href="https://github.com/KronicDeth/intellij-elixir/issues/2410">#2410</a>, so Issue <a href="https://github.com/KronicDeth/intellij-elixir/issues/2386">#2386</a>
         was fixed by Pull Request <a href="https://github.com/KronicDeth/intellij-elixir/pull/2441">#2441</a>, but since <a href="https://github.com/alexxero">@alexxero</a> was nice enough to upload the <code>.beam</code> file for Issue <a href="https://github.com/KronicDeth/intellij-elixir/issues/2386">#2386</a>, I might as well add it as a regression test too.</li>
+      <li>Regression test for <a href="https://github.com/KronicDeth/intellij-elixir/issues/2446">#2446</a></li>
     </ul>
   </li>
   <li>
@@ -69,6 +70,9 @@
         Since the annotators will run in arbitrary order, the <code>Textual</code> annotator has to avoid annotating the same nodes as the <code>ModuleAttribute</code> annotator or the colors can get interleaved.</li>
       <li>Put <code>ENTRANCE</code> and Initial Visited Element in <code>__module__.Resolver</code>.</li>
       <li>Keep searching when resolving type parameters if bitstring is encountered.</li>
+      <li>Fix <code>UnaliasedName.unaliasedName</code> for atoms.</li>
+      <li>Restore <code>ElixirAtom#getName</code><br>
+        Lost when parser was regenerated when Elixir &lt;= 1.6 support was dropped in <a href="https://github.com/KronicDeth/intellij-elixir/commit/679a9689cfe097018b9baa4e894d4550a84d7aac">679a968</a>.</li>
     </ul>
   </li>
 </ul>

--- a/src/org/elixir_lang/Elixir.bnf
+++ b/src/org/elixir_lang/Elixir.bnf
@@ -2671,6 +2671,7 @@ atom ::= COLON (ATOM_FRAGMENT | line)
            methods = [
              getReference
              quote
+             getName
              setName
            ]
          }

--- a/src/org/elixir_lang/reference/module/UnaliasedName.kt
+++ b/src/org/elixir_lang/reference/module/UnaliasedName.kt
@@ -16,6 +16,8 @@ object UnaliasedName {
     fun unaliasedName(namedElement: PsiNamedElement): String? =
             if (namedElement is QualifiableAlias) {
                 unaliasedName(namedElement)
+            } else if (namedElement is ElixirAtom) {
+                ":${namedElement.name}"
             } else if (namedElement is Call && namedElement.isCalling(KERNEL, Function.__MODULE__, 0)) {
                 __MODULE__
                         .reference(namedElement, useCall = null)
@@ -37,10 +39,11 @@ object UnaliasedName {
                 is ElixirAccessExpression -> {
                     val children = element.children
 
-                    assert(children.size >= 1)
+                    assert(children.isNotEmpty())
 
                     down(children[0])
                 }
+                is ElixirAtom -> ":${element.name}"
                 is QualifiableAlias -> element.name
                 else -> {
                     Logger.error(

--- a/testData/org/elixir_lang/reference/module/as/issue_2446/asd_xS@ps.ex
+++ b/testData/org/elixir_lang/reference/module/as/issue_2446/asd_xS@ps.ex
@@ -1,0 +1,4 @@
+defmodule :asd_xS@ps do
+  def foo do
+  end
+end

--- a/testData/org/elixir_lang/reference/module/as/issue_2446/index.ex
+++ b/testData/org/elixir_lang/reference/module/as/issue_2446/index.ex
@@ -1,0 +1,7 @@
+defmodule Index do
+  alias :asd_xS@ps, as: PS
+
+  def index do
+    PS.<caret>
+  end
+end

--- a/tests/org/elixir_lang/reference/module/as/Issue2446Test.kt
+++ b/tests/org/elixir_lang/reference/module/as/Issue2446Test.kt
@@ -1,0 +1,17 @@
+package org.elixir_lang.reference.module.`as`
+
+import com.intellij.codeInsight.completion.CompletionType
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+
+class Issue2446Test : BasePlatformTestCase() {
+    fun testCompletion() {
+        myFixture.configureByFiles("index.ex", "asd_xS@ps.ex")
+        myFixture.complete(CompletionType.BASIC, 1)
+        val strings = myFixture.lookupElementStrings
+        assertNotNull("Completion lookup shown", strings)
+        assertEquals(1, strings!!.size)
+        assertContainsElements(strings, listOf("foo"))
+    }
+
+    override fun getTestDataPath(): String = "testData/org/elixir_lang/reference/module/as/issue_2446"
+}


### PR DESCRIPTION
# Changelog
## Enhancements
* Regression test for #2446

## Bug Fixes
* Fix `UnaliasedName.unaliasedName` for atoms.
* Restore `ElixirAtom#getName`
  Lost when parser was regenerated when Elixir <= 1.6 support was dropped in 679a9689cfe097018b9baa4e894d4550a84d7aac.
