### PR TITLE
Enable "Ultimate" in runIde task and reduce startup noise

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -25,11 +25,12 @@ useDynamicEapVersion=false
 
 # --- IDE Run Configuration Versions ---
 # Controls which run configuration tasks (e.g. runRubyMine) are generated
-runIdePlatforms=IntellijIdeaCommunity,IntellijIdeaUltimate,RubyMine,PyCharmCommunity,PyCharmProfessional,WebStorm
+# Note: IntellijIdeaCommunity is intentionally omitted (IU-only workflow). Add it back with
+# platformVersionIntellijIdeaCommunity if Community run tasks are needed.
+runIdePlatforms=IntellijIdeaUltimate,RubyMine,PyCharmCommunity,PyCharmProfessional,WebStorm
 enableEAPIDEs=true
 
 # Stable Versions (2025.3)
-platformVersionIntellijIdeaCommunity=2025.3
 platformVersionIntellijIdeaUltimate=2025.3
 platformVersionRubyMine=2025.3
 platformVersionPyCharmCommunity=2025.3
@@ -37,7 +38,6 @@ platformVersionPyCharmProfessional=2025.3
 platformVersionWebStorm=2025.3
 
 # EAP Versions
-platformVersionIntellijIdeaCommunityEAP=253-EAP-SNAPSHOT
 platformVersionIntellijIdeaUltimateEAP=253-EAP-SNAPSHOT
 platformVersionRubyMineEAP=253-EAP-SNAPSHOT
 platformVersionPyCharmCommunityEAP=253-EAP-SNAPSHOT
@@ -71,6 +71,9 @@ runIdeCompatiblePlugins=
 # Note: intelliLang changed to a module (intellij.platform.langInjection) in 2025.3+
 platformBundledPlugins=org.intellij.plugins.markdown,com.intellij.java
 platformBundledModules=intellij.platform.langInjection
+
+# Disable automatic plugin reloading in runIde; re-enable with -PideaAutoReload=true if needed.
+ideaAutoReload=false
 
 # --- Gradle Performance & Memory ---
 org.gradle.jvmargs=-Xmx4096m


### PR DESCRIPTION
This updates the `runIde` Ultimate task to automatically enable ultimate and reduce error/warning noise. Key changes include:

- Default `autoReload` turned off with `ideaAutoReload` toggle.
- Disabled Kubernetes due to persistent SEVERE error messages.
- Disabled Sass in the `runIde` sandbox to avoid missing Darcula color scheme warnings.
- Removed `IntellijIdeaCommunity` from `runIdePlatform`, as it has been merged with Ultimate as of 2025.3.