### PR TITLE
Fix `ModuleWithNameAlreadyExists` when importing umbrella projects with same-named root and child app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v23.0.5
+
+### Bug Fixes
+* Fixed Umbrella project import crash when root folder and child app share the same name (e.g., `emqx/` root with `apps/emqx/` child). The quick import path (`File` -> `Open` on `mix.exs`) bypassed the wizard's duplicate detection, causing `ModuleWithNameAlreadyExists`. Module names are now disambiguated using the relative path (e.g., `emqx` for the root, `emqx-apps-emqx` for the child). - [@joshuataylor](https://github.com/joshuataylor), (Thanks to [@JiaRG](https://github.com/JiaRG) for the thorough and reproducible bug report and excellent example umbrella project!)
+
 ## v23.0.4
 
 ### Enhancements

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@
 # --- Plugin Metadata ---
 pluginGroup=org.elixir_lang
 pluginName=Elixir
-pluginVersion=23.0.4
+pluginVersion=23.0.5
 pluginRepositoryUrl=https://github.com/KronicDeth/intellij-elixir/
 vendorName=Elle Imhoff
 vendorEmail=Kronic.Deth@gmail.com

--- a/resources/META-INF/changelog.html
+++ b/resources/META-INF/changelog.html
@@ -1,6 +1,16 @@
 <html>
 <body>
 
+<h1>v23.0.5</h1>
+<ul>
+    <li>
+        <p>Bug Fixes</p>
+        <ul>
+            <li>Fixed Umbrella project import crash when root folder and child app share the same name (e.g., <code>emqx/</code> root with <code>apps/emqx/</code> child). The quick import path (<code>File</code> &gt; <code>Open</code> on <code>mix.exs</code>) bypassed the wizard's duplicate detection, causing <code>ModuleWithNameAlreadyExists</code>. Module names are now disambiguated using the relative path (e.g., <code>emqx</code> for the root, <code>emqx-apps-emqx</code> for the child). - <a href="https://github.com/joshuataylor">@joshuataylor</a>, with thanks to <a href="https://github.com/JiaRG">@JiaRG</a> for the thorough and reproducible bug report and excellent example umbrella project!</li>
+        </ul>
+    </li>
+</ul>
+
 <h1>v23.0.4</h1>
 <ul>
     <li>

--- a/src/org/elixir_lang/mix/Project.kt
+++ b/src/org/elixir_lang/mix/Project.kt
@@ -66,22 +66,59 @@ object Project {
             val nameCompareResult = String.CASE_INSENSITIVE_ORDER.compare(o1.name, o2.name)
 
             if (nameCompareResult == 0) {
-                String.CASE_INSENSITIVE_ORDER.compare(o1.root.path, o1.root.path)
+                String.CASE_INSENSITIVE_ORDER.compare(o1.root.path, o2.root.path)
             } else {
                 nameCompareResult
             }
         })
     }
 
