### PR TITLE
Update since build for RubyMine and WebStorm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -280,6 +280,13 @@
 
 </details>
 
+## v15.0.1
+
+### Bug Fixes
+* [#3183](https://github.com/KronicDeth/intellij-elixir/pull/3183) - [@vanderson139](https://github.com/vanderson139)
+  * Support 2023.1 RubyMine and WebStorm.
+    RubyMine and WebStorm have a `FIX` version of `174`, which is less than IntelliJ's `175` in IntelliJ 2023.1's builder number, `231.8109.175`.
+
 ## v15.0.0
 
 ### Incompatible Changes

--- a/build.gradle
+++ b/build.gradle
@@ -69,7 +69,7 @@ allprojects {
         changeNotes.set(bodyInnerHTML("resources/META-INF/changelog.html"))
         pluginDescription.set(bodyInnerHTML("resources/META-INF/description.html"))
 
-        sinceBuild = "231.8109.175"
+        sinceBuild = "231.8109.174"
         untilBuild = "231.*"
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 # Available idea versions:
 # https://www.jetbrains.com/intellij-repository/releases
 # https://www.jetbrains.com/intellij-repository/snapshots
-baseVersion=15.0.0
+baseVersion=15.0.1
 ideaVersion=2023.1
 # MUST stay at 1.8 for JPS (Build/Compile Project) compatibility even if JRE/JBR is newer
 javaVersion=17

--- a/resources/META-INF/changelog.html
+++ b/resources/META-INF/changelog.html
@@ -1,5 +1,20 @@
 <html>
 <body>
+<h1>v15.0.1</h1>
+<ul>
+  <li>
+    <p>Bug Fixes</p>
+    <ul>
+      <li>
+        <p>Support 2023.1 RubyMine and WebStorm.</p>
+        <p>
+          RubyMine and WebStorm have a <code>FIX</code> version of <code>174</code>, which is less than IntelliJ's
+          <code>175</code> in IntelliJ 2023.1's builder number, <code>231.8109.175</code>.
+        </p>
+      </li>
+    </ul>
+  </li>
+</ul>
 <h1>v15.0.0</h1>
 <ul>
   <li>
@@ -25,7 +40,7 @@
         </p>
       </li>
       <li>Re-enable canary releases.</li>
-      <li>Remove duplicate dependency on `com.intellij.modules.java` plugin.</li>
+      <li>Remove duplicate dependency on <code>com.intellij.modules.java</code> plugin.</li>
     </ul>
   </li>
 </ul>


### PR DESCRIPTION
Latest build for RubyMine 2023.1 is 231.8109.174
https://www.jetbrains.com/ruby/download/other.html