### PR TITLE
Support Debugger in Elixir 1.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -296,6 +296,8 @@
       3. Click the `mix format` tab
       4. Expand the General group
       5. Uncheck "Format files with `mix format`".
+* [#2697](https://github.com/KronicDeth/intellij-elixir/pull/2697) - [@KronicDeth](https://github.com/KronicDeth)
+  * Support Elixir 1.13.0 in debugger.
 
 ### Bug Fixes
 
@@ -363,6 +365,9 @@
 * [#2695](https://github.com/KronicDeth/intellij-elixir/pull/2695) - [@KronicDeth](https://github.com/KronicDeth)
   * Restrict `UsageTargetProvider` to `ElixirFile`s
     Without this restriction, it tries to run when developing the plugin itself and breaks Kotlin syntax highlighting.
+* [#2697](https://github.com/KronicDeth/intellij-elixir/pull/2697) - [@KronicDeth](https://github.com/KronicDeth)
+  * Fix environment not being passed to debug runs of ESpec and ExUnit Run Configurations.
+    The `env` from the `Configuration` was dropped because a local `env` was created to set `MIX_ENV` `true`.
 
 ## v13.0.0
 

--- a/resources/META-INF/changelog.html
+++ b/resources/META-INF/changelog.html
@@ -52,6 +52,7 @@
           </li>
         </ul>
       </li>
+      <li>Support Elixir 1.13.0 in debugger.</li>
     </ul>
   </li>
   <li>
@@ -126,6 +127,8 @@
       <li>Remove <code class="notranslate">CodeStyleSettingsProvider</code> because it is redundant with <code class="notranslate">LanguageCodeStyleSettingsProvider</code></li>
       <li>Restrict <code class="notranslate">UsageTargetProvider</code> to <code class="notranslate">ElixirFile</code>s<br>
         Without this restriction, it tries to run when developing the plugin itself and breaks Kotlin syntax highlighting.</li>
+      <li>Fix environment not being passed to debug runs of ESpec and ExUnit Run Configurations.<br>
+        The <code class="notranslate">env</code> from the <code class="notranslate">Configuration</code> was dropped because a local <code class="notranslate">env</code> was created to set <code class="notranslate">MIX_ENV</code> <code class="notranslate">true</code>.</li>
     </ul>
   </li>
 </ul>
@@ -893,23 +896,6 @@
         Walk map constructin arguments, associatons, and variables when resolving type parameters.
       </li>
       <li>Don't use <code>PluginId.findId</code> that doesn't exist in 2021.1.X</li>
-    </ul>
-  </li>
-</ul>
-<h1>v11.13.0</h1>
-<ul>
-  <li>
-    <p>Bug Fixes</p>
-    <ul>
-      <li>Remove bintray repositories.</li>
-    </ul>
-  </li>
-  <li>
-    <p>Enhancements</p>
-    <ul>
-      <li>Update build to IntelliJ IDEA 2021.2.</li>
-      <li>Upgrade to Gradle 7.1.1.</li>
-      <li>Expand compatibility range to 2021.1.2-2021.2.</li>
     </ul>
   </li>
 </ul>

--- a/resources/debugger/lib/intellij_elixir/debugger/server.ex
+++ b/resources/debugger/lib/intellij_elixir/debugger/server.ex
@@ -37,7 +37,7 @@ defmodule IntelliJElixir.Debugger.Server do
         stacktrace: false
       )
 
-    true ->
+    Version.compare(System.version(), "1.10.0") == :lt ->
       # https://github.com/elixir-lang/elixir/blob/v1.9.2/lib/elixir/src/elixir.hrl#L8-L18
       Record.defrecordp(
         :elixir_erl,
@@ -50,6 +50,19 @@ defmodule IntelliJElixir.Debugger.Server do
         counter: %{},
         expand_captures: false,
         stacktrace: false
+      )
+    true ->
+      # https://github.com/elixir-lang/elixir/blob/v1.10.0/lib/elixir/src/elixir.hrl#L8-L17
+      Record.defrecordp(
+        :elixir_erl,
+        context: nil,
+        extra: nil,
+        caller: false,
+        var_names: %{},
+        extra_guards: [],
+        counter: %{},
+        expand_captures: false,
+        stacktrace: nil
       )
   end
 
@@ -256,16 +269,8 @@ defmodule IntelliJElixir.Debugger.Server do
                 {elixir_variable_name, nil}
               end)
 
-            parsed_scope =
-              elixir_erl(
-                vars: vars(elixir_variable_tuples),
-                counter: counter(elixir_variable_tuples)
-              )
-
-            # https://github.com/elixir-lang/elixir/blob/8a971fcb44391bd8b16456666f3033b633c6ff77/lib/elixir/src/elixir.erl#L255
-            # Elixir 1.7+ has :elixir_env.with_vars, but can't use here for Elixir 1.6.5 compatibility, so use
-            # https://github.com/elixir-lang/elixir/blob/v1.6.5/lib/elixir/src/elixir.erl#L223
-            vars_env = %{env | vars: parsed_vars}
+            parsed_scope = parsed_scope(elixir_variable_tuples)
+            vars_env = elixir_env_with_vars(env, parsed_vars)
 
             # Elixir 1.7+ uses current_vars
             current_vars_env =
@@ -276,7 +281,7 @@ defmodule IntelliJElixir.Debugger.Server do
               end
 
             # https://github.com/elixir-lang/elixir/blob/8a971fcb44391bd8b16456666f3033b633c6ff77/lib/elixir/src/elixir.erl#L256
-            {erl, _new_env, _new_scope} = quoted_to_erl(quoted, current_vars_env, parsed_scope)
+            erl = quoted_to_erl(quoted, current_vars_env, parsed_scope)
 
             code =
               [:erl_pp.expr(erl), ?.]
@@ -337,10 +342,18 @@ defmodule IntelliJElixir.Debugger.Server do
     :int.meta(meta_pid, :bindings, level)
   end
 
-  defp counter(elixir_variable_tuples) when is_list(elixir_variable_tuples) do
-    Enum.into(elixir_variable_tuples, %{}, fn {elixir_variable_name, counter, _} ->
-      {elixir_variable_name, counter}
-    end)
+  if Version.compare(System.version(), "1.10.0") == :lt do
+    defp counter(elixir_variable_tuples) when is_list(elixir_variable_tuples) do
+      Enum.into(elixir_variable_tuples, %{}, fn {elixir_variable_name, counter, _} ->
+        {elixir_variable_name, counter}
+      end)
+    end
+  else
+    defp counter(elixir_variable_tuples) when is_list(elixir_variable_tuples) do
+      Enum.into(elixir_variable_tuples, %{}, fn {elixir_variable_name, counter, _} ->
+        {elixir_variable_name, counter - 1}
+      end)
+    end
   end
 
   defp elixir_module_name_to_erlang_module_name(":" <> erlang_module_name), do: erlang_module_name
@@ -391,17 +404,27 @@ defmodule IntelliJElixir.Debugger.Server do
   end
 
   # `:elixir.quoted_to_erl/3` became private in Elixir 1.8, so need to inline it here.
-  if Version.compare(System.version(), "1.8.0") == :lt do
-    defp quoted_to_erl(quoted, env, scope) do
-      :elixir.quoted_to_erl(quoted, env, scope)
-    end
-  else
-    defp quoted_to_erl(quoted, env, scope) do
-      {expanded, new_env} = :elixir_expand.expand(quoted, env)
-      {erl, new_scope} = :elixir_erl_pass.translate(expanded, scope)
+  cond do
+    Version.compare(System.version(), "1.8.0") == :lt ->
+      defp quoted_to_erl(quoted, env, scope) do
+        {erl, _, _} = :elixir.quoted_to_erl(quoted, env, scope)
 
-      {erl, new_env, new_scope}
-    end
+        erl
+      end
+    Version.compare(System.version(), "1.13.0") == :lt ->
+      defp quoted_to_erl(quoted, env, scope) do
+        {expanded, _} = :elixir_expand.expand(quoted, env)
+        {erl, _} = :elixir_erl_pass.translate(expanded, scope)
+
+        erl
+      end
+    true ->
+      defp quoted_to_erl(quoted, env, scope) do
+        {expanded, _, _} = :elixir_expand.expand(quoted, :elixir_env.env_to_ex(env), env)
+        {erl, _} = :elixir_erl_pass.translate(expanded, :erl_anno.new(env.line), scope)
+
+        erl
+      end
   end
 
   defp time_interpret(module) when is_atom(module) do
@@ -539,6 +562,33 @@ defmodule IntelliJElixir.Debugger.Server do
       Enum.into(elixir_variable_tuples, %{}, fn {elixir_variable_name, _counter, erlang_variable_name} ->
         {{elixir_variable_name, nil}, {0, erlang_variable_name}}
       end)
+    end
+  end
+
+  if Version.compare(System.version(), "1.7.0") == :lt do
+    defp elixir_env_with_vars(env, parsed_vars) do
+      # https://github.com/elixir-lang/elixir/blob/v1.6.5/lib/elixir/src/elixir.erl#L223
+      %{env | vars: parsed_vars}
+    end
+  else
+    defp elixir_env_with_vars(env, parsed_vars) do
+      :elixir_env.with_vars(env, parsed_vars)
+    end
+  end
+
+  if Version.compare(System.version(), "1.10.0") == :lt do
+    defp parsed_scope(elixir_variable_tuples) do
+      elixir_erl(
+        vars: vars(elixir_variable_tuples),
+        counter: counter(elixir_variable_tuples)
+      )
+    end
+  else
+    defp parsed_scope(elixir_variable_tuples) do
+      elixir_erl(
+        var_names: vars(elixir_variable_tuples),
+        counter: counter(elixir_variable_tuples)
+      )
     end
   end
 end

--- a/resources/debugger/lib/intellij_elixir/debugger/server.ex
+++ b/resources/debugger/lib/intellij_elixir/debugger/server.ex
@@ -7,7 +7,7 @@ defmodule IntelliJElixir.Debugger.Server do
 
   # *.hrl files are not included in all SDK installs, so need to inline definition here
 
-  cond  do
+  cond do
     Version.compare(System.version(), "1.7.0") == :lt ->
       # https://github.com/elixir-lang/elixir/blob/v1.5.0/lib/elixir/src/elixir.hrl#L7-L17
       Record.defrecordp(
@@ -22,6 +22,7 @@ defmodule IntelliJElixir.Debugger.Server do
         counter: %{},
         file: "nofile"
       )
+
     Version.compare(System.version(), "1.9.2") == :lt ->
       # https://github.com/elixir-lang/elixir/blob/v1.7.0/lib/elixir/src/elixir.hrl#L7-L16
       Record.defrecordp(
@@ -35,6 +36,7 @@ defmodule IntelliJElixir.Debugger.Server do
         counter: %{},
         stacktrace: false
       )
+
     true ->
       # https://github.com/elixir-lang/elixir/blob/v1.9.2/lib/elixir/src/elixir.hrl#L8-L18
       Record.defrecordp(

--- a/src/org/elixir_lang/espec/Configuration.kt
+++ b/src/org/elixir_lang/espec/Configuration.kt
@@ -50,7 +50,7 @@ class Configuration(name: String, project: Project) :
 
         // Explicit MIX_ENV so that `intellij_elixir.debug` uses the test code paths
         val envs = mutableMapOf<String, String>()
-        envs.putAll(envs)
+        envs.putAll(this.envs)
         envs.putIfAbsent("MIX_ENV", "test")
         debugged.envs = envs
 

--- a/src/org/elixir_lang/exunit/Configuration.kt
+++ b/src/org/elixir_lang/exunit/Configuration.kt
@@ -50,7 +50,7 @@ class Configuration(name: String, project: Project) :
 
         // Explicit MIX_ENV so that `intellij_elixir.debug` uses the test code paths
         val envs = mutableMapOf<String, String>()
-        envs.putAll(envs)
+        envs.putAll(this.envs)
         envs.putIfAbsent("MIX_ENV", "test")
         debugged.envs = envs
 


### PR DESCRIPTION
Fixes #2488
Fixes #2696

# Changelog
## Enhancements
* Support Elixir 1.13.0 in debugger.

## Bug Fixes
* Fix environment not being passed to debug runs of ESpec and ExUnit Run Configurations.
  The `env` from the `Configuration` was dropped because a local `env` was created to set `MIX_ENV` `true`.