### PR TITLE
Ignore pipelines for injecting Markdown in doc comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -304,6 +304,8 @@
     * Tuples
 * [#2890](https://github.com/KronicDeth/intellij-elixir/pull/2890) - [@KronicDeth](https://github.com/KronicDeth)
   * Stop `ancestorTypeSpec` on `QualifiedMultipleAliases`.
+* [#2891](https://github.com/KronicDeth/intellij-elixir/pull/2891) - [@KronicDeth](https://github.com/KronicDeth)
+  * Ignore pipelines for injecting Markdown in doc comments.
 
 ## v13.2.0
 

--- a/resources/META-INF/changelog.html
+++ b/resources/META-INF/changelog.html
@@ -27,6 +27,7 @@
         </ul>
       </li>
       <li>Stop <code class="notranslate">ancestorTypeSpec</code> on <code class="notranslate">QualifiedMultipleAliases</code>.</li>
+      <li>Ignore pipelines for injecting Markdown in doc comments.</li>
     </ul>
   </li>
 </ul>

--- a/src/org/elixir_lang/injection/markdown/Injector.kt
+++ b/src/org/elixir_lang/injection/markdown/Injector.kt
@@ -31,7 +31,15 @@ class Injector : MultiHostInjector {
                 injectElixirInCodeBlocksInQuote(registrar, documentation)
             }
 
-            is ElixirAlias, is ElixirAtomKeyword -> Unit
+            is ElixirAlias,
+                // @external_resource "README.md"
+                // @moduledoc @external_resource
+                //            |> File.read!()
+                //            |> String.split("<!-- MDOC !-->")
+                //            |> Enum.fetch!(1)
+            is ElixirMatchedArrowOperation,
+            is ElixirAtomKeyword -> Unit
+
             is ElixirLine -> injectMarkdownInQuote(registrar, documentation)
             is QuotableKeywordPair -> {
                 when (val key = documentation.keywordKey.text) {


### PR DESCRIPTION
Fixes #2847

# Changelog
## Bug Fixes
* Ignore pipelines for injecting Markdown in doc comments.