### PR TITLE
Ignore `authors: ...` for documentation when injecting Markdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -282,6 +282,8 @@
     Parsing complex decompiles can freeze the IDE.  Logging before parsing the decompiles will give a chance of finding the file and recovering the decompiled code to find the error or complexity that needs to be suppressed.
   * Use `Options.truncateDecompiledBodyz on Elixir decompiled bodies too.
     Previously, this was only used for Erlang functions.  Fixes parsing decompiled code causing freezes for some files.
+* [#2804](https://github.com/KronicDeth/intellij-elixir/pull/2804) - [@KronicDeth](https://github.com/KronicDeth) 
+  *  Ignore `authors: ...` for documentation when injecting Markdown.
 
 ## v13.2.0
 

--- a/resources/META-INF/changelog.html
+++ b/resources/META-INF/changelog.html
@@ -11,6 +11,7 @@
         Parsing complex decompiles can freeze the IDE.  Logging before parsing the decompiles will give a chance of finding the file and recovering the decompiled code to find the error or complexity that needs to be suppressed.</li>
       <li>Use `Options.truncateDecompiledBodyz on Elixir decompiled bodies too.<br>
         Previously, this was only used for Erlang functions.  Fixes parsing decompiled code causing freezes for some files.</li>
+      <li>Ignore <code class="notranslate">authors: ...</code> for documentation when injecting Markdown.</li>
     </ul>
   </li>
 </ul>

--- a/src/org/elixir_lang/injection/markdown/Injector.kt
+++ b/src/org/elixir_lang/injection/markdown/Injector.kt
@@ -33,7 +33,7 @@ class Injector : MultiHostInjector {
             is QuotableKeywordPair -> {
                 when (val key = documentation.keywordKey.text) {
                     "deprecated" -> getLanguagesToInjectInQuote(registrar, documentation.keywordValue)
-                    "guard", "since" -> Unit
+                    "authors", "guard", "since" -> Unit
                     else -> {
                         Logger.error(
                             javaClass,


### PR DESCRIPTION
Fixes #2798

# Changelog
## Bug Fixes
* Ignore `authors: ...` for documentation when injecting Markdown.