### PR TITLE
Re-enable canary releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   test:

--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ Table of Contents[![Backers on Open Collective](https://opencollective.com/intel
 
 # Elixir plugin
 
-[![Build Status](https://travis-ci.org/KronicDeth/intellij-elixir.svg?branch=master)](https://travis-ci.org/KronicDeth/intellij-elixir)
+[![Build Status](https://travis-ci.org/KronicDeth/intellij-elixir.svg?branch=main)](https://travis-ci.org/KronicDeth/intellij-elixir)
 
 This is a plugin that adds support for [Elixir](http://elixir-lang.org/) to JetBrains IDEs.
 
@@ -5775,7 +5775,7 @@ The Visibility icons indicated whether the element is usable outside its definin
 
 ### Canary releases
 
-Builds on `master` will produce pre-release builds of format `NEXT_VERSION-pre+YYYYMMDDHHMMSS`.
+Builds on `main` will produce pre-release builds of format `NEXT_VERSION-pre+YYYYMMDDHHMMSS`.
 
 #### Inside IDE using JetBrains repository
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -4,7 +4,7 @@
 
 Any changes to the README are delayed until the last PR before release because in the past new users have read the
 README and assumed that any features in the README MUST exist in the version they can install from the JetBrains
-repository, so documenting `master` features in the README leads to just more support work.
+repository, so documenting `main` features in the README leads to just more support work.
 
 ## Build Release
 


### PR DESCRIPTION
I think that the GitHub Action for making canary releases was overlooked when the default branch was renamed. Hopefully this PR will resolve that. This assumes that the GitHub Action is still functional and just needs to be triggered on the correct branch. 