### PR TITLE
Ignore top-level Aliases when collecting docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -592,6 +592,8 @@
     The SDK has to be able to work for `mix new`.
 * [#3086](https://github.com/KronicDeth/intellij-elixir/pull/3086) - [@KronicDeth](https://github.com/KronicDeth)
   * Ignore strings, charlists, and sigils at the top of file when looking for doc comments.
+* [#3097](https://github.com/KronicDeth/intellij-elixir/pull/3097) - [@KronicDeth](https://github.com/KronicDeth)
+  * Ignore top-level Aliases when collecting docs.
 
 ## v14.0.0
 

--- a/resources/META-INF/changelog.html
+++ b/resources/META-INF/changelog.html
@@ -49,6 +49,7 @@
         <p>The SDK has to be able to work for <code>mix new</code>.</p>
       </li>
       <li>Ignore strings, charlists, and sigils at the top of file when looking for doc comments.</li>
+      <li>Ignore top-level Aliases when collecting docs.</li>
     </ul>
   </li>
 </ul>

--- a/src/org/elixir_lang/documentation/ElixirDocumentationProvider.kt
+++ b/src/org/elixir_lang/documentation/ElixirDocumentationProvider.kt
@@ -95,6 +95,8 @@ class ElixirDocumentationProvider : DocumentationProvider {
             is ElixirList, is ElixirMapOperation, is ElixirTuple,
                 // Strings, Charlists, and Sigils
             is Parent,
+                // Aliases
+            is QualifiableAlias,
             is PsiErrorElement
             -> Unit
 


### PR DESCRIPTION
Fixes #2926