### PR TITLE
Set sinceBuild to IntelliJ IDEA 2022.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -578,6 +578,9 @@
   * Ignore hexadecimal numbers at the root of the file when collecting doc comment.
 * [#3076](https://github.com/KronicDeth/intellij-elixir/pull/3076) - [@KronicDeth](https://github.com/KronicDeth)
   * Return an empty array of primaryArguments instead of array with null operand for unary operation without operand.
+* [#3079](https://github.com/KronicDeth/intellij-elixir/pull/3079) - [@KronicDeth](https://github.com/KronicDeth)
+  * Set `sinceBuild` to IntelliJ IDEA 2022.3.
+    Fixes incorrect compatibility listed with < 2022.3 when < 2022.3 support was removed in 14.0.0 with #2946.
 
 ## v14.0.0
 

--- a/build.gradle
+++ b/build.gradle
@@ -69,7 +69,7 @@ allprojects {
         changeNotes.set(bodyInnerHTML("resources/META-INF/changelog.html"))
         pluginDescription.set(bodyInnerHTML("resources/META-INF/description.html"))
 
-        sinceBuild = "221.5080"
+        sinceBuild = "223.7571.182"
         untilBuild = "223.*"
     }
 

--- a/resources/META-INF/changelog.html
+++ b/resources/META-INF/changelog.html
@@ -26,6 +26,10 @@
       <li>Ignore if stubs ids can't be found when resolving Callables.</li>
       <li>Ignore hexadecimal numbers at the root of the file when collecting doc comment.</li>
       <li>Return an empty array of primaryArguments instead of array with null operand for unary operation without operand.</li>
+      <li>
+        <p>Set <code>sinceBuild</code> to IntelliJ IDEA 2022.3.</p>
+        <p>Fixes incorrect compatibility listed with < 2022.3 when < 2022.3 support was removed in 14.0.0 with #2946.</p>
+      </li>
     </ul>
   </li>
 </ul>


### PR DESCRIPTION
Fixes #2960

# Changelog
## Bug Fixes
* Set `sinceBuild` to IntelliJ IDEA 2022.3.
  Fixes incorrect compatibility listed with < 2022.3 when < 2022.3 support was removed in 14.0.0 with #2946.