### PR TITLE
Fix duplicate vv tag prefix in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           custom_tag: ${{ env.TAG }}
+          tag_prefix: ''
 
       - name: Create Release
         id: create_release


### PR DESCRIPTION
Fixed `mathieudutour/github-tag-action` creating tags with double `vv` prefix

See [tag_prefix](https://github.com/mathieudutour/github-tag-action/blob/master/action.yml#L36)
