### PR TITLE
Ignore calls and literals at root of file when collecting doc comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -296,6 +296,12 @@
   * Don't descend inside struct literal when resolving types.
 * [#2848](https://github.com/KronicDeth/intellij-elixir/pull/2848) - [@KronicDeth](https://github.com/KronicDeth) 
   * Ignore injecting Markdown in calls that read the text from a file, such as in `@moduledoc File.read!(Path.join([__DIR__, "..", "README.md"]))`
+* [#2858](https://github.com/KronicDeth/intellij-elixir/pull/2858) - [@KronicDeth](https://github.com/KronicDeth)
+  * Ignore undocument script code at root of files.
+    * Alias used in qualified call.
+    * Integers
+    * Floats
+    * Tuples
 
 ## v13.2.0
 

--- a/resources/META-INF/changelog.html
+++ b/resources/META-INF/changelog.html
@@ -18,6 +18,14 @@
       <li>Return <code class="notranslate">emptySequence</code> from <code class="notranslate">childExpressions</code> when <code class="notranslate">PsiElement</code> has no <code class="notranslate">firstChild</code> or <code class="notranslate">lastChild</code>.</li>
       <li>Don't descend inside struct literal when resolving types.</li>
       <li>Ignore injecting Markdown in calls that read the text from a file, such as in <code class="notranslate">@moduledoc File.read!(Path.join([__DIR__, "..", "README.md"]))</code></li>
+      <li>Ignore undocument script code at root of files.
+        <ul dir="auto">
+          <li>Alias used in qualified call.</li>
+          <li>Integers</li>
+          <li>Floats</li>
+          <li>Tuples</li>
+        </ul>
+      </li>
     </ul>
   </li>
 </ul>

--- a/src/org/elixir_lang/documentation/ElixirDocumentationProvider.kt
+++ b/src/org/elixir_lang/documentation/ElixirDocumentationProvider.kt
@@ -64,11 +64,13 @@ class ElixirDocumentationProvider : DocumentationProvider {
                                 heredocLine.text.substring(startIndex)
                             }
                         }
+
                         is ElixirLine -> quote.body?.text
                         else -> null
                     }
                 }
             }
+
             else -> null
         }
 
