### PR TITLE
Don't descend inside struct literal when resolving types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -292,6 +292,8 @@
   * Ignore maps at the root of files when collecting doc comments.
 * [#2812](https://github.com/KronicDeth/intellij-elixir/pull/2812) - [@KronicDeth](https://github.com/KronicDeth) 
   * Return `emptySequence` from `childExpressions` when `PsiElement` has no `firstChild` or `lastChild`.
+* [#2814](https://github.com/KronicDeth/intellij-elixir/pull/2814) - [@KronicDeth](https://github.com/KronicDeth) 
+  * Don't descend inside struct literal when resolving types.
 
 ## v13.2.0
 

--- a/resources/META-INF/changelog.html
+++ b/resources/META-INF/changelog.html
@@ -16,6 +16,7 @@
       <li>Skip <code class="notranslate">-1</code> and other unary operations when resolving types.</li>
       <li>Ignore maps at the root of files when collecting doc comments.</li>
       <li>Return <code class="notranslate">emptySequence</code> from <code class="notranslate">childExpressions</code> when <code class="notranslate">PsiElement</code> has no <code class="notranslate">firstChild</code> or <code class="notranslate">lastChild</code>.</li>
+      <li>Don't descend inside struct literal when resolving types.</li>
     </ul>
   </li>
 </ul>

--- a/src/org/elixir_lang/psi/scope/Type.kt
+++ b/src/org/elixir_lang/psi/scope/Type.kt
@@ -42,9 +42,10 @@ abstract class Type : PsiScopeProcessor {
             // type variable in a `when key: type`
             is ElixirKeywordKey -> executeOnParameter(element, state)
             is ElixirNoParenthesesOneArgument, is ElixirAccessExpression -> executeOnChildren(element, state)
-            is ElixirAtom, is ElixirFile, is ElixirLine, is ElixirList, is ElixirParentheticalStab, is ElixirTuple,
-            is WholeNumber,
+            is ElixirAtom, is ElixirFile, is ElixirLine, is ElixirList, is ElixirParentheticalStab,
+            is ElixirStructOperation, is ElixirTuple, is WholeNumber
             -> false
+
             is ModuleImpl<*> -> execute(element, state)
             is TypeDefinitionImpl<*> -> execute(element, state)
             is CallDefinitionImpl<*> -> true
@@ -162,6 +163,7 @@ abstract class Type : PsiScopeProcessor {
                         } ?: true
                     }
                 }
+
                 else -> TODO()
             }
         } ?: true
@@ -171,6 +173,7 @@ abstract class Type : PsiScopeProcessor {
             is Call -> descendant.whileInStabBodyChildExpressions {
                 executeOnDefprotocolDefinitionExpression(it, state)
             }
+
             else -> {
                 true
             }
@@ -196,6 +199,7 @@ abstract class Type : PsiScopeProcessor {
                 } else {
                     true
                 }
+
             else -> true
         }
 
@@ -228,6 +232,7 @@ internal fun PsiElement.ancestorTypeSpec(): AtUnqualifiedNoParenthesesCall<*>? =
                 null
             }
         }
+
         is Arguments,
         is ElixirAccessExpression,
         is ElixirKeywords,
@@ -278,6 +283,7 @@ internal fun PsiElement.ancestorTypeSpec(): AtUnqualifiedNoParenthesesCall<*>? =
             // __MODULE__.* does not matter that it is in a type
         is QualifiableAlias,
         -> null
+
         else -> {
             Logger.error(PsiElement::class.java, "Don't know how to find ancestorTypeSpec", this)
 


### PR DESCRIPTION
Fixes #2807

# Changelog
## Bug Fixes
* Don't descend inside struct literal when resolving types.