### PR TITLE
Don't restrict Run Configurations to Run in Modules to Elixir modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -279,6 +279,9 @@
   * Implement Deprecated metadata handling for docs from BEAM files.
 * [#2709](https://github.com/KronicDeth/intellij-elixir/pull/2709) - [@KronicDeth](https://github.com/KronicDeth)
   * Don't assume Elixir `SDK` `sdkAdditionalData` is non-`null`.
+* [#2711](https://github.com/KronicDeth/intellij-elixir/pull/2711) - [@KronicDeth](https://github.com/KronicDeth)
+  * Don't restrict Run Configurations to Run in Modules to Elixir modules.
+    The docs for `ModuleType` say the concept is meant to be deprecated, so don't enforce it and trying to load `ElixirModuleType` in RubyMine breaks as it tries to load `ElixirModuleBuilder` and therefore `JavaModuleBuilder`, which only works in IntelliJ.
 
 ## v13.1.0
 

--- a/resources/META-INF/changelog.html
+++ b/resources/META-INF/changelog.html
@@ -16,6 +16,8 @@
         When switching over to delayed decompilation, <code class="notranslate">ModuleImpl</code> did not have <code class="notranslate">processDeclaration</code> overloadded, so the <code class="notranslate">PsiScopeProcessor</code> was never called on it and so the <code class="notranslate">CallDefinitionClause</code> scope processor did not check the <code class="notranslate">ModuleImpl#callDefinitons</code>.</li>
       <li>Implement Deprecated metadata handling for docs from BEAM files.</li>
       <li>Don't assume Elixir <code class="notranslate">SDK</code> <code class="notranslate">sdkAdditionalData</code> is non-<code class="notranslate">null</code>.</li>
+      <li>Don't restrict Run Configurations to Run in Modules to Elixir modules.<br>
+        The docs for <code class="notranslate">ModuleType</code> say the concept is meant to be deprecated, so don't enforce it and trying to load <code class="notranslate">ElixirModuleType</code> in RubyMine breaks as it tries to load <code class="notranslate">ElixirModuleBuilder</code> and therefore <code class="notranslate">JavaModuleBuilder</code>, which only works in IntelliJ.</li>
     </ul>
   </li>
 </ul>

--- a/src/org/elixir_lang/elixir/configuration/Editor.java
+++ b/src/org/elixir_lang/elixir/configuration/Editor.java
@@ -26,7 +26,7 @@ public final class Editor extends SettingsEditor<Configuration> {
     }
 
     public void reset(@NotNull Configuration configuration) {
-        modulesComboBox.fillModules(configuration.getProject(), ElixirModuleType.getInstance());
+        modulesComboBox.fillModules(configuration.getProject());
         final Module module = configuration.getConfigurationModule().getModule();
 
         if (module != null) {

--- a/src/org/elixir_lang/erl/configuration/Editor.java
+++ b/src/org/elixir_lang/erl/configuration/Editor.java
@@ -28,7 +28,7 @@ public final class Editor extends com.intellij.openapi.options.SettingsEditor<Co
     }
 
     public void reset(@NotNull Configuration configuration) {
-        modulesComboBox.fillModules(configuration.getProject(), ElixirModuleType.getInstance());
+        modulesComboBox.fillModules(configuration.getProject());
         final Module module = configuration.getConfigurationModule().getModule();
 
         if (module != null) {

--- a/src/org/elixir_lang/espec/configuration/Editor.java
+++ b/src/org/elixir_lang/espec/configuration/Editor.java
@@ -28,7 +28,7 @@ public final class Editor extends com.intellij.openapi.options.SettingsEditor<Co
     }
 
     public void reset(@NotNull Configuration configuration) {
-        modulesComboBox.fillModules(configuration.getProject(), ElixirModuleType.getInstance());
+        modulesComboBox.fillModules(configuration.getProject());
         final Module module = configuration.getConfigurationModule().getModule();
 
         if (module != null) {

--- a/src/org/elixir_lang/exunit/configuration/Editor.java
+++ b/src/org/elixir_lang/exunit/configuration/Editor.java
@@ -28,7 +28,7 @@ public final class Editor extends com.intellij.openapi.options.SettingsEditor<Co
     }
 
     public void reset(@NotNull Configuration configuration) {
-        modulesComboBox.fillModules(configuration.getProject(), ElixirModuleType.getInstance());
+        modulesComboBox.fillModules(configuration.getProject());
         final Module module = configuration.getConfigurationModule().getModule();
 
         if (module != null) {

--- a/src/org/elixir_lang/iex/configuration/Editor.java
+++ b/src/org/elixir_lang/iex/configuration/Editor.java
@@ -26,7 +26,7 @@ public final class Editor extends SettingsEditor<Configuration> {
     }
 
     public void reset(@NotNull Configuration configuration) {
-        modulesComboBox.fillModules(configuration.getProject(), ElixirModuleType.getInstance());
+        modulesComboBox.fillModules(configuration.getProject());
         final Module module = configuration.getConfigurationModule().getModule();
 
         if (module != null) {

--- a/src/org/elixir_lang/iex/mix/configuration/Editor.java
+++ b/src/org/elixir_lang/iex/mix/configuration/Editor.java
@@ -26,7 +26,7 @@ public final class Editor extends SettingsEditor<Configuration> {
     }
 
     public void reset(@NotNull Configuration configuration) {
-        modulesComboBox.fillModules(configuration.getProject(), ElixirModuleType.getInstance());
+        modulesComboBox.fillModules(configuration.getProject());
         final Module module = configuration.getConfigurationModule().getModule();
 
 

--- a/src/org/elixir_lang/mix/configuration/Editor.java
+++ b/src/org/elixir_lang/mix/configuration/Editor.java
@@ -28,7 +28,7 @@ public final class Editor extends com.intellij.openapi.options.SettingsEditor<Co
     }
 
     public void reset(@NotNull Configuration configuration) {
-        modulesComboBox.fillModules(configuration.getProject(), ElixirModuleType.getInstance());
+        modulesComboBox.fillModules(configuration.getProject());
         final Module module = configuration.getConfigurationModule().getModule();
 
         if (module != null) {


### PR DESCRIPTION
Fixes #2703

# Changelog
## Bug Fixes
* Don't restrict Run Configurations to Run in Modules to Elixir modules.
  The docs for `ModuleType` say the concept is meant to be deprecated, so don't enforce it and trying to load `ElixirModuleType` in RubyMine breaks as it tries to load `ElixirModuleBuilder` and therefore `JavaModuleBuilder`, which only works in IntelliJ.