### PR TITLE
Simplify CI by delegating Gradle caching to setup-gradle

### DIFF
--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -12,11 +12,11 @@ inputs:
     required: false
     default: '24.3.4.6'
   idea-version:
-    description: 'IntelliJ IDEA version to test against. Keep in sync with matrix-setup in shared-test.yml'
+    description: 'IntelliJ IDEA version to test against. Keep in sync with the matrix in shared-test.yml'
     required: false
     default: '253.30387.90'  # 2025.3.2 - should match first version in shared-test.yml
   gradle-cache-read-only:
-    description: 'Controls whether CI should save caches (used to gate Elixir cache saving). Gradle caching is handled in workflows.'
+    description: 'If true, Gradle and Elixir caches are read-only (no writes). Set to false on main branch to seed caches for PRs.'
     required: false
     default: 'true'
   github-token:
@@ -93,7 +93,7 @@ runs:
       id: setup-gradle
       uses: gradle/actions/setup-gradle@v5
       with:
-        cache-disabled: true
+        cache-read-only: ${{ inputs.gradle-cache-read-only }}
         add-job-summary-as-pr-comment: 'on-failure'
         build-scan-publish: ${{ inputs.build-scan-publish }}
         build-scan-terms-of-use-url: 'https://gradle.com/terms-of-service'
@@ -134,8 +134,7 @@ runs:
       uses: actions/cache/save@v5
       with:
         path: |
-          cache/elixir-${{ inputs.elixir-version }}-intellij_elixir-2.1.0/_build
-          cache/elixir-${{ inputs.elixir-version }}-intellij_elixir-2.1.0/deps
+          cache/elixir-${{ inputs.elixir-version }}-intellij_elixir-2.1.0
           !cache/**/tmp/pipe/**
           !cache/**/distillery/priv
         key: ${{ steps.cache-elixir-restore.outputs.cache-primary-key }}

--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -6,33 +6,17 @@ on:
 jobs:
   publish-to-canary:
     runs-on: ubuntu-22.04
-    env:
-      GRADLE_USER_HOME: ${{ github.workspace }}/.gradle
-      GRADLE_CACHE_SCOPE: ${{ github.event.pull_request.head.repo.id || github.repository_id }}
-      GRADLE_CACHE_IDE_VERSION: '2025.3.2'
     steps:
       - name: Checkout
         id: checkout
         uses: actions/checkout@v6
-
-      - name: Restore Gradle cache
-        id: gradle-cache-restore
-        uses: actions/cache/restore@v5
-        with:
-          path: |
-            ${{ env.GRADLE_USER_HOME }}/caches
-            ${{ env.GRADLE_USER_HOME }}/wrapper
-            ${{ env.GRADLE_USER_HOME }}/notifications
-          key: gradle-${{ runner.os }}-${{ runner.arch }}-${{ env.GRADLE_CACHE_SCOPE }}-${{ env.GRADLE_CACHE_IDE_VERSION }}-${{ hashFiles('build.gradle.kts', 'settings.gradle.kts', 'gradle.properties', 'gradle/libs.versions.toml', 'gradle/wrapper/gradle-wrapper.properties', 'buildSrc/build.gradle.kts', 'buildSrc/settings.gradle.kts') }}
-          restore-keys: |
-            gradle-${{ runner.os }}-${{ runner.arch }}-${{ env.GRADLE_CACHE_SCOPE }}-${{ env.GRADLE_CACHE_IDE_VERSION }}-
-            gradle-${{ runner.os }}-${{ runner.arch }}-${{ env.GRADLE_CACHE_SCOPE }}-
 
       - name: Setup Build Environment
         id: setup-env
         uses: ./.github/actions/setup-env
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          gradle-cache-read-only: 'false'
           setup-elixir: false
 
       - name: Download Release Asset
@@ -50,14 +34,3 @@ jobs:
           JET_BRAINS_MARKETPLACE_TOKEN: ${{ secrets.JetBrainsMarketplaceToken }}
         run: |
           ./gradlew publishPlugin -PdistributionFile=intellij-elixir-${{ github.ref_name }}.zip
