### PR TITLE
Highlight CallDefinitionImpl as predefined if it is in Kernel or Kernel.SpecialForms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -323,6 +323,9 @@
 * [#2679](https://github.com/KronicDeth/intellij-elixir/pull/2679) - [@KronicDeth](https://github.com/KronicDeth)
   * Catch `StackOverflowError` in `find_usages.Provider.getType()`.
   * Element descriptions for `CallDefinitionImpl`
+* [#2680](https://github.com/KronicDeth/intellij-elixir/pull/2680) - [@KronicDeth](https://github.com/KronicDeth)
+* Highlight `CallDefinitionImpl` references as predefined if resolved `CallDefinitionImpl` is in `Kernel` or `Kernel.SpecialForms`.
+  Fixes highlighting `def` and other defined when using SDKs without source like Homebrew after the delayed-decompilation fixes from 12.2.1.  Now source-less (Homebrew) and SDKs with sources (ASDF) will both be able to highlight predefineds.
 
 ## v13.0.0
 

--- a/resources/META-INF/changelog.html
+++ b/resources/META-INF/changelog.html
@@ -76,6 +76,8 @@
         I dropped an <code class="notranslate">!</code> when converting from <code class="notranslate">equals</code> to <code class="notranslate">==</code> when fixing the deprecation warnings, which made the Project SDK selection <em>only</em> be <strong>HIDDEN</strong> where it needed to be <strong>SHOWN</strong>.</li>
       <li>Catch <code class="notranslate">StackOverflowError</code> in <code class="notranslate">find_usages.Provider.getType()</code>.</li>
       <li>Element descriptions for <code class="notranslate">CallDefinitionImpl</code></li>
+      <li>Highlight <code class="notranslate">CallDefinitionImpl</code> references as predefined if resolved <code class="notranslate">CallDefinitionImpl</code> is in <code class="notranslate">Kernel</code> or <code class="notranslate">Kernel.SpecialForms</code>.<br>
+        Fixes highlighting <code class="notranslate">def</code> and other defined when using SDKs without source like Homebrew after the delayed-decompilation fixes from 12.2.1.  Now source-less (Homebrew) and SDKs with sources (ASDF) will both be able to highlight predefineds.</li>
     </ul>
   </li>
 </ul>

--- a/src/org/elixir_lang/annotator/Callable.kt
+++ b/src/org/elixir_lang/annotator/Callable.kt
@@ -10,6 +10,7 @@ import com.intellij.openapi.project.DumbAware
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.*
 import org.elixir_lang.ElixirSyntaxHighlighter
+import org.elixir_lang.beam.psi.impl.CallDefinitionImpl
 import org.elixir_lang.psi.AtOperation
 import org.elixir_lang.psi.AtUnqualifiedNoParenthesesCall
 import org.elixir_lang.psi.CallDefinitionClause
@@ -20,6 +21,7 @@ import org.elixir_lang.psi.call.name.Module.KERNEL_SPECIAL_FORMS
 import org.elixir_lang.reference.Callable.Companion.BIT_STRING_TYPES
 import org.elixir_lang.reference.Callable.Companion.isBitStreamSegmentOption
 import org.elixir_lang.safeMultiResolve
+import org.elixir_lang.structure_view.element.Timed
 import java.util.*
 
 /**
@@ -37,194 +39,218 @@ class Callable : Annotator, DumbAware {
      */
     override fun annotate(element: PsiElement, holder: AnnotationHolder) {
         element.accept(
-                object : PsiElementVisitor() {
-                    /*
-                     * Public Instance Methods
-                     */
+            object : PsiElementVisitor() {
+                /*
+                 * Public Instance Methods
+                 */
 
-                    private fun visitCall(call: Call) {
-                        if (!(call is AtOperation || call is AtUnqualifiedNoParenthesesCall<*>)) {
-                            visitNonModuleAttributeCall(call)
-                        }
+                private fun visitCall(call: Call) {
+                    if (!(call is AtOperation || call is AtUnqualifiedNoParenthesesCall<*>)) {
+                        visitNonModuleAttributeCall(call)
                     }
+                }
 
-                    /*
-                     * Private Instance Methods
-                     */
+                /*
+                 * Private Instance Methods
+                 */
 
-                    private fun visitCallDefinitionClause(call: Call) {
-                        // visit the `def(macro)?p? for Kernel PREDEFINED highlighting
+                private fun visitCallDefinitionClause(call: Call) {
+                    // visit the `def(macro)?p? for Kernel PREDEFINED highlighting
+                    visitPlainCall(call)
+
+                    CallDefinitionClause.head(call)?.let { head ->
+                        visitCallDefinitionHead(head, call)
+                    }
+                }
+
+                /*
+                 * Private Instance Methods
+                 */
+
+                private fun visitCallDefinitionHead(head: PsiElement, clause: Call) {
+                    val stripped = org.elixir_lang.structure_view.element.CallDefinitionHead.strip(head)
+
+                    if (stripped is Call) {
+                        visitStrippedCallDefinitionHead(stripped, clause)
+                    }
+                }
+
+                override fun visitElement(element: PsiElement) {
+                    when (element) {
+                        is Call -> visitCall(element)
+                        is UnqualifiedBracketOperation -> visitUnqualifiedBracketOperation(element)
+                    }
+                }
+
+                private fun visitNonModuleAttributeCall(call: Call) {
+                    if (CallDefinitionClause.`is`(call)) {
+                        visitCallDefinitionClause(call)
+                    } else {
                         visitPlainCall(call)
-
-                        CallDefinitionClause.head(call)?.let { head ->
-                            visitCallDefinitionHead(head, call)
-                        }
                     }
+                }
 
-                    /*
-                     * Private Instance Methods
-                     */
+                private fun visitPlainCall(call: Call) {
+                    val reference = call.reference
 
-                    private fun visitCallDefinitionHead(head: PsiElement, clause: Call) {
-                        val stripped = org.elixir_lang.structure_view.element.CallDefinitionHead.strip(head)
-
-                        if (stripped is Call) {
-                            visitStrippedCallDefinitionHead(stripped, clause)
-                        }
-                    }
-
-                    override fun visitElement(element: PsiElement) {
-                        when (element) {
-                            is Call -> visitCall(element)
-                            is UnqualifiedBracketOperation -> visitUnqualifiedBracketOperation(element)
-                        }
-                    }
-
-                    private fun visitNonModuleAttributeCall(call: Call) {
-                        if (CallDefinitionClause.`is`(call)) {
-                            visitCallDefinitionClause(call)
-                        } else {
-                            visitPlainCall(call)
-                        }
-                    }
-
-                    private fun visitPlainCall(call: Call) {
-                        val reference = call.reference
-
-                        if (reference != null) {
-                            val resolvedCollection =
-                                    if (reference is PsiPolyVariantReference) {
-                                        safeMultiResolve(reference, false)
-                                                .filter { it.isValidResult }
-                                                .mapNotNull(ResolveResult::getElement)
-                                    } else {
-                                        reference.resolve()?.let { resolved ->
-                                            setOf(resolved)
-                                        }
-                                    }
-
-                            if (resolvedCollection != null && resolvedCollection.isNotEmpty()) {
-                                highlight(call, reference.rangeInElement, resolvedCollection, holder)
-                            } else if (call.hasDoBlockOrKeyword()) {
-                                /* Even though it can't be resolved, it is called like a macro, so highlight like one */
-                                call.functionNameElement()?.let { functionNameElement ->
-                                    highlight(
-                                            functionNameElement.textRange,
-                                            holder,
-                                            ElixirSyntaxHighlighter.MACRO_CALL
-                                    )
+                    if (reference != null) {
+                        val resolvedCollection =
+                            if (reference is PsiPolyVariantReference) {
+                                safeMultiResolve(reference, false)
+                                    .filter { it.isValidResult }
+                                    .mapNotNull(ResolveResult::getElement)
+                            } else {
+                                reference.resolve()?.let { resolved ->
+                                    setOf(resolved)
                                 }
                             }
-                        } else if (isBitStreamSegmentOption(call)) {
-                            val name = call.name
 
-                            if (name != null && BIT_STRING_TYPES.contains(name)) {
-                                highlight(call, holder, ElixirSyntaxHighlighter.TYPE)
+                        if (resolvedCollection != null && resolvedCollection.isNotEmpty()) {
+                            highlight(call, reference.rangeInElement, resolvedCollection, holder)
+                        } else if (call.hasDoBlockOrKeyword()) {
+                            /* Even though it can't be resolved, it is called like a macro, so highlight like one */
+                            call.functionNameElement()?.let { functionNameElement ->
+                                highlight(
+                                    functionNameElement.textRange,
+                                    holder,
+                                    ElixirSyntaxHighlighter.MACRO_CALL
+                                )
                             }
                         }
-                    }
+                    } else if (isBitStreamSegmentOption(call)) {
+                        val name = call.name
 
-                    private fun visitStrippedCallDefinitionHead(stripped: Call, clause: Call) {
-                        stripped.functionNameElement()?.let { functionNameElement ->
-                            val textAttributeKey = when {
-                                CallDefinitionClause.isFunction(clause) -> ElixirSyntaxHighlighter.FUNCTION_DECLARATION
-                                CallDefinitionClause.isMacro(clause) -> ElixirSyntaxHighlighter.MACRO_DECLARATION
-                                else -> null
-                            }
-
-                            if (textAttributeKey != null) {
-                                highlight(functionNameElement, holder, textAttributeKey)
-                            }
-                        }
-                    }
-
-                    private fun visitUnqualifiedBracketOperation(unqualifiedBracketOperation: UnqualifiedBracketOperation) {
-                        val identifier = unqualifiedBracketOperation.identifier
-
-                        identifier.reference?.let { it as PsiPolyVariantReference }?.let { reference ->
-                            val resolvedElements = reference.multiResolve(false).filter { it.isValidResult }.map { (it as PsiElementResolveResult).element }
-
-                            if (resolvedElements.isNotEmpty()) {
-                                highlight(identifier, reference.rangeInElement, resolvedElements, holder)
-                            }
+                        if (name != null && BIT_STRING_TYPES.contains(name)) {
+                            highlight(call, holder, ElixirSyntaxHighlighter.TYPE)
                         }
                     }
                 }
+
+                private fun visitStrippedCallDefinitionHead(stripped: Call, clause: Call) {
+                    stripped.functionNameElement()?.let { functionNameElement ->
+                        val textAttributeKey = when {
+                            CallDefinitionClause.isFunction(clause) -> ElixirSyntaxHighlighter.FUNCTION_DECLARATION
+                            CallDefinitionClause.isMacro(clause) -> ElixirSyntaxHighlighter.MACRO_DECLARATION
+                            else -> null
+                        }
+
+                        if (textAttributeKey != null) {
+                            highlight(functionNameElement, holder, textAttributeKey)
+                        }
+                    }
+                }
+
+                private fun visitUnqualifiedBracketOperation(unqualifiedBracketOperation: UnqualifiedBracketOperation) {
+                    val identifier = unqualifiedBracketOperation.identifier
+
+                    identifier.reference?.let { it as PsiPolyVariantReference }?.let { reference ->
+                        val resolvedElements = reference.multiResolve(false).filter { it.isValidResult }
+                            .map { (it as PsiElementResolveResult).element }
+
+                        if (resolvedElements.isNotEmpty()) {
+                            highlight(identifier, reference.rangeInElement, resolvedElements, holder)
+                        }
+                    }
+                }
+            }
         )
     }
 
     private fun callHighlight(resolved: Call, previousCallHighlight: CallHighlight?): CallHighlight? =
-            when {
-                CallDefinitionClause.isFunction(resolved) -> {
-                    val referrerTextAttributesKeys = referrerTextAttributesKeys(
-                            resolved,
-                            FUNCTION_CALL_TEXT_ATTRIBUTE_KEYS,
-                            PREDEFINED_FUNCTION_CALL_TEXT_ATTRIBUTE_KEYS
-                    )
+        when {
+            CallDefinitionClause.isFunction(resolved) -> {
+                val referrerTextAttributesKeys = referrerTextAttributesKeys(
+                    resolved,
+                    FUNCTION_CALL_TEXT_ATTRIBUTE_KEYS,
+                    PREDEFINED_FUNCTION_CALL_TEXT_ATTRIBUTE_KEYS
+                )
 
-                    CallHighlight.nullablePut(
-                            previousCallHighlight,
-                            referrerTextAttributesKeys
-                    )
-                }
-                CallDefinitionClause.isMacro(resolved) -> {
-                    val referrerTextAttributesKeys = referrerTextAttributesKeys(
-                            resolved,
-                            MACRO_CALL_TEXT_ATTRIBUTES_KEYS,
-                            PREDEFINED_MACRO_CALL_TEXT_ATTRIBUTES_KEYS
-                    )
-
-                    CallHighlight.nullablePut(
-                            previousCallHighlight,
-                            referrerTextAttributesKeys
-                    )
-                }
-                org.elixir_lang.reference.Callable.isParameter(resolved) -> {
-                    CallHighlight.nullablePut(
-                            previousCallHighlight,
-                            PARAMETER_TEXT_ATTRIBUTE_KEYS
-                    )
-                }
-                org.elixir_lang.reference.Callable.isParameterWithDefault(resolved) -> {
-                    CallHighlight.nullablePut(
-                            previousCallHighlight,
-                            PARAMETER_TEXT_ATTRIBUTE_KEYS
-                    )
-                }
-                org.elixir_lang.reference.Callable.isVariable(resolved) -> {
-                    CallHighlight.nullablePut(
-                            previousCallHighlight,
-                            VARIABLE_TEXT_ATTRIBUTE_KEYS
-                    )
-                }
-                else -> {
-                    previousCallHighlight
-                }
+                CallHighlight.nullablePut(
+                    previousCallHighlight,
+                    referrerTextAttributesKeys
+                )
             }
+            CallDefinitionClause.isMacro(resolved) -> {
+                val referrerTextAttributesKeys = referrerTextAttributesKeys(
+                    resolved,
+                    MACRO_CALL_TEXT_ATTRIBUTES_KEYS,
+                    PREDEFINED_MACRO_CALL_TEXT_ATTRIBUTES_KEYS
+                )
+
+                CallHighlight.nullablePut(
+                    previousCallHighlight,
+                    referrerTextAttributesKeys
+                )
+            }
+            org.elixir_lang.reference.Callable.isParameter(resolved) -> {
+                CallHighlight.nullablePut(
+                    previousCallHighlight,
+                    PARAMETER_TEXT_ATTRIBUTE_KEYS
+                )
+            }
+            org.elixir_lang.reference.Callable.isParameterWithDefault(resolved) -> {
+                CallHighlight.nullablePut(
+                    previousCallHighlight,
+                    PARAMETER_TEXT_ATTRIBUTE_KEYS
+                )
+            }
+            org.elixir_lang.reference.Callable.isVariable(resolved) -> {
+                CallHighlight.nullablePut(
+                    previousCallHighlight,
+                    VARIABLE_TEXT_ATTRIBUTE_KEYS
+                )
+            }
+            else -> {
+                previousCallHighlight
+            }
+        }
 
     private fun callHighlight(resolved: PsiElement, previousCallHighlight: CallHighlight?): CallHighlight? =
-            when (resolved) {
-                is Call -> callHighlight(resolved, previousCallHighlight)
-                else ->
-                    if (org.elixir_lang.reference.Callable.isIgnored(resolved)) {
-                        CallHighlight.nullablePut(
-                                previousCallHighlight,
-                                IGNORED_VARIABLE_TEXT_ATTRIBUTE_KEYS
-                        )
-                    } else {
-                        previousCallHighlight
-                    }
-            }
+        when (resolved) {
+            is Call -> callHighlight(resolved, previousCallHighlight)
+            is CallDefinitionImpl<*> -> callHighlight(resolved, previousCallHighlight)
+            else ->
+                if (org.elixir_lang.reference.Callable.isIgnored(resolved)) {
+                    CallHighlight.nullablePut(
+                        previousCallHighlight,
+                        IGNORED_VARIABLE_TEXT_ATTRIBUTE_KEYS
+                    )
+                } else {
+                    previousCallHighlight
+                }
+        }
+
+    private fun callHighlight(resolved: CallDefinitionImpl<*>, previousCallHighlight: CallHighlight?): CallHighlight? {
+        val referrerTextAttributesKeys = when (resolved.time) {
+            Timed.Time.COMPILE -> referrerTextAttributesKeys(
+                resolved,
+                MACRO_CALL_TEXT_ATTRIBUTES_KEYS,
+                PREDEFINED_MACRO_CALL_TEXT_ATTRIBUTES_KEYS
+            )
+            Timed.Time.RUN -> referrerTextAttributesKeys(
+                resolved,
+                FUNCTION_CALL_TEXT_ATTRIBUTE_KEYS,
+                PREDEFINED_FUNCTION_CALL_TEXT_ATTRIBUTE_KEYS
+            )
+        }
+
+        return CallHighlight.nullablePut(
+            previousCallHighlight,
+            referrerTextAttributesKeys
+        )
+    }
 
     private fun callHighlight(resolvedCollection: Collection<PsiElement>): CallHighlight? =
         resolvedCollection.fold(null) { acc: CallHighlight?, resolved ->
             callHighlight(resolved, acc)
         }
 
-    private fun highlight(referrer: PsiElement,
-                          rangeInReferrer: TextRange,
-                          resolvedCollection: Collection<PsiElement>,
-                          annotationHolder: AnnotationHolder) {
+    private fun highlight(
+        referrer: PsiElement,
+        rangeInReferrer: TextRange,
+        resolvedCollection: Collection<PsiElement>,
+        annotationHolder: AnnotationHolder
+    ) {
         val callHighlight = callHighlight(resolvedCollection)
 
         if (callHighlight != null) {
@@ -236,22 +262,26 @@ class Callable : Annotator, DumbAware {
         }
     }
 
-    private fun highlight(element: PsiElement,
-                          annotationHolder: AnnotationHolder,
-                          textAttributesKey: TextAttributesKey) {
+    private fun highlight(
+        element: PsiElement,
+        annotationHolder: AnnotationHolder,
+        textAttributesKey: TextAttributesKey
+    ) {
         highlight(element.textRange, annotationHolder, textAttributesKey)
     }
 
-    private fun highlight(element: PsiElement,
-                          rangeInElement: TextRange,
-                          annotationHolder: AnnotationHolder,
-                          vararg textAttributesKeys: TextAttributesKey) {
+    private fun highlight(
+        element: PsiElement,
+        rangeInElement: TextRange,
+        annotationHolder: AnnotationHolder,
+        vararg textAttributesKeys: TextAttributesKey
+    ) {
         val elementRangeInDocument = element.textRange
         val startOffset = elementRangeInDocument.startOffset
 
         val rangeInElementInDocument = TextRange(
-                startOffset + rangeInElement.startOffset,
-                startOffset + rangeInElement.endOffset
+            startOffset + rangeInElement.startOffset,
+            startOffset + rangeInElement.endOffset
         )
 
         highlight(rangeInElementInDocument, annotationHolder, *textAttributesKeys)
@@ -264,12 +294,14 @@ class Callable : Annotator, DumbAware {
      * @param annotationHolder   the container which receives annotations created by the plugin.
      * @param textAttributesKeys text attributes to apply to the `node`.
      */
-    private fun highlight(textRange: TextRange,
-                          annotationHolder: AnnotationHolder,
-                          vararg textAttributesKeys: TextAttributesKey) {
+    private fun highlight(
+        textRange: TextRange,
+        annotationHolder: AnnotationHolder,
+        vararg textAttributesKeys: TextAttributesKey
+    ) {
         if (textAttributesKeys.isNotEmpty()) {
             val editorColorsScheme = EditorColorsManager.getInstance().globalScheme
-            val mergedTextAttributes = textAttributesKeys.fold(null) { acc: TextAttributes?, textAttributesKey->
+            val mergedTextAttributes = textAttributesKeys.fold(null) { acc: TextAttributes?, textAttributesKey ->
                 val textAttributes = editorColorsScheme.getAttributes(textAttributesKey)
 
                 TextAttributes.merge(acc, textAttributes)
@@ -287,45 +319,45 @@ class Callable : Annotator, DumbAware {
                 this
             } else {
                 CallHighlight(
-                        updatedReferrerTextAttributeKeys
+                    updatedReferrerTextAttributeKeys
                 )
             }
         }
 
         private fun bestReferrerTextAttributeKeys(referrerTextAttributeKeys: Array<TextAttributesKey>?): Array<TextAttributesKey>? =
-                if (this.referrerTextAttributeKeys != null) {
-                    if (referrerTextAttributeKeys != null) {
-                        var currentPredefined = false
+            if (this.referrerTextAttributeKeys != null) {
+                if (referrerTextAttributeKeys != null) {
+                    var currentPredefined = false
 
-                        for (textAttributesKey in this.referrerTextAttributeKeys) {
-                            if (textAttributesKey === ElixirSyntaxHighlighter.PREDEFINED_CALL) {
-                                currentPredefined = true
-                                break
-                            }
+                    for (textAttributesKey in this.referrerTextAttributeKeys) {
+                        if (textAttributesKey === ElixirSyntaxHighlighter.PREDEFINED_CALL) {
+                            currentPredefined = true
+                            break
                         }
+                    }
 
-                        if (currentPredefined) {
-                            this.referrerTextAttributeKeys
-                        } else {
-                            referrerTextAttributeKeys
-                        }
-                    } else {
+                    if (currentPredefined) {
                         this.referrerTextAttributeKeys
+                    } else {
+                        referrerTextAttributeKeys
                     }
                 } else {
-                    referrerTextAttributeKeys
+                    this.referrerTextAttributeKeys
                 }
+            } else {
+                referrerTextAttributeKeys
+            }
 
         companion object {
             internal fun nullablePut(
-                    callHighlight: CallHighlight?,
-                    referrerTextAttributeKeys: Array<TextAttributesKey>?
+                callHighlight: CallHighlight?,
+                referrerTextAttributeKeys: Array<TextAttributesKey>?
             ): CallHighlight =
-                    callHighlight?.put(
-                            referrerTextAttributeKeys
-                    ) ?: CallHighlight(
-                            referrerTextAttributeKeys
-                    )
+                callHighlight?.put(
+                    referrerTextAttributeKeys
+                ) ?: CallHighlight(
+                    referrerTextAttributeKeys
+                )
         }
     }
 
@@ -334,29 +366,42 @@ class Callable : Annotator, DumbAware {
         private val IGNORED_VARIABLE_TEXT_ATTRIBUTE_KEYS = arrayOf(ElixirSyntaxHighlighter.IGNORED_VARIABLE)
         private val MACRO_CALL_TEXT_ATTRIBUTES_KEYS = arrayOf(ElixirSyntaxHighlighter.MACRO_CALL)
         private val PARAMETER_TEXT_ATTRIBUTE_KEYS = arrayOf(ElixirSyntaxHighlighter.PARAMETER)
-        private val PREDEFINED_FUNCTION_CALL_TEXT_ATTRIBUTE_KEYS = arrayOf(ElixirSyntaxHighlighter.FUNCTION_CALL, ElixirSyntaxHighlighter.PREDEFINED_CALL)
+        private val PREDEFINED_FUNCTION_CALL_TEXT_ATTRIBUTE_KEYS =
+            arrayOf(ElixirSyntaxHighlighter.FUNCTION_CALL, ElixirSyntaxHighlighter.PREDEFINED_CALL)
 
         private val PREDEFINED_LOCATION_STRING_SET = HashSet(
-                Arrays.asList(
-                        KERNEL,
-                        KERNEL_SPECIAL_FORMS
-                )
+            Arrays.asList(
+                KERNEL,
+                KERNEL_SPECIAL_FORMS
+            )
         )
-        private val PREDEFINED_MACRO_CALL_TEXT_ATTRIBUTES_KEYS = arrayOf(ElixirSyntaxHighlighter.MACRO_CALL, ElixirSyntaxHighlighter.PREDEFINED_CALL)
+        private val PREDEFINED_MACRO_CALL_TEXT_ATTRIBUTES_KEYS =
+            arrayOf(ElixirSyntaxHighlighter.MACRO_CALL, ElixirSyntaxHighlighter.PREDEFINED_CALL)
         private val VARIABLE_TEXT_ATTRIBUTE_KEYS = arrayOf(ElixirSyntaxHighlighter.VARIABLE)
 
         private fun referrerTextAttributesKeys(
-                psiElement: PsiElement,
-                standardTextAttributeKeys: Array<TextAttributesKey>,
-                predefinedTextAttributesKeys: Array<TextAttributesKey>
+            psiElement: PsiElement,
+            standardTextAttributeKeys: Array<TextAttributesKey>,
+            predefinedTextAttributesKeys: Array<TextAttributesKey>
         ): Array<TextAttributesKey> =
-                psiElement.let { it as? NavigationItem }?.presentation?.locationString?.let { locationString ->
-                    if (PREDEFINED_LOCATION_STRING_SET.any { locationString.endsWith(it) }) {
-                        predefinedTextAttributesKeys
-                    } else {
-                        null
+            when (psiElement) {
+                is CallDefinitionImpl<*> -> if (psiElement.parent.name in PREDEFINED_LOCATION_STRING_SET) {
+                    predefinedTextAttributesKeys
+                } else {
+                    null
+                }
+                is NavigationItem -> {
+                    psiElement.presentation?.locationString?.let { locationString ->
+                        if (PREDEFINED_LOCATION_STRING_SET.any { locationString.endsWith(it) }) {
+                            predefinedTextAttributesKeys
+                        } else {
+                            null
+                        }
                     }
-                } ?: standardTextAttributeKeys
+                }
+                else -> null
+            }
+                ?: standardTextAttributeKeys
 
         private fun sameFile(referrer: PsiElement, resolved: PsiElement): Boolean =
             referrer.containingFile.virtualFile == resolved.containingFile.virtualFile


### PR DESCRIPTION
Fixes #2661

# Changelog
## Bug Fixes
* Highlight `CallDefinitionImpl` references as predefined if resolved `CallDefinitionImpl` is in `Kernel` or `Kernel.SpecialForms`.
  Fixes highlighting `def` and other defined when using SDKs without source like Homebrew after the delayed-decompilation fixes from 12.2.1.  Now source-less (Homebrew) and SDKs with sources (ASDF) will both be able to highlight predefineds.