### PR TITLE
Ignore `null` operands for `not in` `primaryArguments()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -584,6 +584,9 @@
 * [#3082](https://github.com/KronicDeth/intellij-elixir/pull/3082) - [@KronicDeth](https://github.com/KronicDeth)
   * Use `minByOrNull` to protect from empty module list.
     This fix may not work as the line number reported in the errors is actually outside of the file. This is only a guess that `minBy` was what was throwing the `NoSuchElement` exception.
+* [#3083](https://github.com/KronicDeth/intellij-elixir/pull/3083) - [@KronicDeth](https://github.com/KronicDeth)
+  * Ignore `null` operands for `not in` `primaryArguments()`.
+    Instead of including both left and right operand always and so having null operand in fixed size array return array with only non-null operands.
 
 ## v14.0.0
 

--- a/resources/META-INF/changelog.html
+++ b/resources/META-INF/changelog.html
@@ -37,6 +37,13 @@
           a guess that <code>minBy</code> was what was throwing the <code>NoSuchElement</code> exception.
         </p>
       </li>
+      <li>
+        <p>Ignore <code>null</code> operands for <code>not in</code> <code>primaryArguments()</code>.</p>
+        <p>
+          Instead of including both left and right operand always and so having null operand in fixed size array return
+          array with only non-null operands.
+        </p>
+      </li>
     </ul>
   </li>
 </ul>

--- a/src/org/elixir_lang/psi/impl/call/CallImpl.kt
+++ b/src/org/elixir_lang/psi/impl/call/CallImpl.kt
@@ -74,6 +74,7 @@ fun Call.computeReference(): PsiReference? =
                 }
                     ?: computeCallableReference()
             }
+
             parent.isSlashInCaptureNameSlashArity() -> null
             else -> computeCallableReference()
         }
@@ -86,6 +87,7 @@ private fun PsiElement.isCaptureNonNumericOperation(): Boolean =
         is ElixirMatchedCaptureNonNumericOperation,
         is ElixirUnmatchedCaptureNonNumericOperation ->
             true
+
         else ->
             false
     }
@@ -589,12 +591,21 @@ object CallImpl {
 
     @Contract(pure = true)
     @JvmStatic
-    fun primaryArguments(notIn: NotIn): Array<PsiElement?> {
+    fun primaryArguments(notIn: NotIn): Array<PsiElement> {
         val children = notIn.children
         val leftOperand = org.elixir_lang.psi.operation.not_in.Normalized.leftOperand(children)
-        val rightOperand = org.elixir_lang.psi.operation.not_in.Normalized.rightOperand(children)
 
-        return arrayOf(leftOperand, rightOperand)
+        return if (leftOperand != null) {
+            val rightOperand = org.elixir_lang.psi.operation.not_in.Normalized.rightOperand(children)
+
+            if (rightOperand != null) {
+                arrayOf(leftOperand, rightOperand)
+            } else {
+                arrayOf(leftOperand)
+            }
+        } else {
+            emptyArray()
+        }
     }
 
     @Contract(pure = true)


### PR DESCRIPTION
Fixes #2725

# Changelog
## Bug Fixes
* Ignore `null` operands for `not in` `primaryArguments()`.
  Instead of including both left and right operand always and so having null operand in fixed size array return array with only non-null operands.