### PR TITLE
Keep looking for variants above terminal resolution constructs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -616,6 +616,14 @@
 * [#3126](https://github.com/KronicDeth/intellij-elixir/pull/3126) - [@KronicDeth](https://github.com/KronicDeth)
   * Log if new name element type does not match old name element type.
   * Replace name with relative identifier instead of identifier for qualified calls on rename.
+* [#3127](https://github.com/KronicDeth/intellij-elixir/pull/3127) - [@KronicDeth](https://github.com/KronicDeth)
+  * Keep looking for variants above if and unless 
+    `if` and `unless` used to call `keepProcessing()` after checking if the child calls when resolving or searching for variants, but Variants returned `false` always from `keepProcessing()`.
+  
+    This stops the variant search from terminating inside of an `if` or `unless` when it wouldn't outside of one as was reported in [#2751](https://github.com/KronicDeth/intellij-elixir/issues/2751).
+  * List `Kernel` and `Kernel.SpecialForms` variants inside modulars.
+    Keep processing at end of modulars when looking for variants, which will check the implicit imports of `Kernel` and `Kernel.SpecialForms`.
+  * Prevent listing variants from outer module in nested module 
 
 ## v14.0.0
 

--- a/gen/org/elixir_lang/psi/scope/call_definition_clause/Variants.kt
+++ b/gen/org/elixir_lang/psi/scope/call_definition_clause/Variants.kt
@@ -166,7 +166,7 @@ class Variants : CallDefinitionClause() {
      *
      * @return `true` to keep searching up the PSI tree; `false` to stop searching.
      */
-    override fun keepProcessing(): Boolean = false
+    override fun keepProcessing(): Boolean = true
 
 
     companion object {

--- a/resources/META-INF/changelog.html
+++ b/resources/META-INF/changelog.html
@@ -80,6 +80,24 @@
       <li>Don't inject markdown in empty heredoc docs.</li>
       <li>Log if new name element type does not match old name element type.</li>
       <li>Replace name with relative identifier instead of identifier for qualified calls on rename.</li>
+      <li>
+        <p>Keep looking for variants above <code>if</code> and <code>unless</code>.</p>
+        <p>
+          <code>if</code> and <code>unless</code> used to call <code>keepProcessing()</code> after checking if the child
+          calls when resolving or searching for variants, but Variants returned <code>false</code> always from
+          <code>keepProcessing()</code>.
+        </p>
+        <p>
+          This stops the variant search from terminating inside of an <code>if</code> or <code>unless</code> when it
+          wouldn't outside of one as was reported in
+          <a href="https://github.com/KronicDeth/intellij-elixir/issues/2751">#2751</a>.
+        </p>
+      </li>
+      <li>
+        <p>List `Kernel` and `Kernel.SpecialForms` variants inside modulars.</p>
+        <p>Keep processing at end of modulars when looking for variants, which will check the implicit imports of `Kernel` and `Kernel.SpecialForms`.</p>
+      </li>
+      <li>Prevent listing variants from outer module in nested module.</li>
     </ul>
   </li>
 </ul>
@@ -92,7 +110,7 @@
     </ul>
   </li>
   <li>
-    <p>Enhancments</p>
+    /<p>Enhancments</p>
     <ul>
       <li>Add 2022.3 compatibility.</li>
     </ul>

--- a/src/org/elixir_lang/psi/scope/CallDefinitionClause.kt
+++ b/src/org/elixir_lang/psi/scope/CallDefinitionClause.kt
@@ -136,7 +136,7 @@ abstract class CallDefinitionClause : PsiScopeProcessor {
                     }
                 }
 
-                keepProcessing()
+                true
             }
             Import.`is`(element) -> {
                 try {

--- a/testData/org/elixir_lang/reference/callable/issue_2751/inside_if.ex
+++ b/testData/org/elixir_lang/reference/callable/issue_2751/inside_if.ex
@@ -1,0 +1,15 @@
+defmodule Foo do
+  def foo do
+    if true do
+      b<caret>
+    end
+  end
+
+  def bar do
+    "bar"
+  end
+
+  def baz do
+    "baz"
+  end
+end

--- a/testData/org/elixir_lang/reference/callable/issue_2751/outside_if.ex
+++ b/testData/org/elixir_lang/reference/callable/issue_2751/outside_if.ex
@@ -1,0 +1,15 @@
+defmodule Foo do
+  def foo do
+    if true do
+    end
+    b<caret>
+  end
+
+  def bar do
+    "bar"
+  end
+
+  def baz do
+    "baz"
+  end
+end

--- a/tests/org/elixir_lang/reference/callable/Issue2751Test.kt
+++ b/tests/org/elixir_lang/reference/callable/Issue2751Test.kt
@@ -1,0 +1,52 @@
+package org.elixir_lang.reference.callable
+
+import com.intellij.codeInsight.completion.CompletionType
+import com.intellij.codeInsight.lookup.LookupElementBuilder
+import org.elixir_lang.PlatformTestCase
+
+/**
+ * https://github.com/KronicDeth/intellij-elixir/issues/2751
+ */
+class Issue2751Test : PlatformTestCase() {
+    fun testInsideIf() {
+        myFixture.configureByFile("inside_if.ex")
+        val completions = myFixture.complete(CompletionType.BASIC, 1)
+
+        assertEquals(2, completions.size)
+
+        assertInstanceOf(completions[0], LookupElementBuilder::class.java)
+
+        val firstCompletion = completions[0] as LookupElementBuilder
+
+        assertEquals("bar", firstCompletion.lookupString)
+
+        assertInstanceOf(completions[1], LookupElementBuilder::class.java)
+
+        val secondCompletion = completions[1] as LookupElementBuilder
+
+        assertEquals("baz", secondCompletion.lookupString)
+    }
+
+    fun testOutsideIf() {
+        myFixture.configureByFile("outside_if.ex")
+        val completions = myFixture.complete(CompletionType.BASIC, 1)
+
+        assertEquals(2, completions.size)
+
+        assertInstanceOf(completions[0], LookupElementBuilder::class.java)
+
+        val firstCompletion = completions[0] as LookupElementBuilder
+
+        assertEquals("bar", firstCompletion.lookupString)
+
+        assertInstanceOf(completions[1], LookupElementBuilder::class.java)
+
+        val secondCompletion = completions[1] as LookupElementBuilder
+
+        assertEquals("baz", secondCompletion.lookupString)
+    }
+
+    override fun getTestDataPath(): String {
+        return "testData/org/elixir_lang/reference/callable/issue_2751"
+    }
+}


### PR DESCRIPTION
Fixes #2751

![Screenshot 2023-03-20 at 8 58 06 AM](https://user-images.githubusercontent.com/298259/226364991-ff77ebd7-e93e-40de-b818-7291bce27db2.png)

# Changelog
## Bug Fixes
* Keep looking for variants above if and unless 
  `if` and `unless` used to call `keepProcessing()` after checking if the child calls when resolving or searching for variants, but Variants returned `false` always from `keepProcesssing()`.

This stops the variant search from terminating inside of an `if` or `unless` when it wouldn't outside of one as was reported in https://github.com/KronicDeth/intellij-elixir/issues/2751.
* List `Kernel` and `Kernel.SpecialForms` variants inside modulars.
  Keep processing at end of modulars when looking for variants, which will check the implicit imports of `Kernel` and `Kernel.SpecialForms`.
* Prevent listing variants from outer module in nested module
