### PR TITLE
Ignore strings, charlists, and sigils at the top of file when looking for doc comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -590,6 +590,8 @@
 * [#3085](https://github.com/KronicDeth/intellij-elixir/pull/3085) - [@KronicDeth](https://github.com/KronicDeth)
   * Don't allow Elixir SDK without Erlang SDK to be selected for New Project.
     The SDK has to be able to work for `mix new`.
+* [#3086](https://github.com/KronicDeth/intellij-elixir/pull/3086) - [@KronicDeth](https://github.com/KronicDeth)
+  * Ignore strings, charlists, and sigils at the top of file when looking for doc comments.
 
 ## v14.0.0
 

--- a/resources/META-INF/changelog.html
+++ b/resources/META-INF/changelog.html
@@ -48,6 +48,7 @@
         <p>Don't allow Elixir SDK without Erlang SDK to be selected for New Project.</p>
         <p>The SDK has to be able to work for <code>mix new</code>.</p>
       </li>
+      <li>Ignore strings, charlists, and sigils at the top of file when looking for doc comments.</li>
     </ul>
   </li>
 </ul>

--- a/src/org/elixir_lang/documentation/ElixirDocumentationProvider.kt
+++ b/src/org/elixir_lang/documentation/ElixirDocumentationProvider.kt
@@ -93,6 +93,8 @@ class ElixirDocumentationProvider : DocumentationProvider {
             is ElixirDecimalFloat, is ElixirDecimalWholeNumber, is ElixirHexadecimalWholeNumber,
                 // Containers
             is ElixirList, is ElixirMapOperation, is ElixirTuple,
+                // Strings, Charlists, and Sigils
+            is Parent,
             is PsiErrorElement
             -> Unit
 


### PR DESCRIPTION
Fixes #2932