### PR TITLE
Skip -1 and other unary operations when resolving types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -286,6 +286,8 @@
   *  Ignore `authors: ...` for documentation when injecting Markdown.
 * [#2808](https://github.com/KronicDeth/intellij-elixir/pull/2808) - [@KronicDeth](https://github.com/KronicDeth) 
   * Stop `prependQualifiers` when reaching a qualified bracket operation (`Alias.function[key]`).
+* [#2809](https://github.com/KronicDeth/intellij-elixir/pull/2809) - [@KronicDeth](https://github.com/KronicDeth) 
+  * Skip `-1` and other unary operations when resolving types.
 
 ## v13.2.0
 

--- a/gen/org/elixir_lang/psi/scope/type/MultiResolve.kt
+++ b/gen/org/elixir_lang/psi/scope/type/MultiResolve.kt
@@ -90,6 +90,8 @@ private constructor(private val name: String,
                 is UnqualifiedParenthesesCall<*>,
                 // Literals
                 is QualifiableAlias,
+                // -1 and other negative integer literals
+                is UnaryOperation,
                 is ElixirAtom,
                 is ElixirAtomKeyword,
                 is ElixirBitString,

--- a/resources/META-INF/changelog.html
+++ b/resources/META-INF/changelog.html
@@ -13,6 +13,7 @@
         Previously, this was only used for Erlang functions.  Fixes parsing decompiled code causing freezes for some files.</li>
       <li>Ignore <code class="notranslate">authors: ...</code> for documentation when injecting Markdown.</li>
       <li>Stop <code class="notranslate">prependQualifiers</code> when reaching a qualified bracket operation (<code class="notranslate">Alias.function[key]</code>).</li>
+      <li>Skip <code class="notranslate">-1</code> and other unary operations when resolving types.</li>
     </ul>
   </li>
 </ul>


### PR DESCRIPTION
Fixes #2795

# Changelog
## Bug Fixes
* Skip `-1` and other unary operations when resolving types.