### PR TITLE
Protect from `null` `containingFile` when fetching docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 <details>
 
+* [v13.0.1](#v1301)
 * [v13.0.0](#v1300)
   * [Incompatible Changes](#incompatible-changes)
   * [Enhancements](#enhancements)
@@ -259,6 +260,13 @@
   * [Bug Fixes](#bug-fixes-77)
 
 </details>
+
+## v13.0.1
+
+### Bug Fixes
+
+* [#2637](https://github.com/KronicDeth/intellij-elixir/pull/2637) - [@KronicDeth](https://github.com/KronicDeth)
+  * Protect from `null` `containingFile` when fetching docs.
 
 ## v13.0.0
 
@@ -1832,7 +1840,7 @@
   * Ignore the `incompleteCode` flag and instead always use the criteria used when `incompleteCode` was set.
 
     | name prefix | exact name | ResolveResult | valid |
-                                                                              |-------------|------------|---------------|-------|
+                                                                                                  |-------------|------------|---------------|-------|
     | ❌           | N/A        | ❌             | N/A   |
     | ✅           | ❌          | ✅             | ❌     |
     | ✅           | ✅          | ✅             | ✅     |
@@ -2087,7 +2095,7 @@
     for non-Go projects, so it is also excluded. How the support appears in each non-IntelliJ IDEA is shown below:
 
     | IDE            | Works? |                                                                                                                                                                                                                                                                                                                                                                    |
-                                                                               |:---------------|:-------|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+                                                                                                   |:---------------|:-------|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
     | Android Studio | YES    | Android Studio is built on top of IntelliJ, so it has full multi-Module support. It is not Small IDE.                                                                                                                                                                                                                                                             |
     | CLion          | NO     | No Attach to Project support to multiple module support.                                                                                                                                                                                                                                                                                                           |
     | DataGrip       | No     | DataGrip doesn't have a Project View and doesn't support Attach to Project. You can still run tests if you directly open the file.                                                                                                                                                                                                                                |
@@ -2542,7 +2550,7 @@
     additions.
 
     | number |        name        |         Added         |
-                                                                               |:-------|:-------------------|:----------------------|
+                                                                                                   |:-------|:-------------------|:----------------------|
     | `160`  | `build_stacktrace` | Before OTP 21 release |
     | `161`  | `raw_raise`        | Now                   |
     | `162`  | `get_hd`           | Now                   |
@@ -2786,7 +2794,7 @@
       The `Atom`/`AtU8` tab shows a table with the columns
 
       | Column     | Description                                                                                                           | Source  |
-                                                                                                                        |:-----------|:----------------------------------------------------------------------------------------------------------------------|:--------|
+                                                                                                                                                      |:-----------|:----------------------------------------------------------------------------------------------------------------------|:--------|
       | Index      | Which is 1-based to match Erlang convention. In the `Code` chunk, `atom(0)` is reserved to always translate to `nil` | Derived |
       | Byte Count | The byte count for the atom's bytes                                                                                   | Raw     |
       | Characters | From encoding the bytes as LATIN-1 for `Atom` chunk or UTF-8 for `AtU8` chunk                                         | Derived |
@@ -2801,7 +2809,7 @@
       The `Attr` tab shows a table with the columns
 
       | Column | Description                                                                                                      | Source |
-                                                                                                                        |:-------|:-----------------------------------------------------------------------------------------------------------------|:-------|
+                                                                                                                                                      |:-------|:-----------------------------------------------------------------------------------------------------------------|:-------|
       | Key    | Attribute name                                                                                                   | Raw    |
       | Value  | Attribute value. **Note: The value always appears as a list as read from the binary format. I don't
       know why.** | Raw    |
@@ -2815,7 +2823,7 @@
       The `CInf` tab shows a table with the columns
 
       | Column | Description     | Source |
-                                                                                                                        |:-------|:----------------|:-------|
+                                                                                                                                                      |:-------|:----------------|:-------|
       | Key    | Option name     | Raw    |
       | Value  | Inspected value | Raw    |
 
@@ -3007,7 +3015,7 @@
   * Support for https://github.com/elixir-lang/elixir/commit/23c7542d95683a497a7b93071b9ccbbeb9e45d2f
 
     | Version  | Struct               | Started Event     | Finished Event     | `%ExUnit.Test{}` field |
-                                                                              |----------|----------------------|-------------------|--------------------|------------------------|
+                                                                                                  |----------|----------------------|-------------------|--------------------|------------------------|
     | < 1.6.0  | `%ExUnit.TestCase{}` | `:case_started`   | `:case_finished`   | `case`                 |
     | > = 1.6.0 | `%ExUnit.TestCase{}` | `:module_started` | `:module_finished` | `module`               |
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 # Available idea versions:
 # https://www.jetbrains.com/intellij-repository/releases
 # https://www.jetbrains.com/intellij-repository/snapshots
-baseVersion=13.0.0
+baseVersion=13.0.1
 ideaVersion=2022.1
 # MUST stay at 1.8 for JPS (Build/Compile Project) compatibility even if JRE/JBR is newer
 javaVersion=1.8

--- a/resources/META-INF/changelog.html
+++ b/resources/META-INF/changelog.html
@@ -1,5 +1,14 @@
 <html>
 <body>
+<h1>v13.0.1</h1>
+<ul>
+  <li>
+    <p>Bug Fixes</p>
+    <ul dir="auto">
+      <li>Protect from <code class="notranslate">null</code> <code class="notranslate">containingFile</code> when fetching docs.</li>
+    </ul>
+  </li>
+</ul>
 <h1>v13.0.0</h1>
 <ul>
   <li>

--- a/src/org/elixir_lang/documentation/ElixirDocumentationProvider.kt
+++ b/src/org/elixir_lang/documentation/ElixirDocumentationProvider.kt
@@ -186,7 +186,7 @@ class ElixirDocumentationProvider : DocumentationProvider {
 
     private fun fetchDocs(element: PsiElement): FetchedDocs? =
         // If resolves to .beam file then fetch docs from the decompiled docs
-        if (element.containingFile.originalFile is BeamFileImpl) {
+        if (element.containingFile?.originalFile is BeamFileImpl) {
             BeamDocsHelper.fetchDocs(element)
         } else {
             SourceFileDocsHelper.fetchDocs(element)


### PR DESCRIPTION
Fixes #2564

# Changelog
## Bug Fixes
* Protect from `null` `containingFile` when fetching docs.