### PR TITLE
Don't assume Elixir SDK sdkAdditionalData is non-null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -277,6 +277,8 @@
   * Fix Go To Definition for function in compiled modules.
     When switching over to delayed decompilation, `ModuleImpl` did not have `processDeclaration` overloadded, so the `PsiScopeProcessor` was never called on it and so the `CallDefinitionClause` scope processor did not check the `ModuleImpl#callDefinitons`.
   * Implement Deprecated metadata handling for docs from BEAM files.
+* [#2709](https://github.com/KronicDeth/intellij-elixir/pull/2709) - [@KronicDeth](https://github.com/KronicDeth)
+  * Don't assume Elixir `SDK` `sdkAdditionalData` is non-`null`.
 
 ## v13.1.0
 

--- a/resources/META-INF/changelog.html
+++ b/resources/META-INF/changelog.html
@@ -15,6 +15,7 @@
       <li>Fix Go To Definition for function in compiled modules.<br>
         When switching over to delayed decompilation, <code class="notranslate">ModuleImpl</code> did not have <code class="notranslate">processDeclaration</code> overloadded, so the <code class="notranslate">PsiScopeProcessor</code> was never called on it and so the <code class="notranslate">CallDefinitionClause</code> scope processor did not check the <code class="notranslate">ModuleImpl#callDefinitons</code>.</li>
       <li>Implement Deprecated metadata handling for docs from BEAM files.</li>
+      <li>Don't assume Elixir <code class="notranslate">SDK</code> <code class="notranslate">sdkAdditionalData</code> is non-<code class="notranslate">null</code>.</li>
     </ul>
   </li>
 </ul>

--- a/src/org/elixir_lang/Elixir.kt
+++ b/src/org/elixir_lang/Elixir.kt
@@ -3,6 +3,7 @@ package org.elixir_lang
 import com.intellij.execution.configurations.GeneralCommandLine
 import com.intellij.openapi.projectRoots.Sdk
 import org.elixir_lang.Erl.prependCodePaths
+import org.elixir_lang.sdk.erlang_dependent.MissingErlangSdk
 import org.elixir_lang.sdk.erlang_dependent.SdkAdditionalData
 
 object Elixir {
@@ -30,7 +31,8 @@ object Elixir {
     }
 
     fun elixirSdkToEnsuredErlangSdk(elixirSdk: Sdk): Sdk =
-        elixirSdk.sdkAdditionalData.let { it as SdkAdditionalData }.ensureErlangSdk()
+        elixirSdk.sdkAdditionalData?.let { it as SdkAdditionalData }?.ensureErlangSdk()
+            ?: throw MissingErlangSdk(elixirSdk)
 
     /**
      * Adds `-pa ebinDirectory` for those in the `elixirSdk` that aren't in the `erlangSdk`


### PR DESCRIPTION
Fixes #2706

# Changelog
## Bug Fixes
* Don't assume Elixir `SDK` `sdkAdditionalData` is non-`null`.