### PR TITLE
Validate `--app` is set correctly for new projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -626,7 +626,14 @@
   * Prevent listing variants from outer module in nested module 
 * [#3139](https://github.com/KronicDeth/intellij-elixir/pull/3139) - [@KronicDeth](https://github.com/KronicDeth)
   * Log the accumulated and target usage type that cannot be folded.
-
+* [#3140](https://github.com/KronicDeth/intellij-elixir/pull/3140) - [@KronicDeth](https://github.com/KronicDeth)
+  * Fix reporting `mix new` errors as notifications
+    * Don't associate mix new errors with new project as it doesn't have a frame, so the notification was suppressed before.
+    * Strip color codes from mix new error notification.
+  * Validate `--app` is set correctly for new projects
+    * If inferred from project name, make sure the name is valid application name the same as `mix new` does.
+    * If `--app` is set explicitly, make sure it follows naming rules for `mix new`.
+  
 ## v14.0.0
 
 ### Incompatible Changes

--- a/resources/META-INF/changelog.html
+++ b/resources/META-INF/changelog.html
@@ -99,6 +99,18 @@
       </li>
       <li>Prevent listing variants from outer module in nested module.</li>
       <li>Log the accumulated and target usage type that cannot be folded.</li>
+      <li>Fix reporting <code>mix new</code> errors as notifications
+        <ul dir="auto">
+          <li>Don't associate mix new errors with new project as it doesn't have a frame, so the notification was suppressed before.</li>
+          <li>Strip color codes from mix new error notification.</li>
+        </ul>
+      </li>
+      <li>Validate <code>--app</code> is set correctly for new projects
+        <ul dir="auto">
+          <li>If inferred from project name, make sure the name is valid application name the same as <code>mix new</code> does.</li>
+          <li>If <code>--app</code> is set explicitly, make sure it follows naming rules for <code>mix new</code>.</li>
+        </ul>
+      </li>
     </ul>
   </li>
 </ul>

--- a/src/org/elixir_lang/new_project_wizard/Step.kt
+++ b/src/org/elixir_lang/new_project_wizard/Step.kt
@@ -68,6 +68,31 @@ class Step(parent: NewProjectWizardLanguageStep) : AbstractNewProjectWizardStep(
                     textField()
                         .bindText(mixNewAppProperty)
                         .horizontalAlign(HorizontalAlign.FILL)
+                        .validationOnApply {
+                            if (mixNewApp.isNullOrBlank()) {
+                                val name = this@Step.name
+
+                                if (!name.matches(APPLICATION_NAME_REGEX)) {
+                                    error(
+                                        "Application name ust start with a lowercase ASCII letter, followed by " +
+                                                "lowercase ASCII letters, numbers, or underscores, got: \"${name}\"" +
+                                                ". The application name is inferred from the path, if you'd like to" +
+                                                " explicitly name the application set --app"
+                                    )
+                                } else {
+                                    null
+                                }
+                            } else {
+                                if (!mixNewApp.matches(APPLICATION_NAME_REGEX)) {
+                                    error(
+                                        "Application name ust start with a lowercase ASCII letter, followed by " +
+                                                "lowercase ASCII letters, numbers, or underscores."
+                                    )
+                                } else {
+                                    null
+                                }
+                            }
+                        }
                 }.bottomGap(BottomGap.SMALL)
                 row("--module") {
                     textField()
@@ -191,6 +216,7 @@ private val ANY_SDK_FILTER: ((Sdk) -> Boolean) = { true }
 private val ANY_SDK_TYPE_FILTER: ((SdkTypeId) -> Boolean) = { true }
 private val ANY_SUGGESTED_SDK_FILTER: ((SdkListItem.SuggestedItem) -> Boolean) = { true }
 private val NEW_SDK_CALLBACK_DEFAULT: ((Sdk) -> Unit) = {}
+private val APPLICATION_NAME_REGEX: Regex = Regex("[a-z]([a-z0-9_])*")
 
 fun Row.elixirSdkComboBox(context: WizardContext, sdkProperty: ObservableMutableProperty<Sdk?>): Cell<JdkComboBox> {
     val sdksModel = ProjectSdksModel()

--- a/src/org/elixir_lang/new_project_wizard/Step.kt
+++ b/src/org/elixir_lang/new_project_wizard/Step.kt
@@ -136,10 +136,12 @@ class Step(parent: NewProjectWizardLanguageStep) : AbstractNewProjectWizardStep(
             } else if (processOutput.isTimeout) {
                 throw TimeoutException()
             } else if (processOutput.exitCode != 0) {
+                val stderrWithoutColorCodes = processOutput.stderr.replace(Regex("\u001B\\[[;\\d]*m"), "")
+
                 NotificationGroupManager
                     .getInstance()
                     .getNotificationGroup("Elixir")
-                    .createNotification("mix new failed", processOutput.stderr, NotificationType.ERROR)
+                    .createNotification("mix new failed", stderrWithoutColorCodes, NotificationType.ERROR)
                     // project will fail to initialize and not have a window, so don't use `project`
                     .notify(null)
 

--- a/src/org/elixir_lang/new_project_wizard/Step.kt
+++ b/src/org/elixir_lang/new_project_wizard/Step.kt
@@ -140,7 +140,8 @@ class Step(parent: NewProjectWizardLanguageStep) : AbstractNewProjectWizardStep(
                     .getInstance()
                     .getNotificationGroup("Elixir")
                     .createNotification("mix new failed", processOutput.stderr, NotificationType.ERROR)
-                    .notify(project)
+                    // project will fail to initialize and not have a window, so don't use `project`
+                    .notify(null)
 
                 throw IOException()
             }


### PR DESCRIPTION
# Changelog
## Bug Fixes
* Fix reporting `mix new` errors as notifications
  * Don't associate mix new errors with new project as it doesn't have a frame, so the notification was suppressed before.
  * Strip color codes from mix new error notification.
* Validate `--app` is set correctly for new projects
  * If inferred from project name, make sure the name is valid application name the same as `mix new` does.
  * If `--app` is set explicitly, make sure it follows naming rules for `mix new`.