### PR TITLE
Stop ancestorTypeSpec on QualifiedMultipleAliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -302,6 +302,8 @@
     * Integers
     * Floats
     * Tuples
+* [#2890](https://github.com/KronicDeth/intellij-elixir/pull/2890) - [@KronicDeth](https://github.com/KronicDeth)
+  * Stop `ancestorTypeSpec` on `QualifiedMultipleAliases`.
 
 ## v13.2.0
 

--- a/resources/META-INF/changelog.html
+++ b/resources/META-INF/changelog.html
@@ -26,6 +26,7 @@
           <li>Tuples</li>
         </ul>
       </li>
+      <li>Stop <code class="notranslate">ancestorTypeSpec</code> on <code class="notranslate">QualifiedMultipleAliases</code>.</li>
     </ul>
   </li>
 </ul>

--- a/src/org/elixir_lang/psi/scope/Type.kt
+++ b/src/org/elixir_lang/psi/scope/Type.kt
@@ -241,7 +241,7 @@ internal fun PsiElement.ancestorTypeSpec(): AtUnqualifiedNoParenthesesCall<*>? =
         is Pipe,
         is ElixirStructOperation,
             // <variable>.<tuple> while typing
-        is ElixirMatchedQualifiedMultipleAliases,
+        is QualifiedMultipleAliases,
             // <tuple> while typing after `<variable>.`
         is ElixirMultipleAliases,
         is ElixirNoParenthesesOneArgument,


### PR DESCRIPTION
Fixes #2878

# Changelog
## Bug Fixes
* Stop `ancestorTypeSpec` on `QualifiedMultipleAliases`.