### PR TITLE
Ignore request_body and responses for docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -568,6 +568,8 @@
   * Ignore if package virtual file is disposed before the deps can be read.
 * [#3060](https://github.com/KronicDeth/intellij-elixir/pull/3060) - [@KronicDeth](https://github.com/KronicDeth)
   * Don't decompile Erlang `And` as Elixir `and`.
+* [#3061](https://github.com/KronicDeth/intellij-elixir/pull/3061) - [@KronicDeth](https://github.com/KronicDeth)
+  * Ignore `request_body` and `responses` for docs.
 
 ## v14.0.0
 

--- a/resources/META-INF/changelog.html
+++ b/resources/META-INF/changelog.html
@@ -21,6 +21,7 @@
       <li>Ignore identifier when <code>@*doc</code> attribute isn't quoted.</li>
       <li>Ignore if package virtual file is disposed before the deps can be read.</li>
       <li>Don't decompile Erlang <code>And</code> as Elixir <code>and</code>.</li>
+      <li>Ignore <code>request_body</code> and <code>responses</code> for docs.</li>
     </ul>
   </li>
 </ul>

--- a/src/org/elixir_lang/injection/markdown/Injector.kt
+++ b/src/org/elixir_lang/injection/markdown/Injector.kt
@@ -46,7 +46,7 @@ class Injector : MultiHostInjector {
             is QuotableKeywordPair -> {
                 when (val key = documentation.keywordKey.text) {
                     "deprecated" -> getLanguagesToInjectInQuote(registrar, documentation.keywordValue)
-                    "authors", "guard", "since", "type" -> Unit
+                    "authors", "guard", "request_body", "since", "type" -> Unit
                     else -> {
                         Logger.error(
                             javaClass,

--- a/src/org/elixir_lang/injection/markdown/Injector.kt
+++ b/src/org/elixir_lang/injection/markdown/Injector.kt
@@ -46,7 +46,7 @@ class Injector : MultiHostInjector {
             is QuotableKeywordPair -> {
                 when (val key = documentation.keywordKey.text) {
                     "deprecated" -> getLanguagesToInjectInQuote(registrar, documentation.keywordValue)
-                    "authors", "guard", "request_body", "since", "type" -> Unit
+                    "authors", "guard", "request_body", "responses", "since", "type" -> Unit
                     else -> {
                         Logger.error(
                             javaClass,


### PR DESCRIPTION
Fixes #2974

# Changelog
## Bug Fixes
* Ignore `request_body` and `responses` for docs.