### PR TITLE
Avoid deadlocks when indexing by using FileContent for BEAM

### DIFF
--- a/src/org/elixir_lang/beam/Cache.kt
+++ b/src/org/elixir_lang/beam/Cache.kt
@@ -25,7 +25,24 @@ class Cache private constructor(private val beam: Beam) {
     companion object {
         private val KEY = Key.create<Pair<Long, Cache?>>("beam.cache")
 
-        fun from(fileContent: FileContent) = from(fileContent.file)
+        fun from(fileContent: FileContent): Cache? {
+            val virtualFile = fileContent.file
+            val currentModificationCount = virtualFile.modificationCount
+
+            // FileBasedIndexExtension treats FileContent as the indexing input, and
+            // FileContent already provides normalized bytes for parsing.
+            // Avoid reopening VirtualFile.inputStream here: blocking I/O in read-action-
+            // sensitive indexing paths can stall pending write actions and freeze the EDT
+            // (for example via WSL/IJent fsBlocking/runBlocking).
+            val cache = virtualFile.getUserData(KEY)?.let { (cachedModificationCount, cachedCache) ->
+                if (cachedModificationCount == currentModificationCount) cachedCache else null
+            } ?: Beam.from(fileContent)?.let(::Cache)
+
+            virtualFile.putUserData(KEY, Pair(currentModificationCount, cache))
+
+            return cache
+        }
+
         fun from(virtualFile: VirtualFile): Cache? {
             val currentModificationCount = virtualFile.modificationCount
 


### PR DESCRIPTION
- Changed the `org.elixir_lang.beam.Cache.from(FileContent)` method to utilize `org.elixir_lang.beam.Beam.from(fileContent)` directly, to avoid calling `Cache.from(virtualFile)` during cache misses.
- Avoids potential deadlocks during indexing caused by reopening `VirtualFile.inputStream` under certain conditions (e.g., on WSL/IJ environments).


<details>

<summary>Thread Analysis</summary>

```java

Long read action in org.elixir_lang.reference.ResolveWithCachingComputable.compute

======= Stack Trace: ========= 
"JobScheduler FJ pool 12/31" prio=0 tid=0x0 nid=0x0 waiting on condition
     java.lang.Thread.State: TIMED_WAITING
 on kotlinx.coroutines.BlockingCoroutine@f93c80c
	at java.base@25.0.2/jdk.internal.misc.Unsafe.park(Native Method)
	at java.base@25.0.2/java.util.concurrent.locks.LockSupport.parkNanos(LockSupport.java:271)
	at kotlinx.coroutines.BlockingCoroutine.joinBlocking(Builders.kt:121)
	at kotlinx.coroutines.BuildersKt__BuildersKt.runBlocking$BuildersKt__BuildersKt(Builders.kt:87)
	at kotlinx.coroutines.BuildersKt__BuildersKt.runBlocking(Builders.kt:55)
	at kotlinx.coroutines.BuildersKt.runBlocking(Unknown Source)
	at com.intellij.platform.ijent.community.impl.nio.IjentNioFileSystemUtil.fsBlockingWithoutParallelismCompensation(IjentNioFileSystemUtil.kt:40)
	at com.intellij.platform.ijent.community.impl.nio.IjentNioFileSystemUtil.fsBlocking$lambda$0(IjentNioFileSystemUtil.kt:31)
	at com.intellij.platform.ijent.community.impl.nio.IjentNioFileSystemUtil$$Lambda/0x000000001aa43678.invoke(Unknown Source)
	at kotlinx.coroutines.internal.intellij.IntellijCoroutines.runAndCompensateParallelism-VtjQ1oo(intellij.kt:91)
	at com.intellij.util.IntelliJCoroutinesFacade.runAndCompensateParallelism-VtjQ1oo(IntelliJCoroutinesFacade.kt:45)
	at com.intellij.platform.ijent.community.impl.nio.IjentNioFileSystemUtil.fsBlocking(IjentNioFileSystemUtil.kt:30)
	at com.intellij.platform.ijent.community.impl.nio.IjentNioFileSystemProvider.newFileChannel(IjentNioFileSystemProvider.kt:223)
	at com.intellij.platform.ijent.community.impl.nio.IjentNioFileSystemProvider.newByteChannel(IjentNioFileSystemProvider.kt:182)
	at java.base@25.0.2/java.nio.file.Files.newByteChannel(Files.java:357)
	at java.base@25.0.2/java.nio.file.Files.newByteChannel(Files.java:399)
	at java.base@25.0.2/java.nio.file.spi.FileSystemProvider.newInputStream(FileSystemProvider.java:371)
	at com.intellij.platform.ide.impl.wsl.ijent.nio.IjentWslNioFileSystemProvider.newInputStream(IjentWslNioFileSystemProvider.kt:152)
	at com.intellij.platform.core.nio.fs.DelegatingFileSystemProvider.newInputStream(DelegatingFileSystemProvider.java:87)
	at java.base@25.0.2/java.nio.file.Files.newInputStream(Files.java:154)
	at com.intellij.openapi.vfs.impl.local.LocalFileSystemBase.getInputStream(LocalFileSystemBase.java:437)
	at com.intellij.openapi.vfs.newvfs.persistent.PersistentFSImpl.getInputStream(PersistentFSImpl.java:1076)
	at com.intellij.openapi.vfs.newvfs.impl.VirtualFileImpl.getInputStream(VirtualFileImpl.java:117)
	at org.elixir_lang.beam.BeamKt.virtualFileToInputStream(Beam.kt:53)
	at org.elixir_lang.beam.BeamKt.access$virtualFileToInputStream(Beam.kt:1)
	at org.elixir_lang.beam.Beam$Companion.from(Beam.kt:183)
	at org.elixir_lang.beam.Cache$Companion.from(Cache.kt:38)
	at org.elixir_lang.beam.Cache$Companion.from(Cache.kt:28)
	at org.elixir_lang.beam.chunk.lines.file_names.Indexer.map(Indexer.kt:9)
	at org.elixir_lang.beam.chunk.lines.file_names.Indexer.map(Indexer.kt:7)
	at com.intellij.util.indexing.impl.MapReduceIndex.mapByIndexer(MapReduceIndex.java:368)
	at com.intellij.util.indexing.impl.MapReduceIndex.mapInput(MapReduceIndex.java:359)
	at com.intellij.util.indexing.impl.MapReduceIndex.mapInputAndPrepareUpdate(MapReduceIndex.java:284)
	at com.intellij.util.indexing.FileBasedIndexImpl.createSingleIndexValueApplier(FileBasedIndexImpl.java:1727)
	at com.intellij.util.indexing.FileBasedIndexImpl.lambda$doIndexFileContent$20(FileBasedIndexImpl.java:1598)
	at com.intellij.util.indexing.FileBasedIndexImpl$$Lambda/0x000000001cc41ad8.run(Unknown Source)
	at com.intellij.openapi.fileTypes.impl.FileTypeManagerImpl.lambda$freezeFileTypeTemporarilyWithProvidedValueIn$15(FileTypeManagerImpl.java:833)
	at com.intellij.openapi.fileTypes.impl.FileTypeManagerImpl$$Lambda/0x000000001bf83b38.run(Unknown Source)
	at com.intellij.openapi.fileTypes.impl.FileTypeManagerImpl.cacheFileTypesInside(FileTypeManagerImpl.java:904)
	at com.intellij.openapi.fileTypes.impl.FileTypeManagerImpl.freezeFileTypeTemporarilyWithProvidedValueIn(FileTypeManagerImpl.java:829)
	at com.intellij.util.indexing.FileBasedIndexImpl.doIndexFileContent(FileBasedIndexImpl.java:1551)
	at com.intellij.util.indexing.FileBasedIndexImpl.indexFileContent(FileBasedIndexImpl.java:1526)
	at com.intellij.util.indexing.FileBasedIndexImpl.processRefreshedFile(FileBasedIndexImpl.java:1466)
	at com.intellij.util.indexing.FileBasedIndexImpl$VirtualFileUpdateTask.doProcess(FileBasedIndexImpl.java:1856)
	at com.intellij.util.indexing.FileBasedIndexImpl$VirtualFileUpdateTask.doProcess(FileBasedIndexImpl.java:1850)
	at com.intellij.util.indexing.UpdateTask.process(UpdateTask.java:75)
	at com.intellij.util.indexing.UpdateTask.processAll(UpdateTask.java:43)
	at com.intellij.util.indexing.FileBasedIndexImpl.forceUpdate(FileBasedIndexImpl.java:1877)
	at com.intellij.util.indexing.FileBasedIndexImpl.ensureUpToDate(FileBasedIndexImpl.java:936)
	at com.intellij.psi.stubs.StubIndexEx.getContainingIds(StubIndexEx.java:388)
	at com.intellij.psi.stubs.StubIndexEx.processElements(StubIndexEx.java:204)
	at com.intellij.psi.stubs.StubIndex.processElements(StubIndex.java:63)
	at org.elixir_lang.psi.scope.CallDefinitionClause.implicitImport(CallDefinitionClause.kt:300)
	at org.elixir_lang.psi.scope.CallDefinitionClause.implicitImports(CallDefinitionClause.kt:283)
	at org.elixir_lang.psi.scope.CallDefinitionClause.execute(CallDefinitionClause.kt:212)
	at org.elixir_lang.psi.scope.CallDefinitionClause.execute(CallDefinitionClause.kt:48)
	at org.elixir_lang.psi.impl.ProcessDeclarationsImpl.processDeclarations(ProcessDeclarationsImpl.kt:208)
	at org.elixir_lang.psi.ElixirFile.processDeclarations(ElixirFile.kt:28)
	at com.intellij.psi.util.PsiTreeUtil.treeWalkUp(PsiTreeUtil.java:1342)
	at org.elixir_lang.psi.scope.call_definition_clause.MultiResolve$Companion.resolveResults(MultiResolve.kt:255)
	at org.elixir_lang.psi.scope.call_definition_clause.MultiResolve$Companion.resolveResults$default(MultiResolve.kt:242)
	at org.elixir_lang.reference.resolver.Callable.resolveUnqualified(Callable.kt:134)
	at org.elixir_lang.reference.resolver.Callable.resolveInScope(Callable.kt:105)
	at org.elixir_lang.reference.resolver.Callable.resolve(Callable.kt:91)
	at org.elixir_lang.reference.resolver.Callable.resolveAll(Callable.kt:87)
	at org.elixir_lang.reference.resolver.Callable.resolvePreferred(Callable.kt:77)
	at org.elixir_lang.reference.resolver.Callable.resolve(Callable.kt:40)
	at org.elixir_lang.reference.resolver.Callable.resolve(Callable.kt:36)
	at org.elixir_lang.reference.resolver.Callable.resolve(Callable.kt:30)
	at com.intellij.psi.impl.source.resolve.ResolveCache.lambda$resolveWithCaching$1(ResolveCache.java:175)
	at com.intellij.psi.impl.source.resolve.ResolveCache$$Lambda/0x000000001cfae1b0.compute(Unknown Source)
	at com.intellij.openapi.util.Computable.get(Computable.java:16)
	at com.intellij.psi.impl.source.resolve.ResolveCache.lambda$loggingResolver$4(ResolveCache.java:250)
	at com.intellij.psi.impl.source.resolve.ResolveCache$$Lambda/0x000000001cfae910.compute(Unknown Source)
	at com.intellij.openapi.util.Computable.get(Computable.java:16)
	at com.intellij.psi.impl.source.resolve.ResolveCache.resolve(ResolveCache.java:229)
	at com.intellij.psi.impl.source.resolve.ResolveCache.resolveWithCaching(ResolveCache.java:174)
	at com.intellij.psi.impl.source.resolve.ResolveCache.resolveWithCaching(ResolveCache.java:156)
	at org.elixir_lang.reference.ResolveWithCachingComputable.compute(Callable.kt:607)
	at org.elixir_lang.reference.ResolveWithCachingComputable.compute(Callable.kt:598)
	at com.intellij.openapi.application.impl.ApplicationImpl$$Lambda/0x000000001b2b2698.invoke(Unknown Source)
	at com.intellij.platform.locking.impl.NestedLocksThreadingSupport.runReadAction(NestedLocksThreadingSupport.kt:854)
	at com.intellij.openapi.application.impl.ApplicationImpl.runReadAction(ApplicationImpl.java:1104)
	at org.elixir_lang.reference.CallableKt.resolveWithCaching(Callable.kt:596)
	at org.elixir_lang.reference.CallableKt.access$resolveWithCaching(Callable.kt:1)
	at org.elixir_lang.reference.Callable.multiResolve(Callable.kt:104)
	at org.elixir_lang.ReferenceKt.safeMultiResolve(reference.kt:16)
	at org.elixir_lang.annotator.Callable$annotate$1.visitPlainCall(Callable.kt:99)
	at org.elixir_lang.annotator.Callable$annotate$1.visitNonModuleAttributeCall(Callable.kt:89)
	at org.elixir_lang.annotator.Callable$annotate$1.visitCall(Callable.kt:49)
	at org.elixir_lang.annotator.Callable$annotate$1.visitElement(Callable.kt:80)
	at com.intellij.psi.impl.PsiElementBase.accept(PsiElementBase.java:277)
	at org.elixir_lang.psi.impl.ElixirUnmatchedUnqualifiedNoArgumentsCallImpl.accept(ElixirUnmatchedUnqualifiedNoArgumentsCallImpl.java:39)
	at org.elixir_lang.annotator.Callable.annotate(Callable.kt:41)
	at com.intellij.codeInsight.daemon.impl.AnnotationHolderImpl.runAnnotatorWithContext(AnnotationHolderImpl.java:222)
	at com.intellij.codeInsight.daemon.impl.AnnotatorRunner.lambda$runAnnotator$2(AnnotatorRunner.java:142)
	at com.intellij.codeInsight.daemon.impl.AnnotatorRunner$$Lambda/0x000000001cf6d278.apply(Unknown Source)
	at com.intellij.codeInsight.daemon.impl.AnnotationSessionImpl.computeWithSession(AnnotationSessionImpl.java:91)
	at com.intellij.codeInsight.daemon.impl.AnnotatorRunner.runAnnotator(AnnotatorRunner.java:132)
	at com.intellij.codeInsight.daemon.impl.AnnotatorRunner.lambda$runAnnotatorsAsync$0(AnnotatorRunner.java:78)
	at com.intellij.codeInsight.daemon.impl.AnnotatorRunner$$Lambda/0x000000001cf56268.run(Unknown Source)
	at com.intellij.openapi.application.impl.AppImplKt$runnableUnitFunction$1.invoke(appImpl.kt:124)
	at com.intellij.openapi.application.impl.AppImplKt$runnableUnitFunction$1.invoke(appImpl.kt:124)
	at com.intellij.platform.locking.impl.NestedLocksThreadingSupport.tryRunReadAction(NestedLocksThreadingSupport.kt:900)
	at com.intellij.openapi.application.impl.ApplicationImpl.tryRunReadAction(ApplicationImpl.java:1266)
	at com.intellij.codeInsight.daemon.impl.AnnotatorRunner.lambda$runAnnotatorsAsync$1(AnnotatorRunner.java:78)
	at com.intellij.codeInsight.daemon.impl.AnnotatorRunner$$Lambda/0x000000001cf49eb0.process(Unknown Source)
	at com.intellij.concurrency.ApplierCompleter.processArrayItem(ApplierCompleter.java:121)
	at com.intellij.concurrency.ApplierCompleter.processArray(ApplierCompleter.java:221)
	at com.intellij.concurrency.ApplierCompleter.execAll(ApplierCompleter.java:171)
	at com.intellij.concurrency.JobLauncherImpl.lambda$invokeConcurrentlyUnderProgressAsync$3(JobLauncherImpl.java:120)
	at com.intellij.concurrency.JobLauncherImpl$$Lambda/0x000000001cf6c710.run(Unknown Source)
	at com.intellij.openapi.application.impl.AppImplKt$runnableUnitFunction$1.invoke(appImpl.kt:124)
	at com.intellij.openapi.application.impl.AppImplKt$runnableUnitFunction$1.invoke(appImpl.kt:124)
	at com.intellij.platform.locking.impl.NestedLocksThreadingSupport.tryRunReadAction(NestedLocksThreadingSupport.kt:900)
	at com.intellij.openapi.application.impl.ApplicationImpl.tryRunReadAction(ApplicationImpl.java:1266)
	at com.intellij.concurrency.ApplierCompleter.lambda$wrapInReadActionAndIndicator$2(ApplierCompleter.java:153)
	at com.intellij.concurrency.ApplierCompleter$$Lambda/0x000000001cf53710.run(Unknown Source)
	at com.intellij.openapi.progress.impl.CoreProgressManager.lambda$executeProcessUnderProgress$14(CoreProgressManager.java:744)
	at com.intellij.openapi.progress.impl.CoreProgressManager$$Lambda/0x000000001b607000.compute(Unknown Source)
	at com.intellij.openapi.progress.impl.CoreProgressManager.registerIndicatorAndRun(CoreProgressManager.java:819)
	at com.intellij.openapi.progress.impl.CoreProgressManager.computeUnderProgress(CoreProgressManager.java:775)
	at com.intellij.openapi.progress.impl.CoreProgressManager.executeProcessUnderProgress(CoreProgressManager.java:743)
	at com.intellij.openapi.progress.impl.ProgressManagerImpl.executeProcessUnderProgress(ProgressManagerImpl.java:87)
	at com.intellij.concurrency.ApplierCompleter.wrapInReadActionAndIndicator(ApplierCompleter.java:164)
	at com.intellij.concurrency.ApplierCompleter.lambda$wrapAndRun$1(ApplierCompleter.java:145)
	at com.intellij.concurrency.ApplierCompleter$$Lambda/0x000000001cf51860.run(Unknown Source)
	at com.intellij.openapi.application.impl.ApplicationImpl.executeByImpatientReader(ApplicationImpl.java:306)
	at com.intellij.concurrency.ApplierCompleter.wrapAndRun(ApplierCompleter.java:145)
	at com.intellij.concurrency.JobLauncherImpl.lambda$invokeConcurrentlyUnderProgressAsync$4(JobLauncherImpl.java:120)
	at com.intellij.concurrency.JobLauncherImpl$$Lambda/0x000000001cf6c268.consume(Unknown Source)
	at com.intellij.concurrency.JobLauncherImpl.safeIterate(JobLauncherImpl.java:200)
	at com.intellij.concurrency.JobLauncherImpl.lambda$invokeConcurrentlyUnderProgressAsync$5(JobLauncherImpl.java:117)
	at com.intellij.concurrency.JobLauncherImpl$$Lambda/0x000000001cf6c000.invoke(Unknown Source)
	at com.intellij.concurrency.ThreadContext.resetThreadContext(threadContext.kt:294)
	at com.intellij.concurrency.JobLauncherImpl.invokeConcurrentlyUnderProgressAsync(JobLauncherImpl.java:116)
	at com.intellij.concurrency.JobLauncherImpl.processConcurrentlyAsync(JobLauncherImpl.java:498)
	at com.intellij.codeInsight.daemon.impl.AnnotatorRunner.runAnnotatorsAsync(AnnotatorRunner.java:79)
	at com.intellij.codeInsight.daemon.impl.GeneralHighlightingPass.collectHighlights(GeneralHighlightingPass.java:254)
	at com.intellij.codeInsight.daemon.impl.GeneralHighlightingPass.lambda$collectInformationWithProgress$8(GeneralHighlightingPass.java:171)
	at com.intellij.codeInsight.daemon.impl.GeneralHighlightingPass$$Lambda/0x000000001c9b61e8.accept(Unknown Source)
	at com.intellij.codeInsight.daemon.impl.HighlightInfoUpdaterImpl.lambda$runWithInvalidPsiRecycler$51(HighlightInfoUpdaterImpl.java:1041)
	at com.intellij.codeInsight.daemon.impl.HighlightInfoUpdaterImpl$$Lambda/0x000000001c9b6c50.accept(Unknown Source)
	at com.intellij.codeInsight.daemon.impl.ManagedHighlighterRecycler.runWithRecycler(ManagedHighlighterRecycler.java:105)
	at com.intellij.codeInsight.daemon.impl.HighlightInfoUpdaterImpl.runWithInvalidPsiRecycler(HighlightInfoUpdaterImpl.java:1014)
	at com.intellij.codeInsight.daemon.impl.GeneralHighlightingPass.lambda$collectInformationWithProgress$9(GeneralHighlightingPass.java:208)
	at com.intellij.codeInsight.daemon.impl.GeneralHighlightingPass$$Lambda/0x000000001c986fd0.consume(Unknown Source)
	at com.intellij.codeInsight.daemon.impl.HighlightVisitorRunner.createHighlightVisitorsFor(HighlightVisitorRunner.java:92)
	at com.intellij.codeInsight.daemon.impl.GeneralHighlightingPass.collectInformationWithProgress(GeneralHighlightingPass.java:121)
	at com.intellij.codeInsight.daemon.impl.ProgressableTextEditorHighlightingPass.doCollectInformation(ProgressableTextEditorHighlightingPass.java:97)
	at com.intellij.codeHighlighting.TextEditorHighlightingPass.collectInformation(TextEditorHighlightingPass.java:76)
	at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.lambda$doRun$2(PassExecutorService.java:449)
	at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass$$Lambda/0x000000001c9861b0.invoke(Unknown Source)
	at com.intellij.platform.diagnostic.telemetry.helpers.TraceKt.use(trace.kt:29)
	at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.lambda$doRun$3(PassExecutorService.java:445)
	at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass$$Lambda/0x000000001c985ce0.run(Unknown Source)
	at com.intellij.openapi.application.impl.AppImplKt$runnableUnitFunction$1.invoke(appImpl.kt:124)
	at com.intellij.openapi.application.impl.AppImplKt$runnableUnitFunction$1.invoke(appImpl.kt:124)
	at com.intellij.platform.locking.impl.NestedLocksThreadingSupport.tryRunReadAction(NestedLocksThreadingSupport.kt:900)
	at com.intellij.openapi.application.impl.ApplicationImpl.tryRunReadAction(ApplicationImpl.java:1266)
	at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.lambda$doRun$4(PassExecutorService.java:435)
	at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass$$Lambda/0x000000001c985810.run(Unknown Source)
	at com.intellij.openapi.progress.impl.CoreProgressManager.lambda$executeProcessUnderProgress$14(CoreProgressManager.java:744)
	at com.intellij.openapi.progress.impl.CoreProgressManager$$Lambda/0x000000001b607000.compute(Unknown Source)
	at com.intellij.openapi.progress.impl.CoreProgressManager.registerIndicatorAndRun(CoreProgressManager.java:819)
	at com.intellij.openapi.progress.impl.CoreProgressManager.computeUnderProgress(CoreProgressManager.java:775)
	at com.intellij.openapi.progress.impl.CoreProgressManager.executeProcessUnderProgress(CoreProgressManager.java:743)
	at com.intellij.openapi.progress.impl.ProgressManagerImpl.executeProcessUnderProgress(ProgressManagerImpl.java:87)
	at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.doRun(PassExecutorService.java:434)
	at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.lambda$run$0(PassExecutorService.java:409)
	at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass$$Lambda/0x000000001c9855a8.run(Unknown Source)
	at com.intellij.openapi.fileTypes.impl.FileTypeManagerImpl.cacheFileTypesInside(FileTypeManagerImpl.java:904)
	at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.lambda$run$1(PassExecutorService.java:409)
	at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass$$Lambda/0x000000001c9850d8.run(Unknown Source)
	at com.intellij.openapi.application.impl.ApplicationImpl.executeByImpatientReader(ApplicationImpl.java:306)
	at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.run(PassExecutorService.java:407)
	at com.intellij.concurrency.JobLauncherImpl$VoidForkJoinTask$1.exec(JobLauncherImpl.java:289)
	at java.base@25.0.2/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:511)
	at java.base@25.0.2/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1450)
	at java.base@25.0.2/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:2019)
	at java.base@25.0.2/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:187)
, "AWT-EventQueue-0" prio=0 tid=0x0 nid=0x0 waiting on condition
     java.lang.Thread.State: TIMED_WAITING
 on java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject@665b6dd9
	at java.base@25.0.2/jdk.internal.misc.Unsafe.park(Native Method)
	at java.base@25.0.2/java.util.concurrent.locks.LockSupport.parkNanos(LockSupport.java:271)
	at java.base@25.0.2/java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.awaitNanos(AbstractQueuedSynchronizer.java:1803)
	at java.base@25.0.2/java.util.concurrent.LinkedBlockingQueue.poll(LinkedBlockingQueue.java:460)
	at com.intellij.openapi.progress.util.EventStealer.waitForPing(EventStealer.java:126)
	at com.intellij.openapi.progress.util.SuvorovProgress.showNiceOverlay(SuvorovProgress.kt:216)
	at com.intellij.openapi.progress.util.SuvorovProgress.dispatchEventsUntilComputationCompletes(SuvorovProgress.kt:153)
	at com.intellij.openapi.application.impl.ApplicationImpl.lambda$postInit$15(ApplicationImpl.java:1453)
	at com.intellij.openapi.application.impl.ApplicationImpl$$Lambda/0x000000001a51bac0.invoke(Unknown Source)
	at com.intellij.platform.locking.impl.RunSuspend.await(NestedLocksThreadingSupport.kt:1690)
	at com.intellij.platform.locking.impl.NestedLocksThreadingSupportKt.runSuspendWithWaitingConsumer(NestedLocksThreadingSupport.kt:1665)
	at com.intellij.platform.locking.impl.NestedLocksThreadingSupportKt.access$runSuspendWithWaitingConsumer(NestedLocksThreadingSupport.kt:1)
	at com.intellij.platform.locking.impl.NestedLocksThreadingSupport.runSuspendMaybeConsuming(NestedLocksThreadingSupport.kt:1604)
	at com.intellij.platform.locking.impl.NestedLocksThreadingSupport$ComputationState.upgradeWritePermit(NestedLocksThreadingSupport.kt:382)
	at com.intellij.platform.locking.impl.NestedLocksThreadingSupport.prepareWriteFromWriteIntentBlocking$lambda$0(NestedLocksThreadingSupport.kt:1203)
	at com.intellij.platform.locking.impl.NestedLocksThreadingSupport$$Lambda/0x000000001b381408.invoke(Unknown Source)
	at com.intellij.platform.locking.impl.NestedLocksThreadingSupport.processWriteLockAcquisition(NestedLocksThreadingSupport.kt:1427)
	at com.intellij.platform.locking.impl.NestedLocksThreadingSupport.prepareWriteFromWriteIntentBlocking(NestedLocksThreadingSupport.kt:1202)
	at com.intellij.platform.locking.impl.NestedLocksThreadingSupport.runWriteActionBlocking(NestedLocksThreadingSupport.kt:995)
	at com.intellij.openapi.application.impl.ApplicationImpl.runWriteAction(ApplicationImpl.java:1161)
	at com.intellij.openapi.command.WriteCommandAction$BuilderImpl.lambda$doRunWriteCommandAction$2(WriteCommandAction.java:153)
	at com.intellij.openapi.command.WriteCommandAction$BuilderImpl$$Lambda/0x000000001e6be510.run(Unknown Source)
	at com.intellij.openapi.command.impl.CoreCommandProcessor.lambda$executeCommand$1(CoreCommandProcessor.java:143)
	at com.intellij.openapi.command.impl.CoreCommandProcessor$$Lambda/0x000000001da790e0.run(Unknown Source)
	at com.intellij.openapi.command.impl.CoreCommandProcessor.runCommandTask(CoreCommandProcessor.java:409)
	at com.intellij.openapi.command.impl.CoreCommandProcessor.executeCommand(CoreCommandProcessor.java:158)
	at com.intellij.openapi.command.impl.CoreCommandProcessor.executeCommand(CoreCommandProcessor.java:93)
	at com.intellij.openapi.command.WriteCommandAction$BuilderImpl.doRunWriteCommandAction(WriteCommandAction.java:162)
	at com.intellij.openapi.command.WriteCommandAction$BuilderImpl.run(WriteCommandAction.java:129)
	at com.intellij.openapi.command.WriteCommandAction.runWriteCommandAction(WriteCommandAction.java:349)
	at com.intellij.openapi.command.WriteCommandAction.runWriteCommandAction(WriteCommandAction.java:337)
	at com.github.copilot.diff.BuiltInDiffService.showDiff(BuiltInDiffService.kt:97)
	at com.github.copilot.diff.BuiltInDiffService.showDiff$default(BuiltInDiffService.kt:72)
	at com.github.copilot.agent.input.CopilotAgentInputWorkingSetViewModel.showDiff(CopilotAgentInputWorkingSetViewModel.kt:47)
	at com.github.copilot.agent.session.CopilotAgentSessionController.editVirtualFile$lambda$55(CopilotAgentSessionController.kt:743)
	at com.github.copilot.agent.session.CopilotAgentSessionController$$Lambda/0x0000000020b4a4d0.invoke(Unknown Source)
	at com.intellij.openapi.application.ActionsKt.invokeLater$lambda$0(actions.kt:77)
	at com.intellij.openapi.application.ActionsKt$$Lambda/0x000000001bc30c38.run(Unknown Source)
	at com.intellij.openapi.application.TransactionGuardImpl.runWithWritingAllowed(TransactionGuardImpl.java:236)
	at com.intellij.openapi.application.TransactionGuardImpl.access$100(TransactionGuardImpl.java:22)
	at com.intellij.openapi.application.TransactionGuardImpl$1.run(TransactionGuardImpl.java:198)
	at com.intellij.openapi.application.impl.AppImplKt$runnableUnitFunction$1.invoke(appImpl.kt:124)
	at com.intellij.openapi.application.impl.AppImplKt$runnableUnitFunction$1.invoke(appImpl.kt:124)
	at com.intellij.platform.locking.impl.NestedLocksThreadingSupport.runWriteIntentReadAction(NestedLocksThreadingSupport.kt:705)
	at com.intellij.openapi.application.impl.ApplicationImpl.runIntendedWriteActionOnCurrentThread(ApplicationImpl.java:1094)
	at com.intellij.openapi.application.impl.ApplicationImpl$7.lambda$run$0(ApplicationImpl.java:648)
	at com.intellij.openapi.application.impl.ApplicationImpl$7$$Lambda/0x000000001b2689a8.invoke(Unknown Source)
	at com.intellij.concurrency.ThreadContext.installThreadContext(threadContext.kt:305)
	at com.intellij.openapi.application.impl.ApplicationImpl$7.run(ApplicationImpl.java:646)
	at com.intellij.util.concurrency.ChildContext$runInChildContext$1.invoke(propagation.kt:192)
	at com.intellij.util.concurrency.ChildContext$runInChildContext$1.invoke(propagation.kt:192)
	at com.intellij.util.concurrency.ChildContext.runInChildContext(propagation.kt:198)
	at com.intellij.util.concurrency.ChildContext.runInChildContext(propagation.kt:192)
	at com.intellij.util.concurrency.ContextRunnable.lambda$run$0(ContextRunnable.java:26)
	at com.intellij.util.concurrency.ContextRunnable$$Lambda/0x000000001a2d95f0.invoke(Unknown Source)
	at com.intellij.concurrency.ThreadContext.resetThreadContext(threadContext.kt:294)
	at com.intellij.util.concurrency.ContextRunnable.run(ContextRunnable.java:25)
	at com.intellij.openapi.application.impl.NonBlockingFlushQueue.runNextEvent$lambda$1$1$0(NonBlockingFlushQueue.kt:334)
	at com.intellij.openapi.application.impl.NonBlockingFlushQueue$$Lambda/0x000000001b059a90.compute(Unknown Source)
	at com.intellij.openapi.progress.impl.CoreProgressManager.computePrioritized(CoreProgressManager.java:928)
	at com.intellij.openapi.application.impl.NonBlockingFlushQueue.runNextEvent$lambda$1$1(NonBlockingFlushQueue.kt:333)
	at com.intellij.openapi.application.impl.NonBlockingFlushQueue$$Lambda/0x000000001aaac998.invoke(Unknown Source)
	at com.intellij.concurrency.ThreadContext.resetThreadContext(threadContext.kt:294)
	at com.intellij.openapi.application.impl.NonBlockingFlushQueue.runNextEvent$lambda$1(NonBlockingFlushQueue.kt:330)
	at com.intellij.openapi.application.impl.NonBlockingFlushQueue$$Lambda/0x000000001aaa6d58.invoke(Unknown Source)
	at com.intellij.platform.locking.impl.NestedLocksThreadingSupport.tryRunWriteIntentReadAction(NestedLocksThreadingSupport.kt:747)
	at com.intellij.openapi.application.impl.NonBlockingFlushQueue.runNextEvent(NonBlockingFlushQueue.kt:326)
	at com.intellij.openapi.application.impl.NonBlockingFlushQueue.flushNow(NonBlockingFlushQueue.kt:305)
	at com.intellij.openapi.application.impl.NonBlockingFlushQueue.FLUSH_NOW$lambda$0(NonBlockingFlushQueue.kt:167)
	at com.intellij.openapi.application.impl.NonBlockingFlushQueue$$Lambda/0x000000001a1bcff8.run(Unknown Source)
	at java.desktop/java.awt.event.InvocationEvent.dispatch(InvocationEvent.java:323)
	at java.desktop/java.awt.EventQueue.dispatchEventImpl(EventQueue.java:732)
	at java.desktop/java.awt.EventQueue.dispatchEvent(EventQueue.java:711)
	at com.intellij.ide.IdeEventQueue.defaultDispatchEvent(IdeEventQueue.kt:720)
	at com.intellij.ide.IdeEventQueue._dispatchEvent(IdeEventQueue.kt:573)
	at com.intellij.ide.IdeEventQueue.dispatchEvent$lambda$0$0$0(IdeEventQueue.kt:377)
	at com.intellij.ide.IdeEventQueue$$Lambda/0x000000001a7c5938.invoke(Unknown Source)
	at com.intellij.ide.IdeEventQueueKt.performActivity$lambda$0(IdeEventQueue.kt:1110)
	at com.intellij.ide.IdeEventQueueKt$$Lambda/0x000000001a7cd238.run(Unknown Source)
	at com.intellij.openapi.application.TransactionGuardImpl.performActivity(TransactionGuardImpl.java:106)
	at com.intellij.ide.IdeEventQueueKt.performActivity(IdeEventQueue.kt:1110)
	at com.intellij.ide.IdeEventQueue.dispatchEvent$lambda$0(IdeEventQueue.kt:375)
	at com.intellij.ide.IdeEventQueue$$Lambda/0x000000001a7c0248.run(Unknown Source)
	at com.intellij.ide.IdeEventQueue.dispatchEvent(IdeEventQueue.kt:415)
	at java.desktop/java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:207)
	at java.desktop/java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:128)
	at java.desktop/java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:117)
	at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:113)
	at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:105)
	at java.desktop/java.awt.EventDispatchThread.run(EventDispatchThread.java:92)

```
</details>