### PR TITLE
Implement Deprecated metadata handling for docs from BEAM files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -273,6 +273,10 @@
     * Catch and log `IOException`s swallowed by Project Initialization Failed.
     * Recursively delete project directory before running `mix new`.
       Previously, the directory was only deleted if empty, but whether the `.idea` directory is written when `setupProject` is called differs between IDE versions, so to be safe, recursively delete.
+* [#2705](https://github.com/KronicDeth/intellij-elixir/pull/2705) - [@KronicDeth](https://github.com/KronicDeth)
+  * Fix Go To Definition for function in compiled modules.
+    When switching over to delayed decompilation, `ModuleImpl` did not have `processDeclaration` overloadded, so the `PsiScopeProcessor` was never called on it and so the `CallDefinitionClause` scope processor did not check the `ModuleImpl#callDefinitons`.
+  * Implement Deprecated metadata handling for docs from BEAM files.
 
 ## v13.1.0
 

--- a/resources/META-INF/changelog.html
+++ b/resources/META-INF/changelog.html
@@ -12,6 +12,9 @@
             Previously, the directory was only deleted if empty, but whether the <code class="notranslate">.idea</code> directory is written when <code class="notranslate">setupProject</code> is called differs between IDE versions, so to be safe, recursively delete.</li>
         </ul>
       </li>
+      <li>Fix Go To Definition for function in compiled modules.<br>
+        When switching over to delayed decompilation, <code class="notranslate">ModuleImpl</code> did not have <code class="notranslate">processDeclaration</code> overloadded, so the <code class="notranslate">PsiScopeProcessor</code> was never called on it and so the <code class="notranslate">CallDefinitionClause</code> scope processor did not check the <code class="notranslate">ModuleImpl#callDefinitons</code>.</li>
+      <li>Implement Deprecated metadata handling for docs from BEAM files.</li>
     </ul>
   </li>
 </ul>

--- a/src/org/elixir_lang/beam/psi/impl/ModuleImpl.kt
+++ b/src/org/elixir_lang/beam/psi/impl/ModuleImpl.kt
@@ -8,6 +8,7 @@ import com.intellij.psi.ResolveState
 import com.intellij.psi.StubBasedPsiElement
 import com.intellij.psi.impl.source.SourceTreeToPsiMap
 import com.intellij.psi.impl.source.tree.TreeElement
+import com.intellij.psi.scope.PsiScopeProcessor
 import com.intellij.psi.stubs.IStubElementType
 import com.intellij.util.IncorrectOperationException
 import org.elixir_lang.beam.psi.Module
@@ -144,6 +145,14 @@ class ModuleImpl<T : ModuleStub<*>?>(private val stub: T) : ModuleElementImpl(),
         throw IncorrectOperationException("Cannot modify module name in Beam files")
 
     override fun getNavigationElement(): PsiElement = mirror
+
+    override fun processDeclarations(
+        processor: PsiScopeProcessor,
+        state: ResolveState,
+        lastParent: PsiElement?,
+        place: PsiElement
+    ): Boolean =
+        processor.execute(this, state)
 
     override fun getNode(): ASTNode? = null
 

--- a/src/org/elixir_lang/documentation/ElixirDocumentationProvider.kt
+++ b/src/org/elixir_lang/documentation/ElixirDocumentationProvider.kt
@@ -1,5 +1,7 @@
 package org.elixir_lang.documentation
 
+import com.ericsson.otp.erlang.OtpErlangBinary
+import com.ericsson.otp.erlang.OtpErlangObject
 import com.intellij.lang.documentation.DocumentationMarkup
 import com.intellij.lang.documentation.DocumentationProvider
 import com.intellij.openapi.editor.Editor
@@ -12,6 +14,7 @@ import org.elixir_lang.beam.chunk.beam_documentation.docs.documented.Hidden
 import org.elixir_lang.beam.chunk.beam_documentation.docs.documented.MarkdownByLanguage
 import org.elixir_lang.beam.chunk.beam_documentation.docs.documented.None
 import org.elixir_lang.beam.psi.BeamFileImpl
+import org.elixir_lang.errorreport.Logger
 import org.elixir_lang.psi.CallDefinitionClause
 import org.elixir_lang.psi.ElixirIdentifier
 import org.elixir_lang.psi.QualifiableAlias
@@ -125,14 +128,12 @@ class ElixirDocumentationProvider : DocumentationProvider {
                     documentationHtml.append(DocumentationMarkup.SECTIONS_START)
 
                     if (deprecated != null) {
-                        TODO()
-
-//                        documentationHtml
-//                                .append(DocumentationMarkup.SECTION_HEADER_START)
-//                                .append("Deprecated")
-//                                .append(DocumentationMarkup.SECTION_SEPARATOR)
-//                                .append(html(deprecated))
-//                                .append(DocumentationMarkup.SECTION_END)
+                        documentationHtml
+                            .append(DocumentationMarkup.SECTION_HEADER_START)
+                            .append("Deprecated")
+                            .append(DocumentationMarkup.SECTION_SEPARATOR)
+                            .append(html(deprecated))
+                            .append(DocumentationMarkup.SECTION_END)
                     }
 
                     if (implsIsNotEmpty) {
@@ -175,6 +176,20 @@ class ElixirDocumentationProvider : DocumentationProvider {
 
         return documentationHtml.toString()
     }
+
+    private fun html(otpErlangObject: OtpErlangObject): String =
+        when (otpErlangObject) {
+            is OtpErlangBinary ->
+                otpErlangObject
+                    .binaryValue()
+                    .let { String(it, Charsets.UTF_8) }
+                    .let { html(it) }
+            else -> {
+                Logger.error(javaClass, "Don't know how to render deprecated metadata", otpErlangObject)
+
+                ""
+            }
+        }
 
     private fun html(markdownText: String): String {
         val flavour = GFMFlavourDescriptor()

--- a/src/org/elixir_lang/psi/scope/CallDefinitionClause.kt
+++ b/src/org/elixir_lang/psi/scope/CallDefinitionClause.kt
@@ -42,6 +42,7 @@ abstract class CallDefinitionClause : PsiScopeProcessor {
     override fun execute(element: PsiElement, state: ResolveState): Boolean =
         when (element) {
             is Call -> execute(element, state)
+            is ModuleImpl<*> -> execute(element, state)
             is CallDefinitionImpl<*> -> execute(element, state)
             is ElixirFile -> execute(element, state)
             else -> true
@@ -213,6 +214,11 @@ abstract class CallDefinitionClause : PsiScopeProcessor {
         // if there is a view file then it will have implicit imports, not this template
         else {
             true
+        }
+
+    private fun execute(element: ModuleImpl<*>, state: ResolveState): Boolean =
+        whileIn(element.callDefinitions()) {
+            execute(it, state)
         }
 
     protected abstract fun execute(element: CallDefinitionImpl<*>, state: ResolveState): Boolean


### PR DESCRIPTION
Fixes #2704

# Changelog
## Bug Fixes
* Fix Go To Definition for function in compiled modules.
  When switching over to delayed decompilation, `ModuleImpl` did not have `processDeclaration` overloadded, so the `PsiScopeProcessor` was never called on it and so the `CallDefinitionClause` scope processor did not check the `ModuleImpl#callDefinitons`.
* Implement Deprecated metadata handling for docs from BEAM files.