### PR TITLE
Enable 232 version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        ideaVersion: [ "2023.1" ]
+        ideaVersion: [ "2023.2" ]
 
     steps:
       - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,73 +1,15 @@
 # Changelog
 
-## v15.1.0
-
-### Enhancemnts
-* [#3279](https://github.com/KronicDeth/intellij-elixir/pull/3279) - [@osbre](https://github.com/osbre)
-  * Add "Homebrew on Linux" SDK locations.
-
-### Bug Fixes
-* [#3185](https://github.com/KronicDeth/intellij-elixir/pull/3213) - [@KronicDeth](https://github.com/KronicDeth)
-  * Replace uses of `Cell.horizontalAlign(HorizontalAlign)`
-    The API is scheduled for removal and is replaced by `Call.align(AlignX.FILL)`.
-* [#3214](https://github.com/KronicDeth/intellij-elixir/pull/3214) - [@KronicDeth](https://github.com/KronicDeth)
-  * Ignore `group:` for docs.
-* [#3242](https://github.com/KronicDeth/intellij-elixir/pull/3242) - [@KronicDeth](https://github.com/KronicDeth)
-  * Don't resolve built-in types against the index if index is updating.
-* [#3249](https://github.com/KronicDeth/intellij-elixir/pull/3249) - [@KronicDeth](https://github.com/KronicDeth)
-  * `findModuleForPsiElement` in `mostSpecificSdk` in read action.
-* [#3250](https://github.com/KronicDeth/intellij-elixir/pull/3250) - [@KronicDeth](https://github.com/KronicDeth)
-  * Skip finding `mix.exs` for OTP apps if it can't be read.
-* [#3251](https://github.com/KronicDeth/intellij-elixir/pull/3251) - [@KronicDeth](https://github.com/KronicDeth)
-  * Include `mix new` stderr in `IOException` for better triage.
-* [#3251](https://github.com/KronicDeth/intellij-elixir/pull/3251) - [@KronicDeth](https://github.com/KronicDeth)
-  * Include `mix new` stderr in `IOException` for better triage.
-* [#3252](https://github.com/KronicDeth/intellij-elixir/pull/3252) - [@KronicDeth](https://github.com/KronicDeth)
-  * Highlight binary numbers as usual in types.
-* [#3253](https://github.com/KronicDeth/intellij-elixir/pull/3253) - [@KronicDeth](https://github.com/KronicDeth)
-  * Highlight module attributes as usual in types.
-* [#3254](https://github.com/KronicDeth/intellij-elixir/pull/3254) - [@KronicDeth](https://github.com/KronicDeth)
-  * Use `org.apache.commons.lang.SystemUtils` instead of `org.codehaus.plexus.interpolation.os.Os` to detect if on Windows for Test marker file URL.
-* [#3260](https://github.com/KronicDeth/intellij-elixir/pull/3260) - [@KronicDeth](https://github.com/KronicDeth)
-  * Call `FileIndex.getContentRootForFile` in `ReadAction` when getting working directory for `mix format`.
-* [#3261](https://github.com/KronicDeth/intellij-elixir/pull/3261) - [@KronicDeth](https://github.com/KronicDeth)
-  * Don't include `null` target usage types when finding usage type across all targets.
-* [#3262](https://github.com/KronicDeth/intellij-elixir/pull/3262) - [@KronicDeth](https://github.com/KronicDeth)
-  * Skip bare Aliases when resolving Types.
-* [#3263](https://github.com/KronicDeth/intellij-elixir/pull/3263) - [@KronicDeth](https://github.com/KronicDeth)
-  * Exclude `.elixir_ls` directory when configuring new `Project`s.
-    If the `.elixir_ls` directory is included the `.beam` it produces can interfere with normal `StubIndex`.
-* [#3271](https://github.com/KronicDeth/intellij-elixir/pull/3271) - [@KronicDeth](https://github.com/KronicDeth)
-  * Check if Internal Erlang SDK home path exists for SDK for New Project.
-* [#3288](https://github.com/KronicDeth/intellij-elixir/pull/3288) - [@KronicDeth](https://github.com/KronicDeth)
-  * Stop `prependingQualifiers` at EEx tags.
-
-## v15.0.1
-
-### Bug Fixes
-* [#3183](https://github.com/KronicDeth/intellij-elixir/pull/3183) - [@vanderson139](https://github.com/vanderson139)
-  * Support 2023.1 RubyMine and WebStorm.
-    RubyMine and WebStorm have a `FIX` version of `174`, which is less than IntelliJ's `175` in IntelliJ 2023.1's builder number, `231.8109.175`.
-
-## v15.0.0
+## v16.0.0
 
 ### Incompatible Changes
-* [#3146](https://github.com/KronicDeth/intellij-elixir/pull/3146) - [@ViseLuca](https://github.com/ViseLuca)
-  * Drop support for <= 2022 IDEs.
+* [#3327](https://github.com/KronicDeth/intellij-elixir/pull/3327) - [@marceloneppel](https://github.com/marceloneppel)
+  * Drop support for <= 2023.1 IDEs.
 
 ### Enhancements
-* [#3146](https://github.com/KronicDeth/intellij-elixir/pull/3146) - [@ViseLuca](https://github.com/ViseLuca)
-  * Support 2023.1 IDEs.
+* [#3327](https://github.com/KronicDeth/intellij-elixir/pull/3327) - [@marceloneppel](https://github.com/marceloneppel)
+  * Support 2023.2 IDEs.
 
-### Bug Fixes
-* [#3172](https://github.com/KronicDeth/intellij-elixir/pull/3172) - [@KronicDeth](https://github.com/KronicDeth)
-  * Ignore from preload list that doesn't have square brackets.
-    When trying to resolve keyword keys to `from`, don't error on unknown keys if any previous key was preload as this may be a list of preloads that is missing the square brackets.
-* [#3176](https://github.com/KronicDeth/intellij-elixir/pull/3176) - [@sh41](https://github.com/sh41)
-  * Re-enable canary releases.
-* [#3180](https://github.com/KronicDeth/intellij-elixir/pull/3180) - [@KronicDeth](https://github.com/KronicDeth)
-  * Remove duplicate dependency on `com.intellij.modules.java` plugin.
+## v15
 
-## v14
-
-The [CHANGELOG for v14](https://github.com/KronicDeth/intellij-elixir/blob/v14.0.1/CHANGELOG.md) can be found in [the v14.01 tag](https://github.com/KronicDeth/intellij-elixir/tree/v14.0.1).
+The [CHANGELOG for v15](https://github.com/KronicDeth/intellij-elixir/blob/v15.1.0/CHANGELOG.md) can be found in [the v14.1.0 tag](https://github.com/KronicDeth/intellij-elixir/tree/v14.1.0).

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id "org.jetbrains.intellij" version "1.13.3"
-    id "org.jetbrains.kotlin.jvm" version "1.7.20"
+    id "org.jetbrains.kotlin.jvm" version "1.9.0"
     id "de.undercouch.download" version "4.1.2"
 }
 
@@ -69,8 +69,8 @@ allprojects {
         changeNotes.set(bodyInnerHTML("resources/META-INF/changelog.html"))
         pluginDescription.set(bodyInnerHTML("resources/META-INF/description.html"))
 
-        sinceBuild = "231.8109.174"
-        untilBuild = "231.*"
+        sinceBuild = "232.8660.143"
+        untilBuild = "232.*"
     }
 
     publishPlugin {
@@ -82,7 +82,7 @@ allprojects {
     }
 
     runPluginVerifier {
-        ideVersions = ["2023.1"]
+        ideVersions = ["2023.2"]
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,8 +1,8 @@
 # Available idea versions:
 # https://www.jetbrains.com/intellij-repository/releases
 # https://www.jetbrains.com/intellij-repository/snapshots
-baseVersion=15.1.0
-ideaVersion=2023.1
+baseVersion=16.0.0
+ideaVersion=2023.2
 # MUST stay at 1.8 for JPS (Build/Compile Project) compatibility even if JRE/JBR is newer
 javaVersion=17
 javaTargetVersion=17

--- a/resources/META-INF/changelog.html
+++ b/resources/META-INF/changelog.html
@@ -1,5 +1,20 @@
 <html>
 <body>
+<h1>v16.0.0</h1>
+<ul>
+    <li>
+        <p>Incompatible Changes</p>
+        <ul>
+            <li>Drop support for <= 2023.1 IDEs.</li>
+        </ul>
+    </li>
+    <li>
+        <p>Enhancements</p>
+        <ul>
+            <li>Support 2023.2 IDEs.</li>
+        </ul>
+    </li>
+</ul>
 <h1>v15.1.0</h1>
 <ul>
     <li>

--- a/src/org/elixir_lang/mix/project/_import/step/ElixirSdkForModuleStep.kt
+++ b/src/org/elixir_lang/mix/project/_import/step/ElixirSdkForModuleStep.kt
@@ -75,7 +75,7 @@ class ElixirSdkForModuleStep(private val wizardContext: WizardContext) : ModuleW
         )
 
         val jdkLabel = JLabel(JavaUiBundle.message("label.project.jdk")).apply {
-            font = StartupUiUtil.getLabelFont().deriveFont(Font.BOLD)
+            font = StartupUiUtil.labelFont.deriveFont(Font.BOLD)
         }
         add(
             jdkLabel, GridBagConstraints(


### PR DESCRIPTION
2023.2 (232 version) was released last week, and it doesn't support the current plugin version.

Fixes https://github.com/KronicDeth/intellij-elixir/issues/3325.
Fixes https://github.com/KronicDeth/intellij-elixir/issues/3326.