### PR TITLE
Look above CallDefinitionImpl for Type scope processing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -277,6 +277,9 @@
 * [#2641](https://github.com/KronicDeth/intellij-elixir/pull/2641) - [@KronicDeth](https://github.com/KronicDeth)
   * Catch `AlreadyDisposedException` when trying to find module for PsiElement in `mostSpecificSdk`.
     * Check if the project`is disposed before using it to get module for `PsiElement`.
+* [#2670](https://github.com/KronicDeth/intellij-elixir/pull/2670) - [@KronicDeth](https://github.com/KronicDeth)
+  * Look above `CallDefinitionImp`l for Type scope processing
+    It should go up to the `ModuleImpl` to find the `TypeDefinitionImpl`.
 
 ## v13.0.0
 
@@ -381,12 +384,15 @@
     the `.beam` file for Issue #2386, I might as well add it as a regression test too.
 * [#2453](https://github.com/KronicDeth/intellij-elixir/pull/2453) - [@KronicDeth](https://github.com/KronicDeth)
   * Regression test for #2446
-# [#2642](https://github.com/KronicDeth/intellij-elixir/pull/2642) - [@KronicDeth](https://github.com/KronicDeth)
+* [#2642](https://github.com/KronicDeth/intellij-elixir/pull/2642) - [@KronicDeth](https://github.com/KronicDeth)
   * Ignore `()` as a type parameter as it occurs during typing.
 * [#2643](https://github.com/KronicDeth/intellij-elixir/pull/2643) - [@KronicDeth](https://github.com/KronicDeth)
   * Default the variable color if the specific type foreground is `null`.
 * [#2644](https://github.com/KronicDeth/intellij-elixir/pull/2644) - [@KronicDeth](https://github.com/KronicDeth)
   * Log unknown element for fetching docs from BEAM file.
+* [#2645](https://github.com/KronicDeth/intellij-elixir/pull/2645) - [@KronicDeth](https://github.com/KronicDeth)
+  * Look above `CallDefinitionImpl` for `Type` scope processing
+    It should go up to the `ModuleImpl` to find the `TypeDefinitionImpl`.
 
 ### Bug Fixes
 

--- a/resources/META-INF/changelog.html
+++ b/resources/META-INF/changelog.html
@@ -17,6 +17,10 @@
       <li>Ignore <code class="notranslate">()</code> as a type parameter as it occurs during typing.</li>
       <li>Default the variable color if the specific type foreground is <code class="notranslate">null</code></li>
       <li>Log unknown element for fetching docs from BEAM file</li>
+      <li>Look above <code class="notranslate">CallDefinitionImpl</code> for <code class="notranslate">Type</code> scope processing<br>
+        It should go up to the <code class="notranslate">ModuleImpl</code> to find the <code class="notranslate">TypeDefinitionImpl</code>.</li>
+      <li>Look above <code class="notranslate">CallDefinitionImp</code>l for Type scope processing<br>
+        It should go up to the <code class="notranslate">ModuleImpl</code> to find the <code class="notranslate">TypeDefinitionImpl</code>.</li>
     </ul>
   </li>
 </ul>


### PR DESCRIPTION
Fixes #2596

# Changelog
## Bug Fixes
* Look above `CallDefinitionImp`l for Type scope processing
  It should go up to the `ModuleImpl` to find the `TypeDefinitionImpl`.