### PR TITLE
Revert "Update intellij gradle plugin to 1.6.0"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.jetbrains.intellij' version "1.6.0"
+    id 'org.jetbrains.intellij' version "1.5.3"
     id "org.jetbrains.kotlin.jvm" version "1.5.10"
     id 'de.undercouch.download' version "4.1.2"
 }


### PR DESCRIPTION
This reverts commit 4978c6e30fd2f8d6efa850e3767de6728793deba.

# Changelog
## Bug Fixes
* Downgrade `gradle-intellij-plugin` to `1.5.3`.  The upgrade broke packaging `.form` derived code, so that Run Configuration editors had `null` fields after the upgrade.