### PR TITLE
Setting name on a call definition clause sets the name on the head instead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -601,6 +601,9 @@
   * Handle binary modules when processing protocols and implementations for line markers and definition search.
 * [#3100](https://github.com/KronicDeth/intellij-elixir/pull/3100) - [@KronicDeth](https://github.com/KronicDeth)
   * Skip unqualified no arguments calls when Ecto.Query.from arguments are being typed.
+* [#3103](https://github.com/KronicDeth/intellij-elixir/pull/3103) - [@KronicDeth](https://github.com/KronicDeth)
+  * Setting name on a call definition clause sets the name on the head instead.
+    The JetBrains API both renames the usage references AND the original element where the rename refactoring was started, but when started on a call definition clause the `functionNameElement` is the `def`, `defp`, `defmacro`, or `defmacrop` and so both the name of the call was changed, but the `def*` was also changed to the new name.  Now, if `setName` is called on a definition, the head is renamed instead.
 
 ## v14.0.0
 

--- a/resources/META-INF/changelog.html
+++ b/resources/META-INF/changelog.html
@@ -61,6 +61,16 @@
       <li>
         Skip unqualified no arguments calls when Ecto.Query.from arguments are being typed.
       </li>
+      <li>
+        <p>Setting name on a call definition clause sets the name on the head instead.</p>
+        <p>
+          The JetBrains API both renames the usage references AND the original element where the rename refactoring was
+          started, but when started on a call definition clause the <code>functionNameElement</code> is the
+          <code>def</code>, <code>defp</code>, <code>defmacro</code>, or <code>defmacrop</code> and so both the name of
+          the call was changed, but the <code>def*</code> was also changed to the new name.  Now, if
+          <code>setName</code> is called on a definition, the head is renamed instead.
+        </p>
+      </li>
     </ul>
   </li>
 </ul>

--- a/src/org/elixir_lang/psi/impl/PsiNamedElementImpl.kt
+++ b/src/org/elixir_lang/psi/impl/PsiNamedElementImpl.kt
@@ -104,14 +104,18 @@ object PsiNamedElementImpl {
         named: org.elixir_lang.psi.call.Named,
         newName: String
     ): PsiElement {
-        val functionNameElement = named.functionNameElement()
-        val newFunctionNameElementCall = ElementFactory.createUnqualifiedNoArgumentsCall(named.project, newName)
+        if (CallDefinitionClause.`is`(named)) {
+            CallDefinitionClause.head(named)?.let { it as? org.elixir_lang.psi.call.Named }?.setName(newName)
+        } else {
+            val functionNameElement = named.functionNameElement()
+            val newFunctionNameElementCall = ElementFactory.createUnqualifiedNoArgumentsCall(named.project, newName)
 
-        val nameNode = functionNameElement!!.node
-        val newNameNode = newFunctionNameElementCall.functionNameElement().node
+            val nameNode = functionNameElement!!.node
+            val newNameNode = newFunctionNameElementCall.functionNameElement().node
 
-        val node = nameNode.treeParent
-        node.replaceChild(nameNode, newNameNode)
+            val node = nameNode.treeParent
+            node.replaceChild(nameNode, newNameNode)
+        }
 
         return named
     }


### PR DESCRIPTION
…stead

Fixes #2094
Fixes #2917

# Changelog
## Bug Fixes
* Setting name on a call definition clause sets the name on the head instead.
  The JetBrains API both renames the usage references AND the original element where the rename refactoring was started, but when started on a call definition clause the `functionNameElement` is the `def`, `defp`, `defmacro`, or `defmacrop` and so both the name of the call was changed, but the `def*` was also changed to the new name.  Now, if `setName` is called on a definition, the head is renamed instead.