### PR TITLE
Exclude .elixir_ls directory when configuring new Projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@
   * Don't include `null` target usage types when finding usage type across all targets.
 * [#3262](https://github.com/KronicDeth/intellij-elixir/pull/3262) - [@KronicDeth](https://github.com/KronicDeth)
   * Skip bare Aliases when resolving Types.
+* [#3263](https://github.com/KronicDeth/intellij-elixir/pull/3263) - [@KronicDeth](https://github.com/KronicDeth)
+  * Exclude `.elixir_ls` directory when configuring new `Project`s.
+    If the `.elixir_ls` directory is included the `.beam` it produces can interfere with normal `StubIndex`.
 
 ## v15.0.1
 

--- a/resources/META-INF/changelog.html
+++ b/resources/META-INF/changelog.html
@@ -24,6 +24,11 @@
             </li>
             <li>Don't include <code>null</code> target usage types when finding usage type across all targets.</li>
             <li>Skip bare Aliases when resolving Types.</li>
+            <li>
+                <p>Exclude <code>.elixir_ls</code> directory when configuring new <code>Project</code>s.</p>
+                <p>If the <code>.elixir_ls</code> directory is included the <code>.beam</code> it produces can interfere
+                    with normal <code>StubIndex</code>.</p>
+            </li>
         </ul>
     </li>
 </ul>

--- a/src/org/elixir_lang/mix/Project.kt
+++ b/src/org/elixir_lang/mix/Project.kt
@@ -129,6 +129,8 @@ object Project {
         addSourceDirToContent(content, root, "spec", true)
         addSourceDirToContent(content, root, "test", true)
 
+        // Directory added by Elixir Language Server
+        excludeDirFromContent(content, root, ".elixir_ls")
         // Weird symlink phoenix and phoenix_html make to themselves in deps
         excludeDirFromContent(content, root, "assets/node_modules/phoenix")
         excludeDirFromContent(content, root, "assets/node_modules/phoenix_html")


### PR DESCRIPTION
Fixes #3174

If the `.elixir_ls` directory is included the `.beam` it produces can interfere with normal `StubIndex` creation.