### PR TITLE
Use erl to retrieve OTP_RELEASE & ERLANG_SDK_HOME if no environment variable is set when testing

### DIFF
--- a/jps-builder/tests/org/elixir_lang/jps/BuilderTest.java
+++ b/jps-builder/tests/org/elixir_lang/jps/BuilderTest.java
@@ -21,6 +21,9 @@ import org.jetbrains.jps.util.JpsPathUtil;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+
 
 /**
  * Created by zyuyou on 15/7/17.
@@ -28,12 +31,52 @@ import java.io.IOException;
 public class BuilderTest extends JpsBuildTestCase {
     private static final String TEST_MODULE_NAME = "m";
     private JpsSdk<SdkProperties> elixirSdk;
+    private static String otpReleaseVersion = null;
 
+    /**
+     * Retrieves the OTP Release version, eg 24.3.4.6
+     * This method first checks for an environment variable OTP_RELEASE (used in CI).
+     * If not set, it attempts to infer the version path from the erl command.
+     *
+     * @return A String representing the OTP Release version.
+     * @throws AssertionError if ERLANG_SDK_HOME is not set and cannot be inferred from PATH.
+     */
     private static String otpRelease() {
+        if (otpReleaseVersion != null) {
+            return otpReleaseVersion;
+        }
+
         String otpRelease = System.getenv("OTP_RELEASE");
+        if (otpRelease != null && !otpRelease.isEmpty()) {
+            otpReleaseVersion = otpRelease;
+            return otpRelease;
+        }
 
-        assertNotNull("OTP_RELEASE is not set", otpRelease);
+        try {
+            Process process = Runtime.getRuntime().exec(new String[]{
+                    "erl",
+                    "-eval",
+                    "{ok, Version} = file:read_file(filename:join([code:root_dir(), \"releases\", erlang:system_info(otp_release), \"OTP_VERSION\"])), io:fwrite(Version), halt().",
+                    "-noshell"
+            });
 
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
+                otpRelease = reader.readLine();
+            }
+
+            int exitCode = process.waitFor();
+            if (exitCode != 0) {
+                throw new RuntimeException("Failed to get OTP release. Exit code: " + exitCode);
+            }
+        } catch (IOException | InterruptedException e) {
+            throw new RuntimeException("Failed to get OTP release", e);
+        }
+
+        if (otpRelease == null || otpRelease.isEmpty()) {
+            throw new RuntimeException("Failed to get OTP release");
+        }
+
+        otpReleaseVersion = otpRelease;
         return otpRelease;
     }
 
@@ -42,11 +85,45 @@ public class BuilderTest extends JpsBuildTestCase {
         return sdkHomeFromEbinDirectory(ebinDirectory());
     }
 
+    /**
+     * Retrieves the Erlang SDK home directory.
+     * This method first checks for an environment variable ERLANG_SDK_HOME.
+     * If not set, it attempts to infer the SDK home from the erl command.
+     *
+     * @return A String representing the path to the Erlang SDK home directory.
+     * @throws AssertionError if ERLANG_SDK_HOME is not set and cannot be retrieved from the erl command.
+     */
     @NotNull
     private static String erlangSdkHome() {
         String erlangSdkHome = System.getenv("ERLANG_SDK_HOME");
 
-        assertNotNull("ERLANG_SDK_HOME is not set", erlangSdkHome);
+        if (erlangSdkHome != null && !erlangSdkHome.isEmpty()) {
+            return erlangSdkHome;
+        }
+
+        try {
+            Process process = Runtime.getRuntime().exec(new String[]{
+                    "erl",
+                    "-eval",
+                    "io:format(\"~s~n\", [code:root_dir()]), halt().",
+                    "-noshell"
+            });
+
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
+                erlangSdkHome = reader.readLine();
+            }
+
+            int exitCode = process.waitFor();
+            if (exitCode != 0) {
+                throw new RuntimeException("Failed to get Erlang SDK home. Exit code: " + exitCode);
+            }
+        } catch (IOException | InterruptedException e) {
+            throw new RuntimeException("Failed to get Erlang SDK home", e);
+        }
+
+        if (erlangSdkHome == null || erlangSdkHome.isEmpty()) {
+            throw new RuntimeException("Failed to get Erlang SDK home");
+        }
 
         return erlangSdkHome;
     }


### PR DESCRIPTION
## Problem

Currently, the `ERLANG_SDK_HOME` and `OTP_RELEASE` environment variables need to be set manually when developing and are set in [CI](https://github.com/KronicDeth/intellij-elixir/blob/main/.github/workflows/test.yml#L24).

Example of current setup:

```sh
export ERLANG_SDK_HOME="/home/user/.local/share/mise/installs/erlang/24.3.4.6"
export OTP_VERSION="24.3.4.6"
```

This then breaks when running `gradle test` without these.


## Solution

This PR implements a quick approach to determine the Erlang SDK home and OTP release version:

1. It first checks for the `ERLANG_SDK_HOME` and `OTP_RELEASE` environment variables.
2. If these are not set, it attempts to infer the values using the `erl` command, which is likely already in the user's PATH.

This change provides a quick and pragmatic fix to improve the developer experience, especially for those who already have Erlang installed and configured in their environment.

## Implementation Details

- Added methods to infer `ERLANG_SDK_HOME` and `OTP_RELEASE` using `erl` command if environment variables are not set.
- Implemented caching for OTP release version to avoid repeated calls.
- Added error handling and appropriate exceptions for cases where values cannot be determined.

## Future Improvements

As this is a 5 minute patch, let's improve this code once 2024.x etc is out.