### PR TITLE
Stop prepend qualifier when reaching a qualified bracket operation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -284,6 +284,8 @@
     Previously, this was only used for Erlang functions.  Fixes parsing decompiled code causing freezes for some files.
 * [#2804](https://github.com/KronicDeth/intellij-elixir/pull/2804) - [@KronicDeth](https://github.com/KronicDeth) 
   *  Ignore `authors: ...` for documentation when injecting Markdown.
+* [#2808](https://github.com/KronicDeth/intellij-elixir/pull/2808) - [@KronicDeth](https://github.com/KronicDeth) 
+  * Stop `prependQualifiers` when reaching a qualified bracket operation (`Alias.function[key]`).
 
 ## v13.2.0
 

--- a/resources/META-INF/changelog.html
+++ b/resources/META-INF/changelog.html
@@ -12,6 +12,7 @@
       <li>Use `Options.truncateDecompiledBodyz on Elixir decompiled bodies too.<br>
         Previously, this was only used for Erlang functions.  Fixes parsing decompiled code causing freezes for some files.</li>
       <li>Ignore <code class="notranslate">authors: ...</code> for documentation when injecting Markdown.</li>
+      <li>Stop <code class="notranslate">prependQualifiers</code> when reaching a qualified bracket operation (<code class="notranslate">Alias.function[key]</code>).</li>
     </ul>
   </li>
 </ul>

--- a/src/org/elixir_lang/psi/impl/QualifiableAliasImpl.kt
+++ b/src/org/elixir_lang/psi/impl/QualifiableAliasImpl.kt
@@ -34,6 +34,7 @@ fun QualifiableAlias.computeReference(): PsiPolyVariantReference? =
                 // If the parent ends at the same offset, then the parent should supply the reference
                 null
             }
+
         else ->
 
             if (this.fullyQualifiedName() !in arrayOf(
@@ -99,6 +100,7 @@ private fun PsiReference.toModulars(): Set<PsiElement> =
                     ?: emptySet()
             }.toSet()
         }
+
         else -> {
             resolve()
                 ?.let { resolved -> toModulars(resolved) }
@@ -142,9 +144,13 @@ object QualifiableAliasImpl {
                 // Top of expression inside of interpolation
             is ElixirInterpolation,
                 // Typing an alias on a new line in the body of function
-            is ElixirStabBody -> accumulator
+            is ElixirStabBody,
+                // bracket like `Alias.function[key]`
+            is QualifiedBracketOperation -> accumulator
+
             is ElixirAccessExpression, is ElixirMultipleAliases ->
                 prependQualifiers(ancestor.parent, ancestor, accumulator)
+
             is QualifiedAlias, is Qualified, is QualifiedMultipleAliases -> {
                 val children = ancestor.children
                 val operatorIndex = operatorIndex(children)
@@ -170,6 +176,7 @@ object QualifiableAliasImpl {
 
                                         "?.${accumulator}"
                                     }
+
                                     1 -> "${modularSet.single().name}.${accumulator}"
                                     else -> {
                                         Logger.error(
@@ -182,6 +189,7 @@ object QualifiableAliasImpl {
                                     }
                                 }
                             }
+
                             else -> {
                                 Logger.error(
                                     QualifiableAlias::class.java,
@@ -201,6 +209,7 @@ object QualifiableAliasImpl {
                     "?.${accumulator}"
                 }
             }
+
             else -> {
                 Logger.error(QualifiableAlias::class.java, "Don't know how to prepend qualifier", ancestor)
 


### PR DESCRIPTION
Fixes #2799

# Changelog
## Bug Fixes
* Stop `prependQualifiers` when reaching a qualified bracket operation (`Alias.function[key]`).