### PR TITLE
Log if erl binary is not found when trying to run mix format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -287,6 +287,9 @@
 * [#2717](https://github.com/KronicDeth/intellij-elixir/pull/2717) - [@KronicDeth](https://github.com/KronicDeth)
   * Increase `SUSPECT_NAME_SET_SIZE` to `20`.
     Increased to cover the `15` `impl`s of `String.Chars` in the `geo` hex package.
+* [#2719](https://github.com/KronicDeth/intellij-elixir/pull/2719) - [@KronicDeth](https://github.com/KronicDeth)
+  * Log if `erl` binary is not found when trying to run `mix format`.
+    Log instead of letting it throw up the stack and cause an error report since the SDK not being set will be very common.
 
 ## v13.1.0
 

--- a/resources/META-INF/changelog.html
+++ b/resources/META-INF/changelog.html
@@ -21,6 +21,8 @@
       <li>Add the facet in a write action in addition to setting the SDK.</li>
       <li>Increase <code class="notranslate">SUSPECT_NAME_SET_SIZE</code> to <code class="notranslate">20</code>.<br>
         Increased to cover the <code class="notranslate">15</code> <code class="notranslate">impl</code>s of <code class="notranslate">String.Chars</code> in the <code class="notranslate">geo</code> hex package.</li>
+      <li>Log if <code class="notranslate">erl</code> binary is not found when trying to run <code class="notranslate">mix format</code>.<br>
+        Log instead of letting it throw up the stack and cause an error report since the SDK not being set will be very common.</li>
     </ul>
   </li>
 </ul>


### PR DESCRIPTION
Fixes #2718

# Changelog
## Bug Fixes
* Log if `erl` binary is not found when trying to run `mix format`.
  Log instead of letting it throw up the stack and cause an error report since the SDK not being set will be very common.