### PR TITLE
Restore Project configuration for Small IDEs 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -317,6 +317,9 @@
     * `@type name :: String.()`
     * `@type String.()`
     * `@type S`
+* [#2676](https://github.com/KronicDeth/intellij-elixir/pull/2676) - [@KronicDeth](https://github.com/KronicDeth)
+  * Restore Project configuration for Small IDEs.
+    I dropped an `!` when converting from `equals` to `==` when fixing the deprecation warnings, which made the Project SDK selection _only_ be **HIDDEN** where it needed to be **SHOWN**.
 
 ## v13.0.0
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 # Available idea versions:
 # https://www.jetbrains.com/intellij-repository/releases
 # https://www.jetbrains.com/intellij-repository/snapshots
-baseVersion=13.0.1
+baseVersion=13.1.0
 ideaVersion=2022.1
 # MUST stay at 1.8 for JPS (Build/Compile Project) compatibility even if JRE/JBR is newer
 javaVersion=1.8

--- a/resources/META-INF/changelog.html
+++ b/resources/META-INF/changelog.html
@@ -72,6 +72,8 @@
           <li><code class="notranslate">@type S</code></li>
         </ul>
       </li>
+      <li>Restore Project configuration for Small IDEs.<br>
+        I dropped an <code class="notranslate">!</code> when converting from <code class="notranslate">equals</code> to <code class="notranslate">==</code> when fixing the deprecation warnings, which made the Project SDK selection <em>only</em> be <strong>HIDDEN</strong> where it needed to be <strong>SHOWN</strong>.</li>
     </ul>
   </li>
 </ul>

--- a/src/org/elixir_lang/facet/configurable/Project.kt
+++ b/src/org/elixir_lang/facet/configurable/Project.kt
@@ -18,7 +18,7 @@ class Project(project: Project) : ModuleAwareProjectConfigurable<Configurable>(p
     override fun isSuitableForModule(module: Module): Boolean =
     // CANNOT use ModuleType.is(module, ElixirModuleType.getInstance()) as ElixirModuleType depends on
         // JavaModuleBuilder and so only available in IntelliJ
-        ModuleType.get(module).id == "ELIXIR_MODULE"
+        ModuleType.get(module).id != "ELIXIR_MODULE"
 
     override fun createModuleConfigurable(module: Module): Configurable {
         return object : Configurable(module) {


### PR DESCRIPTION
Fixes #2656

# Changelog
## Bug Fixes
* Restore Project configuration for Small IDEs.
   I dropped an `!` when converting from `equals` to `==` when fixing the deprecation warnings, which made the Project SDK selection _only_ be **HIDDEN** where it needed to be **SHOWN**.