-
-      - name: Save Gradle cache
-        id: gradle-cache-save
-        if: always() && steps.gradle-cache-restore.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v5
-        with:
-          path: |
-            ${{ env.GRADLE_USER_HOME }}/caches
-            ${{ env.GRADLE_USER_HOME }}/wrapper
-            ${{ env.GRADLE_USER_HOME }}/notifications
-          key: ${{ steps.gradle-cache-restore.outputs.cache-primary-key }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,33 +13,17 @@ jobs:
   release:
     needs: [ test-and-verify ]
     runs-on: ubuntu-22.04
-    env:
-      GRADLE_USER_HOME: ${{ github.workspace }}/.gradle
-      GRADLE_CACHE_SCOPE: ${{ github.event.pull_request.head.repo.id || github.repository_id }}
-      GRADLE_CACHE_IDE_VERSION: '2025.3.2'
     steps:
       - name: Checkout
         id: checkout
         uses: actions/checkout@v6
-
-      - name: Restore Gradle cache
-        id: gradle-cache-restore
-        uses: actions/cache/restore@v5
-        with:
-          path: |
-            ${{ env.GRADLE_USER_HOME }}/caches
-            ${{ env.GRADLE_USER_HOME }}/wrapper
-            ${{ env.GRADLE_USER_HOME }}/notifications
-          key: gradle-${{ runner.os }}-${{ runner.arch }}-${{ env.GRADLE_CACHE_SCOPE }}-${{ env.GRADLE_CACHE_IDE_VERSION }}-${{ hashFiles('build.gradle.kts', 'settings.gradle.kts', 'gradle.properties', 'gradle/libs.versions.toml', 'gradle/wrapper/gradle-wrapper.properties', 'buildSrc/build.gradle.kts', 'buildSrc/settings.gradle.kts') }}
-          restore-keys: |
-            gradle-${{ runner.os }}-${{ runner.arch }}-${{ env.GRADLE_CACHE_SCOPE }}-${{ env.GRADLE_CACHE_IDE_VERSION }}-
-            gradle-${{ runner.os }}-${{ runner.arch }}-${{ env.GRADLE_CACHE_SCOPE }}-
 
       - name: Setup Build Environment
         id: setup-env
         uses: ./.github/actions/setup-env
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          gradle-cache-read-only: 'false'
           skip-searchable-options: 'false'
 
       - name: Build with Gradle
@@ -76,17 +60,6 @@ jobs:
           prerelease: true
           files: ${{ env.ASSET_PATH }}
           fail_on_unmatched_files: true
-
-      - name: Save Gradle cache
-        id: gradle-cache-save
-        if: always() && steps.gradle-cache-restore.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v5
-        with:
-          path: |
-            ${{ env.GRADLE_USER_HOME }}/caches
-            ${{ env.GRADLE_USER_HOME }}/wrapper
-            ${{ env.GRADLE_USER_HOME }}/notifications
-          key: ${{ steps.gradle-cache-restore.outputs.cache-primary-key }}
 
 #     - name: Publish
 #       env:

--- a/.github/workflows/shared-test.yml
+++ b/.github/workflows/shared-test.yml
@@ -35,95 +35,14 @@ defaults:
     shell: bash
 
 jobs:
-  matrix-setup:
-    runs-on: ubuntu-latest
-    outputs:
-      idea-versions: '["2025.3.2", "LATEST-EAP-SNAPSHOT"]'
-    steps:
-      - run: echo "Defining idea-versions matrix"
-
-  seed-gradle-cache:
-    needs: matrix-setup
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        # Stay with windows-2022 until https://github.com/erlef/setup-beam/commit/b94e7d372a9ef22d376b75a9374a7adeb0e2ea94 is released.
-        os: [ubuntu-22.04, windows-2022]
-        idea-version: ${{ fromJson(needs.matrix-setup.outputs.idea-versions) }}
-
-    env:
-      GRADLE_USER_HOME: ${{ github.workspace }}/.gradle
-      GRADLE_CACHE_SCOPE: ${{ github.event.pull_request.head.repo.id || github.repository_id }}
-      GRADLE_CACHE_IDE_VERSION: ${{ matrix.idea-version }}
-
-    steps:
-
-      - name: Checkout
-        id: checkout
-        uses: actions/checkout@v6
-        with:
-          ref: ${{ inputs.ref || github.ref }}
-
-      - name: Restore Gradle cache
-        id: gradle-cache-restore
-        uses: actions/cache/restore@v5
-        with:
-          path: |
-            ${{ env.GRADLE_USER_HOME }}/caches
-            ${{ env.GRADLE_USER_HOME }}/wrapper
-            ${{ env.GRADLE_USER_HOME }}/notifications
-          # Fork-scoped cache key:
-          # - Avoids cross-PR cache poisoning between forks.
-          # - Includes IDE version and build inputs to keep cache correctness.
-          key: gradle-${{ runner.os }}-${{ runner.arch }}-${{ env.GRADLE_CACHE_SCOPE }}-${{ env.GRADLE_CACHE_IDE_VERSION }}-${{ hashFiles('build.gradle.kts', 'settings.gradle.kts', 'gradle.properties', 'gradle/libs.versions.toml', 'gradle/wrapper/gradle-wrapper.properties', 'buildSrc/build.gradle.kts', 'buildSrc/settings.gradle.kts') }}
-          # Graceful fallback:
-          # - First try exact IDE version match.
-          # - Then fall back to the same fork scope on this OS/arch.
-          restore-keys: |
-            gradle-${{ runner.os }}-${{ runner.arch }}-${{ env.GRADLE_CACHE_SCOPE }}-${{ env.GRADLE_CACHE_IDE_VERSION }}-
-            gradle-${{ runner.os }}-${{ runner.arch }}-${{ env.GRADLE_CACHE_SCOPE }}-
-
-      - name: Setup Build Environment
-        id: setup-env
-        uses: ./.github/actions/setup-env
-        with:
-          elixir-version: ${{ inputs.elixir-version || '1.13.4' }}
-          otp-version: ${{ inputs.otp-version || '24.3.4.6' }}
-          idea-version: ${{ matrix.idea-version }}
-          setup-elixir: false
-          gradle-cache-read-only: true
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Resolve External Dependencies
-        id: resolve-external-deps
-        run: ./gradlew :jps-builder:resolveExternalDependencies
-
-      - name: Save Gradle cache
-        id: gradle-cache-save
-        if: always() && steps.gradle-cache-restore.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v5
-        with:
-          path: |
-            ${{ env.GRADLE_USER_HOME }}/caches
-            ${{ env.GRADLE_USER_HOME }}/wrapper
-            ${{ env.GRADLE_USER_HOME }}/notifications
-          key: ${{ steps.gradle-cache-restore.outputs.cache-primary-key }}
-
   test:
-    needs: [matrix-setup, seed-gradle-cache]
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         # Stay with windows-2022 until https://github.com/erlef/setup-beam/commit/b94e7d372a9ef22d376b75a9374a7adeb0e2ea94 is released.
         os: [ubuntu-22.04, windows-2022]
-        idea-version: ${{ fromJson(needs.matrix-setup.outputs.idea-versions) }}
-
-    env:
-      GRADLE_USER_HOME: ${{ github.workspace }}/.gradle
-      GRADLE_CACHE_SCOPE: ${{ github.event.pull_request.head.repo.id || github.repository_id }}
-      GRADLE_CACHE_IDE_VERSION: ${{ matrix.idea-version }}
+        idea-version: ['2025.3.2', 'LATEST-EAP-SNAPSHOT']
 
     steps:
       - name: Checkout
@@ -132,25 +51,6 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.ref }}
 
