### PR TITLE
Add correct iex CLI parameters for Elixir v1.17+

### DIFF
--- a/src/org/elixir_lang/IEx.kt
+++ b/src/org/elixir_lang/IEx.kt
@@ -8,15 +8,15 @@ import org.elixir_lang.Elixir.prependNewCodePaths
 
 object IEx {
     fun commandLine(
-            environment: Map<String, String>,
-            workingDirectory: String?,
-            elixirSdk: Sdk,
-            erlArgumentList: kotlin.collections.List<String>
+        environment: Map<String, String>,
+        workingDirectory: String?,
+        elixirSdk: Sdk,
+        erlArgumentList: kotlin.collections.List<String>
     ): GeneralCommandLine {
         /* `iex` is an alternative mode of the `elixir` script, which changes the `erl` options, so the state needs to
-           be built on top of `erl`, not `elixir`. */
+         * be built on top of `erl`, not `elixir`. */
         val erlangSdk = elixirSdkToEnsuredErlangSdk(elixirSdk)
-        val commandLine = org.elixir_lang.Erl.commandLine(true, environment, workingDirectory, erlangSdk)
+        val commandLine = Erl.commandLine(true, environment, workingDirectory, erlangSdk)
         prependNewCodePaths(commandLine, elixirSdk, erlangSdk)
         commandLine.addParameters("-elixir", "ansi_enabled", "true")
         commandLine.addParameters(erlArgumentList)
@@ -31,20 +31,30 @@ object IEx {
 
         val elixirVersion = elixirSdk.versionString?.let { Version.parseVersion(it) }
         if (elixirVersion?.lessThan(1, 15, 0) == true) {
-            /* Pre Elixir 1.15.0, IEx entrypoint was as Elixir.IEx.CLI start() */
+            /* Pre Elixir 1.15.0, IEx entrypoint was as Elixir.IEx.CLI start()
+             * Pattern: erl -pa <multiple-paths> -noshell -user Elixir.IEx.CLI -extra --no-halt +iex */
             commandLine.addParameters("-user", "Elixir.IEx.CLI")
             commandLine.addParameter("-extra")
         } else if (elixirVersion?.`is`(1, 15, 0) == true) {
             /* Weird case for 1.15.0-rc1 to 1.15.0
-             * It had a bugged start_iex that needs to be specified differently. */
+             * It had a bugged start_iex that needs to be specified differently.
+             * Pattern: erl -pa <multiple-paths> -noshell -user Elixir.IEx.CLI -extra --no-halt +iex
+             */
             commandLine.addParameters("-s", "elixir", "start_cli")
             commandLine.addParameters("-user", "elixir")
             commandLine.addParameter("-extra")
             commandLine.addParameters("-e", ":elixir.start_iex()")
-        } else {
-            /* Case for elixir 1.16.0+ (and 1.15.1+ from the 1.15 branch).
-             * We can call start_iex directly from elixir entrypoint. */
+        } else if (elixirVersion?.lessThan(1, 17, 0) == true) {
+            /* Elixir 1.15.1 - 1.16.x series (e.g., 1.15.1, 1.16.3)
+             * Pattern: erl -noshell -elixir_root elixir/lib -pa elixir/lib/elixir/ebin -s elixir start_iex -user elixir -extra --no-halt +iex
+             */
             commandLine.addParameters("-s", "elixir", "start_iex")
+            commandLine.addParameters("-user", "elixir")
+            commandLine.addParameter("-extra")
+        } else { // elixirVersion.isAtLeast(1, 17, 0)
+            /* Elixir 1.17.x - 1.19.x and potentially future versions if the pattern continues
+             * Pattern: erl -noshell -elixir_root elixir/lib -pa elixir/lib/elixir/ebin -user elixir -extra --no-halt +iex
+             */
             commandLine.addParameters("-user", "elixir")
             commandLine.addParameter("-extra")
         }


### PR DESCRIPTION
Adds the appropriate `iex` CLI parameters to ensure compatibility with Elixir v1.17+.  

I had an LLM knock up a script to brute force check all of the cli arguments from Elixir 1.13 to current and then had it analyse the results for me: 
| Elixir Version Range | `erl` Command Arguments                                                                                                                                                                                                                                                                         | Key Characteristics / Differences                                                                                                                                                                                                                                                                                                                                                                                        |
| :------------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
| **1.17.x - 1.19.x** | `erl -noshell -elixir_root elixir/lib -pa elixir/lib/elixir/ebin -user elixir -extra --no-halt +iex`                                                                                                                                                                                        | **Current/Modern:** Relies on `-elixir_root` for library path. Uses a single `-pa` for `elixir/ebin`. Startup appears to be handled implicitly by `+iex` and other flags, without an explicit `-s` call to an Elixir module.                                                                                                                                                                                                |
| **1.16.x & 1.15.1 - 1.15.8** | `erl -noshell -elixir_root elixir/lib -pa elixir/lib/elixir/ebin -s elixir start_iex -user elixir -extra --no-halt +iex`                                                                                                                                                              | **Transitional:** Also uses `-elixir_root` and a single `elixir/ebin` path. **Introduces `-s elixir start_iex`** to explicitly call the `start_iex` function within the `elixir` module for `iex` startup.                                                                                                                                                                                                           |
| **1.15.0** | `erl -noshell -elixir_root elixir/lib -pa elixir/lib/elixir/ebin -s elixir start_cli -user elixir -extra --no-halt -e :elixir.start_iex() +iex`                                                                                                                                                    | **Specific `1.15.0` Behavior:** Similar to transitional, but notably uses `-s elixir start_cli` (suggesting a CLI boot mechanism) and includes an **explicit Erlang evaluation `-e :elixir.start_iex()`** to kick off the `iex` session.                                                                                                                                                                                |
| **1.13.x - 1.14.x** | `erl -pa elixir/lib/eex/ebin elixir/lib/elixir/ebin elixir/lib/ex_unit/ebin elixir/lib/iex/ebin elixir/lib/logger/ebin elixir/lib/mix/ebin -noshell -user Elixir.IEx.CLI -extra --no-halt +iex` | **Older/Explicit Paths:** Does **not** use `-elixir_root`. Instead, it explicitly lists **multiple `ebin` paths** (`eex`, `elixir`, `ex_unit`, `iex`, `logger`, `mix`) via `-pa`. It also specifies `-user Elixir.IEx.CLI` directly, indicating a more direct invocation of the `iex` CLI module within the Erlang VM. |

It looks like the cli arguments changed in 1.17, so that's the fix I've applied. 

To get debugging to work, I had to add `:debugger` to my `extra_applications`:
```elixir
  def application do
    [
      mod: {MyApp.Application, []},
      extra_applications: [:logger, :runtime_tools, :debugger]
    ]
  end
  ```

### Related Issues

- Fixes #3673