### PR TITLE
Ignore maps at the root of files when collecting doc comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -288,6 +288,8 @@
   * Stop `prependQualifiers` when reaching a qualified bracket operation (`Alias.function[key]`).
 * [#2809](https://github.com/KronicDeth/intellij-elixir/pull/2809) - [@KronicDeth](https://github.com/KronicDeth) 
   * Skip `-1` and other unary operations when resolving types.
+* [#2810](https://github.com/KronicDeth/intellij-elixir/pull/2810) - [@KronicDeth](https://github.com/KronicDeth) 
+  * Ignore maps at the root of files when collecting doc comments.
 
 ## v13.2.0
 

--- a/resources/META-INF/changelog.html
+++ b/resources/META-INF/changelog.html
@@ -14,6 +14,7 @@
       <li>Ignore <code class="notranslate">authors: ...</code> for documentation when injecting Markdown.</li>
       <li>Stop <code class="notranslate">prependQualifiers</code> when reaching a qualified bracket operation (<code class="notranslate">Alias.function[key]</code>).</li>
       <li>Skip <code class="notranslate">-1</code> and other unary operations when resolving types.</li>
+      <li>Ignore maps at the root of files when collecting doc comments.</li>
     </ul>
   </li>
 </ul>

--- a/src/org/elixir_lang/documentation/ElixirDocumentationProvider.kt
+++ b/src/org/elixir_lang/documentation/ElixirDocumentationProvider.kt
@@ -85,7 +85,7 @@ class ElixirDocumentationProvider : DocumentationProvider {
         when (element) {
             is Call -> collectDocComments(element, sink)
             is ElixirAccessExpression -> collectDocComments(element.stripAccessExpression(), sink)
-            is DummyBlock, is ElixirList, is PsiErrorElement -> Unit
+            is DummyBlock, is ElixirList, is ElixirMapOperation, is PsiErrorElement -> Unit
             else -> {
                 Logger.error(javaClass, "Don't know how to collect doc comments", element)
             }


### PR DESCRIPTION
# Changelog
## Bug Fixes
* Ignore maps at the root of files when collecting doc comments.