-      - name: Restore Gradle cache
-        id: gradle-cache-restore
-        uses: actions/cache/restore@v5
-        with:
-          path: |
-            ${{ env.GRADLE_USER_HOME }}/caches
-            ${{ env.GRADLE_USER_HOME }}/wrapper
-            ${{ env.GRADLE_USER_HOME }}/notifications
-          # Fork-scoped cache key:
-          # - Avoids cross-PR cache poisoning between forks.
-          # - Includes IDE version and build inputs to keep cache correctness.
-          key: gradle-${{ runner.os }}-${{ runner.arch }}-${{ env.GRADLE_CACHE_SCOPE }}-${{ env.GRADLE_CACHE_IDE_VERSION }}-${{ hashFiles('build.gradle.kts', 'settings.gradle.kts', 'gradle.properties', 'gradle/libs.versions.toml', 'gradle/wrapper/gradle-wrapper.properties', 'buildSrc/build.gradle.kts', 'buildSrc/settings.gradle.kts') }}
-          # Graceful fallback:
-          # - First try exact IDE version match.
-          # - Then fall back to the same fork scope on this OS/arch.
-          restore-keys: |
-            gradle-${{ runner.os }}-${{ runner.arch }}-${{ env.GRADLE_CACHE_SCOPE }}-${{ env.GRADLE_CACHE_IDE_VERSION }}-
-            gradle-${{ runner.os }}-${{ runner.arch }}-${{ env.GRADLE_CACHE_SCOPE }}-
-
       - name: Setup Build Environment
         id: setup-env
         uses: ./.github/actions/setup-env
