### PR TITLE
Check Elixir SDK has Erlang SDK before running dialyzer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -606,6 +606,9 @@
     The JetBrains API both renames the usage references AND the original element where the rename refactoring was started, but when started on a call definition clause the `functionNameElement` is the `def`, `defp`, `defmacro`, or `defmacrop` and so both the name of the call was changed, but the `def*` was also changed to the new name.  Now, if `setName` is called on a definition, the head is renamed instead.
 * [#3111](https://github.com/KronicDeth/intellij-elixir/pull/3111) - [@KronicDeth](https://github.com/KronicDeth)
   * Filter out Elixir SDKs that don't have an Erlang SDK when importing projects.
+* [#3121](https://github.com/KronicDeth/intellij-elixir/pull/3121) - [@KronicDeth](https://github.com/KronicDeth)
+  * Check Elixir SDK has Erlang SDK before running dialyzer.
+    Notify user of configuration error instead of throwin exceptiion when constructing `mix` commandline.
 
 ## v14.0.0
 

--- a/resources/META-INF/changelog.html
+++ b/resources/META-INF/changelog.html
@@ -72,6 +72,10 @@
         </p>
       </li>
       <li>Filter out Elixir SDKs that don't have an Erlang SDK when importing projects.</li>
+      <li>
+        <p>Check Elixir SDK has Erlang SDK before running dialyzer.</p>
+        <p>Notify user of configuration error instead of throwin exceptiion when constructing <code>mix</code> commandline.</p>
+      </li>
     </ul>
   </li>
 </ul>


### PR DESCRIPTION
Fixes #2913

# Changelog
## Bug Fixes
* Check Elixir SDK has Erlang SDK before running dialyzer.
  Notify user of configuration error instead of throwin exceptiion when constructing `mix` commandline.