### PR TITLE
Include mix new stderr in IOException for better triage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -298,6 +298,8 @@
   * `findModuleForPsiElement` in `mostSpecificSdk` in read action.
 * [#3250](https://github.com/KronicDeth/intellij-elixir/pull/3250) - [@KronicDeth](https://github.com/KronicDeth)
   * Skip finding `mix.exs` for OTP apps if it can't be read.
+* [#3251](https://github.com/KronicDeth/intellij-elixir/pull/3251) - [@KronicDeth](https://github.com/KronicDeth)
+  * Include `mix new` stderr in `IOException` for better triage.
 
 ## v15.0.1
 

--- a/resources/META-INF/changelog.html
+++ b/resources/META-INF/changelog.html
@@ -13,6 +13,7 @@
       <li>Don't resolve built-in types against the index if index is updating.</li>
       <li><code>findModuleForPsiElement</code> in <code>mostSpecificSdk</code> in read action.</li>
       <li>Skip finding <code>mix.exs</code> for OTP apps if it can't be read.</li>
+      <li>Include <code>mix new</code> stderr in <code>IOException</code> for better triage.</li>
     </ul>
   </li>
 </ul>

--- a/src/org/elixir_lang/new_project_wizard/Step.kt
+++ b/src/org/elixir_lang/new_project_wizard/Step.kt
@@ -169,7 +169,7 @@ class Step(parent: NewProjectWizardLanguageStep) : AbstractNewProjectWizardStep(
                     // project will fail to initialize and not have a window, so don't use `project`
                     .notify(null)
 
-                throw IOException()
+                throw IOException("mix new failed: $stderrWithoutColorCodes")
             }
 
             super.setupProject(project)


### PR DESCRIPTION
Until it can be determined how to exit the `setupProject` step cleanly, make the error reporting better for better pre-validation.

Fixes #3238