### PR TITLE
Fix Inspection warnings in `~r` sigils with interpolated variables.

### DIFF
--- a/src/org/elixir_lang/injection/ElixirSigilInjector.kt
+++ b/src/org/elixir_lang/injection/ElixirSigilInjector.kt
@@ -5,7 +5,11 @@ import com.intellij.lang.html.HTMLLanguage
 import com.intellij.lang.injection.MultiHostInjector
 import com.intellij.lang.injection.MultiHostRegistrar
 import com.intellij.openapi.diagnostic.logger
+import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiElement
+import com.intellij.psi.util.PsiTreeUtil
+import org.elixir_lang.psi.ElixirInterpolation
+import org.elixir_lang.psi.HeredocLine
 import org.elixir_lang.psi.SigilHeredoc
 import org.elixir_lang.psi.SigilLine
 import org.intellij.lang.regexp.RegExpLanguage
@@ -14,6 +18,13 @@ import org.elixir_lang.eex.Language as EexLanguage
 private val LOG = logger<ElixirSigilInjector>()
 
 internal class ElixirSigilInjector : MultiHostInjector {
+    // Per-line view of a sigil body used to compute injection ranges consistently for line and heredoc sigils.
+    private data class InjectionLine(
+        val hostRange: TextRange,
+        val bodyElement: PsiElement?,
+        val bodyStartInHost: Int
+    )
+
     override fun getLanguagesToInject(registrar: MultiHostRegistrar, context: PsiElement) {
         when (context) {
             is SigilLine -> handleSigilLine(registrar, context)
@@ -25,13 +36,14 @@ internal class ElixirSigilInjector : MultiHostInjector {
     private fun handleSigilLine(registrar: MultiHostRegistrar, sigilLine: SigilLine) {
         if (!sigilLine.isValidHost) return
         val lang = languageForSigil(sigilLine.sigilName()) ?: return
+        val ranges = sigilLineInjectionRanges(sigilLine, lang)
+        if (ranges.isEmpty()) return
 
-        sigilLine.body?.let { lineBody ->
-            registrar
-                .startInjecting(lang)
-                .addPlace(null, null, sigilLine, lineBody.textRangeInParent)
-                .doneInjecting()
+        registrar.startInjecting(lang)
+        for (range in ranges) {
+            registrar.addPlace(null, null, sigilLine, range)
         }
+        registrar.doneInjecting()
     }
 
     private fun handleSigilHeredoc(registrar: MultiHostRegistrar, sigilHeredoc: SigilHeredoc) {
@@ -48,33 +60,42 @@ internal class ElixirSigilInjector : MultiHostInjector {
         }
 
         val lang = languageForSigil(sigilHeredoc.sigilName()) ?: return
-        registrar.startInjecting(lang)
+        val heredocLineList = sigilHeredoc.heredocLineList
+
         if (LOG.isDebugEnabled) {
-            LOG.debug("handleSigilHeredoc: injecting ${lang.displayName} into ${sigilHeredoc.heredocLineList.size} lines")
-        }
-        for (item in sigilHeredoc.heredocLineList) {
-            if (item.isValid) {
-                if (LOG.isDebugEnabled) {
-                    LOG.debug("handleSigilHeredoc: injecting into heredocLine: ${item.text}")
-                }
-                registrar.addPlace(null, null, sigilHeredoc, item.textRangeInParent)
-            } else if (LOG.isDebugEnabled) {
-                LOG.debug("handleSigilHeredoc: skipping invalid heredocLine")
-            }
-        }
-        if (LOG.isDebugEnabled) {
-            LOG.debug("handleSigilHeredoc: done injecting into ${sigilHeredoc.heredocLineList.size} lines")
+            LOG.debug("handleSigilHeredoc: injecting ${lang.displayName} into ${heredocLineList.size} lines")
         }
 
+        val ranges = sigilHeredocInjectionRanges(heredocLineList, lang)
+        if (ranges.isEmpty()) {
+            return
+        }
+
+        registrar.startInjecting(lang)
+        for (range in ranges) {
+            if (LOG.isDebugEnabled) {
+                LOG.debug("handleSigilHeredoc: injecting range $range")
+            }
+            registrar.addPlace(null, null, sigilHeredoc, range)
+        }
+        if (LOG.isDebugEnabled) {
+            LOG.debug("handleSigilHeredoc: done injecting into ${heredocLineList.size} lines")
+        }
         registrar.doneInjecting()
+    }
+
+    private fun sigilHeredocInjectionRanges(
+        heredocLineList: List<HeredocLine>,
+        lang: Language
+    ): List<TextRange> {
+        val lines = heredocInjectionLines(heredocLineList)
+        return injectionRangesForLines(lines, lang)
     }
 
     override fun elementsToInjectIn() = listOf(SigilHeredoc::class.java, SigilLine::class.java)
 
     private fun languageForSigil(sigilName: Char): Language? {
-        if (LOG.isDebugEnabled) {
-            LOG.debug("languageForSigil: sigilName='$sigilName'")
-        }
+        LOG.debug("languageForSigil: sigilName='$sigilName'")
 
         return when (sigilName) {
             'H' -> HTMLLanguage.INSTANCE
@@ -83,4 +104,102 @@ internal class ElixirSigilInjector : MultiHostInjector {
             else -> null
         }
     }
+
+    private fun interpolationRanges(body: PsiElement, bodyStartOffsetInHost: Int): List<TextRange> {
+        val interpolations = PsiTreeUtil.findChildrenOfType(body, ElixirInterpolation::class.java)
+        if (interpolations.isEmpty()) {
+            return emptyList()
+        }
+
+        return interpolations
+            .map { it.textRangeInParent.shiftRight(bodyStartOffsetInHost) }
+            .sortedBy { it.startOffset }
+    }
+
+    private fun regexInjectionRangesExcludingInterpolations(
+        baseRange: TextRange,
+        body: PsiElement?,
+        bodyStartOffsetInHost: Int
+    ): List<TextRange> {
+        if (body == null) return listOf(baseRange)
+
+        // Interpolations like #{...} must be excluded from injected RegExpLanguage, or the parser will
+        // treat `{` as a quantifier start and raise false "Number expected" warnings.
+        val interpolations = interpolationRanges(body, bodyStartOffsetInHost)
+        return buildInjectionRanges(baseRange, interpolations)
+    }
+
+    private fun sigilLineInjectionRanges(sigilLine: SigilLine, lang: Language): List<TextRange> {
+        val lineBody = sigilLine.body ?: return emptyList()
+        val hostRange = lineBody.textRangeInParent
+
+        val lines = listOf(InjectionLine(hostRange, lineBody, hostRange.startOffset))
+        return injectionRangesForLines(lines, lang)
+    }
+
+    private fun heredocInjectionLines(heredocLineList: List<HeredocLine>): List<InjectionLine> {
+        val lines = mutableListOf<InjectionLine>()
+        for (item in heredocLineList) {
+            if (!item.isValid) {
+                if (LOG.isDebugEnabled) {
+                    LOG.debug("handleSigilHeredoc: skipping invalid heredocLine")
+                }
+                continue
+            }
+
+            val hostRange = item.textRangeInParent
+            val lineBody = item.body
+            // The body start is needed to shift interpolation ranges into the sigil host coordinate space.
+            val bodyStartInHost = hostRange.startOffset + (lineBody?.textRangeInParent?.startOffset ?: 0)
+            lines.add(InjectionLine(hostRange, lineBody, bodyStartInHost))
+        }
+
+        return lines
+    }
+
+    private fun injectionRangesForLines(lines: List<InjectionLine>, lang: Language): List<TextRange> {
+        if (lines.isEmpty()) return emptyList()
+        // Non-regex sigils inject the full body range; regex sigils skip interpolation ranges.
+        if (lang != RegExpLanguage.INSTANCE) {
+            return lines.map { it.hostRange }
+        }
+
+        val ranges = mutableListOf<TextRange>()
+        for (line in lines) {
+            ranges.addAll(
+                regexInjectionRangesExcludingInterpolations(
+                    line.hostRange,
+                    line.bodyElement,
+                    line.bodyStartInHost
+                )
+            )
+        }
+        return ranges
+    }
+
+    private fun buildInjectionRanges(baseRange: TextRange, excludedRanges: List<TextRange>): List<TextRange> {
+        if (baseRange.length <= 0) return emptyList()
+        if (excludedRanges.isEmpty()) return listOf(baseRange)
+
+        val ranges = ArrayList<TextRange>()
+        var currentStart = baseRange.startOffset
+
+        for (excluded in excludedRanges) {
+            val start = maxOf(baseRange.startOffset, excluded.startOffset)
+            val end = minOf(baseRange.endOffset, excluded.endOffset)
+            if (start > currentStart) {
+                ranges.add(TextRange(currentStart, start))
+            }
+            if (end > currentStart) {
+                currentStart = end
+            }
+        }
+
+        if (currentStart < baseRange.endOffset) {
+            ranges.add(TextRange(currentStart, baseRange.endOffset))
+        }
+
+        return ranges
+    }
+
 }

--- a/tests/org/elixir_lang/injection/RegexSigilInjectionTest.kt
+++ b/tests/org/elixir_lang/injection/RegexSigilInjectionTest.kt
@@ -1,0 +1,249 @@
+package org.elixir_lang.injection
+
+import com.intellij.codeInsight.daemon.impl.HighlightInfo
+import com.intellij.lang.annotation.HighlightSeverity
+import com.intellij.lang.injection.InjectedLanguageManager
+import com.intellij.psi.PsiFile
+import com.intellij.psi.util.PsiTreeUtil
+import org.elixir_lang.PlatformTestCase
+import org.elixir_lang.psi.SigilHeredoc
+import org.elixir_lang.psi.SigilLine
+import org.elixir_lang.reference.Callable.Companion.isVariable
+import org.elixir_lang.settings.ElixirExperimentalSettings
+import org.intellij.lang.regexp.RegExpLanguage
+
+/**
+ * Tests for regex sigil injection to ensure interpolation doesn't cause false warnings
+ */
+class RegexSigilInjectionTest : PlatformTestCase() {
+    private var originalEnableHtmlInjection = false
+
+    override fun setUp() {
+        super.setUp()
+        val settings = ElixirExperimentalSettings.instance
+        originalEnableHtmlInjection = settings.state.enableHtmlInjection
+        settings.state.enableHtmlInjection = true
+        ensureSigilInjectorRegistered()
+    }
+
+    override fun tearDown() {
+        try {
+            ElixirExperimentalSettings.instance.state.enableHtmlInjection = originalEnableHtmlInjection
+        } finally {
+            super.tearDown()
+        }
+    }
+
+    /**
+     * Test that interpolated regex sigils don't produce "Number expected" warnings
+     * when using interpolation with curly braces.
+     *
+     * The issue: ElixirSigilInjector injects RegExpLanguage across the entire sigil body,
+     * including interpolation tokens like #{...}. The regex parser treats { as a quantifier
+     * start and expects a number, producing a false "Number expected" warning.
+     */
+    fun testInterpolatedRegexSigilNoFalseWarning() {
+        assertNoProblemHighlights(
+            """
+                defmodule Test do
+                  def test do
+                    my_var = %{item: "value"}
+                    my_regex = ~r/some text#{my_var.item}somemore text/
+                  end
+                end
+            """.trimIndent()
+        )
+    }
+
+    /**
+     * Test with multiple interpolations in a regex sigil
+     */
+    fun testMultipleInterpolationsInRegexSigil() {
+        assertNoProblemHighlights(
+            """
+                defmodule Test do
+                  def test(params) do
+                    regex = ~r|/text_values/#{params.param1}/more_text_values/#{params.param2}|
+                  end
+                end
+            """.trimIndent()
+        )
+    }
+
+    fun testInterpolatedRegexSigilVariableReferenceResolves() {
+        assertNoProblemHighlights(
+            """
+                defmodule Test do
+                  def test do
+                    payload_type = "foo"
+                    regex = ~r|/items/#{<caret>payload_type}|
+                  end
+                end
+            """.trimIndent()
+        )
+
+        val reference = myFixture.file.findReferenceAt(myFixture.caretOffset)
+        assertNotNull("Expected reference for interpolated variable", reference)
+
+        val resolved = reference!!.resolve()
+        assertNotNull("Expected interpolated variable to resolve", resolved)
+        assertTrue("Interpolated variable should be treated as variable", isVariable(resolved!!))
+        assertEquals("payload_type", resolved.text)
+    }
+
+    fun testInterpolatedRegexHeredocVariableReferenceResolves() {
+        assertNoProblemHighlights(
+            """
+                defmodule Test do
+                  def test do
+                    payload_type = "foo"
+                    regex = ~r'''
+                    ^/items/#{<caret>payload_type}$
+                    '''
+                  end
+                end
+            """.trimIndent()
+        )
+
+        val reference = myFixture.file.findReferenceAt(myFixture.caretOffset)
+        assertNotNull("Expected reference for interpolated heredoc variable", reference)
+
+        val resolved = reference!!.resolve()
+        assertNotNull("Expected interpolated heredoc variable to resolve", resolved)
+        assertTrue("Interpolated heredoc variable should be treated as variable", isVariable(resolved!!))
+        assertEquals("payload_type", resolved.text)
+    }
+
+    /**
+     * Test that literal regex sigils (uppercase ~R) work correctly without interpolation
+     */
+    fun testLiteralRegexSigilWithBraces() {
+        assertNoProblemHighlights(
+            """
+                defmodule Test do
+                  def test do
+                    # Literal sigil with actual regex quantifier - should be valid
+                    regex = ~R/a{2,3}/
+                  end
+                end
+            """.trimIndent(),
+            expectInjection = false
+        )
+    }
+
+    /**
+     * Test interpolation with nested braces
+     */
+    fun testInterpolatedRegexWithNestedBraces() {
+        assertNoProblemHighlights(
+            """
+                defmodule Test do
+                  def test do
+                    pattern = "test"
+                    regex = ~r/prefix #{pattern <> "{suffix}"} end/
+                  end
+                end
+            """.trimIndent()
+        )
+    }
+
+    /**
+     * Test interpolated regex heredoc sigils
+     */
+    fun testInterpolatedRegexHeredoc() {
+        assertNoProblemHighlights(
+            """
+                defmodule Test do
+                  def test(params) do
+                    regex = ~r'''
+                    ^/devices/#{params.device_id}$
+                    '''
+                  end
+                end
+            """.trimIndent()
+        )
+    }
+
+    /**
+     * Test interpolated regex heredoc sigils with multiple lines
+     */
+    fun testInterpolatedRegexHeredocMultipleLines() {
+        assertNoProblemHighlights(
+            """
+                defmodule Test do
+                  def test(params) do
+                    regex = ~r'''
+                    ^/events/#{params.event_id}/devices/#{params.device_id}$
+                    ^/events/#{params.event_id}/users/#{params.user_id}$
+                    '''
+                  end
+                end
+            """.trimIndent()
+        )
+    }
+
+    /**
+     * Test interpolated regex heredoc sigils with multi-line interpolation
+     */
+    fun testInterpolatedRegexHeredocMultilineInterpolation() {
+        assertNoProblemHighlights(
+            """
+                defmodule Test do
+                  def test(params) do
+                    regex = ~r'''
+                    ^/items/#{
+                      params.item_id
+                    }$
+                    '''
+                  end
+                end
+            """.trimIndent()
+        )
+    }
+
+    private fun assertNoProblemHighlights(text: String, expectInjection: Boolean = true) {
+        val file = myFixture.configureByText("test.ex", text)
+        if (expectInjection) {
+            assertRegexInjectionPresent(file)
+        }
+        val problemHighlights = problemHighlights()
+        assertTrue(
+            "Unexpected highlights: ${formatHighlights(problemHighlights)}",
+            problemHighlights.isEmpty()
+        )
+    }
+
+    private fun assertRegexInjectionPresent(file: PsiFile) {
+        val sigilLine = PsiTreeUtil.findChildOfType(file, SigilLine::class.java)
+        val sigilHeredoc = PsiTreeUtil.findChildOfType(file, SigilHeredoc::class.java)
+        val host = sigilLine ?: sigilHeredoc
+        checkNotNull(host) { "Sigil host not found in test file" }
+
+        val injected = InjectedLanguageManager.getInstance(project).getInjectedPsiFiles(host).orEmpty()
+        assertTrue(
+            "Expected RegExp injection in sigil",
+            injected.any { it.first.language.isKindOf(RegExpLanguage.INSTANCE) }
+        )
+    }
+
+    private fun problemHighlights(): List<HighlightInfo> {
+        val minimumSeverity = HighlightSeverity.WEAK_WARNING.myVal
+        return myFixture.doHighlighting().filter { info ->
+            info.severity.myVal >= minimumSeverity
+        }
+    }
+
+    private fun formatHighlights(highlights: List<HighlightInfo>): String {
+        return highlights.joinToString { info ->
+            val description = info.description ?: info.severity.name
+            "$description @ ${info.startOffset}-${info.endOffset}"
+        }
+    }
+
+    private fun ensureSigilInjectorRegistered() {
+        InjectedLanguageManager
+            .getInstance(project)
+            .registerMultiHostInjector(ElixirSigilInjector(), testRootDisposable)
+    }
+
+}


### PR DESCRIPTION
When the new `~H` feature enabled there were warnings like this in regex with interpolation: 
<img width="454" height="129" alt="image" src="https://github.com/user-attachments/assets/fad65fab-17dd-407f-885f-084e4c2bfb65" />

This adds a test for the bug and resolves it by removing interpolations from the regex before passing it to the IDE for inspection. 