### PR TITLE
Add GitHub Action for automatic publish to the Canary channel

### DIFF
--- a/.github/actions/setup-jbr/action.yml
+++ b/.github/actions/setup-jbr/action.yml
@@ -1,0 +1,10 @@
+name: 'Setup JetBrains Runtime (JBR) 21'
+description: 'Installs and sets up JBR 21 using a standardized step'
+runs:
+  using: "composite"
+  steps:
+    - name: Setup JBR 21 ☕
+      uses: gmitch215/setup-java@6d2c5e1f82f180ae79f799f0ed6e3e5efb4e664d
+      with:
+        distribution: 'jetbrains'
+        java-version: 21

--- a/.github/actions/setup-jbr/action.yml
+++ b/.github/actions/setup-jbr/action.yml
@@ -4,7 +4,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup JBR 21 ☕
-      uses: gmitch215/setup-java@6d2c5e1f82f180ae79f799f0ed6e3e5efb4e664d
+      uses: actions/setup-java@v5
       with:
         distribution: 'jetbrains'
         java-version: 21

--- a/.github/actions/setup-jbr/action.yml
+++ b/.github/actions/setup-jbr/action.yml
@@ -8,3 +8,4 @@ runs:
       with:
         distribution: 'jetbrains'
         java-version: 21
+        cache: 'gradle'

--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -1,7 +1,9 @@
 name: Publish to Canary
 on:
-  release:
-    types: [prereleased]
+#  release:
+#    types: [prereleased]
+  workflow_dispatch:
+
 jobs:
   publish-to-canary:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository 💾
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup JetBrains Runtime (JBR) ☕
         uses: ./.github/actions/setup-jbr

--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -1,0 +1,28 @@
+name: Publish to Canary
+on:
+  release:
+    types: [prereleased]
+jobs:
+  publish-to-canary:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository 💾
+        uses: actions/checkout@v4
+
+      - name: Setup JetBrains Runtime (JBR) ☕
+        uses: ./.github/actions/setup-jbr
+
+      - name: Download release asset 📦
+        id: download_asset
+        uses: dsaltares/fetch-gh-release-asset@1.1.2
+        with:
+          repo: ${{ github.repository }}
+          version: tags/${{ github.ref_name }}
+          file: intellij-elixir-${{ github.ref_name }}.zip
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish to Canary 🐣
+        env:
+          JET_BRAINS_MARKETPLACE_TOKEN: ${{ secrets.JetBrainsMarketplaceToken }}
+        run: >
+          ./gradlew publishPlugin -PdistributionFile=intellij-elixir-${{ github.ref_name }}.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v5
       - name: Setup JetBrains Runtime (JBR)
         uses: ./.github/actions/setup-jbr
       - name: Set up Elixir
@@ -34,9 +34,8 @@ jobs:
         run: ./gradlew --stacktrace test
   verifyPlugin:
     runs-on: ubuntu-latest
-
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v5
       - name: Setup JetBrains Runtime (JBR)
         uses: ./.github/actions/setup-jbr
       - name: Grant execute permission for gradlew
@@ -46,9 +45,8 @@ jobs:
   release:
     needs: [ test, verifyPlugin ]
     runs-on: ubuntu-latest
-
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v5
       - name: Setup JetBrains Runtime (JBR)
         uses: ./.github/actions/setup-jbr
       - name: Grant execute permission for gradlew

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,11 +11,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Setup JBR 21
-        uses: gmitch215/setup-java@6d2c5e1f82f180ae79f799f0ed6e3e5efb4e664d
-        with:
-          distribution: 'jetbrains'
-          java-version: 21
+      - name: Setup JetBrains Runtime (JBR)
+        uses: ./.github/actions/setup-jbr
       - name: Set up Elixir
         uses: erlef/setup-beam@v1
         with:
