### PR TITLE
Render code snippets that are not links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
-## v17
+## v17.0.1
+
+### Bug Fixes
+* [#3491](https://github.com/KronicDeth/intellij-elixir/pull/3491) - [neominik](https://github.com/neominik)
+  * Render code snippets that are not links.
+
+## v17.0.0
 
 ### Breaking changes
 * [#3500](https://github.com/KronicDeth/intellij-elixir/pull/3500) - [@KronicDeth](https://github.com/KronicDeth)

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 # Available idea versions:
 # https://www.jetbrains.com/intellij-repository/releases
 # https://www.jetbrains.com/intellij-repository/snapshots
-baseVersion=17.0.0
+baseVersion=17.0.1
 ideaVersion=2023.3
 # MUST stay at 1.8 for JPS (Build/Compile Project) compatibility even if JRE/JBR is newer
 javaVersion=17

--- a/resources/META-INF/changelog.html
+++ b/resources/META-INF/changelog.html
@@ -1,5 +1,14 @@
 <html>
 <body>
+<h1>v17.0.1</h1>
+<ul>
+    <li>
+        <p>Bug Fixes</p>
+        <ul>
+            <li>Render code snippets that are not links.</li>
+        </ul>
+    </li>
+</ul>
 <h1>v17.0.0</h1>
 <ul>
     <li>

--- a/src/org/elixir_lang/documentation/MarkdownFlavourDescriptor.kt
+++ b/src/org/elixir_lang/documentation/MarkdownFlavourDescriptor.kt
@@ -19,6 +19,20 @@ import org.intellij.markdown.parser.LinkMap
 import java.util.regex.Pattern
 
 class MarkdownFlavourDescriptor(private val project: Project) : GFMFlavourDescriptor() {
+    fun renderGenericCode(
+        gfmHtmlGeneratingProvider: GeneratingProvider?,
+        visitor: HtmlGenerator.HtmlGeneratingVisitor,
+        text: String,
+        node: ASTNode
+    ) {
+        visitor.consumeTagOpen(
+            node,
+            "code",
+        )
+        gfmHtmlGeneratingProvider!!.processNode(visitor, text, node)
+        visitor.consumeTagClose("code")
+    }
+
     override fun createHtmlGeneratingProviders(linkMap: LinkMap, baseURI: URI?): Map<IElementType, GeneratingProvider> =
         super
             .createHtmlGeneratingProviders(linkMap, baseURI)
@@ -73,6 +87,8 @@ class MarkdownFlavourDescriptor(private val project: Project) : GFMFlavourDescri
                                         )
                                         gfmHtmlGeneratingProvider!!.processNode(visitor, text, node)
                                         visitor.consumeTagClose("a")
+                                    } else {
+                                        renderGenericCode(gfmHtmlGeneratingProvider, visitor, text, node)
                                     }
                                 }
                                 5 -> {
@@ -103,11 +119,15 @@ class MarkdownFlavourDescriptor(private val project: Project) : GFMFlavourDescri
                                                     )
                                                     gfmHtmlGeneratingProvider!!.processNode(visitor, text, node)
                                                     visitor.consumeTagClose("a")
+                                                } else {
+                                                    renderGenericCode(gfmHtmlGeneratingProvider, visitor, text, node)
                                                 }
                                             }
                                         }
+                                        else -> renderGenericCode(gfmHtmlGeneratingProvider, visitor, text, node)
                                     }
                                 }
+                                else -> renderGenericCode(gfmHtmlGeneratingProvider, visitor, text, node)
                             }
                         }
                     }


### PR DESCRIPTION
I recently started using Elixir and noticed that code snippets would not be rendered in the documentation. This turned out to be due to missing else branches when rendering links in code snippets. Since the documentation of standard library functions makes heavy use of code to refer to parameters and other things, this will be a great improvement to my Elixir journey.