### PR TITLE
Rename NewProjectWizard to use language generator

### DIFF
--- a/resources/META-INF/rich-platform-plugin.xml
+++ b/resources/META-INF/rich-platform-plugin.xml
@@ -5,7 +5,7 @@
 <idea-plugin>
     <extensions defaultExtensionNs="com.intellij">
         <moduleType id="ELIXIR_MODULE" implementationClass="org.elixir_lang.module.ElixirModuleType"/>
-        <newProjectWizard.language implementation="org.elixir_lang.NewProjectWizard"/>
+        <newProjectWizard.languageGenerator implementation="org.elixir_lang.NewProjectWizard"/>
 
         <projectStructureDetector implementation="org.elixir_lang.module.ElixirProjectStructureDetector"/>
         <moduleConfigurationEditorProvider implementation="org.elixir_lang.module.DefaultModuleEditorsProvider"

--- a/src/org/elixir_lang/NewProjectWizard.kt
+++ b/src/org/elixir_lang/NewProjectWizard.kt
@@ -1,14 +1,15 @@
 package org.elixir_lang
 
-import com.intellij.ide.wizard.LanguageNewProjectWizard
-import com.intellij.ide.wizard.NewProjectWizardLanguageStep
 import com.intellij.ide.wizard.NewProjectWizardStep
+import com.intellij.ide.wizard.language.LanguageGeneratorNewProjectWizard
 import org.elixir_lang.new_project_wizard.Step
+import javax.swing.Icon
 
-class NewProjectWizard : LanguageNewProjectWizard {
+class NewProjectWizard : LanguageGeneratorNewProjectWizard {
     override val name: String = "Elixir"
     override val ordinal: Int = Int.MAX_VALUE
+    override val icon: Icon = Icons.LANGUAGE
 
-    override fun createStep(parent: NewProjectWizardLanguageStep): NewProjectWizardStep =
+    override fun createStep(parent: NewProjectWizardStep): NewProjectWizardStep =
         Step(parent)
 }

--- a/src/org/elixir_lang/new_project_wizard/Step.kt
+++ b/src/org/elixir_lang/new_project_wizard/Step.kt
@@ -7,7 +7,8 @@ import com.intellij.ide.JavaUiBundle
 import com.intellij.ide.util.projectWizard.WizardContext
 import com.intellij.ide.wizard.AbstractNewProjectWizardStep
 import com.intellij.ide.wizard.NewProjectWizardBaseData
-import com.intellij.ide.wizard.NewProjectWizardLanguageStep
+import com.intellij.ide.wizard.NewProjectWizardBaseData.Companion.baseData
+import com.intellij.ide.wizard.NewProjectWizardStep
 import com.intellij.notification.NotificationGroupManager
 import com.intellij.notification.NotificationType
 import com.intellij.openapi.diagnostic.Logger
@@ -39,10 +40,10 @@ import java.nio.file.Paths
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
 
-// Based on [NewPythonProjectStep](https://github.com/JetBrains/intellij-community/blob/dcb0ce2edd2c3b1dffb7e60103898acd5b913cfb/python/src/com/jetbrains/python/newProject/PythonNewProjectWizard.kt#L82-L145)
-class Step(parent: NewProjectWizardLanguageStep) : AbstractNewProjectWizardStep(parent),
-                                                   NewProjectWizardBaseData by parent,
-                                                   Data {
+// Based on [NewPythonProjectStep](https://github.com/JetBrains/intellij-community/blob/7bb876b50c1601c8563c444d5f133dd19247e814/python/src/com/jetbrains/python/newProject/NewProjectWizardPythonData.kt#L74)
+class Step(parent: NewProjectWizardStep) : AbstractNewProjectWizardStep(parent),
+                                           NewProjectWizardBaseData by parent.baseData!!,
+                                           Data {
     override val sdkProperty = propertyGraph.property<Sdk?>(null)
     override val mixNewAppProperty = propertyGraph.property<String>("")
     override val mixNewModuleProperty = propertyGraph.property<String>("")


### PR DESCRIPTION
The LanguageNewProjectWizard API has recently been redesigned as the new LanguageGeneratorNewProjectWizard.

Some APIs may also provide deprecation warnings.

<img width="856" height="229" alt="image" src="https://github.com/user-attachments/assets/6bceeb66-9df4-4205-a661-61a6519b2359">

Additionally...

~~~
'class NewProjectWizardLanguageStep : AbstractNewProjectWizardStep, LanguageNewProjectWizardData, NewProjectWizardBaseData' is deprecated. See LanguageNewProjectWizardData documentation for details.
~~~

We have replaced the interface and implemented support to display the Elixir icon when creating a project. (This is a screenshot taken after building locally and installing the plugin.)

<img width="496" height="232" alt="image" src="https://github.com/user-attachments/assets/febfa0ab-10e2-4635-b210-de0236e46af5" />

- Update rich-platform-plugin.xml to change the language implementation.
- Refactor NewProjectWizard to extend LanguageGeneratorNewProjectWizard.
- Adjust createStep method to accept NewProjectWizardStep as a parameter.
- Modify Step class to implement the new project structure.