### PR TITLE
Settings, Credo & Formatting Infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -5898,9 +5898,9 @@ The Visibility icons indicated whether the element is usable outside its definin
 
 ## Experimental Features
 
-As we develop new functionality that requires additional testing and feedback, we offer an opt-in system for Experimental Features via the `Elixir Experimental Settings` page.
+As we develop new functionality that requires additional testing and feedback, we offer an opt-in system for Experimental Features via the `Elixir > Experimental Settings` page.
 
-You can view the currently available Experimental Features by navigating to `Languages & Frameworks` and selecting `Elixir Experimental Settings`, which is marked with the [BETA icon](https://plugins.jetbrains.com/docs/intellij/settings-guide.html#l6vycg_378). Alternatively, you can access it directly via [Settings | Languages & Frameworks | Elixir Experimental Settings](jetbrains://Idea/settings?name=Languages+%26+Frameworks--Elixir+Experimental+Settings).
+You can view the currently available Experimental Features by navigating to `Languages & Frameworks > Elixir` and selecting `Experimental Settings`, which is marked with the [BETA icon](https://plugins.jetbrains.com/docs/intellij/settings-guide.html#l6vycg_378). Alternatively, you can access it directly via [Settings | Languages & Frameworks | Elixir | Experimental Settings](jetbrains://Idea/settings?name=Languages+%26+Frameworks--Elixir--Experimental+Settings).
 
 ![Elixir Experimental Settings UI](/screenshots/experimental/elixir-experimental-settings-ui.png)
 
@@ -5940,10 +5940,10 @@ More information about [Language Injections](https://www.jetbrains.com/help/idea
 To enable support for HTML syntax highlighting and autocomplete:
 
 1. Open [Settings](https://www.jetbrains.com/help/idea/configure-project-settings.html).
-2. Navigate to [Settings | Languages & Frameworks | Elixir Experimental Settings](jetbrains://Idea/settings?name=Languages+%26+Frameworks--Elixir+Experimental+Settings).
+2. Navigate to [Settings | Languages & Frameworks | Elixir | Experimental Settings](jetbrains://Idea/settings?name=Languages+%26+Frameworks--Elixir--Experimental+Settings).
 3. Enable the **~H Sigil HTML Injection** feature.
 
-![Settings | Languages & Frameworks | Elixir Experimental Settings](/screenshots/experimental/elixir-experimental-settings-ui.png?raw=true "Elixir Experimental Settings UI")
+![Settings | Languages & Frameworks | Elixir | Experimental Settings](/screenshots/experimental/elixir-experimental-settings-ui.png?raw=true "Elixir Experimental Settings UI")
 
 > [!NOTE]
 > This Experimental Feature is currently enabled on a **per-project** basis. We are considering adding application-level support or enabling it by default in future versions based on feedback

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -120,7 +120,11 @@
         <facetType implementation="org.elixir_lang.facet.Type"/>
 
         <applicationService serviceInterface="org.elixir_lang.configuration.BeforeRunTaskProvider"
-                            serviceImplementation="org.elixir_lang.configuration.DefaultBeforeRunTaskProvider"/>
+                            serviceImplementation="org.elixir_lang.configuration.DefaultBeforeRunTaskProvider"
+                            open="true"/>
+        <applicationService serviceInterface="org.elixir_lang.facet.configurable.TopLevelElixirConfigurableFactory"
+                            serviceImplementation="org.elixir_lang.facet.configurable.SmallIdeTopLevelElixirConfigurableFactory"
+                            open="true"/>
 
         <!-- WSL Support Service -->
         <applicationService serviceInterface="org.elixir_lang.sdk.wsl.WslCompatService"
@@ -128,7 +132,8 @@
         <applicationService serviceInterface="org.elixir_lang.sdk.erlang_dependent.ErlangSdkResolver"
                             serviceImplementation="org.elixir_lang.sdk.erlang_dependent.DefaultErlangSdkResolver"/>
         <applicationService serviceInterface="org.elixir_lang.sdk.elixir.SdkSettingsOpener"
-                            serviceImplementation="org.elixir_lang.sdk.elixir.SettingsSdkSettingsOpener"/>
+                            serviceImplementation="org.elixir_lang.sdk.elixir.SettingsSdkSettingsOpener"
+                            open="true"/>
 
 
         <!-- for template -->

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -99,7 +99,7 @@
 
         <projectConfigurable
                 parentId="language.elixir"
-                displayName="Elixir Experimental Settings"
+                displayName="Experimental Settings"
                 id="org.elixir_lang.settings.ElixirExperimentalSettingsConfigurable"
                 instance="org.elixir_lang.settings.ElixirExperimentalSettingsConfigurable"/>
 
@@ -169,8 +169,10 @@
                           implementationClass="org.elixir_lang.credo.inspection_tool.Global" language="Elixir"
                           level="WARNING"
                           shortName="Credo"/>
-        // groupId/parentId "Errors" is Editor > Inspections
-        <projectConfigurable instance="org.elixir_lang.credo.Configurable" groupId="Errors" parentId="Errors"
+        <!-- Credo settings -->
+        <projectConfigurable id="language.elixir.credo"
+                             parentId="language.elixir"
+                             instance="org.elixir_lang.credo.Configurable"
                              displayName="Credo"/>
 
         <!-- <code>.beam</code> -->
@@ -312,8 +314,12 @@
                           language="Elixir" level="ERROR"/>
         <projectService serviceInterface="org.elixir_lang.dialyzer.service.DialyzerService"
                         serviceImplementation="org.elixir_lang.dialyzer.service.DialyzerServiceImpl"/>
-        <projectConfigurable instance="org.elixir_lang.dialyzer.service.Configurable" groupId="Errors"
-                             parentId="Errors" displayName="Dialyzer"/>
+        <projectConfigurable id="language.elixir.dialyzer"
+                             parentId="language.elixir"
+                             instance="org.elixir_lang.dialyzer.service.Configurable"
+                             displayName="Dialyzer"/>
+
+        <search.optionContributor implementation="org.elixir_lang.settings.ElixirSearchableOptionContributor"/>
     </extensions>
 
     <projectListeners>

--- a/resources/META-INF/rich-platform-plugin.xml
+++ b/resources/META-INF/rich-platform-plugin.xml
@@ -31,6 +31,9 @@
         <applicationService serviceInterface="org.elixir_lang.configuration.BeforeRunTaskProvider"
                             serviceImplementation="org.elixir_lang.configuration.JpsBeforeRunTaskProvider"
                             overrides="true"/>
+        <applicationService serviceInterface="org.elixir_lang.facet.configurable.TopLevelElixirConfigurableFactory"
+                            serviceImplementation="org.elixir_lang.facet.configurable.RichPlatformTopLevelElixirConfigurableFactory"
+                            overrides="true"/>
         <applicationService serviceInterface="org.elixir_lang.sdk.elixir.SdkSettingsOpener"
                             serviceImplementation="org.elixir_lang.sdk.elixir.ProjectStructureSdkSettingsOpener"
                             overrides="true"/>

--- a/src/org/elixir_lang/credo/Action.kt
+++ b/src/org/elixir_lang/credo/Action.kt
@@ -1,9 +1,9 @@
 package org.elixir_lang.credo
 
-import com.intellij.ide.actions.ShowSettingsUtilImpl
 import com.intellij.notification.Notification
 import com.intellij.notification.NotificationAction
 import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.options.ShowSettingsUtil
 import com.intellij.openapi.project.Project
 
 /**
@@ -12,6 +12,8 @@ import com.intellij.openapi.project.Project
  */
 class Action(private val project: Project) : NotificationAction("Configure credo") {
     override fun actionPerformed(e: AnActionEvent, notification: Notification) {
-        ShowSettingsUtilImpl.showSettingsDialog(project, "Errors", "Credo")
+        if (project.isDisposed) return
+
+        ShowSettingsUtil.getInstance().showSettingsDialog(project, Configurable::class.java)
     }
 }

--- a/src/org/elixir_lang/credo/Configurable.java
+++ b/src/org/elixir_lang/credo/Configurable.java
@@ -9,7 +9,8 @@ import org.jetbrains.annotations.Nullable;
 import javax.swing.*;
 
 public class Configurable implements SearchableConfigurable {
-    private static final String ID = "Credo";
+    private static final String ID = "language.elixir.credo";
+    private static final String DISPLAY_NAME = "Credo";
     private JPanel panel;
     private JTextField elixirArguments;
     private JTextField erlArguments;
@@ -23,7 +24,7 @@ public class Configurable implements SearchableConfigurable {
     @NotNull
     @Override
     public String getDisplayName() {
-        return ID;
+        return DISPLAY_NAME;
     }
 
     @Nullable

--- a/src/org/elixir_lang/credo/inspection_tool/Global.kt
+++ b/src/org/elixir_lang/credo/inspection_tool/Global.kt
@@ -8,6 +8,7 @@ import com.intellij.execution.util.ExecUtil
 import com.intellij.notification.NotificationGroupManager
 import com.intellij.notification.NotificationType
 import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.module.Module
 import com.intellij.openapi.module.ModuleManager
 import com.intellij.openapi.progress.ProgressIndicator
@@ -24,9 +25,85 @@ import org.elixir_lang.mix.Project
 import org.elixir_lang.notification.setup_sdk.Notifier
 import org.elixir_lang.sdk.elixir.Type.Companion.mostSpecificSdk
 import java.nio.charset.StandardCharsets
+import java.nio.file.InvalidPathException
 import java.nio.file.Paths
 
+// Phase 2 location parsing: try the most specific location shape first to avoid path/line ambiguity.
+// lib/level_web/ui/empty_state.ex:1:11: R: Modules should have a @moduledoc tag.
+private val FLYCHECK_LINE_COLUMN_LOCATION_REGEX =
+    Regex("(?<path>.+):(?<line>\\d+):(?<column>\\d+)")
+
+// lib/level_web/ui/empty_state.ex:1: W: Prefer explicit module aliases
+private val FLYCHECK_LINE_LOCATION_REGEX =
+    Regex("(?<path>.+):(?<line>\\d+)")
+
+// Phase 1 record parsing: split "location" from "tag/message" before parsing the location itself.
+// apps/smoke_test/lib/smoke_test.ex: W: Test files should end with .exs
+private val FLYCHECK_RECORD_REGEX =
+    Regex("(?<location>.+): (?<tag>[A-Z]): (?<message>.+)")
+
+internal data class FlycheckFinding(
+    val path: String,
+    val line: Int?,
+    val column: Int?,
+    val message: String,
+)
+
+internal fun parseFlycheckFinding(line: String): FlycheckFinding? {
+    val recordMatch = FLYCHECK_RECORD_REGEX.matchEntire(line) ?: return null
+    val recordGroups = recordMatch.groups as MatchNamedGroupCollection
+    val location = recordGroups["location"]!!.value
+    val message = recordGroups["message"]!!.value
+
+    val lineColumnLocationMatch = FLYCHECK_LINE_COLUMN_LOCATION_REGEX.matchEntire(location)
+
+    if (lineColumnLocationMatch != null) {
+        val groups = lineColumnLocationMatch.groups as MatchNamedGroupCollection
+
+        return FlycheckFinding(
+            path = groups["path"]!!.value,
+            line = groups["line"]!!.value.toInt(),
+            column = groups["column"]!!.value.toInt(),
+            message = message,
+        )
+    }
+
+    val lineLocationMatch = FLYCHECK_LINE_LOCATION_REGEX.matchEntire(location)
+
+    if (lineLocationMatch != null) {
+        val groups = lineLocationMatch.groups as MatchNamedGroupCollection
+
+        return FlycheckFinding(
+            path = groups["path"]!!.value,
+            line = groups["line"]!!.value.toInt(),
+            column = null,
+            message = message,
+        )
+    }
+
+    return FlycheckFinding(
+        path = location,
+        line = null,
+        column = null,
+        message = message,
+    )
+}
+
+private val LOG = logger<Global>()
+
 class Global : GlobalInspectionTool() {
+    private data class CredoRunOutcome(
+        val findingCount: Int,
+        val failureSummary: String? = null,
+        val warningSummary: String? = null,
+    )
+
+    private data class CredoExecutionIssue(
+        val module: Module,
+        val workingDirectory: String,
+        val summary: String,
+    )
+
     override fun runInspection(
         scope: AnalysisScope,
         manager: InspectionManager,
@@ -34,9 +111,74 @@ class Global : GlobalInspectionTool() {
         problemDescriptionsProcessor: ProblemDescriptionsProcessor,
     ) {
         val project = scope.project
+        val scopedModules = ApplicationManager.getApplication().runReadAction<List<Module>> {
+            ModuleManager.getInstance(project).modules.filter { scope.containsModule(it) }
+        }
+        val moduleByWorkingDirectory = linkedMapOf<String, Module>()
+        val executionFailures = mutableListOf<CredoExecutionIssue>()
+        val executionWarnings = mutableListOf<CredoExecutionIssue>()
 
-        for (module in ModuleManager.getInstance(project).modules) {
-            runInspection(scope, manager, globalContext, problemDescriptionsProcessor, module)
+        for (module in scopedModules) {
+            ProgressManager.checkCanceled()
+
+            for (workingDirectory in workingDirectorySet(module)) {
+                moduleByWorkingDirectory.putIfAbsent(workingDirectory, module)
+            }
+        }
+
+        val selectedWorkingDirectories = mutableListOf<Pair<Module, String>>()
+
+        // Multiple modules can collapse to the same umbrella root; run Credo once per root.
+        for ((workingDirectory, module) in moduleByWorkingDirectory.entries.sortedBy { it.key.length }) {
+            if (selectedWorkingDirectories.none { isSameOrAncestorPath(it.second, workingDirectory) }) {
+                selectedWorkingDirectories.add(module to workingDirectory)
+            }
+        }
+
+        for ((module, workingDirectory) in selectedWorkingDirectories) {
+            ProgressManager.checkCanceled()
+
+            val outcome = runWorkingDirectoryInspection(
+                manager,
+                globalContext,
+                problemDescriptionsProcessor,
+                module,
+                workingDirectory
+            )
+
+            outcome.failureSummary?.let { summary ->
+                executionFailures.add(CredoExecutionIssue(module, workingDirectory, summary))
+            }
+
+            outcome.warningSummary?.let { summary ->
+                executionWarnings.add(CredoExecutionIssue(module, workingDirectory, summary))
+            }
+        }
+
+        // Surface external-tool failures in inspection results to avoid misleading "nothing to report" UX.
+        for (failure in executionFailures) {
+            registerCredoExecutionFailureProblem(
+                manager,
+                globalContext,
+                problemDescriptionsProcessor,
+                failure
+            )
+        }
+
+        if (executionFailures.isNotEmpty()) {
+            notifyCredoIssue(
+                project,
+                title = "Credo inspection failed in ${executionFailures.size} working director${if (executionFailures.size == 1) "y" else "ies"}",
+                message = buildCredoIssueMessage(executionFailures),
+                type = NotificationType.ERROR
+            )
+        } else if (executionWarnings.isNotEmpty()) {
+            notifyCredoIssue(
+                project,
+                title = "Credo reported execution warnings",
+                message = buildCredoIssueMessage(executionWarnings),
+                type = NotificationType.WARNING
+            )
         }
     }
 
@@ -47,155 +189,431 @@ class Global : GlobalInspectionTool() {
             .filter { virtualFile ->
                 virtualFile.findChild(Project.MIX_EXS) != null
             }
-            .map(VirtualFile::getPath)
+            .map(::resolveCredoWorkingDirectory)
             .toHashSet()
 
-    private fun runInspection(
-        scope: AnalysisScope,
+    private fun resolveCredoWorkingDirectory(contentRoot: VirtualFile): String {
+        val parent = contentRoot.parent
+        val grandParent = parent?.parent
+
+        return if (parent?.name == "apps" && grandParent?.findChild(Project.MIX_EXS) != null) {
+            // In umbrella projects, run Credo from the umbrella root so task/config are available.
+            grandParent.path
+        } else {
+            contentRoot.path
+        }
+    }
+
+    private fun runWorkingDirectoryInspection(
         manager: InspectionManager,
         globalContext: GlobalInspectionContext,
         problemDescriptionsProcessor: ProblemDescriptionsProcessor,
         module: Module,
-    ) {
-        val workingDirectorySet = workingDirectorySet(module)
+        workingDirectory: String,
+    ): CredoRunOutcome {
+        val elixirSdk = mostSpecificSdk(module)
+        val project = module.project
 
-        if (workingDirectorySet.isNotEmpty()) {
-            val elixirSdk = mostSpecificSdk(module)
-            val project = module.project
+        if (elixirSdk == null) {
+            Notifier.error(
+                module,
+                "Missing module Elixir SDK",
+                "There is no configured Elixir SDK for the module ${module.name} or its project ${project.name}, so credo cannot be run"
+            )
+            return CredoRunOutcome(findingCount = 0, failureSummary = "Missing Elixir SDK for module ${module.name}")
+        }
 
-            if (elixirSdk != null) {
-                val service = org.elixir_lang.credo.Service.getInstance(project)
-                val environment = service.environmentVariableData.envs
-                val erlParameters = ParametersList.parse(service.erlArguments).toList()
-                val elixirParameters = ParametersList.parse(service.elixirArguments).toList()
+        val service = org.elixir_lang.credo.Service.getInstance(project)
+        val environment = service.environmentVariableData.envs
+        val erlParameters = ParametersList.parse(service.erlArguments).toList()
+        val elixirParameters = ParametersList.parse(service.elixirArguments).toList()
 
-                for (workingDirectory in workingDirectorySet) {
-                    val processOutput = ProgressManager
-                        .getInstance()
-                        .run(object : Task.WithResult<ProcessOutput, ExecutionException>(
-                            project,
-                            "mix credo in $workingDirectory",
-                            true
-                        ) {
-                            @Throws(ExecutionException::class)
-                            override fun compute(indicator: ProgressIndicator): ProcessOutput {
-                                indicator.isIndeterminate = true
+        ProgressManager.checkCanceled()
 
-                                val commandLine =
-                                    Mix
-                                        .commandLine(
-                                            environment,
-                                            workingDirectory,
-                                            elixirSdk,
-                                            erlParameters,
-                                            elixirParameters,
-                                            false
-                                        )
-                                        .withCharset(StandardCharsets.UTF_8)
-                                        .withWorkDirectory(workingDirectory)
-                                        .apply { addParameters("credo", "--format", "flycheck") }
+        val processOutput = ProgressManager
+            .getInstance()
+            .run(object : Task.WithResult<ProcessOutput, ExecutionException>(
+                project,
+                "mix credo in $workingDirectory",
+                true
+            ) {
+                @Throws(ExecutionException::class)
+                override fun compute(indicator: ProgressIndicator): ProcessOutput {
+                    indicator.isIndeterminate = true
 
-                                return ExecUtil.execAndGetOutput(commandLine)
-                            }
-                        })
-
-                    val stderr = processOutput.stderr
-
-                    if (stderr.isNotEmpty()) {
-                        NotificationGroupManager
-                            .getInstance()
-                            .getNotificationGroup("Elixir")
-                            .createNotification(
-                                "Error running credo",
-                                stderr.stripColor().toHTML(),
-                                NotificationType.ERROR
-                            )
-                            .addAction(Action(project))
-                            .notify(project)
-                    }
-
-                    // lib/level_web/ui/empty_state.ex:1:11: R: Modules should have a @moduledoc tag.
-                    val flycheckRegex =
-                        Regex("(?<path>.+?):(?<line>\\d+):(?:(?<column>\\d+):)? (?<tag>[CFRSW]): (?<message>.+)")
-
-                    for (colorizedLine in processOutput.stdoutLines) {
-                        ProgressManager.checkCanceled()
-
-                        val line = colorizedLine.stripColor()
-                        val match = flycheckRegex.matchEntire(line) ?: continue
-                        val groups = match.groups as MatchNamedGroupCollection
-                        val path = groups["path"]!!.value
-                        val absolutePath = Paths.get(workingDirectory, path).toString()
-                        val virtualFile = LocalFileSystem.getInstance().findFileByPath(absolutePath) ?: continue
-
-                        ApplicationManager.getApplication().runReadAction {
-                            val psiFile = PsiManager.getInstance(project).findFile(virtualFile) ?: return@runReadAction
-                            val document = psiFile.viewProvider.document ?: return@runReadAction
-                            val lineNumber = groups["line"]!!.value.toInt() - 1
-
-                            if (lineNumber !in 0 until document.lineCount) return@runReadAction
-
-                            val lineStartOffset = document.getLineStartOffset(lineNumber)
-                            val lineEndOffset = document.getLineEndOffset(lineNumber)
-                            val start: Int
-                            val end: Int
-
-                            val columnNumber = groups["column"]?.value?.toInt()
-
-                            if (columnNumber != null) {
-                                val offset = lineStartOffset + columnNumber
-
-                                if (offset !in lineStartOffset until lineEndOffset) return@runReadAction
-
-                                start = offset
-                                end = start + 1
-                            } else {
-                                start = lineStartOffset
-                                end = lineEndOffset
-                            }
-
-                            if (end <= start) return@runReadAction
-
-                            val startElement = psiFile.findElementAt(start) ?: return@runReadAction
-                            val endElement = psiFile.findElementAt(end - 1) ?: return@runReadAction
-                            val message = groups["message"]!!.value
-                            val problemDescriptor = manager.createProblemDescriptor(
-                                startElement,
-                                endElement,
-                                message,
-                                ProblemHighlightType.GENERIC_ERROR_OR_WARNING,
+                    val commandLine =
+                        Mix
+                            .commandLine(
+                                environment,
+                                workingDirectory,
+                                elixirSdk,
+                                erlParameters,
+                                elixirParameters,
+                                false,
+                                project,
                                 false
                             )
-                            val refElement = globalContext.refManager.getReference(psiFile)
+                            .withCharset(StandardCharsets.UTF_8)
+                            .withWorkDirectory(workingDirectory)
+                            .apply { addParameters("credo", "--format", "flycheck", "--mute-exit-status") }
 
-                            problemDescriptionsProcessor.addProblemElement(
-                                refElement,
-                                problemDescriptor
-                            )
-                        }
+                    if (LOG.isDebugEnabled) {
+                        LOG.debug(
+                            "Running Credo inspection command workingDirectory='${workingDirectory}' command='${commandLine.commandLineString}'"
+                        )
                     }
+
+                    return ExecUtil.execAndGetOutput(commandLine)
                 }
-            } else {
-                Notifier.error(
-                    module,
-                    "Missing module Elixir SDK",
-                    "There is no configured Elixir SDK for the module ${module.name} or its project ${project.name}, so credo" +
-                            " cannot be run"
+            })
+
+        if (LOG.isDebugEnabled) {
+            LOG.debug(
+                "Credo process completed workingDirectory='${workingDirectory}' exitCode=${processOutput.exitCode} " +
+                    "stdoutLines=${processOutput.stdoutLines.size} stderrLines=${processOutput.stderrLines.size} " +
+                    "timeout=${processOutput.isTimeout} cancelled=${processOutput.isCancelled}"
+            )
+        }
+
+        val stdout = processOutput.stdout.stripColor()
+        val stderr = processOutput.stderr.stripColor()
+        val combinedOutput = listOf(stdout, stderr).filter { it.isNotBlank() }.joinToString("\n")
+
+        if (processOutput.isCancelled || processOutput.isTimeout) {
+            return CredoRunOutcome(
+                findingCount = 0,
+                failureSummary = summarizeCredoOutput(combinedOutput.ifBlank { "Credo process did not complete." })
+            )
+        }
+
+        if (stderr.isNotEmpty()) {
+            LOG.warn("Credo STDERR:\n$stderr")
+        }
+
+        var unmatchedLineCount = 0
+        var unmatchedLineSuppressed = false
+        var findingCount = 0
+
+        // Credo can emit non-flycheck preamble/progress lines; ignore them with debug throttling.
+        for (colorizedLine in processOutput.stdoutLines) {
+            ProgressManager.checkCanceled()
+
+            val line = colorizedLine.stripColor()
+            val finding = parseFlycheckFinding(line)
+
+            if (finding == null) {
+                unmatchedLineCount += 1
+
+                if (unmatchedLineCount <= 5) {
+                    debugSkip(
+                        reason = "line did not match flycheck format",
+                        workingDirectory = workingDirectory,
+                        rawLine = line
+                    )
+                } else if (!unmatchedLineSuppressed && LOG.isDebugEnabled) {
+                    unmatchedLineSuppressed = true
+                    LOG.debug(
+                        "Skipping additional non-flycheck Credo output lines " +
+                            "workingDirectory='${workingDirectory}' alreadySkipped=$unmatchedLineCount"
+                    )
+                }
+
+                continue
+            }
+
+            val path = finding.path
+            // Keep one malformed path from aborting the whole inspection run (seen on Windows/WSL paths).
+            val absolutePath = try {
+                Paths.get(workingDirectory, path).toString()
+            } catch (invalidPathException: InvalidPathException) {
+                debugSkip(
+                    reason = "invalid path from Credo output",
+                    workingDirectory = workingDirectory,
+                    rawLine = line,
+                    details = "path='$path' error='${invalidPathException.message}'"
                 )
+                continue
+            }
+            val virtualFile = LocalFileSystem.getInstance().findFileByPath(absolutePath)
+
+            if (virtualFile == null) {
+                debugSkip(
+                    reason = "virtual file not found",
+                    workingDirectory = workingDirectory,
+                    rawLine = line,
+                    details = "path='$path' absolutePath='$absolutePath'"
+                )
+                continue
+            }
+
+            ApplicationManager.getApplication().runReadAction {
+                val psiFile = PsiManager.getInstance(project).findFile(virtualFile)
+                if (psiFile == null) {
+                    debugSkip(
+                        reason = "PsiFile not found for virtual file",
+                        workingDirectory = workingDirectory,
+                        rawLine = line,
+                        details = "absolutePath='$absolutePath'"
+                    )
+                    return@runReadAction
+                }
+
+                val document = psiFile.viewProvider.document
+                if (document == null) {
+                    debugSkip(
+                        reason = "document unavailable for PsiFile",
+                        workingDirectory = workingDirectory,
+                        rawLine = line,
+                        details = "absolutePath='$absolutePath'"
+                    )
+                    return@runReadAction
+                }
+
+                val lineNumber = finding.line?.minus(1)
+                val start: Int
+                val end: Int
+                val columnNumber = finding.column
+
+                // Support line+column, line-only, and file-level findings from Credo flycheck output.
+                if (lineNumber != null) {
+                    if (lineNumber !in 0 until document.lineCount) {
+                        debugSkip(
+                            reason = "line number out of document range",
+                            workingDirectory = workingDirectory,
+                            rawLine = line,
+                            details = "lineNumber=$lineNumber documentLineCount=${document.lineCount} absolutePath='$absolutePath'"
+                        )
+                        return@runReadAction
+                    }
+
+                    val lineStartOffset = document.getLineStartOffset(lineNumber)
+                    val lineEndOffset = document.getLineEndOffset(lineNumber)
+
+                    if (columnNumber != null) {
+                        val offset = lineStartOffset + (columnNumber - 1)
+
+                        if (offset !in lineStartOffset until lineEndOffset) {
+                            debugSkip(
+                                reason = "column offset out of line range",
+                                workingDirectory = workingDirectory,
+                                rawLine = line,
+                                details = "columnNumber=$columnNumber lineStartOffset=$lineStartOffset lineEndOffset=$lineEndOffset absolutePath='$absolutePath'"
+                            )
+                            return@runReadAction
+                        }
+
+                        start = offset
+                        end = start + 1
+                    } else {
+                        start = lineStartOffset
+                        end = lineEndOffset
+                    }
+                } else {
+                    // No line info means the finding applies to the file as a whole.
+                    start = 0
+                    end = document.textLength
+                }
+
+                if (end <= start) {
+                    debugSkip(
+                        reason = "invalid descriptor range (end <= start)",
+                        workingDirectory = workingDirectory,
+                        rawLine = line,
+                        details = "start=$start end=$end absolutePath='$absolutePath'"
+                    )
+                    return@runReadAction
+                }
+
+                val startElement = psiFile.findElementAt(start)
+                if (startElement == null) {
+                    debugSkip(
+                        reason = "start PSI element not found",
+                        workingDirectory = workingDirectory,
+                        rawLine = line,
+                        details = "start=$start absolutePath='$absolutePath'"
+                    )
+                    return@runReadAction
+                }
+
+                val endElement = psiFile.findElementAt(end - 1)
+                if (endElement == null) {
+                    debugSkip(
+                        reason = "end PSI element not found",
+                        workingDirectory = workingDirectory,
+                        rawLine = line,
+                        details = "end=${end - 1} absolutePath='$absolutePath'"
+                    )
+                    return@runReadAction
+                }
+
+                val message = finding.message
+                val problemDescriptor = manager.createProblemDescriptor(
+                    startElement,
+                    endElement,
+                    message,
+                    ProblemHighlightType.GENERIC_ERROR_OR_WARNING,
+                    false
+                )
+                val refElement = globalContext.refManager.getReference(psiFile)
+
+                problemDescriptionsProcessor.addProblemElement(
+                    refElement,
+                    problemDescriptor
+                )
+
+                findingCount += 1
             }
         }
+
+        val fatalExecutionFailure = isFatalCredoExecutionFailure(processOutput.exitCode, combinedOutput)
+
+        return when {
+            fatalExecutionFailure && findingCount == 0 -> {
+                CredoRunOutcome(
+                    findingCount = 0,
+                    failureSummary = summarizeCredoOutput(
+                        combinedOutput.ifBlank { "Credo failed with exit code ${processOutput.exitCode}." }
+                    )
+                )
+            }
+
+            fatalExecutionFailure -> {
+                // Keep findings, but warn that mix/compile errors may have made results incomplete.
+                CredoRunOutcome(
+                    findingCount = findingCount,
+                    warningSummary = summarizeCredoOutput(combinedOutput)
+                )
+            }
+
+            else -> CredoRunOutcome(findingCount = findingCount)
+        }
+    }
+
+    private fun registerCredoExecutionFailureProblem(
+        manager: InspectionManager,
+        globalContext: GlobalInspectionContext,
+        problemDescriptionsProcessor: ProblemDescriptionsProcessor,
+        issue: CredoExecutionIssue,
+    ) {
+        val project = issue.module.project
+        val mixExsPath = Paths.get(issue.workingDirectory, Project.MIX_EXS).toString()
+        val virtualFile = LocalFileSystem.getInstance().findFileByPath(mixExsPath) ?: return
+
+        ApplicationManager.getApplication().runReadAction {
+            val psiFile = PsiManager.getInstance(project).findFile(virtualFile) ?: return@runReadAction
+            val startElement = psiFile.firstChild ?: return@runReadAction
+            val endElement = psiFile.lastChild ?: startElement
+            val message = "Credo execution failed for '${issue.workingDirectory}': ${issue.summary}"
+            val problemDescriptor = manager.createProblemDescriptor(
+                startElement,
+                endElement,
+                message,
+                ProblemHighlightType.GENERIC_ERROR_OR_WARNING,
+                false
+            )
+            val refElement = globalContext.refManager.getReference(psiFile)
+
+            problemDescriptionsProcessor.addProblemElement(refElement, problemDescriptor)
+        }
+    }
+
+    private fun isSameOrAncestorPath(ancestor: String, candidate: String): Boolean {
+        val ancestorPath = Paths.get(ancestor).normalize()
+        val candidatePath = Paths.get(candidate).normalize()
+
+        return candidatePath.startsWith(ancestorPath)
     }
 
     private fun String.stripColor(): String = this.replace(Regex("\u001B\\[[;\\d]*m"), "")
     private fun String.toHTML(): String = this.replace("\n", "<br/>\n")
 
+    private fun isFatalCredoExecutionFailure(exitCode: Int, output: String): Boolean {
+        if (output.isBlank()) return exitCode != 0
+
+        val normalized = output.lowercase()
+
+        // Treat known mix/compile failures as fatal so users get a notification instead of silent zero findings.
+        return normalized.contains("the task \"credo\" could not be found") ||
+            normalized.contains("could not compile dependency") ||
+            normalized.contains("validate_compile_env") ||
+            normalized.contains("aborting boot") ||
+            (exitCode != 0 && !normalized.contains(": c: ") && !normalized.contains(": r: ") &&
+                !normalized.contains(": f: ") && !normalized.contains(": s: ") && !normalized.contains(": w: "))
+    }
+
+    private fun notifyCredoIssue(
+        project: com.intellij.openapi.project.Project,
+        title: String,
+        message: String,
+        type: NotificationType,
+    ) {
+        val cleanMessage = message.ifBlank { "Unknown Credo error" }
+        LOG.warn("Credo execution issue:\n$cleanMessage")
+
+        NotificationGroupManager
+            .getInstance()
+            .getNotificationGroup("Elixir")
+            .createNotification(
+                title,
+                cleanMessage.toHTML(),
+                type
+            )
+            .addAction(Action(project))
+            .notify(project)
+    }
+
+    private fun buildCredoIssueMessage(issues: List<CredoExecutionIssue>): String {
+        val lines = mutableListOf<String>()
+
+        lines.add("Credo could not produce a complete result set.")
+        lines.add("IntelliJ can still show 'did not find anything' because external execution failed.")
+        lines.add("")
+
+        for (issue in issues.take(3)) {
+            lines.add("- ${issue.workingDirectory}: ${issue.summary}")
+        }
+
+        val remaining = issues.size - 3
+        if (remaining > 0) {
+            lines.add("- ...and $remaining more")
+        }
+
+        return lines.joinToString("\n")
+    }
+
+    private fun summarizeCredoOutput(output: String, maxLength: Int = 280): String {
+        val firstLine = output
+            .lineSequence()
+            .map(String::trim)
+            .firstOrNull { it.isNotEmpty() }
+            ?: "Unknown Credo error"
+
+        return if (firstLine.length <= maxLength) {
+            firstLine
+        } else {
+            firstLine.take(maxLength - 3) + "..."
+        }
+    }
+
+    private fun debugSkip(
+        reason: String,
+        workingDirectory: String,
+        rawLine: String,
+        details: String = ""
+    ) {
+        if (!LOG.isDebugEnabled) return
+
+        val suffix = if (details.isNotBlank()) " details=$details" else ""
+        LOG.debug("Skipping Credo finding: $reason workingDirectory='$workingDirectory' rawLine='$rawLine'$suffix")
+    }
+
     override fun isGraphNeeded(): Boolean = true
     override fun isReadActionNeeded(): Boolean = false
     override fun worksInBatchModeOnly(): Boolean = true
+    override fun getShortName(): String = SHORT_NAME
 
     companion object {
         // Referenced by inspection registration via reflection.
-        @Suppress("unused")
-        val SHORT_NAME = "Credo"
+        const val SHORT_NAME = "Credo"
     }
 }

--- a/src/org/elixir_lang/credo/inspection_tool/Global.kt
+++ b/src/org/elixir_lang/credo/inspection_tool/Global.kt
@@ -8,18 +8,14 @@ import com.intellij.execution.util.ExecUtil
 import com.intellij.notification.NotificationGroupManager
 import com.intellij.notification.NotificationType
 import com.intellij.openapi.application.ApplicationManager
-import com.intellij.openapi.editor.Document
 import com.intellij.openapi.module.Module
 import com.intellij.openapi.module.ModuleManager
 import com.intellij.openapi.progress.ProgressIndicator
 import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.progress.Task
 import com.intellij.openapi.roots.ModuleRootManager
-import com.intellij.openapi.util.Computable
 import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.VirtualFile
-import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiManager
 import org.elixir_lang.Mix
 import org.elixir_lang.credo.Action
@@ -123,87 +119,59 @@ class Global : GlobalInspectionTool() {
                         Regex("(?<path>.+?):(?<line>\\d+):(?:(?<column>\\d+):)? (?<tag>[CFRSW]): (?<message>.+)")
 
                     for (colorizedLine in processOutput.stdoutLines) {
+                        ProgressManager.checkCanceled()
+
                         val line = colorizedLine.stripColor()
-                        val match = flycheckRegex.matchEntire(line)
+                        val match = flycheckRegex.matchEntire(line) ?: continue
+                        val groups = match.groups as MatchNamedGroupCollection
+                        val path = groups["path"]!!.value
+                        val absolutePath = Paths.get(workingDirectory, path).toString()
+                        val virtualFile = LocalFileSystem.getInstance().findFileByPath(absolutePath) ?: continue
 
-                        if (match != null) {
-                            val groups = match.groups as MatchNamedGroupCollection
-                            val path = groups["path"]!!.value
-                            val absolutePath = Paths.get(workingDirectory, path).toString()
-                            val virtualFile = LocalFileSystem.getInstance().findFileByPath(absolutePath)
+                        ApplicationManager.getApplication().runReadAction {
+                            val psiFile = PsiManager.getInstance(project).findFile(virtualFile) ?: return@runReadAction
+                            val document = psiFile.viewProvider.document ?: return@runReadAction
+                            val lineNumber = groups["line"]!!.value.toInt() - 1
 
-                            if (virtualFile != null) {
-                                val psiFile =
-                                    ApplicationManager
-                                        .getApplication()
-                                        .runReadAction(Computable<PsiFile?> {
-                                            PsiManager.getInstance(project).findFile(virtualFile)
-                                        })
+                            if (lineNumber !in 0 until document.lineCount) return@runReadAction
 
-                                if (psiFile != null) {
-                                    val viewProvider = psiFile.viewProvider
-                                    val document =
-                                        ApplicationManager
-                                            .getApplication()
-                                            .runReadAction(Computable<Document?> {
-                                                viewProvider.document
-                                            })
+                            val lineStartOffset = document.getLineStartOffset(lineNumber)
+                            val lineEndOffset = document.getLineEndOffset(lineNumber)
+                            val start: Int
+                            val end: Int
 
-                                    if (document != null) {
-                                        val lineNumber = groups["line"]!!.value.toInt() - 1
-                                        val lineStartOffset = document.getLineStartOffset(lineNumber)
-                                        val start: Int
-                                        val end: Int
+                            val columnNumber = groups["column"]?.value?.toInt()
 
-                                        val columnNumber = groups["column"]?.value?.toInt()
+                            if (columnNumber != null) {
+                                val offset = lineStartOffset + columnNumber
 
-                                        if (columnNumber != null) {
-                                            start = lineStartOffset + columnNumber
-                                            end = start + 1
-                                        } else {
-                                            start = lineStartOffset
-                                            end = document.getLineEndOffset(lineNumber)
-                                        }
+                                if (offset !in lineStartOffset until lineEndOffset) return@runReadAction
 
-                                        val refElement = globalContext.refManager.getReference(psiFile)
-
-                                        val startElement =
-                                            ApplicationManager
-                                                .getApplication()
-                                                .runReadAction(Computable<PsiElement?> {
-                                                    psiFile.findElementAt(start)
-                                                })
-                                        val endElement =
-                                            ApplicationManager
-                                                .getApplication()
-                                                .runReadAction(Computable<PsiElement?> {
-                                                    psiFile.findElementAt(end - 1)
-                                                })
-
-                                        if (startElement != null && endElement != null) {
-                                            val message = groups["message"]!!.value
-
-                                            val problemDescriptor =
-                                                ApplicationManager
-                                                    .getApplication()
-                                                    .runReadAction(Computable<ProblemDescriptor> {
-                                                        manager.createProblemDescriptor(
-                                                            startElement,
-                                                            endElement,
-                                                            message,
-                                                            ProblemHighlightType.GENERIC_ERROR_OR_WARNING,
-                                                            false
-                                                        )
-                                                    })
-
-                                            problemDescriptionsProcessor.addProblemElement(
-                                                refElement,
-                                                problemDescriptor
-                                            )
-                                        }
-                                    }
-                                }
+                                start = offset
+                                end = start + 1
+                            } else {
+                                start = lineStartOffset
+                                end = lineEndOffset
                             }
+
+                            if (end <= start) return@runReadAction
+
+                            val startElement = psiFile.findElementAt(start) ?: return@runReadAction
+                            val endElement = psiFile.findElementAt(end - 1) ?: return@runReadAction
+                            val message = groups["message"]!!.value
+                            val problemDescriptor = manager.createProblemDescriptor(
+                                startElement,
+                                endElement,
+                                message,
+                                ProblemHighlightType.GENERIC_ERROR_OR_WARNING,
+                                false
+                            )
+                            val refElement = globalContext.refManager.getReference(psiFile)
+
+                            problemDescriptionsProcessor.addProblemElement(
+                                refElement,
+                                problemDescriptor
+                            )
                         }
                     }
                 }

--- a/src/org/elixir_lang/dialyzer/service/Configurable.kt
+++ b/src/org/elixir_lang/dialyzer/service/Configurable.kt
@@ -8,15 +8,20 @@ import javax.swing.JPanel
 import javax.swing.JTextField
 
 class Configurable(project: Project) : SearchableConfigurable {
+    companion object {
+        private const val ID = "language.elixir.dialyzer"
+        private const val DISPLAY_NAME = "Dialyzer"
+    }
+
     private val service: DialyzerService = project.getService(DialyzerService::class.java)
     private var mixArguments: JTextField? = null
     private var elixirArguments: JTextField? = null
     private var erlArguments: JTextField? = null
     private var panel: JPanel? = null
-    override fun getId() = "Dialyzer"
+    override fun getId() = ID
 
     @Nls(capitalization = Nls.Capitalization.Title)
-    override fun getDisplayName(): String = id
+    override fun getDisplayName(): String = DISPLAY_NAME
 
     override fun createComponent(): JComponent? = panel
 

--- a/src/org/elixir_lang/facet/configurable/Provider.kt
+++ b/src/org/elixir_lang/facet/configurable/Provider.kt
@@ -2,9 +2,10 @@ package org.elixir_lang.facet.configurable
 
 import com.intellij.openapi.options.Configurable
 import com.intellij.openapi.options.ConfigurableProvider
-import org.elixir_lang.sdk.ProcessOutput
 
 class Provider(private val project: com.intellij.openapi.project.Project): ConfigurableProvider() {
-    override fun canCreateConfigurable(): Boolean = ProcessOutput.isSmallIde
-    override fun createConfigurable(): Configurable = Project(project)
+    override fun canCreateConfigurable(): Boolean = true
+
+    override fun createConfigurable(): Configurable =
+        TopLevelElixirConfigurableFactory.getInstance().create(project)
 }

--- a/src/org/elixir_lang/facet/configurable/TopLevelElixirConfigurableFactory.kt
+++ b/src/org/elixir_lang/facet/configurable/TopLevelElixirConfigurableFactory.kt
@@ -1,0 +1,23 @@
+package org.elixir_lang.facet.configurable
+
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.options.Configurable
+import com.intellij.openapi.project.Project
+import org.elixir_lang.settings.ElixirTopLevelConfigurable
+
+interface TopLevelElixirConfigurableFactory {
+    fun create(project: Project): Configurable
+
+    companion object {
+        fun getInstance(): TopLevelElixirConfigurableFactory =
+            ApplicationManager.getApplication().getService(TopLevelElixirConfigurableFactory::class.java)
+    }
+}
+
+class SmallIdeTopLevelElixirConfigurableFactory : TopLevelElixirConfigurableFactory {
+    override fun create(project: Project): Configurable = Project(project)
+}
+
+class RichPlatformTopLevelElixirConfigurableFactory : TopLevelElixirConfigurableFactory {
+    override fun create(project: Project): Configurable = ElixirTopLevelConfigurable()
+}

--- a/src/org/elixir_lang/settings/ElixirExperimentalSettingsConfigurable.kt
+++ b/src/org/elixir_lang/settings/ElixirExperimentalSettingsConfigurable.kt
@@ -93,11 +93,11 @@ internal class ElixirExperimentalSettingsConfigurable : Configurable, Configurab
         LOG.debug("Settings were modified, calling updateState(). StatusBarWidget: ${oldState.enableStatusBarWidget} -> ${newState.enableStatusBarWidget}")
 
         // We need to manually trigger the change notification since the state was modified in-place
-        val messageBus = com.intellij.openapi.application.ApplicationManager.getApplication().messageBus
+        val messageBus = ApplicationManager.getApplication().messageBus
         messageBus.syncPublisher(ElixirExperimentalSettings.SETTINGS_CHANGED_TOPIC).settingsChanged(oldState, newState)
     }
 
-    override fun getDisplayName(): String = "Elixir Experimental Settings"
+    override fun getDisplayName(): String = "Experimental Settings"
 
     override fun reset() {
         settingsPanel?.reset()

--- a/src/org/elixir_lang/settings/ElixirSearchableOptionContributor.kt
+++ b/src/org/elixir_lang/settings/ElixirSearchableOptionContributor.kt
@@ -1,0 +1,69 @@
+package org.elixir_lang.settings
+
+import com.intellij.ide.ui.search.SearchableOptionContributor
+import com.intellij.ide.ui.search.SearchableOptionProcessor
+
+/**
+ * Keeps Elixir settings discoverable in search without requiring Elixir-prefixed labels.
+ */
+class ElixirSearchableOptionContributor : SearchableOptionContributor() {
+    override fun processOptions(processor: SearchableOptionProcessor) {
+        addAliases(
+            processor = processor,
+            configurableId = "language.elixir",
+            configurableDisplayName = "Elixir",
+            hit = "Elixir",
+            text = "elixir language framework settings"
+        )
+
+        addAliases(
+            processor = processor,
+            configurableId = "language.elixir.credo",
+            configurableDisplayName = "Credo",
+            hit = "Credo",
+            text = "elixir credo lint linter"
+        )
+
+        addAliases(
+            processor = processor,
+            configurableId = "language.elixir.dialyzer",
+            configurableDisplayName = "Dialyzer",
+            hit = "Dialyzer",
+            text = "elixir dialyzer typespec static analysis"
+        )
+
+        addAliases(
+            processor = processor,
+            configurableId = "org.elixir_lang.settings.ElixirExperimentalSettingsConfigurable",
+            configurableDisplayName = "Experimental Settings",
+            hit = "Experimental Settings",
+            text = "elixir experimental settings liveview heex sigil injection"
+        )
+
+        addAliases(
+            processor = processor,
+            configurableId = "language.elixir.sdks.elixir",
+            configurableDisplayName = "SDKs",
+            hit = "SDKs",
+            text = "elixir sdk interpreter"
+        )
+
+        addAliases(
+            processor = processor,
+            configurableId = "language.elixir.sdks.erlang",
+            configurableDisplayName = "Internal Erlang SDKs",
+            hit = "Internal Erlang SDKs",
+            text = "elixir erlang sdk otp"
+        )
+    }
+
+    private fun addAliases(
+        processor: SearchableOptionProcessor,
+        configurableId: String,
+        configurableDisplayName: String,
+        hit: String,
+        text: String
+    ) {
+        processor.addOptions(text, null, hit, configurableId, configurableDisplayName, true)
+    }
+}

--- a/src/org/elixir_lang/settings/ElixirTopLevelConfigurable.kt
+++ b/src/org/elixir_lang/settings/ElixirTopLevelConfigurable.kt
@@ -1,0 +1,27 @@
+package org.elixir_lang.settings
+
+import com.intellij.openapi.options.Configurable
+import com.intellij.ui.components.JBLabel
+import com.intellij.util.ui.JBUI
+import java.awt.BorderLayout
+import javax.swing.JComponent
+import javax.swing.JPanel
+
+/**
+ * Always-visible top-level Elixir settings page for full IDEs.
+ * Child configurables (Credo, Dialyzer, SDKs, etc.) provide the editable settings.
+ */
+class ElixirTopLevelConfigurable : Configurable, Configurable.NoScroll {
+    override fun getDisplayName(): String = "Elixir"
+
+    override fun createComponent(): JComponent = JPanel(BorderLayout()).apply {
+        border = JBUI.Borders.empty(10)
+        add(JBLabel("Configure Elixir using the child pages in this section (SDKs, Credo, Dialyzer, Experimental Settings)."), BorderLayout.NORTH)
+    }
+
+    override fun isModified(): Boolean = false
+
+    override fun apply() {
+        // No mutable settings at the top-level container.
+    }
+}

--- a/tests/org/elixir_lang/credo/inspection_tool/GlobalFlycheckParsingTest.kt
+++ b/tests/org/elixir_lang/credo/inspection_tool/GlobalFlycheckParsingTest.kt
@@ -1,0 +1,57 @@
+package org.elixir_lang.credo.inspection_tool
+
+import org.elixir_lang.PlatformTestCase
+
+class GlobalFlycheckParsingTest : PlatformTestCase() {
+    fun testParsesLineAndColumnFinding() {
+        val finding = parseFlycheckFinding(
+            "lib/level_web/ui/empty_state.ex:1:11: R: Modules should have a @moduledoc tag."
+        )
+
+        assertNotNull(finding)
+        assertEquals("lib/level_web/ui/empty_state.ex", finding!!.path)
+        assertEquals(1, finding.line)
+        assertEquals(11, finding.column)
+        assertEquals("Modules should have a @moduledoc tag.", finding.message)
+    }
+
+    fun testParsesLineWithoutColumnFinding() {
+        val finding = parseFlycheckFinding(
+            "lib/level_web/ui/empty_state.ex:1: W: Prefer explicit module aliases"
+        )
+
+        assertNotNull(finding)
+        assertEquals("lib/level_web/ui/empty_state.ex", finding!!.path)
+        assertEquals(1, finding.line)
+        assertNull(finding.column)
+        assertEquals("Prefer explicit module aliases", finding.message)
+    }
+
+    fun testParsesLineWithoutColumnFindingInNestedPath() {
+        val finding = parseFlycheckFinding(
+            "apps/ic_core/lib/ic_core/dispatch/randomization.ex:6: C: Prefer Enum.random/1"
+        )
+
+        assertNotNull(finding)
+        assertEquals("apps/ic_core/lib/ic_core/dispatch/randomization.ex", finding!!.path)
+        assertEquals(6, finding.line)
+        assertNull(finding.column)
+        assertEquals("Prefer Enum.random/1", finding.message)
+    }
+
+    fun testParsesFileLevelFinding() {
+        val finding = parseFlycheckFinding(
+            "apps/smoke_test/lib/smoke_test.ex: W: Test files should end with .exs"
+        )
+
+        assertNotNull(finding)
+        assertEquals("apps/smoke_test/lib/smoke_test.ex", finding!!.path)
+        assertNull(finding.line)
+        assertNull(finding.column)
+        assertEquals("Test files should end with .exs", finding.message)
+    }
+
+    fun testDoesNotParseSummaryLines() {
+        assertNull(parseFlycheckFinding("Please report incorrect results: https://example.test"))
+    }
+}


### PR DESCRIPTION
﻿Part of the safer-background-threads split. See #3808 for full context.
### Overview
Improves settings discoverability, refactors the top-level configurable strategy, and hardens the Credo inspection to surface failures and reduce lock churn.
### Key changes
#### Settings improvements
- Fixed `isSmallIde` detection to use `ApplicationInfo` product codes instead of class detection, which broke in 2026.1.
- Moved all Elixir settings panels under a single parent configurable for both full IDEA and small IDEs; added search indexing so Elixir settings are discoverable in Settings Search; dropped redundant "Elixir" prefixes within setting panel titles.
- Refactored top-level configurable selection to use a service-provider strategy.
#### Credo improvements
- Surface Credo execution failures as inspection problems and aggregated notifications rather than silently dropping them, and preserve any partial findings from a run that also hit fatal errors.
- Consolidated per-finding read actions in the global inspection from 4–6 separate read-action acquisitions per output line to one read action per parsed finding, reducing lock churn under 2025.3+ writer-preference locking.
### Risk / compatibility notes
- Settings panel restructuring may affect users who have bookmarked specific settings paths.
### Suggested validation
- Open Settings and verify all Elixir settings panels are grouped together and searchable.
- Open a project using Credo and verify inspection failures surface as notifications rather than silently disappearing.
Partially fixes: #3790 (Credo read-action lock churn)
