### PR TITLE
Add a startup activity for the status bar

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -29,6 +29,7 @@
         <statusBarWidgetFactory
                 id="ElixirSdkStatus"
                 implementation="org.elixir_lang.status_bar_widget.ElixirSdkStatusWidgetFactory"/>
+        <backgroundPostStartupActivity implementation="org.elixir_lang.status_bar_widget.ElixirSdkStatusWidgetStartupActivity"/>
 
         <!--        <errorHandler implementation="org.elixir_lang.errorreport.Submitter"/>-->
         <errorHandler implementation="com.intellij.diagnostic.JetBrainsMarketplaceErrorReportSubmitter"/>

--- a/src/org/elixir_lang/status_bar_widget/ElixirSdkStatusWidgetStartupActivity.kt
+++ b/src/org/elixir_lang/status_bar_widget/ElixirSdkStatusWidgetStartupActivity.kt
@@ -1,0 +1,48 @@
+package org.elixir_lang.status_bar_widget
+
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.diagnostic.logger
+import com.intellij.openapi.project.DumbAware
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.startup.ProjectActivity
+import com.intellij.openapi.wm.impl.status.widget.StatusBarWidgetsManager
+import org.elixir_lang.settings.ElixirExperimentalSettings
+import org.elixir_lang.settings.ElixirExperimentalSettingsListener
+
+private val LOG = logger<ElixirSdkStatusWidgetStartupActivity>()
+
+class ElixirSdkStatusWidgetStartupActivity : ProjectActivity, DumbAware {
+    override suspend fun execute(project: Project) {
+        LOG.debug("Executing startup activity for project: ${project.name}")
+
+        // Initial trigger to show widget if setting is already enabled
+        refreshWidgetVisibility(project)
+
+        // Listen for future setting changes
+        val connection = project.messageBus.connect()
+        connection.subscribe(
+            ElixirExperimentalSettings.SETTINGS_CHANGED_TOPIC,
+            object : ElixirExperimentalSettingsListener {
+                override fun settingsChanged(oldState: ElixirExperimentalSettings.State, newState: ElixirExperimentalSettings.State) {
+                    if (oldState.enableStatusBarWidget != newState.enableStatusBarWidget) {
+                        LOG.debug("Setting changed in ${project.name}, refreshing widget")
+                        refreshWidgetVisibility(project)
+                    }
+                }
+            }
+        )
+    }
+
+    private fun refreshWidgetVisibility(project: Project) {
+        // We use invokeLater to ensure the StatusBar is fully initialized in the UI
+        // before we ask the manager to update the widget.
+        ApplicationManager.getApplication().invokeLater {
+            if (!project.isDisposed) {
+                LOG.debug("Requesting StatusBarWidgetsManager update for ${project.name}")
+                @Suppress("IncorrectServiceRetrieving")
+                val manager = project.getService(StatusBarWidgetsManager::class.java)
+                manager?.updateWidget(ElixirSdkStatusWidgetFactory::class.java)
+            }
+        }
+    }
+}


### PR DESCRIPTION
Loving the Widget, but I found that I needed to disable/enable after every restart due to the ExperimentalSettings flag not being available in the project config when the StatusBarManager starts up.

This PR registers a backgroup startup activity that only runs after the project (including the application) settings have loaded.

It also moves the settings watcher into this class to keep the Factory "pure". When the experimental status of the widget moves to production, the startup activity is still useful for the settings watcher. 

Lastly, and purely because I wasted an hour wondering why the widget wasn't working after a sandbox reset, I've defaulted the widget to display as soon as the experimental setting is enabled. Looking at the comments, I think the setting was originally at project level, but it is now at application level, and it makes sense to me that if I enable it in Experimental Settings, it should immediately appear in the status bar. 