@@ -158,29 +58,8 @@ jobs:
           elixir-version: ${{ inputs.elixir-version || '1.13.4' }}
           otp-version: ${{ inputs.otp-version || '24.3.4.6' }}
           idea-version: ${{ matrix.idea-version }}
-          gradle-cache-read-only: true
+          gradle-cache-read-only: ${{ github.event_name == 'pull_request' }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Debug Maven Central access
-        run: |
-          echo "=== DNS / Network / TLS info ==="
-          ip -4 addr || true
-          uname -a
-          echo "Java version:"
-          java -version || true
-          
-          echo
-          echo "=== HTTP HEAD to POM (show headers) ==="
-          curl -vI 'https://repo.maven.apache.org/maven2/commons-io/commons-io/2.21.0/commons-io-2.21.0.pom' || true
-          
-          echo
-          echo "=== HTTP GET to POM (show first 200 bytes) ==="
-          curl -v 'https://repo.maven.apache.org/maven2/commons-io/commons-io/2.21.0/commons-io-2.21.0.pom' -m 20 -sS -o /tmp/commons.pom || true
-          head -c 200 /tmp/commons.pom || true
-          
-          echo
-          echo "=== Try resolving dependency via Gradle (info) ==="
-          ./gradlew --no-daemon --refresh-dependencies dependencies --configuration compileClasspath --info || true
 
       - name: Run Tests
         id: test
@@ -220,13 +99,7 @@ jobs:
 
   build-plugin-for-verifier:
     name: "Build Plugin for verifyPlugin"
-    needs: seed-gradle-cache
     runs-on: ubuntu-22.04
-
-    env:
-      GRADLE_USER_HOME: ${{ github.workspace }}/.gradle
-      GRADLE_CACHE_SCOPE: ${{ github.event.pull_request.head.repo.id || github.repository_id }}
-      GRADLE_CACHE_IDE_VERSION: '2025.3.2'
 
     steps:
       - name: Checkout
@@ -235,30 +108,12 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.ref }}
 
-      - name: Restore Gradle cache
-        id: gradle-cache-restore
-        uses: actions/cache/restore@v5
-        with:
-          path: |
-            ${{ env.GRADLE_USER_HOME }}/caches
-            ${{ env.GRADLE_USER_HOME }}/wrapper
-            ${{ env.GRADLE_USER_HOME }}/notifications
-          # Fork-scoped cache key:
-          # - Avoids cross-PR cache poisoning between forks.
-          # - Includes IDE version and build inputs to keep cache correctness.
-          key: gradle-${{ runner.os }}-${{ runner.arch }}-${{ env.GRADLE_CACHE_SCOPE }}-${{ env.GRADLE_CACHE_IDE_VERSION }}-${{ hashFiles('build.gradle.kts', 'settings.gradle.kts', 'gradle.properties', 'gradle/libs.versions.toml', 'gradle/wrapper/gradle-wrapper.properties', 'buildSrc/build.gradle.kts', 'buildSrc/settings.gradle.kts') }}
-          # Graceful fallback:
-          # - First try exact IDE version match.
-          # - Then fall back to the same fork scope on this OS/arch.
-          restore-keys: |
-            gradle-${{ runner.os }}-${{ runner.arch }}-${{ env.GRADLE_CACHE_SCOPE }}-${{ env.GRADLE_CACHE_IDE_VERSION }}-
-            gradle-${{ runner.os }}-${{ runner.arch }}-${{ env.GRADLE_CACHE_SCOPE }}-
-
       - name: Setup Build Environment
         id: setup-env
         uses: ./.github/actions/setup-env
         with:
           setup-elixir: false
+          gradle-cache-read-only: ${{ github.event_name == 'pull_request' }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           idea-version: '2025.3.2'
 


### PR DESCRIPTION
GitHub Actions Caching save/restore is really slow, and just not using caching for PRs speeds things up drastically.

Gradle doesn't cache for PRs, by default.

This basically replaces manual actions/cache restore/save blocks with `setup-gradle@v5`'s built-in caching.

- Enable setup-gradle's cache-read-only mode, gated on event type: read-only on PRs (fork-safe), read-write on main pushes and dispatch
- Remove all manual GRADLE_USER_HOME, GRADLE_CACHE_SCOPE, and GRADLE_CACHE_IDE_VERSION env vars and actions/cache blocks from shared-test.yml, release.yml, and publish-canary.yml - Inline the IDE version matrix directly in the test job strategy
- Remove leftover "Debug Maven Central access" step that ran `--refresh-dependencies` on every test run
- Simplify Elixir cache save path to cache the whole quoter directory
