### PR TITLE
Ignore useless `warn_missing` in edeliver's distillery dep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -306,6 +306,8 @@
   * Stop `ancestorTypeSpec` on `QualifiedMultipleAliases`.
 * [#2891](https://github.com/KronicDeth/intellij-elixir/pull/2891) - [@KronicDeth](https://github.com/KronicDeth)
   * Ignore pipelines for injecting Markdown in doc comments.
+* [#2892](https://github.com/KronicDeth/intellij-elixir/pull/2892) - [@KronicDeth](https://github.com/KronicDeth)
+  * Ignore useless `warn_missing` in `edeliver`'s `distillery` dep.
 
 ## v13.2.0
 

--- a/resources/META-INF/changelog.html
+++ b/resources/META-INF/changelog.html
@@ -28,6 +28,7 @@
       </li>
       <li>Stop <code class="notranslate">ancestorTypeSpec</code> on <code class="notranslate">QualifiedMultipleAliases</code>.</li>
       <li>Ignore pipelines for injecting Markdown in doc comments.</li>
+      <li>Ignore useless <code class="notranslate">warn_missing</code> in <code class="notranslate">edeliver</code>'s <code class="notranslate">distillery</code> dep.</li>
     </ul>
   </li>
 </ul>

--- a/src/org/elixir_lang/mix/Dep.kt
+++ b/src/org/elixir_lang/mix/Dep.kt
@@ -48,7 +48,9 @@ data class Dep(val application: String, val path: String, val type: Type = Type.
                                 when (key) {
                                     "app", "branch", "commit", "compile", "env", "git", "github", "hex", "manager",
                                     "only", "optional", "organization", "override", "ref", "repo", "runtime",
-                                    GUARDIAN_RUNTIME_TYPO, "sparse", "submodules", "system_env", "tag", "targets" -> acc
+                                    GUARDIAN_RUNTIME_TYPO, "sparse", "submodules", "system_env", "tag", "targets",
+                                    EDELIVER_DISTILLERY_WARN_MISSING -> acc
+
                                     "in_umbrella" -> acc.copy(path = "apps/$name", type = Type.MODULE)
                                     "path" -> putPath(acc, keywordPair.keywordValue)
                                     else -> {
@@ -142,6 +144,7 @@ data class Dep(val application: String, val path: String, val type: Type = Type.
                         dep
                     }
                 }
+
                 else -> dep
             }
 
@@ -165,3 +168,4 @@ data class Dep(val application: String, val path: String, val type: Type = Type.
 // https://github.com/ueberauth/guardian/issues/594
 @Suppress("SpellCheckingInspection")
 const val GUARDIAN_RUNTIME_TYPO: String = "runtume"
+const val EDELIVER_DISTILLERY_WARN_MISSING: String = "warn_missing"


### PR DESCRIPTION
Fixes #2845

# Changelog
## Bug Fixes
* Ignore useless `warn_missing` in `edeliver`'s `distillery` dep.