### PR TITLE
Add displayName in plugin.xml for configurables for faster menu loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## v16.0.1
+
+### Bug Fixes
+* [#3431](https://github.com/KronicDeth/intellij-elixir/pull/3431) - [@KronicDeth](https://github.com/KronicDeth)
+  * Add `displayName` in `plugin.xml` for configurables for faster menu loading.
+    * `org.elixir_lang.facet.configurable.Project` - "Elixir"
+    * `org.elixir_lang.facets.sdks.erlang.Configurable` - "Internal Erlang SDKs"
+    * `org.elixir_lang.facets.sdks.elixir.Configurable` - "SDKs"
+
 ## v16.0.0
 
 ### Incompatible Changes

--- a/resources/META-INF/changelog.html
+++ b/resources/META-INF/changelog.html
@@ -1,5 +1,20 @@
 <html>
 <body>
+<h1>v16.0.1</h1>
+<ul>
+    <li>
+        <p>Bug Fixes</p>
+        <ul>
+            <li>Add <code>displayName</code> in <code>plugin.xml</code> for configurables for faster menu loading.
+                <ul dir="auto">
+                    <li><code>org.elixir_lang.facet.configurable.Project</code> - "Elixir"</li>
+                    <li><code>org.elixir_lang.facets.sdks.erlang.Configurable</code> - "Internal Erlang SDKs"</li>
+                    <li><code>org.elixir_lang.facets.sdks.elixir.Configurable</code> - "SDKs"</li>
+                </ul>
+            </li>
+        </ul>
+    </li>
+</ul>
 <h1>v16.0.0</h1>
 <ul>
     <li>

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -88,6 +88,7 @@
         <!-- Facet -->
         <applicationConfigurable id="language.elixir.sdks.elixir"
                                  parentId="language.elixir"
+                                 displayName="SDKs"
                                  provider="org.elixir_lang.facet.sdks.elixir.Provider"/>
         <applicationConfigurable id="language.elixir.sdks.erlang"
                                  parentId="language.elixir"

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -98,6 +98,7 @@
                             serviceInterface="org.elixir_lang.facet.SdksService"/>
         <projectConfigurable id="language.elixir"
                              parentId="language"
+                             displayName="Elixir"
                              provider="org.elixir_lang.facet.configurable.Provider"/>
 
         <facetType implementation="org.elixir_lang.facet.Type"/>

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -92,6 +92,7 @@
                                  provider="org.elixir_lang.facet.sdks.elixir.Provider"/>
         <applicationConfigurable id="language.elixir.sdks.erlang"
                                  parentId="language.elixir"
+                                 displayName="Internal Erlang SDKs"
                                  provider="org.elixir_lang.facet.sdks.erlang.Provider"/>
         <applicationService serviceImplementation="org.elixir_lang.facet.SdksService"
                             serviceInterface="org.elixir_lang.facet.SdksService"/>


### PR DESCRIPTION
# Changelog
## Bug Fixes
* Add `displayName` in `plugin.xml` for configurables for faster menu loading.
  * `org.elixir_lang.facet.configurable.Project` - "Elixir"
  * `org.elixir_lang.facets.sdks.erlang.Configurable` - "Internal Erlang SDKs"
  * `org.elixir_lang.facets.sdks.elixir.Configurable` - "SDKs"