### PR TITLE
Default to the variable color if the specific type foreground is null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -383,6 +383,8 @@
   * Regression test for #2446
 # [#2642](https://github.com/KronicDeth/intellij-elixir/pull/2642) - [@KronicDeth](https://github.com/KronicDeth)
   * Ignore `()` as a type parameter as it occurs during typing.
+* [#2643](https://github.com/KronicDeth/intellij-elixir/pull/2643) - [@KronicDeth](https://github.com/KronicDeth)
+  * Default the variable color if the specific type foreground is `null`.
 
 ### Bug Fixes
 

--- a/resources/META-INF/changelog.html
+++ b/resources/META-INF/changelog.html
@@ -15,6 +15,7 @@
         </ul>
       </li>
       <li>Ignore <code class="notranslate">()</code> as a type parameter as it occurs during typing.</li>
+      <li>Default the variable color if the specific type foreground is <code class="notranslate">null</code></li>
     </ul>
   </li>
 </ul>

--- a/src/org/elixir_lang/code_insight/lookup/element_renderer/Variable.java
+++ b/src/org/elixir_lang/code_insight/lookup/element_renderer/Variable.java
@@ -84,7 +84,7 @@ public class Variable extends com.intellij.codeInsight.lookup.LookupElementRende
     @Contract(pure = true)
     @NotNull
     private Color color(@NotNull final PsiElement element) {
-        Color color = JBColor.foreground();
+        Color color = null;
 
         if (isIgnored(element)) {
             color = ElixirSyntaxHighlighter.IGNORED_VARIABLE.getDefaultAttributes().getForegroundColor();
@@ -101,6 +101,10 @@ public class Variable extends com.intellij.codeInsight.lookup.LookupElementRende
             } else if (isVariable(element)) {
                 color = ElixirSyntaxHighlighter.VARIABLE.getDefaultAttributes().getForegroundColor();
             }
+        }
+
+        if (color == null) {
+            color = JBColor.foreground();
         }
 
         return color;


### PR DESCRIPTION
Fixes #2589

# Changelog
## Bug Fixes
* Default the variable color if the specific type foreground is `null`