### PR TITLE
Ignore injecting Markdown in calls that read the text from a file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -294,6 +294,8 @@
   * Return `emptySequence` from `childExpressions` when `PsiElement` has no `firstChild` or `lastChild`.
 * [#2814](https://github.com/KronicDeth/intellij-elixir/pull/2814) - [@KronicDeth](https://github.com/KronicDeth) 
   * Don't descend inside struct literal when resolving types.
+* [#2848](https://github.com/KronicDeth/intellij-elixir/pull/2848) - [@KronicDeth](https://github.com/KronicDeth) 
+  * Ignore injecting Markdown in calls that read the text from a file, such as in `@moduledoc File.read!(Path.join([__DIR__, "..", "README.md"]))`
 
 ## v13.2.0
 

--- a/resources/META-INF/changelog.html
+++ b/resources/META-INF/changelog.html
@@ -17,6 +17,7 @@
       <li>Ignore maps at the root of files when collecting doc comments.</li>
       <li>Return <code class="notranslate">emptySequence</code> from <code class="notranslate">childExpressions</code> when <code class="notranslate">PsiElement</code> has no <code class="notranslate">firstChild</code> or <code class="notranslate">lastChild</code>.</li>
       <li>Don't descend inside struct literal when resolving types.</li>
+      <li>Ignore injecting Markdown in calls that read the text from a file, such as in <code class="notranslate">@moduledoc File.read!(Path.join([__DIR__, "..", "README.md"]))</code></li>
     </ul>
   </li>
 </ul>

--- a/src/org/elixir_lang/injection/markdown/Injector.kt
+++ b/src/org/elixir_lang/injection/markdown/Injector.kt
@@ -31,7 +31,7 @@ class Injector : MultiHostInjector {
                 injectElixirInCodeBlocksInQuote(registrar, documentation)
             }
 
-            is ElixirAtomKeyword -> Unit
+            is ElixirAlias, is ElixirAtomKeyword -> Unit
             is ElixirLine -> injectMarkdownInQuote(registrar, documentation)
             is QuotableKeywordPair -> {
                 when (val key = documentation.keywordKey.text) {

--- a/src/org/elixir_lang/injection/markdown/Injector.kt
+++ b/src/org/elixir_lang/injection/markdown/Injector.kt
@@ -7,6 +7,7 @@ import com.intellij.psi.PsiElement
 import org.elixir_lang.ElixirLanguage
 import org.elixir_lang.errorreport.Logger
 import org.elixir_lang.psi.*
+import org.elixir_lang.psi.impl.stripAccessExpression
 import org.elixir_lang.reference.ModuleAttribute.Companion.DOCUMENTATION_NAME_SET
 import org.intellij.plugins.markdown.lang.MarkdownLanguage
 import java.util.regex.Pattern
@@ -19,6 +20,7 @@ class Injector : MultiHostInjector {
             ?.lastChild
             ?.firstChild
             ?.firstChild
+            ?.stripAccessExpression()
             ?.let { getLanguagesToInjectInQuote(registrar, it) }
     }
 
@@ -28,6 +30,7 @@ class Injector : MultiHostInjector {
                 injectMarkdownInQuote(registrar, documentation)
                 injectElixirInCodeBlocksInQuote(registrar, documentation)
             }
+
             is ElixirAtomKeyword -> Unit
             is ElixirLine -> injectMarkdownInQuote(registrar, documentation)
             is QuotableKeywordPair -> {
@@ -43,6 +46,7 @@ class Injector : MultiHostInjector {
                     }
                 }
             }
+
             else -> {
                 Logger.error(javaClass, "Do not know whether to inject Markdown in documentation", documentation)
             }
@@ -95,19 +99,23 @@ class Injector : MultiHostInjector {
 
                                     CODE_BLOCK_INDENT_LENGTH + IEX_PROMPT_LENGTH
                                 }
+
                                 lineCodeText.startsWith(IEX_CONTINUATION) -> {
                                     CODE_BLOCK_INDENT_LENGTH + IEX_CONTINUATION_LENGTH
                                 }
+
                                 lineCodeText.startsWith(DEBUG_PREFIX) -> {
                                     inException = false
 
                                     lineMarkdownText.length
                                 }
+
                                 lineCodeText.startsWith(EXCEPTION_PREFIX) -> {
                                     inException = true
 
                                     lineMarkdownText.length
                                 }
+
                                 else -> {
                                     if (inException) {
                                         lineMarkdownText.length
@@ -201,6 +209,7 @@ class Injector : MultiHostInjector {
                                             codeOffsetRelativeToQuote + IEX_PROMPT_LENGTH
                                         )
                                     }
+
                                     lineCodeText.startsWith(IEX_CONTINUATION) -> {
                                         inException = false
 
@@ -209,6 +218,7 @@ class Injector : MultiHostInjector {
                                             codeOffsetRelativeToQuote + IEX_CONTINUATION_LENGTH
                                         )
                                     }
+
                                     else -> {
                                         Pair(lineCodeText, codeOffsetRelativeToQuote)
                                     }


### PR DESCRIPTION
Fixes #2771

# Changelog
## Bug Fixes
* Ignore injecting Markdown in calls that read the text from a file, such as in `@moduledoc File.read!(Path.join([__DIR__, "..", "README.md"]))`