### PR TITLE
Fix Kotlin upgrade

### DIFF
--- a/.github/workflows/shared-test.yml
+++ b/.github/workflows/shared-test.yml
@@ -81,7 +81,7 @@ jobs:
 
       - name: Upload Test Reports
         id: upload-test-reports
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         if: ${{ always() && inputs.upload-reports }}
         with:
           name: test-reports-${{ matrix.idea-version }}
@@ -118,7 +118,7 @@ jobs:
 
       - name: Upload Plugin Artifact
         id: upload-plugin
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: plugin-artifact
           path: build/distributions/*.zip
@@ -157,7 +157,7 @@ jobs:
 
       - name: Upload Verify Reports
         id: upload-verify-reports
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         if: ${{ always() && inputs.upload-reports }}
         with:
           name: verify-plugin-reports-${{ matrix.ide-version }}

--- a/.github/workflows/shared-test.yml
+++ b/.github/workflows/shared-test.yml
@@ -135,7 +135,7 @@ jobs:
     steps:
       - name: Download Plugin Artifact
         id: download-plugin
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: plugin-artifact
           path: build/distributions

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,7 @@
 
 [versions]
 # Plugin Versions
-kotlin = "2.2.21"
+kotlin = "2.3.0"
 intellij-platform = "2.10.5"
 gradle-download = "5.6.0"
 test-logger = "4.0.0"

--- a/src/org/elixir_lang/debugger/settings/stepping/ModuleFilter.kt
+++ b/src/org/elixir_lang/debugger/settings/stepping/ModuleFilter.kt
@@ -17,5 +17,5 @@ class ModuleFilter(enabled: Boolean = true, pattern: String = "") {
     override fun equals(other: Any?) =
             other is ModuleFilter && enabled == other.enabled && pattern == other.pattern
 
-    override fun hashCode() = Objects.hashCode(arrayOf(enabled, pattern))
+    override fun hashCode() = Objects.hash(enabled, pattern)
 }


### PR DESCRIPTION
Upgrading the Kotlkin version caused this error in the CI build: 
```
e: file:///home/runner/work/intellij-elixir/intellij-elixir/src/org/elixir_lang/debugger/settings/stepping/ModuleFilter.kt:20:48 Type argument for reified type parameter 'T' was inferred to the intersection of ['Comparable<Boolean & String>' & 'Serializable']. Reification of an intersection type results in the common supertype being used. This may lead to subtle issues and an explicit type argument is encouraged.
```

https://youtrack.jetbrains.com/projects/KT/issues/KT-71420/Report-error-when-reified-type-parameter-is-inferred-to-intersection-type

Switched to `Objects.hash` to avoid needing to specify the types. 

Closes #3745 #3738