+    /**
+     * Computes unique IntelliJ module names for a list of OTP apps, disambiguating when
+     * multiple apps share the same name (e.g., umbrella root and child app both named "emqx").
+     *
+     * Apps with unique names keep their original name. For collisions, the app at [projectRoot]
+     * keeps its name and others get a suffix derived from their relative path.
+     */
+    fun moduleNameForOtpApps(otpApps: List<OtpApp>, projectRoot: VirtualFile? = null): Map<OtpApp, String> {
+        val result = mutableMapOf<OtpApp, String>()
+        val byName = otpApps.groupBy { it.name.lowercase() }
+
+        for ((_, apps) in byName) {
+            if (apps.size == 1) {
+                result[apps.first()] = apps.first().name
+            } else {
+                for (app in apps) {
+                    val isRoot = projectRoot != null && app.root.path == projectRoot.path
+                    if (isRoot) {
+                        result[app] = app.name
+                    } else if (projectRoot != null) {
+                        val relativePath = app.root.path
+                            .removePrefix(projectRoot.path)
+                            .trimStart('/')
+                            .replace('/', '-')
+                        result[app] = "${app.name}-${relativePath}"
+                    } else {
+                        result[app] = "${app.name}-${app.root.name}"
+                    }
+                }
+            }
+        }
+
+        return result
+    }
+
     fun createModulesForOtpApps(
         project: Project,
         otpApps: List<OtpApp>,
         modifiableModuleModelFactory: () -> ModifiableModuleModel,
-        rootModelModifier: (OtpApp, ModifiableRootModel) -> Unit = { _, _ -> }
+        rootModelModifier: (OtpApp, ModifiableRootModel) -> Unit = { _, _ -> },
+        projectRoot: VirtualFile? = null
     ): List<Module> =
         if (otpApps.isNotEmpty()) {
             val moduleModel = modifiableModuleModelFactory()
-            val createdRootModels = otpApps.mapNotNull { createModuleForOtpApp(it, moduleModel, rootModelModifier) }
+            val moduleNames = moduleNameForOtpApps(otpApps, projectRoot)
+            val createdRootModels = otpApps.mapNotNull { createModuleForOtpApp(it, moduleModel, rootModelModifier, moduleNames[it] ?: it.name) }
 
             if (createdRootModels.isNotEmpty()) {
                 // Use WriteAction.run since this is called from EDT via importToProject
@@ -109,10 +146,11 @@ object Project {
     private fun createModuleForOtpApp(
         otpApp: OtpApp,
         moduleModel: ModifiableModuleModel,
-        rootModelModifier: (OtpApp, ModifiableRootModel) -> Unit
+        rootModelModifier: (OtpApp, ModifiableRootModel) -> Unit,
+        moduleName: String
     ): ModifiableRootModel? {
         val ideaModuleDir = otpApp.root
-        val ideaModuleFile = "${ideaModuleDir.canonicalPath}${File.separator}/${otpApp.name}.iml"
+        val ideaModuleFile = "${ideaModuleDir.canonicalPath}${File.separator}/${moduleName}.iml"
         val module = moduleModel.newModule(ideaModuleFile, ElixirModuleType.MODULE_TYPE_ID)
         otpApp.module = module
 

--- a/src/org/elixir_lang/mix/project/_import/Builder.kt
+++ b/src/org/elixir_lang/mix/project/_import/Builder.kt
@@ -75,7 +75,7 @@ class Builder : ProjectImportBuilder<OtpApp>() {
      *
      */
     override fun validate(currentProject: Project?, project: Project): Boolean {
-        if (!findIdeaModuleFiles(mySelectedOtpApps)) {
+        if (!findIdeaModuleFiles(mySelectedOtpApps, myProjectRoot)) {
             return true
         }
 
@@ -149,7 +149,8 @@ class Builder : ProjectImportBuilder<OtpApp>() {
                 )
                 // output paths need to be included, so that they are indexed for Phoenix EEx Template Elixir Line Breakpoints
                 compilerModuleExt.isExcludeOutput = false
-            }
+            },
+            projectRoot = myProjectRoot
         )
 
         if (myIsImportingProject) {
@@ -247,11 +248,12 @@ class Builder : ProjectImportBuilder<OtpApp>() {
             }
         }
 
-        private fun findIdeaModuleFiles(otpApps: List<OtpApp>): Boolean {
+        private fun findIdeaModuleFiles(otpApps: List<OtpApp>, projectRoot: VirtualFile?): Boolean {
+            val moduleNames = org.elixir_lang.mix.Project.moduleNameForOtpApps(otpApps, projectRoot)
             var ideaModuleFileExists = false
             for (importedOtpApp in otpApps) {
                 val applicationRoot = importedOtpApp.root
-                val ideaModuleName = importedOtpApp.name
+                val ideaModuleName = moduleNames[importedOtpApp] ?: importedOtpApp.name
                 val imlFile = applicationRoot.findChild("$ideaModuleName.iml")
                 if (imlFile != null) {
                     ideaModuleFileExists = true


### PR DESCRIPTION
Fixes #3812

(Thanks to @JiaRG for the thorough and reproducible bug report and excellent example umbrella project!)

Fixes a crash when importing Elixir umbrella projects where the root project folder and a child app share the same name (e.g., [emqx/emqx](https://github.com/emqx/emqx) has root `emqx/` and child `apps/emqx/`, both with `app: :emqx`).

The quick import path (`File` -> `Open` on `mix.exs`) bypassed the wizard's duplicate detection (`SelectOtpApps.evalDuplicates()`), so `Builder.commit()` tried to create two IntelliJ modules with the same name, causing `ModuleWithNameAlreadyExists` at `moduleModel.newModule()`.

Now it shows the "root" project as the name, and umbrella apps as `<root>-apps-<app_name>`, e.g `emqx-apps-emqx`.

<img width="1136" height="956" alt="image" src="https://github.com/user-attachments/assets/0b2e4de9-63eb-4a2a-899f-4bed2603960b" />
