### PR TITLE
Fix ancestorTypeSpec when typing <variable>.<tuple>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -285,6 +285,9 @@
     * Allow environment variables to be set similar to Run Configurations for projects that require environment variables to be set for Mix tasks due to checks in their config.
     * No longer support Include Explanations as it takes too long to run.
     * Remove annotator until it can be re-implemented in performant manner using corrected environment and SDK from Global Inspection.
+* [#2672](https://github.com/KronicDeth/intellij-elixir/pull/2672) - [@KronicDeth](https://github.com/KronicDeth)
+  * Look above `<variable>.<tuple>` for `ancestorTypeSpec`.
+    * Look above `<tuple>` after `<variable>.` for `ancestorTypeSpec`.
 
 ## v13.0.0
 

--- a/resources/META-INF/changelog.html
+++ b/resources/META-INF/changelog.html
@@ -28,6 +28,11 @@
           <li>Remove annotator until it can be re-implemented in performant manner using corrected environment and SDK from Global Inspection.</li>
         </ul>
       </li>
+      <li>Look above <code class="notranslate">&lt;variable&gt;.&lt;tuple&gt;</code> for <code class="notranslate">ancestorTypeSpec</code>.
+        <ul dir="auto">
+          <li>Look above <code class="notranslate">&lt;tuple&gt;</code> after <code class="notranslate">&lt;variable&gt;.</code> for <code class="notranslate">ancestorTypeSpec</code>.</li>
+        </ul>
+      </li>
     </ul>
   </li>
 </ul>

--- a/src/org/elixir_lang/psi/scope/Type.kt
+++ b/src/org/elixir_lang/psi/scope/Type.kt
@@ -235,8 +235,10 @@ internal fun PsiElement.ancestorTypeSpec(): AtUnqualifiedNoParenthesesCall<*>? =
         is ElixirMatchedParenthesesArguments,
         is Pipe,
         is ElixirStructOperation,
-            // tuple after variable while typing
+            // <variable>.<tuple> while typing
         is ElixirMatchedQualifiedMultipleAliases,
+            // <tuple> while typing after `<variable>.`
+        is ElixirMultipleAliases,
         is ElixirNoParenthesesOneArgument,
         is ElixirNoParenthesesArguments,
         is ElixirNoParenthesesKeywords,

--- a/src/org/elixir_lang/psi/scope/Type.kt
+++ b/src/org/elixir_lang/psi/scope/Type.kt
@@ -235,6 +235,8 @@ internal fun PsiElement.ancestorTypeSpec(): AtUnqualifiedNoParenthesesCall<*>? =
         is ElixirMatchedParenthesesArguments,
         is Pipe,
         is ElixirStructOperation,
+            // tuple after variable while typing
+        is ElixirMatchedQualifiedMultipleAliases,
         is ElixirNoParenthesesOneArgument,
         is ElixirNoParenthesesArguments,
         is ElixirNoParenthesesKeywords,


### PR DESCRIPTION
Fixes #2610

# Changelog
## Bug Fixes
* Look above `<variable>.<tuple>` for `ancestorTypeSpec`.
  * Look above `<tuple>` after `<variable>.` for `ancestorTypeSpec`.