### PR TITLE
Bump intellij platform gradle to 2.0.1 and IdeaVIM to 2.16.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ import org.jetbrains.intellij.platform.gradle.IntelliJPlatformType
 import org.jetbrains.intellij.platform.gradle.TestFrameworkType
 
 plugins {
-    id "org.jetbrains.intellij.platform" version "2.0.0"
+    id "org.jetbrains.intellij.platform" version "2.0.1"
     id "org.jetbrains.kotlin.jvm" version "1.9.24"
     id "de.undercouch.download" version "4.1.2"
     id 'com.adarshr.test-logger' version '4.0.0'

--- a/gradle.properties
+++ b/gradle.properties
@@ -48,7 +48,7 @@ gradleVersion=8.5
 # Opt-out flag for bundling Kotlin standard library -> https://jb.gg/intellij-platform-kotlin-stdlib
 kotlin.stdlib.default.dependency=false
 publishChannels=canary
-runIdePlugins=IdeaVIM:2.15.0
+runIdePlugins=IdeaVim:2.16.0
 
 # These must be set, or Out of Memory (OOM) errors will occur during compiling.
 org.gradle.jvmargs=-Xmx4096m


### PR DESCRIPTION
When running an IDE via `./gradlew runIntelliJCommunity` etc, IdeaVim is installed to help test the vim integration.

This does a bump the latest version.

<img width="334" alt="SCR-20240820-mlqe-2" src="https://github.com/user-attachments/assets/12c87085-ae96-4d97-9497-e07f788c2161">

This also bumps to 2.0.1 for the intellij gradle plugin.