### PR TITLE
Return an empty array of primaryArguments instead of array with null operand for unary operation without operand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -576,6 +576,8 @@
   * Ignore if stubs ids can't be found when resolving Callables.
 * [#3075](https://github.com/KronicDeth/intellij-elixir/pull/3075) - [@KronicDeth](https://github.com/KronicDeth)
   * Ignore hexadecimal numbers at the root of the file when collecting doc comment.
+* [#3076](https://github.com/KronicDeth/intellij-elixir/pull/3076) - [@KronicDeth](https://github.com/KronicDeth)
+  * Return an empty array of primaryArguments instead of array with null operand for unary operation without operand.
 
 ## v14.0.0
 

--- a/resources/META-INF/changelog.html
+++ b/resources/META-INF/changelog.html
@@ -25,6 +25,7 @@
       <li>Check if heredoc has lines before calculating host text range for Markdown docs.</li>
       <li>Ignore if stubs ids can't be found when resolving Callables.</li>
       <li>Ignore hexadecimal numbers at the root of the file when collecting doc comment.</li>
+      <li>Return an empty array of primaryArguments instead of array with null operand for unary operation without operand.</li>
     </ul>
   </li>
 </ul>

--- a/src/org/elixir_lang/psi/impl/call/CallImpl.kt
+++ b/src/org/elixir_lang/psi/impl/call/CallImpl.kt
@@ -614,7 +614,11 @@ object CallImpl {
 
     @Contract(pure = true)
     @JvmStatic
-    fun primaryArguments(prefix: Prefix): Array<PsiElement?> = arrayOf(prefix.operand())
+    fun primaryArguments(prefix: Prefix): Array<PsiElement> =
+        prefix
+            .operand()
+            ?.let { arrayOf(it) }
+            ?: emptyArray()
 
     @Contract(pure = true)
     @JvmStatic

--- a/tests/org/elixir_lang/psi/operation/PrefixTest.java
+++ b/tests/org/elixir_lang/psi/operation/PrefixTest.java
@@ -29,8 +29,7 @@ public class PrefixTest extends LightPlatformCodeInsightFixtureTestCase {
         PsiElement[] primaryArguments = grandParentPrefixCall.primaryArguments();
 
         assertNotNull(primaryArguments);
-        assertEquals(1, primaryArguments.length);
-        assertNull(primaryArguments[0]);
+        assertEquals(0, primaryArguments.length);
     }
 
     /*


### PR DESCRIPTION
Fixes #3059