### PR TITLE
Increase SUSPECT_NAME_SET_SIZE to 20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -284,6 +284,9 @@
     The docs for `ModuleType` say the concept is meant to be deprecated, so don't enforce it and trying to load `ElixirModuleType` in RubyMine breaks as it tries to load `ElixirModuleBuilder` and therefore `JavaModuleBuilder`, which only works in IntelliJ.
 * [#2712](https://github.com/KronicDeth/intellij-elixir/pull/2712) - [@KronicDeth](https://github.com/KronicDeth)
   * Add the facet in a write action in addition to setting the SDK.
+* [#2717](https://github.com/KronicDeth/intellij-elixir/pull/2717) - [@KronicDeth](https://github.com/KronicDeth)
+  * Increase `SUSPECT_NAME_SET_SIZE` to `20`.
+    Increased to cover the `15` `impl`s of `String.Chars` in the `geo` hex package.
 
 ## v13.1.0
 

--- a/gen/org/elixir_lang/psi/stub/call/Deserialized.java
+++ b/gen/org/elixir_lang/psi/stub/call/Deserialized.java
@@ -19,9 +19,9 @@ public class Deserialized {
        https://github.com/KronicDeth/intellij-elixir/issues/767 */
     private static final int GUARD_LENGTH = 0;
     private static final Logger LOGGER = Logger.getInstance(Deserialized.class);
-    /* Set > than experimentally observed valid values.  >= 13 is needed to accommodate `geo`'s 13 Protocol `impl`s for
-       `String.Chars`.  */
-    private static final int SUSPECT_NAME_SET_SIZE = 15;
+    /* Set > than experimentally observed valid values.  >= 15 is needed to accommodate `geo`'s 15 Protocol `impl`s for
+       `String.Chars` in https://github.com/KronicDeth/intellij-elixir/issues/2698.  */
+    private static final int SUSPECT_NAME_SET_SIZE = 20;
 
     static {
         int i;

--- a/resources/META-INF/changelog.html
+++ b/resources/META-INF/changelog.html
@@ -19,6 +19,8 @@
       <li>Don't restrict Run Configurations to Run in Modules to Elixir modules.<br>
         The docs for <code class="notranslate">ModuleType</code> say the concept is meant to be deprecated, so don't enforce it and trying to load <code class="notranslate">ElixirModuleType</code> in RubyMine breaks as it tries to load <code class="notranslate">ElixirModuleBuilder</code> and therefore <code class="notranslate">JavaModuleBuilder</code>, which only works in IntelliJ.</li>
       <li>Add the facet in a write action in addition to setting the SDK.</li>
+      <li>Increase <code class="notranslate">SUSPECT_NAME_SET_SIZE</code> to <code class="notranslate">20</code>.<br>
+        Increased to cover the <code class="notranslate">15</code> <code class="notranslate">impl</code>s of <code class="notranslate">String.Chars</code> in the <code class="notranslate">geo</code> hex package.</li>
     </ul>
   </li>
 </ul>


### PR DESCRIPTION
Fixes #2698
Fixes #2716

# Changelog
## Bug Fixes
* Increase `SUSPECT_NAME_SET_SIZE` to `20`.
  Increased to cover the `15` `impl`s of `String.Chars` in the `geo` hex package.