### PR TITLE
Ignore hexadecimal numbers at the root of the file when collecting doc comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -574,6 +574,8 @@
   * Check if heredoc has lines before calculating host text range for Markdown docs.
 * [#3064](https://github.com/KronicDeth/intellij-elixir/pull/3064) - [@KronicDeth](https://github.com/KronicDeth)
   * Ignore if stubs ids can't be found when resolving Callables.
+* [#3075](https://github.com/KronicDeth/intellij-elixir/pull/3075) - [@KronicDeth](https://github.com/KronicDeth)
+  * Ignore hexadecimal numbers at the root of the file when collecting doc comment.
 
 ## v14.0.0
 

--- a/resources/META-INF/changelog.html
+++ b/resources/META-INF/changelog.html
@@ -24,6 +24,7 @@
       <li>Ignore <code>request_body</code> and <code>responses</code> for docs.</li>
       <li>Check if heredoc has lines before calculating host text range for Markdown docs.</li>
       <li>Ignore if stubs ids can't be found when resolving Callables.</li>
+      <li>Ignore hexadecimal numbers at the root of the file when collecting doc comment.</li>
     </ul>
   </li>
 </ul>

--- a/src/org/elixir_lang/documentation/ElixirDocumentationProvider.kt
+++ b/src/org/elixir_lang/documentation/ElixirDocumentationProvider.kt
@@ -90,7 +90,7 @@ class ElixirDocumentationProvider : DocumentationProvider {
             is DummyBlock, is ElixirAlias,
             is ElixirAtom,
                 // Numbers
-            is ElixirDecimalFloat, is ElixirDecimalWholeNumber,
+            is ElixirDecimalFloat, is ElixirDecimalWholeNumber, is ElixirHexadecimalWholeNumber,
                 // Containers
             is ElixirList, is ElixirMapOperation, is ElixirTuple,
             is PsiErrorElement


### PR DESCRIPTION
Fixes #3072