### PR TITLE
Switch off dependencies checker pending improvements.

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -32,7 +32,6 @@
         <backgroundPostStartupActivity implementation="org.elixir_lang.status_bar_widget.ElixirSdkStatusWidgetStartupActivity"/>
 
         <postStartupActivity implementation="org.elixir_lang.sdk.SdkTableListenerStartupActivity"/>
-        <postStartupActivity implementation="org.elixir_lang.mix.DepsCheckerStartupActivity"/>
 
         <!--        <errorHandler implementation="org.elixir_lang.errorreport.Submitter"/>-->
         <errorHandler implementation="com.intellij.diagnostic.JetBrainsMarketplaceErrorReportSubmitter"/>


### PR DESCRIPTION
The dependencies checker activity has been disabled as its current implementation requires further work and has been delaying the release.