### PR TITLE
Restrict UsageTargetProvider to ElixirFiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -360,6 +360,9 @@
     `ElementClassHint` is part of the `processDeclaration` system used in Java and so was in the code because `BeamFileImpl` was original based on `ClassFileImpl`, but since the Elixir resolvers don't use the hint system at all, it can just be removed.
 * [#2578](https://github.com/KronicDeth/intellij-elixir/pull/2578) - [@yordis](https://github.com/KronicDeth/intellij-elixir/pull/2578)
   * Remove `CodeStyleSettingsProvider` because it is redundant with `LanguageCodeStyleSettingsProvider`
+* [#2695](https://github.com/KronicDeth/intellij-elixir/pull/2695) - [@KronicDeth](https://github.com/KronicDeth)
+  * Restrict `UsageTargetProvider` to `ElixirFile`s
+    Without this restriction, it tries to run when developing the plugin itself and breaks Kotlin syntax highlighting.
 
 ## v13.0.0
 

--- a/resources/META-INF/changelog.html
+++ b/resources/META-INF/changelog.html
@@ -124,6 +124,8 @@
       <li>Remove references to <code class="notranslate">ElementClassHint</code> in BeamFileImpl that only work in IntelliJ.<br>
         <code class="notranslate">ElementClassHint</code> is part of the <code class="notranslate">processDeclaration</code> system used in Java and so was in the code because <code class="notranslate">BeamFileImpl</code> was original based on <code class="notranslate">ClassFileImpl</code>, but since the Elixir resolvers don't use the hint system at all, it can just be removed.</li>
       <li>Remove <code class="notranslate">CodeStyleSettingsProvider</code> because it is redundant with <code class="notranslate">LanguageCodeStyleSettingsProvider</code></li>
+      <li>Restrict <code class="notranslate">UsageTargetProvider</code> to <code class="notranslate">ElixirFile</code>s<br>
+        Without this restriction, it tries to run when developing the plugin itself and breaks Kotlin syntax highlighting.</li>
     </ul>
   </li>
 </ul>

--- a/src/org/elixir_lang/UsageTargetProvider.kt
+++ b/src/org/elixir_lang/UsageTargetProvider.kt
@@ -8,26 +8,33 @@ import com.intellij.psi.PsiFile
 import com.intellij.usages.UsageTarget
 import org.elixir_lang.beam.psi.impl.ModuleImpl
 import org.elixir_lang.psi.AtOperation
+import org.elixir_lang.psi.ElixirFile
 import org.elixir_lang.psi.QualifiableAlias
 import org.elixir_lang.psi.call.Call
 
 class UsageTargetProvider : com.intellij.usages.UsageTargetProvider {
-    override fun getTargets(editor: Editor, file: PsiFile): Array<UsageTarget>? {
+    override fun getTargets(editor: Editor, file: PsiFile): Array<UsageTarget>? = if (file is ElixirFile) {
         val document = editor.document
         val offset = editor.caretModel.offset
         val adjustedOffset = adjustOffset(file, document, offset)
 
-        return file.findReferenceAt(adjustedOffset)?.element?.let { element ->
+        file.findReferenceAt(adjustedOffset)?.element?.let { element ->
             getTargets(element)
         }
+    } else {
+        null
     }
 
     override fun getTargets(psiElement: PsiElement): Array<UsageTarget>? =
-        when (psiElement) {
-            is AtOperation, is Call, is ModuleImpl<*>, is QualifiableAlias ->
-                arrayOf(PsiElement2UsageTargetAdapter(psiElement, true))
-            else ->
-                null
+        if (psiElement.containingFile is ElixirFile) {
+            when (psiElement) {
+                is AtOperation, is Call, is ModuleImpl<*>, is QualifiableAlias ->
+                    arrayOf(PsiElement2UsageTargetAdapter(psiElement, true))
+                else ->
+                    null
+            }
+        } else {
+            null
         }
 }
 


### PR DESCRIPTION
Fixes #2694

# Changelog
## Bug Fixes
* Restrict `UsageTargetProvider` to `ElixirFile`s
  Without this restriction, it tries to run when developing the plugin itself and breaks Kotlin syntax highlighting.