### PR TITLE
Rename project to align built artifacts with plugin name

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'org.gradle.toolchains.foojay-resolver-convention' version '0.8.0'
 }
-rootProject.name = 'Elixir'
+rootProject.name = 'intellij-elixir'
 include 'jps-shared'
 include 'jps-builder'


### PR DESCRIPTION
This aligns the project name with the expected filenames in the release workflow. 

It should resolve this error:
https://github.com/KronicDeth/intellij-elixir/actions/runs/16662304367/job/47162204667#step:7:8

and allow the canary release to be built successfully. 

It also makes IntelliJ show "intellij-elixir" in the title bar instead of "Elixir", so I'll stop opening the wrong window when I'm working on both elixir and the plugin. 😃 