@@ -85,7 +87,7 @@ class ElixirDocumentationProvider : DocumentationProvider {
         when (element) {
             is Call -> collectDocComments(element, sink)
             is ElixirAccessExpression -> collectDocComments(element.stripAccessExpression(), sink)
-            is DummyBlock, is ElixirList, is ElixirMapOperation, is PsiErrorElement -> Unit
+            is DummyBlock, is ElixirAlias, is ElixirList, is ElixirMapOperation, is PsiErrorElement -> Unit
             else -> {
                 Logger.error(javaClass, "Don't know how to collect doc comments", element)
             }
@@ -182,6 +184,7 @@ class ElixirDocumentationProvider : DocumentationProvider {
                         .let { Resolver.preferSource(it) }
                         .firstOrNull()
                 }
+
                 "c" -> {
                     val relative = relativeLinkMatcher.group("relative")
                     val arity = relativeLinkMatcher.group("arity").toInt()
@@ -228,6 +231,7 @@ class ElixirDocumentationProvider : DocumentationProvider {
                         .let { Resolver.preferSource(it) }
                         .firstOrNull()
                 }
+
                 "t" -> {
                     val relative = relativeLinkMatcher.group("relative")
                     val arity = relativeLinkMatcher.group("arity").toInt()
@@ -253,6 +257,7 @@ class ElixirDocumentationProvider : DocumentationProvider {
                         .let { Resolver.preferSource(it) }
                         .firstOrNull()
                 }
+
                 else -> {
                     Logger.error(
                         javaClass, "Don't know how to find element for link (${link}) of kind (${kind})",
@@ -297,6 +302,7 @@ class ElixirDocumentationProvider : DocumentationProvider {
                         .singleOrNull { CallDefinitionClause.`is`(it) }
                 }
         }
+
         is QualifiableAlias -> {
             val reference = contextElement.getReference()
 
@@ -312,6 +318,7 @@ class ElixirDocumentationProvider : DocumentationProvider {
                 getCustomDocumentationElement(contextElement.parent)
             }
         }
+
         else -> null
     }
 
@@ -326,11 +333,13 @@ class ElixirDocumentationProvider : DocumentationProvider {
             is FetchedDocs.CallbackDocumentation -> {
                 documentationHtml.append(fetchedDocs.head).append("\n")
             }
+
             is FetchedDocs.FunctionOrMacroDocumentation -> {
                 for (head in fetchedDocs.heads) {
                     documentationHtml.append(head).append("\n")
                 }
             }
+
             is FetchedDocs.ModuleDocumentation -> Unit
             is FetchedDocs.TypeDocumentation -> {
                 documentationHtml.append(fetchedDocs.head).append("\n")
@@ -349,6 +358,7 @@ class ElixirDocumentationProvider : DocumentationProvider {
                         .append(DocumentationMarkup.CONTENT_END)
                 }
             }
+
             is FetchedDocs.ModuleDocumentation -> {
                 fetchedDocs.moduledoc.let { moduledoc ->
                     documentationHtml
@@ -357,6 +367,7 @@ class ElixirDocumentationProvider : DocumentationProvider {
                         .append(DocumentationMarkup.CONTENT_END)
                 }
             }
+
             is FetchedDocs.FunctionOrMacroDocumentation -> {
                 fetchedDocs.doc?.let { doc ->
                     when (doc) {
@@ -366,6 +377,7 @@ class ElixirDocumentationProvider : DocumentationProvider {
                                 .append(DocumentationMarkup.CONTENT_START)
                                 .append(false)
                                 .append(DocumentationMarkup.CONTENT_END)
+
                         is MarkdownByLanguage ->
                             doc.formattedByLanguage.values.map { formatted ->
                                 documentationHtml
@@ -429,6 +441,7 @@ class ElixirDocumentationProvider : DocumentationProvider {
                     documentationHtml.append(DocumentationMarkup.SECTIONS_END)
                 }
             }
+
             is FetchedDocs.TypeDocumentation -> {
                 fetchedDocs.typedoc.let { typedoc ->
                     documentationHtml
@@ -450,6 +463,7 @@ class ElixirDocumentationProvider : DocumentationProvider {
                     .binaryValue()
                     .let { String(it, Charsets.UTF_8) }
                     .let { html(project, it) }
+
             else -> {
                 Logger.error(javaClass, "Don't know how to render deprecated metadata", otpErlangObject)
 

--- a/src/org/elixir_lang/documentation/ElixirDocumentationProvider.kt
+++ b/src/org/elixir_lang/documentation/ElixirDocumentationProvider.kt
@@ -87,8 +87,12 @@ class ElixirDocumentationProvider : DocumentationProvider {
         when (element) {
             is Call -> collectDocComments(element, sink)
             is ElixirAccessExpression -> collectDocComments(element.stripAccessExpression(), sink)
-            is DummyBlock, is ElixirAlias, is ElixirDecimalFloat, is ElixirDecimalWholeNumber, is ElixirList,
-            is ElixirMapOperation, is PsiErrorElement
+            is DummyBlock, is ElixirAlias,
+                // Numbers
+            is ElixirDecimalFloat, is ElixirDecimalWholeNumber,
+                // Containers
+            is ElixirList, is ElixirMapOperation, is ElixirTuple,
+            is PsiErrorElement
             -> Unit
 
             else -> {

--- a/src/org/elixir_lang/documentation/ElixirDocumentationProvider.kt
+++ b/src/org/elixir_lang/documentation/ElixirDocumentationProvider.kt
@@ -87,8 +87,8 @@ class ElixirDocumentationProvider : DocumentationProvider {
         when (element) {
             is Call -> collectDocComments(element, sink)
             is ElixirAccessExpression -> collectDocComments(element.stripAccessExpression(), sink)
-            is DummyBlock, is ElixirAlias, is ElixirDecimalWholeNumber, is ElixirList, is ElixirMapOperation,
-            is PsiErrorElement
+            is DummyBlock, is ElixirAlias, is ElixirDecimalFloat, is ElixirDecimalWholeNumber, is ElixirList,
+            is ElixirMapOperation, is PsiErrorElement
             -> Unit
 
             else -> {

--- a/src/org/elixir_lang/documentation/ElixirDocumentationProvider.kt
+++ b/src/org/elixir_lang/documentation/ElixirDocumentationProvider.kt
@@ -87,7 +87,10 @@ class ElixirDocumentationProvider : DocumentationProvider {
         when (element) {
             is Call -> collectDocComments(element, sink)
             is ElixirAccessExpression -> collectDocComments(element.stripAccessExpression(), sink)
-            is DummyBlock, is ElixirAlias, is ElixirList, is ElixirMapOperation, is PsiErrorElement -> Unit
+            is DummyBlock, is ElixirAlias, is ElixirDecimalWholeNumber, is ElixirList, is ElixirMapOperation,
+            is PsiErrorElement
+            -> Unit
+
             else -> {
                 Logger.error(javaClass, "Don't know how to collect doc comments", element)
             }


### PR DESCRIPTION
Fixes #2833

# Changelog
## Bug Fixes
* Ignore undocument script code at root of files.
  * Alias used in qualified call.
  * Integers
  * Floats
  * Tuples