### PR TITLE
Replace name with relative identifier instead of identifier for qualified calls on rename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -613,6 +613,9 @@
   * Log heredoc where Markdown cannot be injected.
 * [#3125](https://github.com/KronicDeth/intellij-elixir/pull/3125) - [@KronicDeth](https://github.com/KronicDeth)
   * Don't inject Markdown in empty heredoc docs.
+* [#3126](https://github.com/KronicDeth/intellij-elixir/pull/3126) - [@KronicDeth](https://github.com/KronicDeth)
+  * Log if new name element type does not match old name element type.
+  * Replace name with relative identifier instead of identifier for qualified calls on rename.
 
 ## v14.0.0
 

--- a/resources/META-INF/changelog.html
+++ b/resources/META-INF/changelog.html
@@ -78,6 +78,8 @@
       </li>
       <li>Log heredoc where Markdown cannot be injected.</li>
       <li>Don't inject markdown in empty heredoc docs.</li>
+      <li>Log if new name element type does not match old name element type.</li>
+      <li>Replace name with relative identifier instead of identifier for qualified calls on rename.</li>
     </ul>
   </li>
 </ul>

--- a/src/org/elixir_lang/psi/ElementFactory.java
+++ b/src/org/elixir_lang/psi/ElementFactory.java
@@ -56,6 +56,10 @@ public class ElementFactory {
         return onlyElementOfType(project, text, AtOperation.class);
     }
 
+    public static QualifiedNoArgumentsCall createQualifiedNoArgumentsCall(Project project, String qualifier, String name) {
+        return onlyElementOfType(project, qualifier + "." + name, QualifiedNoArgumentsCall.class);
+    }
+
     public static UnqualifiedNoArgumentsCall createUnqualifiedNoArgumentsCall(Project project, String name) {
         return onlyElementOfType(project, name, UnqualifiedNoArgumentsCall.class);
     }

--- a/src/org/elixir_lang/psi/impl/PsiNamedElementImpl.kt
+++ b/src/org/elixir_lang/psi/impl/PsiNamedElementImpl.kt
@@ -5,6 +5,7 @@ import com.intellij.openapi.application.runReadAction
 import com.intellij.openapi.util.Computable
 import com.intellij.psi.PsiElement
 import org.elixir_lang.Name
+import org.elixir_lang.errorreport.Logger
 import org.elixir_lang.module.PutAttribute
 import org.elixir_lang.module.RegisterAttribute
 import org.elixir_lang.psi.*
@@ -111,10 +112,20 @@ object PsiNamedElementImpl {
             val newFunctionNameElementCall = ElementFactory.createUnqualifiedNoArgumentsCall(named.project, newName)
 
             val nameNode = functionNameElement!!.node
+            val nameElementType = nameNode.elementType
             val newNameNode = newFunctionNameElementCall.functionNameElement().node
+            val newNameElementType = newNameNode.elementType
 
-            val node = nameNode.treeParent
-            node.replaceChild(nameNode, newNameNode)
+            if (nameElementType == newNameElementType) {
+                val node = nameNode.treeParent
+                node.replaceChild(nameNode, newNameNode)
+            } else {
+                Logger.error(
+                    javaClass,
+                    "New name node elementType (${newNameElementType}) does not match old name node elementType (${nameElementType})",
+                    named
+                )
+            }
         }
 
         return named


### PR DESCRIPTION
# Changelog
## Bug Fixes
* Log if new name element type does not match old name element type.
* Replace name with relative identifier instead of identifier for qualified calls on rename.