### PR TITLE
Find enclosing quote when defs are inside of an fn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -594,6 +594,9 @@
   * Ignore strings, charlists, and sigils at the top of file when looking for doc comments.
 * [#3097](https://github.com/KronicDeth/intellij-elixir/pull/3097) - [@KronicDeth](https://github.com/KronicDeth)
   * Ignore top-level Aliases when collecting docs.
+* [#3098](https://github.com/KronicDeth/intellij-elixir/pull/3098) - [@KronicDeth](https://github.com/KronicDeth)
+  * Ignored `unquote` calls when injecting docs.
+  * Find enclosing `quote` when `def`s are inside an `fn` as in Phoenix Route Helpers.
 
 ## v14.0.0
 

--- a/resources/META-INF/changelog.html
+++ b/resources/META-INF/changelog.html
@@ -50,6 +50,11 @@
       </li>
       <li>Ignore strings, charlists, and sigils at the top of file when looking for doc comments.</li>
       <li>Ignore top-level Aliases when collecting docs.</li>
+      <li>Ignored <code>unquote</code> calls when injecting docs.</li>
+      <li>
+        Find enclosing <code>quote</code> when <code>def</code>s are inside an <code>fn</code> as in
+        Phoenix Route Helpers.
+      </li>
     </ul>
   </li>
 </ul>

--- a/src/org/elixir_lang/injection/markdown/Injector.kt
+++ b/src/org/elixir_lang/injection/markdown/Injector.kt
@@ -31,6 +31,19 @@ class Injector : MultiHostInjector {
                 injectElixirInCodeBlocksInQuote(registrar, documentation)
             }
 
+            // Issue #2923 associated bug.  @moduledoc on unquote
+            //    #
+            //    # * We inline most of the code for performance, so it is specific
+            //    #   per helper module anyway.
+            //    #
+            //    code = quote do
+            //      @moduledoc unquote(docs) && """
+            //      Module with named helpers generated from #{inspect unquote(env.module)}.
+            //      """
+            //      unquote(defhelper)
+            //      unquote(defcatch_all)
+            //      unquote_splicing(impls)
+            is ElixirMatchedUnqualifiedParenthesesCall,
             is ElixirAlias,
                 // @external_resource "README.md"
                 // @moduledoc @external_resource


### PR DESCRIPTION
# Changelog
## Bug Fixes
* Ignored `unquote` calls when injecting docs.
* FInd enclosing `quote` when `def`s are inside an `fn` as in Phoenix Route Helpers.