### PR TITLE
[draft] Get plugin to compile and build on Elixir 1.18 + Erlang 28.1

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,5 +1,5 @@
-elixir 1.13.4-otp-24
-erlang 24.3.4.6
+elixir 1.18
+erlang 28.1
 
 # 21.0.4+7 / Azul Zulu: 21.36.17
 # GitHub actions uses JBR 21

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -425,7 +425,7 @@ val releaseQuoter by tasks.registering(Exec::class) {
     outputs.dir(quoterUnzippedPath.dir("_build"))
         .withPropertyName("buildDir")
 
-    commandLine("mix", "release")
+    commandLine("mix", "do", "local.rebar", "--force,", "local.hex", "--force,", "release")
 }
 
 // Register the QuoterService - Gradle calls close() at build end regardless of failure
@@ -466,4 +466,3 @@ tasks.named<Test>("test") {
 //        setProperty("termsOfServiceAgree", "yes")
 //    }
 //}
-

--- a/gradle.properties
+++ b/gradle.properties
@@ -51,7 +51,7 @@ pluginVerifierVersion=2025.3
 pluginVerifierChannels=RELEASE,EAP,RC,PREVIEW
 
 # --- Tooling Versions ---
-elixirVersion=1.13.4
+elixirVersion=1.18
 quoterVersion=2.1.0
 
 # Plugins which will run ONLY when running `runIde` tasks, not for testing/release.


### PR DESCRIPTION
Relevant: https://github.com/KronicDeth/intellij-elixir/issues/3766

This PR contains what little changes I did to get the plugin working on the most recent version--- (checks notes: recent version is 19.5) ehm, the most recent at the time I installed Elixir -- 1.18

Reason: Erlang 24 and 25 can no longer be built with Kerl, at least on my machine (check issue for details)

Of course a significant chunk of tests fail, hence this PR is just a draft for the sake of showing what I did, but I'm happy I can at least get started. 

Tests:
  3534 passing (1m 15s)
  293 failing

<img width="711" height="226" alt="image" src="https://github.com/user-attachments/assets/c88edb87-27d2-4e00-a14b-7b33b8837bca" />
