### PR TITLE
Catch AlreadyDisposedException when trying to find module for PsiElement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -274,6 +274,9 @@
     plugin, but a configuration change the user needs to do.
 * [#2640](https://github.com/KronicDeth/intellij-elixir/pull/2640) - [@KronicDeth](https://github.com/KronicDeth)
   * Ignore tuples as type restrictions that occur during typing.
+* [#2641](https://github.com/KronicDeth/intellij-elixir/pull/2641) - [@KronicDeth](https://github.com/KronicDeth)
+  * Catch `AlreadyDisposedException` when trying to find module for PsiElement in `mostSpecificSdk`.
+    * Check if the project`is disposed before using it to get module for `PsiElement`.
 
 ## v13.0.0
 
@@ -1847,7 +1850,7 @@
   * Ignore the `incompleteCode` flag and instead always use the criteria used when `incompleteCode` was set.
 
     | name prefix | exact name | ResolveResult | valid |
-                                                                                                                      |-------------|------------|---------------|-------|
+    |-------------|------------|---------------|-------|
     | ❌           | N/A        | ❌             | N/A   |
     | ✅           | ❌          | ✅             | ❌     |
     | ✅           | ✅          | ✅             | ✅     |
@@ -2102,7 +2105,7 @@
     for non-Go projects, so it is also excluded. How the support appears in each non-IntelliJ IDEA is shown below:
 
     | IDE            | Works? |                                                                                                                                                                                                                                                                                                                                                                    |
-                                                                                                                       |:---------------|:-------|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+    |:---------------|:-------|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
     | Android Studio | YES    | Android Studio is built on top of IntelliJ, so it has full multi-Module support. It is not Small IDE.                                                                                                                                                                                                                                                             |
     | CLion          | NO     | No Attach to Project support to multiple module support.                                                                                                                                                                                                                                                                                                           |
     | DataGrip       | No     | DataGrip doesn't have a Project View and doesn't support Attach to Project. You can still run tests if you directly open the file.                                                                                                                                                                                                                                |
@@ -2557,7 +2560,7 @@
     additions.
 
     | number |        name        |         Added         |
-                                                                                                                       |:-------|:-------------------|:----------------------|
+    |:-------|:-------------------|:----------------------|
     | `160`  | `build_stacktrace` | Before OTP 21 release |
     | `161`  | `raw_raise`        | Now                   |
     | `162`  | `get_hd`           | Now                   |
@@ -2801,7 +2804,7 @@
       The `Atom`/`AtU8` tab shows a table with the columns
 
       | Column     | Description                                                                                                           | Source  |
-                                                                                                                                                                                    |:-----------|:----------------------------------------------------------------------------------------------------------------------|:--------|
+      |:-----------|:----------------------------------------------------------------------------------------------------------------------|:--------|
       | Index      | Which is 1-based to match Erlang convention. In the `Code` chunk, `atom(0)` is reserved to always translate to `nil` | Derived |
       | Byte Count | The byte count for the atom's bytes                                                                                   | Raw     |
       | Characters | From encoding the bytes as LATIN-1 for `Atom` chunk or UTF-8 for `AtU8` chunk                                         | Derived |
@@ -2816,7 +2819,7 @@
       The `Attr` tab shows a table with the columns
 
       | Column | Description                                                                                                      | Source |
-                                                                                                                                                                                    |:-------|:-----------------------------------------------------------------------------------------------------------------|:-------|
+      |:-------|:-----------------------------------------------------------------------------------------------------------------|:-------|
       | Key    | Attribute name                                                                                                   | Raw    |
       | Value  | Attribute value. **Note: The value always appears as a list as read from the binary format. I don't
       know why.** | Raw    |
@@ -2830,7 +2833,7 @@
       The `CInf` tab shows a table with the columns
 
       | Column | Description     | Source |
-                                                                                                                                                                                    |:-------|:----------------|:-------|
+      |:-------|:----------------|:-------|
       | Key    | Option name     | Raw    |
       | Value  | Inspected value | Raw    |
 
@@ -3022,7 +3025,7 @@
   * Support for https://github.com/elixir-lang/elixir/commit/23c7542d95683a497a7b93071b9ccbbeb9e45d2f
 
     | Version  | Struct               | Started Event     | Finished Event     | `%ExUnit.Test{}` field |
-                                                                                                                      |----------|----------------------|-------------------|--------------------|------------------------|
+    |----------|----------------------|-------------------|--------------------|------------------------|
     | < 1.6.0  | `%ExUnit.TestCase{}` | `:case_started`   | `:case_finished`   | `case`                 |
     | > = 1.6.0 | `%ExUnit.TestCase{}` | `:module_started` | `:module_finished` | `module`               |
 

--- a/resources/META-INF/changelog.html
+++ b/resources/META-INF/changelog.html
@@ -9,6 +9,11 @@
       <li>Show notification if $HOME_PATH/lib does not exist.<br>
         Instead of logging an error show a notification since it can and does happen and is not a bug to be fixed in the plugin, but a configuration change the user needs to do.</li>
       <li>Ignore tuples as type restrictions that occur during typing</li>
+      <li>Catch <code class="notranslate">AlreadyDisposedException</code> when trying to find module for PsiElement in <code class="notranslate">mostSpecificSdk</code>.
+        <ul dir="auto">
+          <li>Check if the project<code class="notranslate">is disposed before using it to get module for </code>PsiElement`.</li>
+        </ul>
+      </li>
     </ul>
   </li>
 </ul>

--- a/src/org/elixir_lang/sdk/elixir/Type.kt
+++ b/src/org/elixir_lang/sdk/elixir/Type.kt
@@ -530,16 +530,20 @@ ELIXIR_SDK_HOME
             /* ModuleUtilCore.findModuleForPsiElement can fail with NullPointerException if the
            ProjectFileIndex.SERVICE.getInstance(Project) returns {@code null}, so check that the ProjectFileIndex is
            available first */
-            return if (ProjectFileIndex.SERVICE.getInstance(project) != null) {
-                val module = ModuleUtilCore.findModuleForPsiElement(psiElement)
+            return if (!project.isDisposed) {
+                if (ProjectFileIndex.SERVICE.getInstance(project) != null) {
+                    val module = ModuleUtilCore.findModuleForPsiElement(psiElement)
 
-                if (module != null) {
-                    mostSpecificSdk(module)
+                    if (module != null) {
+                        mostSpecificSdk(module)
+                    } else {
+                        mostSpecificSdk(project)
+                    }
                 } else {
                     mostSpecificSdk(project)
                 }
             } else {
-                mostSpecificSdk(project)
+                null
             }
         }
 


### PR DESCRIPTION
Fixes #2582

# Changelog
## Bug Fixes
* Catch `AlreadyDisposedException` when trying to find module for PsiElement in `mostSpecificSdk`.
  * Check if the project`is disposed before using it to get module for `PsiElement`.