@@ -40,11 +37,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Setup JBR 21
-        uses: gmitch215/setup-java@6d2c5e1f82f180ae79f799f0ed6e3e5efb4e664d
-        with:
-          distribution: 'jetbrains'
-          java-version: 21
+      - name: Setup JetBrains Runtime (JBR)
+        uses: ./.github/actions/setup-jbr
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Run Plugin Verifier
@@ -55,11 +49,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Setup JBR 21
-        uses: gmitch215/setup-java@6d2c5e1f82f180ae79f799f0ed6e3e5efb4e664d
-        with:
-          distribution: 'jetbrains'
-          java-version: 21
+      - name: Setup JetBrains Runtime (JBR)
+        uses: ./.github/actions/setup-jbr
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Build with Gradle

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,7 +86,3 @@ jobs:
           asset_path: ${{ env.ASSET_PATH }}
           asset_name: ${{ env.ASSET_NAME }}
           asset_content_type: application/zip
-      - name: Publish
-        env:
-          JET_BRAINS_MARKETPLACE_TOKEN: ${{ secrets.JetBrainsMarketplaceToken }}
-        run: ./gradlew --stacktrace publishPlugin

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: Test
 
-on: pull_request
+on: [ pull_request, workflow_dispatch ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref }}
@@ -12,10 +12,10 @@ jobs:
 
     strategy:
       matrix:
-        ideaVersion: [ "2024.2.0.1" ]
+        ideaVersion: [ "2024.3.6" ]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v5
       - name: Setup JetBrains Runtime (JBR)
         uses: ./.github/actions/setup-jbr
       - name: Set up Elixir
@@ -43,7 +43,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v5
       - name: Setup JetBrains Runtime (JBR)
         uses: ./.github/actions/setup-jbr
       - name: Grant execute permission for gradlew

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,11 +16,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Setup JBR 21
-        uses: gmitch215/setup-java@6d2c5e1f82f180ae79f799f0ed6e3e5efb4e664d
-        with:
-          distribution: 'jetbrains'
-          java-version: 21
+      - name: Setup JetBrains Runtime (JBR)
+        uses: ./.github/actions/setup-jbr
       - name: Set up Elixir
         uses: erlef/setup-beam@v1
         with:
@@ -47,11 +44,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Setup JBR 21
-        uses: gmitch215/setup-java@6d2c5e1f82f180ae79f799f0ed6e3e5efb4e664d
-        with:
-          distribution: 'jetbrains'
-          java-version: 21
+      - name: Setup JetBrains Runtime (JBR)
+        uses: ./.github/actions/setup-jbr
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Run Plugin Verifier

--- a/build.gradle
+++ b/build.gradle
@@ -96,7 +96,6 @@ intellijPlatform {
 
         id = providers.gradleProperty("pluginGroup")
         name = providers.gradleProperty("pluginName")
-        version = providers.gradleProperty("pluginVersion")
         changeNotes.set(bodyInnerHTML("resources/META-INF/changelog.html"))
         description.set(bodyInnerHTML("resources/META-INF/description.html"))
 

--- a/build.gradle
+++ b/build.gradle
@@ -117,7 +117,14 @@ intellijPlatform {
             System.getenv("JET_BRAINS_MARKETPLACE_TOKEN")
         }
         channels = publishChannels.split(',').toList()
-        archiveFile = layout.buildDirectory.file("distributions/${System.getenv("ASSET_NAME")}")
+        
+        // Use the path from the -PdistributionFile property if it exists,
+        // otherwise fall back to the old environment variable method.
+        if (project.hasProperty("distributionFile")) {
+            archiveFile = file(project.property("distributionFile"))
+        } else if (System.getenv("ASSET_NAME")) {
+            archiveFile = layout.buildDirectory.file("distributions/${System.getenv("ASSET_NAME")}")
+        }
     }
     pluginVerification {
         ides {


### PR DESCRIPTION
To allow for easier debugging, I've moved the publishPlugin stage out of the release workflow and in to its own dedicated workflow spec. 

If you're interested in having a workflow to publish full releases I can have a look at that too, although it doesn't look like plugin signing is setup in the workflows, and it isn't clear whether JB will accept submissions that haven't been signed, so that would require some setup from someone with access to the keys. In fact it isn't clear from the [docs](https://plugins.jetbrains.com/docs/intellij/plugin-signing.html) whether JB will even accept a canary release that hasn't been signed.  