### PR TITLE
Don't allow Elixir SDK without Erlang SDK to be selected for New Project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -587,6 +587,9 @@
 * [#3083](https://github.com/KronicDeth/intellij-elixir/pull/3083) - [@KronicDeth](https://github.com/KronicDeth)
   * Ignore `null` operands for `not in` `primaryArguments()`.
     Instead of including both left and right operand always and so having null operand in fixed size array return array with only non-null operands.
+* [#3085](https://github.com/KronicDeth/intellij-elixir/pull/3085) - [@KronicDeth](https://github.com/KronicDeth)
+  * Don't allow Elixir SDK without Erlang SDK to be selected for New Project.
+    The SDK has to be able to work for `mix new`.
 
 ## v14.0.0
 

--- a/resources/META-INF/changelog.html
+++ b/resources/META-INF/changelog.html
@@ -44,6 +44,10 @@
           array with only non-null operands.
         </p>
       </li>
+      <li>
+        <p>Don't allow Elixir SDK without Erlang SDK to be selected for New Project.</p>
+        <p>The SDK has to be able to work for <code>mix new</code>.</p>
+      </li>
     </ul>
   </li>
 </ul>


### PR DESCRIPTION
Fixes #2747

# Changelog
## Bug Fixes
* Don't allow Elixir SDK without Erlang SDK to be selected for New Project.
  The SDK has to be able to work for `mix new`.