### PR TITLE
PSI / Resolver / Code Insight Fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## v23.2.0
+
+### Enhancements
+* [#3818](https://github.com/KronicDeth/intellij-elixir/pull/3818) - [@sh41](https://github.com/sh41)
+  * Code completion deduplication: multi-clause functions (e.g. `Enum.map_every` with 5 clauses) now appear once in completion results instead of once per clause head. Shared `PreferFunctionHead` logic selects bare function heads over implementation clauses.
+  * Parameter info deduplication: parameter hints grouped by `(name, arity)` -- separate arities still show distinct hints, but multiple clauses of the same arity no longer produce duplicate entries.
+  * Completion prefers source-defined modulars over BEAM stubs when both are available, eliminating duplicate completion entries.
+  * Transitive alias resolution: when stub-index lookup finds nothing for a module name that is itself a `QualifiableAlias`, resolution now follows alias chains transitively. Possibly addresses [#1806](https://github.com/KronicDeth/intellij-elixir/issues/1806).
+  * `DefinitionsScopedSearch` cancellation: added `ProgressManager.checkCanceled()` at loop boundaries and honour `Processor.process()` return value for early-exit, preventing hangs during large-project searches.
+
+### Bug Fixes
+* [#3818](https://github.com/KronicDeth/intellij-elixir/pull/3818) - [@sh41](https://github.com/sh41)
+  * **Breaking change**: removed `nameArityInAnyModule` global fallback from resolver. Previously, when `resolveInScope` found no results, the resolver fell back to a global stub-index search returning every function with a matching name from every module (all marked `validResult=false`). This polluted parameter hints with unrelated modules (e.g. hovering `Enum.map()` showed hints from `Stream.Reducers`, `Ecto`, `Phoenix`), caused Go-to-Definition to navigate to wrong-module definitions, and filled the resolution cache with irrelevant results. Calls that were previously "resolved" to functions in unrelated modules will now correctly appear as unresolved references.
+  * Infinite loop in `UnaliasedName.up` when resolving `QualifiedMultipleAliases` -- function overload ordering caused mutual recursion.
+  * Infinite recursion and NPE prevention in PSI resolve/tree-walk paths via `RecursionManager.doPreventingRecursion()` and null-safe `VISITED_ELEMENT_SET` access in `ResolveState`.
+  * `@spec` line marker grouping checked arity equality before name equality -- specs for different functions with the same arity were incorrectly grouped together.
+  * Gutter icons anchored to leaf `PsiElement`s per the `LineMarkerProvider` contract. Non-leaf elements caused markers to blink or appear in wrong positions after edits.
+  * Removed redundant `computeReadAction`/`runReadAction` wrappers from `CallImpl` getters (`functionName`, `moduleName`, `resolvedPrimaryArity`) and `PsiNamedElementImpl` name getters. These trivial PSI reads were called from paths already holding a read lock; under 2025.3+ writer-preference locking, re-acquiring blocks the EDT when a write action is pending. Partially fixes [#3790](https://github.com/KronicDeth/intellij-elixir/issues/3790).
+  * `Elixir.` prefix stripping for module name resolution -- stub index stores names without the prefix, so `Elixir.Enum` lookups now match correctly.
+
 ## v23.1.0
 
 ### Enhancements

--- a/gen/org/elixir_lang/psi/scope/module/MultiResolve.kt
+++ b/gen/org/elixir_lang/psi/scope/module/MultiResolve.kt
@@ -8,6 +8,7 @@ import com.intellij.psi.util.PsiTreeUtil
 import org.elixir_lang.Module.concat
 import org.elixir_lang.Module.split
 import org.elixir_lang.psi.NamedElement
+import org.elixir_lang.psi.QualifiableAlias
 import org.elixir_lang.psi.call.Named
 import org.elixir_lang.psi.impl.ElixirPsiImplUtil.ENTRANCE
 import org.elixir_lang.psi.impl.call.finalArguments
@@ -67,7 +68,7 @@ class MultiResolve internal constructor(private val name: String, private val in
                                 )
                             }
                         }
-            } else if (requireCall != null) {
+            } else {
                 resolveResultOrderedSet.add(match, requireCall.text, true, state.visitedElementSet())
             }
         } else {
@@ -106,6 +107,8 @@ class MultiResolve internal constructor(private val name: String, private val in
         val project = match.project
 
         if (!DumbService.isDumb(project)) {
+            var found = false
+
             StubIndex
                     .getInstance()
                     .processElements(
@@ -115,8 +118,28 @@ class MultiResolve internal constructor(private val name: String, private val in
                             GlobalSearchScope.allScope(project),
                             NamedElement::class.java) {
                 resolveResultOrderedSet.add(it, unaliasedName, true, visitedElementSet)
+                found = true
 
                 true
+            }
+
+            // Transitive alias fallback: if stub lookup found nothing and match is a QualifiableAlias,
+            // resolve it through the module scope to follow alias chains
+            // (e.g., `alias MyNamespace.Referenced; alias Referenced, as: Refd` — resolving `Refd` needs
+            // to follow Referenced → MyNamespace.Referenced transitively)
+            if (!found && match is QualifiableAlias) {
+                val transitiveResults = resolveResults(match.fullyQualifiedName(), incompleteCode, match)
+                for (result in transitiveResults) {
+                    val resolvedElement = result.element
+                    if (resolvedElement is NamedElement) {
+                        resolveResultOrderedSet.add(
+                            resolvedElement,
+                            resolvedElement.name ?: unaliasedName,
+                            result.isValidResult,
+                            visitedElementSet + result.visitedElementSet
+                        )
+                    }
+                }
             }
         }
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@
 # --- Plugin Metadata ---
 pluginGroup=org.elixir_lang
 pluginName=Elixir
-pluginVersion=23.1.0
+pluginVersion=23.2.0
 pluginRepositoryUrl=https://github.com/KronicDeth/intellij-elixir/
 vendorName=Elle Imhoff
 vendorEmail=Kronic.Deth@gmail.com

--- a/resources/META-INF/changelog.html
+++ b/resources/META-INF/changelog.html
@@ -1,6 +1,30 @@
 <html>
 <body>
 
+<h1>v23.2.0</h1>
+<ul>
+    <li>
+        <p>Enhancements</p>
+        <ul>
+            <li>Code completion no longer shows duplicate entries for functions with multiple clauses or guards (e.g. <code>Enum.map_every</code> previously appeared 5 times).</li>
+            <li>Parameter hints deduplicated -- hovering a function call shows one set of hints per arity, not one per clause.</li>
+            <li>Module alias resolution now follows alias chains transitively, improving Go-to-Declaration and completion for aliased modules.</li>
+            <li>Large-project searches (Find Usages, Go-to-Definition) can now be cancelled mid-search and exit early when results are found, preventing UI hangs.</li>
+        </ul>
+    </li>
+    <li>
+        <p>Bug Fixes</p>
+        <ul>
+            <li><b>Breaking change</b>: parameter hints and Go-to-Definition no longer show results from unrelated modules. Previously, unresolvable calls fell back to a global search returning every function with the same name across the entire project. Calls that cannot be resolved now correctly show no results instead of misleading ones.</li>
+            <li>Fixed infinite loop when resolving multi-aliases (e.g. <code>alias Foo.{Bar, Baz}</code>).</li>
+            <li>Fixed infinite recursion and potential crashes in reference resolution.</li>
+            <li>Fixed <code>@spec</code> gutter icons grouping specs for different functions together when they shared the same arity.</li>
+            <li>Fixed gutter icons (line markers) blinking or appearing in wrong positions after editing code.</li>
+            <li>Reduced UI freezes caused by redundant read-lock acquisition in frequently called PSI accessors under IntelliJ 2025.3+ writer-preference locking.</li>
+        </ul>
+    </li>
+</ul>
+
 <h1>v23.1.0</h1>
 <ul>
     <li>

--- a/src/org/elixir_lang/DefinitionsScopedSearch.kt
+++ b/src/org/elixir_lang/DefinitionsScopedSearch.kt
@@ -1,7 +1,7 @@
 package org.elixir_lang
 
-import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.QueryExecutorBase
+import com.intellij.openapi.progress.ProgressManager
 import com.intellij.psi.PsiElement
 import com.intellij.psi.ResolveState
 import com.intellij.psi.search.searches.DefinitionsScopedSearch
@@ -23,7 +23,6 @@ class DefinitionsScopedSearch :
         queryParameters: DefinitionsScopedSearch.SearchParameters,
         consumer: Processor<in PsiElement>
     ) {
-        ApplicationManager.getApplication().assertReadAccessAllowed()
         when (val element = queryParameters.element) {
             is Call -> processQuery(element, consumer)
             is QualifiableAlias -> processQuery(element, consumer)
@@ -31,7 +30,7 @@ class DefinitionsScopedSearch :
     }
 
     private fun processQuery(qualifiableAlias: QualifiableAlias, consumer: Processor<in PsiElement>) {
-        ApplicationManager.getApplication().assertReadAccessAllowed()
+        ProgressManager.checkCanceled()
         qualifiableAlias.outerMostQualifiableAlias().maybeModularNameToModulars(qualifiableAlias.containingFile)
             .map { modular ->
                 processQuery(modular, consumer)
@@ -39,7 +38,6 @@ class DefinitionsScopedSearch :
     }
 
     private fun processQuery(psiElement: PsiElement, consumer: Processor<in PsiElement>) {
-        ApplicationManager.getApplication().assertReadAccessAllowed()
         when (psiElement) {
             is Call -> processQuery(psiElement, consumer)
             is ModuleImpl<*> -> processQuery(psiElement, consumer)
@@ -48,7 +46,6 @@ class DefinitionsScopedSearch :
     }
 
     private fun processQuery(call: Call, consumer: Processor<in PsiElement>) {
-        ApplicationManager.getApplication().assertReadAccessAllowed()
         if (Protocol.`is`(call)) {
             Protocol.processImplementations(call, consumer)
         } else if (CallDefinitionClause.`is`(call)) {
@@ -56,20 +53,56 @@ class DefinitionsScopedSearch :
                 CallDefinitionClause.nameArityInterval(call, ResolveState.initial())?.let { protocolNameArityInterval ->
                     if (Protocol.`is`(modularCall)) {
                         Protocol.processImplementations(modularCall) { defimpl ->
-                            for (defimplChild in (defimpl as Call).macroChildCallList()) {
-                                if (CallDefinitionClause.`is`(defimplChild)) {
-                                    CallDefinitionClause.nameArityInterval(defimplChild, ResolveState.initial())
-                                        ?.let { implNameArityInterval ->
-                                            if (implNameArityInterval.name == protocolNameArityInterval.name &&
-                                                implNameArityInterval.arityInterval.overlaps(protocolNameArityInterval.arityInterval)
-                                            ) {
-                                                consumer.process(defimplChild)
+                            ProgressManager.checkCanceled()
+
+                            var continueProcessing = true
+
+                            when (defimpl) {
+                                is Call -> {
+                                    for (defimplChild in defimpl.macroChildCallList()) {
+                                        ProgressManager.checkCanceled()
+
+                                        if (CallDefinitionClause.`is`(defimplChild)) {
+                                            CallDefinitionClause.nameArityInterval(defimplChild, ResolveState.initial())
+                                                ?.let { implNameArityInterval ->
+                                                    if (implNameArityInterval.name == protocolNameArityInterval.name &&
+                                                        implNameArityInterval.arityInterval.overlaps(protocolNameArityInterval.arityInterval)
+                                                    ) {
+                                                        if (!consumer.process(defimplChild)) {
+                                                            continueProcessing = false
+                                                        }
+                                                    }
+                                                }
+                                        }
+
+                                        if (!continueProcessing) {
+                                            break
+                                        }
+                                    }
+                                }
+
+                                is ModuleImpl<*> -> {
+                                    for (callDefinition in defimpl.callDefinitions()) {
+                                        ProgressManager.checkCanceled()
+
+                                        val implNameArityInterval = callDefinition.nameArityInterval
+
+                                        if (implNameArityInterval.name == protocolNameArityInterval.name &&
+                                            implNameArityInterval.arityInterval.overlaps(protocolNameArityInterval.arityInterval)
+                                        ) {
+                                            if (!consumer.process(callDefinition)) {
+                                                continueProcessing = false
                                             }
                                         }
+
+                                        if (!continueProcessing) {
+                                            break
+                                        }
+                                    }
                                 }
                             }
 
-                            true
+                            continueProcessing
                         }
                     }
                 }
@@ -78,14 +111,12 @@ class DefinitionsScopedSearch :
     }
 
     private fun processQuery(moduleImpl: ModuleImpl<*>, consumer: Processor<in PsiElement>) {
-        ApplicationManager.getApplication().assertReadAccessAllowed()
         if (Protocol.`is`(moduleImpl)) {
             Protocol.processImplementations(moduleImpl, consumer)
         }
     }
 
     private fun processQuery(callDefinitionImpl: CallDefinitionImpl<*>, consumer: Processor<in PsiElement>) {
-        ApplicationManager.getApplication().assertReadAccessAllowed()
         val moduleImpl = callDefinitionImpl.parent
 
         if (Protocol.`is`(moduleImpl)) {
@@ -93,34 +124,54 @@ class DefinitionsScopedSearch :
             val arity = callDefinitionImpl.exportedArity(ResolveState.initial())
 
             Protocol.processImplementations(moduleImpl) { defimpl ->
+                ProgressManager.checkCanceled()
+
+                var continueProcessing = true
+
                 when (defimpl) {
                     is Call -> {
                         for (defimplChild in defimpl.macroChildCallList()) {
+                            ProgressManager.checkCanceled()
+
                             if (CallDefinitionClause.`is`(defimplChild)) {
                                 CallDefinitionClause.nameArityInterval(defimplChild, ResolveState.initial())
                                     ?.let { implNameArityInterval ->
                                         if (implNameArityInterval.name == name &&
                                             implNameArityInterval.arityInterval.contains(arity)
                                         ) {
-                                            consumer.process(defimplChild)
+                                            if (!consumer.process(defimplChild)) {
+                                                continueProcessing = false
+                                            }
                                         }
                                     }
+                            }
+
+                            if (!continueProcessing) {
+                                break
                             }
                         }
                     }
                     is ModuleImpl<*> ->
                         for (callDefinition in defimpl.callDefinitions()) {
+                            ProgressManager.checkCanceled()
+
                             val implNameArityInterval = callDefinition.nameArityInterval
 
                             if (implNameArityInterval.name == name &&
                                 implNameArityInterval.arityInterval.contains(arity)
                             ) {
-                                consumer.process(callDefinition)
+                                if (!consumer.process(callDefinition)) {
+                                    continueProcessing = false
+                                }
+                            }
+
+                            if (!continueProcessing) {
+                                break
                             }
                         }
                 }
 
-                true
+                continueProcessing
             }
         }
     }

--- a/src/org/elixir_lang/beam/psi/Modular.java
+++ b/src/org/elixir_lang/beam/psi/Modular.java
@@ -1,4 +1,0 @@
-package org.elixir_lang.beam.psi;
-
-public interface Modular {
-}

--- a/src/org/elixir_lang/code_insight/ParameterInfo.kt
+++ b/src/org/elixir_lang/code_insight/ParameterInfo.kt
@@ -20,7 +20,7 @@ class ParameterInfo : ParameterInfoHandler<Arguments, Any> {
 
     override fun showParameterInfo(element: Arguments, context: CreateParameterInfoContext) {
         PsiTreeUtil.getParentOfType(element, Call::class.java)?.let { call ->
-            val itemToShowList = call.references.flatMap { reference ->
+            val allClauses = call.references.flatMap { reference ->
                 if (reference is PsiPolyVariantReference) {
                     reference.multiResolve(true).flatMap { resolveResult ->
                         resolveResult.element?.let {
@@ -38,9 +38,14 @@ class ParameterInfo : ParameterInfoHandler<Arguments, Any> {
                         } else {
                             null
                         }
-                    } ?: emptyList<Any>()
+                    } ?: emptyList()
                 }
             }
+
+            // Deduplicate by (name, arity), preferring bare function heads (no do block)
+            // over implementation clauses.  Uses arity-aware grouping so that
+            // genuinely different arities (e.g. foo/1 vs foo/2) each get their own hint.
+            val itemToShowList = preferFunctionHeadsByArity(allClauses)
 
             if (itemToShowList.isNotEmpty()) {
                 context.itemsToShow = itemToShowList.toTypedArray()
@@ -115,9 +120,6 @@ class ParameterInfo : ParameterInfoHandler<Arguments, Any> {
         }
     }
 
-    private fun findArguments(context: ParameterInfoContext): Arguments? {
-        val elementAtOffset = context.file.findElementAt(context.offset)
-
-        return PsiTreeUtil.getParentOfType<Arguments>(elementAtOffset, Arguments::class.java)
-    }
+    private fun findArguments(context: ParameterInfoContext): Arguments? =
+        ParameterInfoUtils.findParentOfType(context.file, context.offset, Arguments::class.java)
 }

--- a/src/org/elixir_lang/code_insight/PreferFunctionHead.kt
+++ b/src/org/elixir_lang/code_insight/PreferFunctionHead.kt
@@ -1,0 +1,52 @@
+package org.elixir_lang.code_insight
+
+import com.intellij.psi.ResolveState
+import org.elixir_lang.psi.CallDefinitionClause
+import org.elixir_lang.psi.call.Call
+
+/**
+ * Given a list of [CallDefinitionClause] calls (potentially multiple clause heads for the same function),
+ * groups them by name and selects one representative per function — preferring **bare function heads**
+ * (those without a `do` block or keyword) over implementation clauses.
+ *
+ * A bare function head like `def map_every(enumerable, nth, fun)` has canonical parameter names,
+ * while implementation clauses like `def map_every([], nth, _fun) when is_integer(nth) and nth > 1, do: []`
+ * have pattern-matched literals and guards that are implementation details.
+ *
+ * Groups by **name only**, collapsing different arities into one entry.
+ * Use for completion where one entry per function name is desired.
+ *
+ * @return a map from function name to the best representative clause
+ */
+fun preferFunctionHeads(clauses: Iterable<Call>): Map<String, Call> =
+    clauses
+        .mapNotNull { call ->
+            CallDefinitionClause.nameArityInterval(call, ResolveState.initial())
+                ?.let { it.name to call }
+        }
+        .groupBy({ it.first }, { it.second })
+        .mapValues { (_, group) -> preferFunctionHead(group) }
+
+/**
+ * Like [preferFunctionHeads] but groups by **(name, arityInterval)**, preserving separate entries
+ * for functions with the same name but different arities (e.g., `foo/1` and `foo/2`).
+ *
+ * Use for parameter info where each arity should appear as a separate hint.
+ *
+ * @return a list of best representative clauses, one per name+arity combination
+ */
+fun preferFunctionHeadsByArity(clauses: Iterable<Call>): List<Call> =
+    clauses
+        .mapNotNull { call ->
+            CallDefinitionClause.nameArityInterval(call, ResolveState.initial())
+                ?.let { it to call }
+        }
+        .groupBy({ it.first }, { it.second })
+        .map { (_, group) -> preferFunctionHead(group) }
+
+/**
+ * From a list of clauses for the same function, prefer the bare function head (no `do` block/keyword)
+ * over implementation clauses. Falls back to the first clause if no bare head exists.
+ */
+private fun preferFunctionHead(clauses: List<Call>): Call =
+    clauses.firstOrNull { !it.hasDoBlockOrKeyword() } ?: clauses.first()

--- a/src/org/elixir_lang/code_insight/completion/provider/CallDefinitionClause.kt
+++ b/src/org/elixir_lang/code_insight/completion/provider/CallDefinitionClause.kt
@@ -6,11 +6,10 @@ import com.intellij.codeInsight.completion.CompletionResultSet
 import com.intellij.codeInsight.lookup.LookupElement
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiWhiteSpace
-import com.intellij.psi.ResolveState
 import com.intellij.util.ProcessingContext
 import org.elixir_lang.beam.psi.impl.ModuleImpl
+import org.elixir_lang.code_insight.preferFunctionHeads
 import org.elixir_lang.navigation.isDecompiled
-import org.elixir_lang.psi.CallDefinitionClause.nameArityInterval
 import org.elixir_lang.psi.ElixirTypes
 import org.elixir_lang.psi.call.Call
 import org.elixir_lang.psi.impl.call.macroChildCalls
@@ -35,24 +34,23 @@ class CallDefinitionClause : CompletionProvider<CompletionParameters>() {
             callDefinitionClauseList
         }
 
-        return callable
-            .mapNotNull {
-                nameArityInterval(it, ResolveState.initial())?.let { (name, _) ->
-                    org.elixir_lang.code_insight.lookup.element.CallDefinitionClause.createWithSmartPointer(
-                        name,
-                        it
-                    )
-                }
-            }
+        return preferFunctionHeads(callable).map { (name, bestClause) ->
+            org.elixir_lang.code_insight.lookup.element.CallDefinitionClause.createWithSmartPointer(
+                name,
+                bestClause
+            )
+        }
     }
 
     private fun callDefinitionClauseLookupElements(moduleImpl: ModuleImpl<*>): Iterable<LookupElement> =
-        moduleImpl.callDefinitions().map { callDefinition ->
-            org.elixir_lang.code_insight.lookup.element.CallDefinitionClause.createWithSmartPointer(
-                callDefinition.exportedName(),
-                callDefinition
-            )
-        }
+        moduleImpl.callDefinitions()
+            .filter { it.isExported }
+            .map { callDefinition ->
+                org.elixir_lang.code_insight.lookup.element.CallDefinitionClause.createWithSmartPointer(
+                    callDefinition.exportedName(),
+                    callDefinition
+                )
+            }
 
     private fun maybeModularName(parameters: CompletionParameters): PsiElement? =
         parameters.originalPosition?.let { originalPosition ->
@@ -100,7 +98,11 @@ class CallDefinitionClause : CompletionProvider<CompletionParameters>() {
                     resultSet
                 }
 
-                for (modular in modulars) {
+                // Prefer source modulars (Call) over BEAM stubs (ModuleImpl) to avoid duplicate completions
+                val sourceModulars = modulars.filterIsInstance<Call>()
+                val effectiveModulars = if (sourceModulars.isNotEmpty()) sourceModulars else modulars
+
+                for (modular in effectiveModulars) {
                     modularsResultSet.addAllElements(
                         callDefinitionClauseLookupElements(modular)
                     )

--- a/src/org/elixir_lang/code_insight/line_marker_provider/CallDefinition.kt
+++ b/src/org/elixir_lang/code_insight/line_marker_provider/CallDefinition.kt
@@ -22,35 +22,57 @@ import org.elixir_lang.structure_view.element.CallDefinitionSpecification.Compan
 import org.elixir_lang.structure_view.element.CallDefinitionSpecification.Companion.specificationType
 
 class CallDefinition : LineMarkerProvider {
-    override fun getLineMarkerInfo(element: PsiElement): LineMarkerInfo<*>? =
-        if (daemonCodeAnalyzerSettings.SHOW_METHOD_SEPARATORS) {
-            when (element) {
-                is AtUnqualifiedNoParenthesesCall<*> -> getLineMarkerInfo(element)
-                is Call -> getLineMarkerInfo(element)
-                else -> null
+    override fun getLineMarkerInfo(element: PsiElement): LineMarkerInfo<*>? {
+        // LineMarkerProvider contract: only return info for leaf elements
+        if (element.firstChild != null) return null
+        if (!daemonCodeAnalyzerSettings.SHOW_METHOD_SEPARATORS) return null
+
+        val parent = element.parent
+
+        // Leaf is IDENTIFIER_TOKEN inside an @-attribute's atIdentifier
+        if (parent != null && element.node.elementType == ElixirTypes.IDENTIFIER_TOKEN) {
+            val grandparent = parent.parent
+            if (grandparent is AtUnqualifiedNoParenthesesCall<*>) {
+                // Verify this is the expected leaf anchor for the attribute
+                val expectedLeaf = grandparent.atIdentifier.node
+                    .findChildByType(ElixirTypes.IDENTIFIER_TOKEN) as? LeafPsiElement
+                if (element == expectedLeaf) {
+                    return getLineMarkerInfo(grandparent)
+                }
             }
-        } else {
-            null
         }
+
+        // Leaf is the marker anchor of a Call (function name identifier).
+        // markerAnchor(call) places the leaf at most 2 levels below the Call
+        // (Call → functionNameElement → IDENTIFIER_TOKEN), so we bound the search.
+        val call = generateSequence(parent) { it.parent }
+            .take(2)
+            .filterIsInstance<Call>()
+            .firstOrNull()
+
+        if (call != null && CallDefinitionClause.`is`(call) && element == markerAnchor(call)) {
+            return getLineMarkerInfo(call)
+        }
+
+        return null
+    }
 
     private val daemonCodeAnalyzerSettings: DaemonCodeAnalyzerSettings = DaemonCodeAnalyzerSettings.getInstance()
     private val editorColorsManager: EditorColorsManager = EditorColorsManager.getInstance()
 
     private fun callDefinitionSeparator(
         atUnqualifiedNoParenthesesCall: AtUnqualifiedNoParenthesesCall<*>
-    ): LineMarkerInfo<*> {
+    ): LineMarkerInfo<*>? {
         val leafPsiElement = atUnqualifiedNoParenthesesCall
             .atIdentifier
             .node
-            .findChildByType(ElixirTypes.IDENTIFIER_TOKEN) as LeafPsiElement?
-            ?: error(
-                "AtUnqualifiedNoParenthesesCall (" +
-                        atUnqualifiedNoParenthesesCall.text +
-                        ") does not have an Tokenizer token"
-            )
+            .findChildByType(ElixirTypes.IDENTIFIER_TOKEN) as? LeafPsiElement
 
-        return callDefinitionSeparator(leafPsiElement)
+        return leafPsiElement?.let(::callDefinitionSeparator)
     }
+
+    private fun callDefinitionSeparator(call: Call): LineMarkerInfo<*>? =
+        markerAnchor(call)?.let(::callDefinitionSeparator)
 
     private fun callDefinitionSeparator(psiElement: PsiElement): LineMarkerInfo<*> =
         LineMarkerInfo(

--- a/src/org/elixir_lang/code_insight/line_marker_provider/CallDefinition.kt
+++ b/src/org/elixir_lang/code_insight/line_marker_provider/CallDefinition.kt
@@ -142,7 +142,7 @@ class CallDefinition : LineMarkerProvider {
                     if (moduleAttributeNameArity != null) {
                         moduleAttributeNameArity(previousModuleAttribute)?.let { previousModuleAttributeNameArity ->
                             // name match, now check if the arities match.
-                            if (moduleAttributeNameArity.arity == previousModuleAttributeNameArity.arity) {
+                            if (moduleAttributeNameArity.name == previousModuleAttributeNameArity.name) {
                                 val moduleAttributeArity = moduleAttributeNameArity.arity
                                 val previousModuleAttributeArity = previousModuleAttributeNameArity.arity
 

--- a/src/org/elixir_lang/code_insight/line_marker_provider/Implementation.kt
+++ b/src/org/elixir_lang/code_insight/line_marker_provider/Implementation.kt
@@ -1,6 +1,5 @@
 package org.elixir_lang.code_insight.line_marker_provider
 
-import com.intellij.codeInsight.ContainerProvider
 import com.intellij.codeInsight.daemon.GutterIconNavigationHandler
 import com.intellij.codeInsight.daemon.LineMarkerInfo
 import com.intellij.codeInsight.daemon.LineMarkerProvider
@@ -8,11 +7,12 @@ import com.intellij.codeInsight.daemon.impl.PsiElementListNavigator
 import com.intellij.codeInsight.navigation.NavigationGutterIconBuilder
 import com.intellij.codeInsight.navigation.NavigationGutterIconRenderer
 import com.intellij.ide.util.PsiElementListCellRenderer
-import com.intellij.navigation.NavigationItem
 import com.intellij.openapi.util.Computable
 import com.intellij.openapi.util.NotNullLazyValue
-import com.intellij.openapi.util.text.StringUtil
-import com.intellij.psi.*
+import com.intellij.psi.NavigatablePsiElement
+import com.intellij.psi.PsiElement
+import com.intellij.psi.ResolveState
+import com.intellij.psi.SmartPsiElementPointer
 import org.elixir_lang.Icons
 import org.elixir_lang.beam.psi.impl.ModuleImpl
 import org.elixir_lang.psi.CallDefinitionClause
@@ -25,14 +25,28 @@ import java.util.*
 import javax.swing.Icon
 
 class Implementation : LineMarkerProvider {
-    override fun getLineMarkerInfo(element: PsiElement): LineMarkerInfo<*>? =
-        when (element) {
-            is Call -> getLineMarkerInfo(element)
-            else -> null
-        }
+    override fun getLineMarkerInfo(element: PsiElement): LineMarkerInfo<*>? {
+        // LineMarkerProvider contract: only return info for leaf elements
+        if (element.firstChild != null) return null
+
+        // Walk up from leaf to find the nearest enclosing Call.
+        // markerAnchor(call) places the leaf at most 2 levels below the Call
+        // (Call → functionNameElement → IDENTIFIER_TOKEN), so we bound the search.
+        val call = generateSequence(element.parent) { it.parent }
+            .take(2)
+            .filterIsInstance<Call>()
+            .firstOrNull()
+            ?: return null
+
+        // Verify this leaf is the marker anchor for the call
+        if (element != markerAnchor(call)) return null
+
+        return getLineMarkerInfo(call)
+    }
 
     private fun getLineMarkerInfo(call: Call): LineMarkerInfo<*>? =
         if (Implementation.`is`(call)) {
+            val anchor = markerAnchor(call) ?: return null
             val targets: NotNullLazyValue<Collection<PsiElement>> = NotNullLazyValue.createValue {
                 val protocols = mutableListOf<PsiElement>()
 
@@ -45,11 +59,12 @@ class Implementation : LineMarkerProvider {
 
             ProtocolsGutterIconBuilder()
                 .setTargets(targets)
-                .createLineMarkerInfo(call)
+                .createLineMarkerInfo(anchor)
         } else if (CallDefinitionClause.`is`(call)) {
             enclosingModularMacroCall(call)?.let { modularCall ->
                 CallDefinitionClause.nameArityInterval(call, ResolveState.initial())?.let { implNameArityInterval ->
                     if (Implementation.`is`(modularCall)) {
+                        val anchor = markerAnchor(call) ?: return null
                         val targets: NotNullLazyValue<Collection<PsiElement>> = NotNullLazyValue.createValue {
                             val protocols = mutableListOf<PsiElement>()
 
@@ -94,7 +109,7 @@ class Implementation : LineMarkerProvider {
 
                         ProtocolsGutterIconBuilder()
                             .setTargets(targets)
-                            .createLineMarkerInfo(call)
+                            .createLineMarkerInfo(anchor)
                     } else {
                         null
                     }
@@ -151,45 +166,15 @@ class Implementation : LineMarkerProvider {
             val renderer = myCellRenderer.compute()
 
             Arrays.sort(targets, Comparator.comparing(renderer::getComparingObject))
-            val escapedName = escapedName(elt)
+            val name = escapedName(elt)
 
-            @Suppress("DialogTitleCapitalization")
             PsiElementListNavigator.openTargets(
                 event,
                 targets,
-                "<html><body>Choose Protocols of <b>${escapedName}</b> (${targets.size} found)</body></html>",
-                "Protocols of $escapedName",
+                "<html><body>Choose Protocols of <b>${name}</b> (${targets.size} found)</body></html>",
+                "Protocols of $name",
                 renderer
             )
         }
-
-        private fun escapedName(element: PsiElement): String {
-            val presentation = (element as NavigationItem).presentation!!
-            val containerText = containerText(element)
-            val prefix = if (containerText == null) {
-                ""
-            } else {
-                "$containerText."
-            }
-            val fullName = prefix + presentation.presentableText
-
-            return StringUtil.escapeXmlEntities(fullName)
-        }
-
-        private fun containerText(element: PsiElement): String? {
-            val container = container(element)
-            val containerPresentation =
-                if (container == null || container is PsiFile) null else (container as NavigationItem).presentation
-            return containerPresentation?.presentableText
-        }
-
-        private fun container(refElement: PsiElement): PsiElement? {
-            for (provider in ContainerProvider.EP_NAME.extensions) {
-                val container = provider.getContainer(refElement)
-                if (container != null) return container
-            }
-            return refElement.parent
-        }
-
     }
 }

--- a/src/org/elixir_lang/code_insight/line_marker_provider/LineMarkerProviderUtil.kt
+++ b/src/org/elixir_lang/code_insight/line_marker_provider/LineMarkerProviderUtil.kt
@@ -1,0 +1,68 @@
+package org.elixir_lang.code_insight.line_marker_provider
+
+import com.intellij.codeInsight.ContainerProvider
+import com.intellij.navigation.NavigationItem
+import com.intellij.openapi.util.text.StringUtil
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import com.intellij.psi.impl.source.tree.LeafPsiElement
+import org.elixir_lang.psi.ElixirTypes
+import org.elixir_lang.psi.call.Call
+
+/**
+ * Extracts a leaf [PsiElement] suitable for use as a [com.intellij.codeInsight.daemon.LineMarkerInfo] anchor.
+ *
+ * The [LineMarkerProvider contract][com.intellij.codeInsight.daemon.LineMarkerProvider.getLineMarkerInfo] requires
+ * that line marker info is created for **leaf elements only** (the smallest possible elements).  Passing a composite
+ * element causes gutter-icon blinking as the two-pass highlighting alternately adds and removes the marker.
+ *
+ * For a [Call], the leaf is the `IDENTIFIER_TOKEN` child of the function-name element, falling back to the
+ * function-name element itself when it is already a leaf (e.g. an operator token).
+ */
+internal fun markerAnchor(call: Call): PsiElement? {
+    val functionNameElement = call.functionNameElement()
+
+    return (functionNameElement?.node?.findChildByType(ElixirTypes.IDENTIFIER_TOKEN) as? LeafPsiElement)
+        ?: (functionNameElement as? LeafPsiElement)
+}
+
+/**
+ * Returns an XML-escaped display name for [element], suitable for gutter-icon popup titles.
+ *
+ * Uses the element's [NavigationItem.presentation] when available, falling back to [PsiElement.getText]
+ * (appropriate for leaf tokens such as identifiers).
+ */
+internal fun escapedName(element: PsiElement): String {
+    val presentation = (element as? NavigationItem)?.presentation
+    val containerText = containerText(element)
+    val prefix = if (containerText == null) {
+        ""
+    } else {
+        "$containerText."
+    }
+    val fullName = prefix + (presentation?.presentableText ?: element.text)
+
+    return StringUtil.escapeXmlEntities(fullName)
+}
+
+/**
+ * Returns the presentable text of the container of [element], or `null` if none.
+ */
+internal fun containerText(element: PsiElement): String? {
+    val container = container(element)
+    val containerPresentation =
+        if (container == null || container is PsiFile) {
+            null
+        } else {
+            (container as? NavigationItem)?.presentation
+        }
+    return containerPresentation?.presentableText
+}
+
+private fun container(refElement: PsiElement): PsiElement? {
+    for (provider in ContainerProvider.EP_NAME.extensions) {
+        val container = provider.getContainer(refElement)
+        if (container != null) return container
+    }
+    return refElement.parent
+}

--- a/src/org/elixir_lang/code_insight/line_marker_provider/Protocol.kt
+++ b/src/org/elixir_lang/code_insight/line_marker_provider/Protocol.kt
@@ -1,7 +1,6 @@
 package org.elixir_lang.code_insight.line_marker_provider
 
 import com.intellij.codeInsight.CodeInsightBundle
-import com.intellij.codeInsight.ContainerProvider
 import com.intellij.codeInsight.daemon.GutterIconNavigationHandler
 import com.intellij.codeInsight.daemon.LineMarkerInfo
 import com.intellij.codeInsight.daemon.LineMarkerProvider
@@ -9,11 +8,12 @@ import com.intellij.codeInsight.daemon.impl.PsiElementListNavigator
 import com.intellij.codeInsight.navigation.NavigationGutterIconBuilder
 import com.intellij.codeInsight.navigation.NavigationGutterIconRenderer
 import com.intellij.ide.util.PsiElementListCellRenderer
-import com.intellij.navigation.NavigationItem
 import com.intellij.openapi.util.Computable
 import com.intellij.openapi.util.NotNullLazyValue
-import com.intellij.openapi.util.text.StringUtil
-import com.intellij.psi.*
+import com.intellij.psi.NavigatablePsiElement
+import com.intellij.psi.PsiElement
+import com.intellij.psi.ResolveState
+import com.intellij.psi.SmartPsiElementPointer
 import org.elixir_lang.Icons
 import org.elixir_lang.beam.psi.impl.ModuleImpl
 import org.elixir_lang.psi.CallDefinitionClause
@@ -26,14 +26,28 @@ import java.util.*
 import javax.swing.Icon
 
 class Protocol : LineMarkerProvider {
-    override fun getLineMarkerInfo(element: PsiElement): LineMarkerInfo<*>? =
-        when (element) {
-            is Call -> getLineMarkerInfo(element)
-            else -> null
-        }
+    override fun getLineMarkerInfo(element: PsiElement): LineMarkerInfo<*>? {
+        // LineMarkerProvider contract: only return info for leaf elements
+        if (element.firstChild != null) return null
+
+        // Walk up from leaf to find the nearest enclosing Call.
+        // markerAnchor(call) places the leaf at most 2 levels below the Call
+        // (Call → functionNameElement → IDENTIFIER_TOKEN), so we bound the search.
+        val call = generateSequence(element.parent) { it.parent }
+            .take(2)
+            .filterIsInstance<Call>()
+            .firstOrNull()
+            ?: return null
+
+        // Verify this leaf is the marker anchor for the call
+        if (element != markerAnchor(call)) return null
+
+        return getLineMarkerInfo(call)
+    }
 
     private fun getLineMarkerInfo(call: Call): LineMarkerInfo<*>? =
         if (Protocol.`is`(call)) {
+            val anchor = markerAnchor(call) ?: return null
             val targets: NotNullLazyValue<Collection<PsiElement>> = NotNullLazyValue.createValue {
                 val implementations = mutableListOf<PsiElement>()
 
@@ -46,11 +60,12 @@ class Protocol : LineMarkerProvider {
 
             ImplsGutterIconBuilder()
                 .setTargets(targets)
-                .createLineMarkerInfo(call)
+                .createLineMarkerInfo(anchor)
         } else if (CallDefinitionClause.`is`(call)) {
             enclosingModularMacroCall(call)?.let { modularCall ->
                 CallDefinitionClause.nameArityInterval(call, ResolveState.initial())?.let { protocolNameArityInterval ->
                     if (Protocol.`is`(modularCall)) {
+                        val anchor = markerAnchor(call) ?: return null
                         val targets: NotNullLazyValue<Collection<PsiElement>> = NotNullLazyValue.createValue {
                             val implementations = mutableListOf<PsiElement>()
 
@@ -95,7 +110,7 @@ class Protocol : LineMarkerProvider {
 
                         ImplsGutterIconBuilder()
                             .setTargets(targets)
-                            .createLineMarkerInfo(call)
+                            .createLineMarkerInfo(anchor)
                     } else {
                         null
                     }
@@ -152,45 +167,15 @@ class Protocol : LineMarkerProvider {
             val renderer = myCellRenderer.compute()
 
             Arrays.sort(targets, Comparator.comparing(renderer::getComparingObject))
-            val escapedName = escapedName(elt)
+            val name = escapedName(elt)
 
-            @Suppress("DialogTitleCapitalization")
             PsiElementListNavigator.openTargets(
                 event,
                 targets,
-                CodeInsightBundle.message("goto.implementation.chooserTitle", escapedName, targets.size, ""),
-                CodeInsightBundle.message("goto.implementation.findUsages.title", escapedName, targets.size),
+                CodeInsightBundle.message("goto.implementation.chooserTitle", name, targets.size, ""),
+                CodeInsightBundle.message("goto.implementation.findUsages.title", name, targets.size),
                 renderer
             )
         }
-
-        private fun escapedName(element: PsiElement): String {
-            val presentation = (element as NavigationItem).presentation!!
-            val containerText = containerText(element)
-            val prefix = if (containerText == null) {
-                ""
-            } else {
-                "$containerText."
-            }
-            val fullName = prefix + presentation.presentableText
-
-            return StringUtil.escapeXmlEntities(fullName)
-        }
-
-        private fun containerText(element: PsiElement): String? {
-            val container = container(element)
-            val containerPresentation =
-                if (container == null || container is PsiFile) null else (container as NavigationItem).presentation
-            return containerPresentation?.presentableText
-        }
-
-        private fun container(refElement: PsiElement): PsiElement? {
-            for (provider in ContainerProvider.EP_NAME.extensions) {
-                val container = provider.getContainer(refElement)
-                if (container != null) return container
-            }
-            return refElement.parent
-        }
-
     }
 }

--- a/src/org/elixir_lang/leex/reference/resolver/Assign.kt
+++ b/src/org/elixir_lang/leex/reference/resolver/Assign.kt
@@ -18,8 +18,11 @@ import org.elixir_lang.psi.impl.childExpressionsFoldWhile
 import org.elixir_lang.psi.impl.stripAccessExpression
 import org.elixir_lang.psi.operation.*
 import org.elixir_lang.psi.stub.index.AllName
+import org.elixir_lang.util.AccumulatorContinue
+import org.elixir_lang.util.foldWhile
+import org.elixir_lang.leex.reference.Assign as ReferenceAssign
 
-object Assign : ResolveCache.PolyVariantResolver<org.elixir_lang.leex.reference.Assign> {
+object Assign : ResolveCache.PolyVariantResolver<ReferenceAssign> {
     override fun resolve(assign: Assign, incompleteCode: Boolean): Array<ResolveResult> {
         val containingFile = assign.element.containingFile
 
@@ -274,7 +277,7 @@ object Assign : ResolveCache.PolyVariantResolver<org.elixir_lang.leex.reference.
                 if (stabBody != null) {
                     resolveInCallDefinitionClauseExpression(assign, incompleteCode, stabBody, initial)
                 } else {
-                    AccumulatorContinue.foldWhile(expression.stabOperationList, initial) { stabOperation, accumulator ->
+                    expression.stabOperationList.foldWhile(initial) { stabOperation, accumulator ->
                         resolveInCallDefinitionClauseExpression(
                             assign,
                             incompleteCode,
@@ -296,7 +299,7 @@ object Assign : ResolveCache.PolyVariantResolver<org.elixir_lang.leex.reference.
             }
 
             is ElixirBlockList ->
-                AccumulatorContinue.foldWhile(expression.blockItemList, initial) { blockItem, accumulator ->
+                expression.blockItemList.foldWhile(initial) { blockItem, accumulator ->
                     resolveInCallDefinitionClauseExpression(assign, incompleteCode, blockItem, accumulator)
                 }
 
@@ -620,7 +623,7 @@ object Assign : ResolveCache.PolyVariantResolver<org.elixir_lang.leex.reference.
                 "put_in" -> when (expression.resolvedFinalArity()) {
                     2 -> {
                         expression.finalArguments()?.let { arguments ->
-                            val path = arguments[0];
+                            val path = arguments[0]
 
                             if (path.textMatches("assigns[:${INNER_CONTENT}]")) {
                                 val validResult = INNER_CONTENT == assign.name
@@ -640,7 +643,7 @@ object Assign : ResolveCache.PolyVariantResolver<org.elixir_lang.leex.reference.
                     val arguments = expression.finalArguments()
 
                     val argumentsAccumulatorContinue = if (arguments != null) {
-                        AccumulatorContinue.foldWhile(arguments, initial) { argument, accumulator ->
+                        arguments.foldWhile(initial) { argument, accumulator ->
                             resolveInToRendered(assign, incompleteCode, argument, accumulator)
                         }
                     } else {
@@ -667,7 +670,7 @@ object Assign : ResolveCache.PolyVariantResolver<org.elixir_lang.leex.reference.
                 if (stabBody != null) {
                     resolveInToRendered(assign, incompleteCode, stabBody, initial)
                 } else {
-                    AccumulatorContinue.foldWhile(expression.stabOperationList, initial) { stabOperation, accumulator ->
+                    expression.stabOperationList.foldWhile(initial) { stabOperation, accumulator ->
                         resolveInToRendered(assign, incompleteCode, stabOperation, accumulator)
                     }
                 }
@@ -788,7 +791,7 @@ object Assign : ResolveCache.PolyVariantResolver<org.elixir_lang.leex.reference.
                 val arguments = expression.finalArguments()
 
                 val argumentsAccumulatorContinue = if (arguments != null) {
-                    AccumulatorContinue.foldWhile(arguments, initial) { argument, accumulator ->
+                    arguments.foldWhile(initial) { argument, accumulator ->
                         resolveMyself(assign, incompleteCode, argument, accumulator)
                     }
                 } else {
@@ -820,7 +823,7 @@ object Assign : ResolveCache.PolyVariantResolver<org.elixir_lang.leex.reference.
             }
 
             is ElixirMapConstructionArguments -> {
-                AccumulatorContinue.foldWhile(expression.arguments(), initial) { argument, accumulator ->
+                expression.arguments().foldWhile(initial) { argument, accumulator ->
                     resolveMyself(assign, incompleteCode, argument, accumulator)
                 }
             }
@@ -831,7 +834,7 @@ object Assign : ResolveCache.PolyVariantResolver<org.elixir_lang.leex.reference.
                 if (stabBody != null) {
                     resolveMyself(assign, incompleteCode, stabBody, initial)
                 } else {
-                    AccumulatorContinue.foldWhile(expression.stabOperationList, initial) { stabOperation, accumulator ->
+                    expression.stabOperationList.foldWhile(initial) { stabOperation, accumulator ->
                         resolveMyself(assign, incompleteCode, stabOperation, accumulator)
                     }
                 }
@@ -848,10 +851,7 @@ object Assign : ResolveCache.PolyVariantResolver<org.elixir_lang.leex.reference.
             }
 
             is QuotableKeywordList ->
-                AccumulatorContinue.foldWhile(
-                    expression.quotableKeywordPairList(),
-                    initial
-                ) { keywordPair, accumulator ->
+                expression.quotableKeywordPairList().foldWhile(initial) { keywordPair, accumulator ->
                     resolveMyself(assign, incompleteCode, keywordPair, accumulator)
                 }
 

--- a/src/org/elixir_lang/mix/DepGatherer.kt
+++ b/src/org/elixir_lang/mix/DepGatherer.kt
@@ -15,6 +15,7 @@ import org.elixir_lang.psi.impl.call.foldChildrenWhile
 import org.elixir_lang.psi.impl.call.macroChildCalls
 import org.elixir_lang.psi.impl.keywordValue
 import org.elixir_lang.psi.impl.stripAccessExpression
+import org.elixir_lang.util.AccumulatorContinue
 
 class DepGatherer : DepGatherer() {
     override fun visitFile(file: PsiFile) {

--- a/src/org/elixir_lang/psi/For.kt
+++ b/src/org/elixir_lang/psi/For.kt
@@ -13,8 +13,17 @@ object For {
      */
     fun `is`(call: Call): Boolean = call.isCalling(KERNEL, FOR, 2)
 
-    fun treeWalkDown(call: Call, resolveState: ResolveState, function: (PsiElement, ResolveState) -> Boolean): Boolean =
-            call.whileInStabBodyChildExpressions { expression ->
-                function(expression, resolveState)
-            }
+    fun treeWalkDown(call: Call, resolveState: ResolveState, function: (PsiElement, ResolveState) -> Boolean): Boolean {
+        if (resolveState.hasBeenVisited(call)) {
+            return true
+        }
+
+        val forResolveState = resolveState.putVisitedElement(call)
+
+        return call.whileInStabBodyChildExpressions { expression ->
+            expression.takeUnlessHasBeenVisited(forResolveState)
+                ?.let { function(it, forResolveState) }
+                ?: true
+        }
+    }
 }

--- a/src/org/elixir_lang/psi/Modular.kt
+++ b/src/org/elixir_lang/psi/Modular.kt
@@ -7,62 +7,7 @@ import org.elixir_lang.beam.psi.impl.ModuleImpl
 import org.elixir_lang.psi.call.Call
 import org.elixir_lang.psi.impl.call.macroChildCallSequence
 import org.elixir_lang.psi.impl.call.macroChildCalls
-import org.elixir_lang.psi.impl.childExpressions
-
-data class AccumulatorContinue<out R>(val accumulator: R, val `continue`: Boolean) {
-    companion object {
-        fun <R> childExpressionsFoldWhile(
-            parent: PsiElement,
-            forward: Boolean,
-            initial: R,
-            folder: (element: PsiElement, accumulator: R) -> AccumulatorContinue<R>
-        ): AccumulatorContinue<R> =
-            parent.childExpressions(forward).let { foldWhile(it, initial, folder) }
-
-        fun <T, R> foldWhile(
-            array: Array<out T>,
-            initial: R,
-            folder: (element: T, accumulator: R) -> AccumulatorContinue<R>
-        ): AccumulatorContinue<R> =
-            foldWhile(array.asIterable(), initial, folder)
-
-        fun <T, R> foldWhile(
-            sequence: Sequence<T>,
-            initial: R,
-            folder: (element: T, accumulator: R) -> AccumulatorContinue<R>
-        ): AccumulatorContinue<R> {
-            var accumulatorContinue = AccumulatorContinue(initial, true)
-
-            for (element in sequence) {
-                accumulatorContinue = folder(element, accumulatorContinue.accumulator)
-
-                if (!accumulatorContinue.`continue`) {
-                    break
-                }
-            }
-
-            return accumulatorContinue
-        }
-
-        fun <T, R> foldWhile(
-            iterable: Iterable<T>,
-            initial: R,
-            folder: (element: T, accumulator: R) -> AccumulatorContinue<R>
-        ): AccumulatorContinue<R> {
-            var accumulatorContinue = AccumulatorContinue(initial, true)
-
-            for (element in iterable) {
-                accumulatorContinue = folder(element, accumulatorContinue.accumulator)
-
-                if (!accumulatorContinue.`continue`) {
-                    break
-                }
-            }
-
-            return accumulatorContinue
-        }
-    }
-}
+import org.elixir_lang.util.AccumulatorContinue
 
 object Modular {
     @JvmStatic

--- a/src/org/elixir_lang/psi/ResolveState.kt
+++ b/src/org/elixir_lang/psi/ResolveState.kt
@@ -1,6 +1,5 @@
 package org.elixir_lang.psi
 
-import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.util.Key
 import com.intellij.psi.PsiElement
 import com.intellij.psi.ResolveState
@@ -11,7 +10,8 @@ private val VISITED_ELEMENT_SET = Key<Set<PsiElement>>("VISITED_ELEMENTS")
 
 fun <T : PsiElement> T.takeUnlessHasBeenVisited(state: ResolveState): T? = takeUnless { state.hasBeenVisited(it) }
 
-fun ResolveState.hasBeenVisited(element: PsiElement): Boolean = this.get(VISITED_ELEMENT_SET).contains(element)
+fun ResolveState.hasBeenVisited(element: PsiElement): Boolean =
+    this.get(VISITED_ELEMENT_SET)?.contains(element) == true
 
 fun ResolveState.visitedElementSet(): Set<PsiElement> = this.get(VISITED_ELEMENT_SET).orEmpty()
 
@@ -34,10 +34,6 @@ fun ResolveState.putVisitedElements(visitedElements: Iterable<PsiElement>): Reso
 
 fun ResolveState.putVisitedElement(visitedElement: PsiElement): ResolveState {
     val visitedElementSet = this.get(VISITED_ELEMENT_SET) ?: emptySet()
-
-    if (this.get(VISITED_ELEMENT_SET) == null) {
-       Logger.getInstance(ResolveState::class.java).error("VISITED_ELEMENT_SET is null.  putInitialVisitedElement was not called")
-    }
 
     return this.put(VISITED_ELEMENT_SET, visitedElementSet + setOf(visitedElement))
 }

--- a/src/org/elixir_lang/psi/Unquote.kt
+++ b/src/org/elixir_lang/psi/Unquote.kt
@@ -49,16 +49,19 @@ object Unquote {
                     .filter(ResolveResult::isValidResult)
                     .mapNotNull(ResolveResult::getElement)
                     .filterIsInstance<Call>()
+                    .filter { !resolveState.hasBeenVisited(it) }
                     .let { resolveds -> treeWalkUpUnquoted(resolveds, resolveState, keepProcessing) }
 
     private fun treeWalkUpUnquoted(unquotedList: List<Call>,
                                    resolveState: ResolveState,
                                    keepProcessing: (PsiElement, ResolveState) -> Boolean): Boolean =
             whileIn(unquotedList) { unquoted ->
+                val unquotedResolveState = resolveState.putVisitedElement(unquoted)
+
                 if (CallDefinitionClause.`is`(unquoted)) {
-                    Using.treeWalkUp(unquoted, null, resolveState, keepProcessing)
+                    Using.treeWalkUp(unquoted, null, unquotedResolveState, keepProcessing)
                 } else {
-                    treeWalkUpUnquotedVariable(unquoted, resolveState, keepProcessing)
+                    treeWalkUpUnquotedVariable(unquoted, unquotedResolveState, keepProcessing)
                     // a variable
 
                     true

--- a/src/org/elixir_lang/psi/Using.kt
+++ b/src/org/elixir_lang/psi/Using.kt
@@ -15,6 +15,7 @@ import org.elixir_lang.psi.impl.call.stabBodyChildExpressions
 import org.elixir_lang.psi.impl.maybeModularNameToModulars
 import org.elixir_lang.psi.impl.stripAccessExpression
 import org.elixir_lang.structure_view.element.Timed
+import org.elixir_lang.util.AccumulatorContinue
 
 object Using {
     fun treeWalkUp(

--- a/src/org/elixir_lang/psi/impl/PsiElementImpl.kt
+++ b/src/org/elixir_lang/psi/impl/PsiElementImpl.kt
@@ -20,8 +20,9 @@ import org.elixir_lang.psi.impl.call.maybeModularNameToModulars
 import org.elixir_lang.psi.operation.Match
 import org.elixir_lang.psi.operation.Pipe
 import org.elixir_lang.psi.scope.WhileIn.whileIn
+import org.elixir_lang.util.AccumulatorContinue
+import org.elixir_lang.util.foldWhile
 import org.jetbrains.annotations.Contract
-import java.util.*
 
 fun PsiElement.ancestorSequence() = generateSequence(this) { it.parent }
 fun PsiElement.document(): Document? = containingFile.viewProvider.let { viewProvider ->
@@ -239,7 +240,7 @@ fun <R> PsiElement.childExpressionsFoldWhile(
         element: PsiElement, accumulator: R
     ) -> AccumulatorContinue<R>
 ): AccumulatorContinue<R> =
-    AccumulatorContinue.childExpressionsFoldWhile(this, forward, initial, folder)
+    childExpressions(forward).foldWhile(initial, folder)
 
 fun PsiElement.childExpressions(forward: Boolean = true): Sequence<PsiElement> {
     val seed = if (forward) {

--- a/src/org/elixir_lang/psi/impl/PsiElementImpl.kt
+++ b/src/org/elixir_lang/psi/impl/PsiElementImpl.kt
@@ -111,9 +111,7 @@ tailrec fun PsiElement.selfOrEnclosingMacroCall(): Call? =
     }
 
 /**
- *
- * @param call
- * @return `null` if call is at top-level
+ * @return `null` if this element is at top-level
  */
 @Contract(pure = true)
 fun PsiElement.enclosingMacroCall(): Call? = parent.selfOrEnclosingMacroCall()
@@ -263,11 +261,11 @@ fun PsiElement.isExpression(): Boolean =
     }
 
 @Contract(pure = true)
-fun PsiElement.siblingExpression(function: (PsiElement) -> PsiElement): PsiElement? {
-    var expression = this
+fun PsiElement.siblingExpression(function: (PsiElement) -> PsiElement?): PsiElement? {
+    var expression: PsiElement? = this
 
     do {
-        expression = function(expression)
+        expression = function(expression ?: return null)
     } while (expression is ElixirEndOfExpression ||
         expression is LeafPsiElement ||
         expression is PsiComment ||

--- a/src/org/elixir_lang/psi/impl/PsiNamedElementImpl.kt
+++ b/src/org/elixir_lang/psi/impl/PsiNamedElementImpl.kt
@@ -1,8 +1,5 @@
 package org.elixir_lang.psi.impl
 
-import com.intellij.openapi.application.ApplicationManager
-import com.intellij.openapi.application.runReadAction
-import com.intellij.openapi.util.Computable
 import com.intellij.psi.PsiElement
 import org.elixir_lang.Name
 import org.elixir_lang.errorreport.Logger
@@ -20,7 +17,7 @@ object PsiNamedElementImpl {
     }
 
     @JvmStatic
-    fun getName(qualifiedAlias: QualifiedAlias): String = runReadAction { qualifiedAlias.text }
+    fun getName(qualifiedAlias: QualifiedAlias): String = qualifiedAlias.text
 
     @JvmStatic
     fun getName(atom: ElixirAtom): String? =
@@ -41,8 +38,7 @@ object PsiNamedElementImpl {
             val nameIdentifier = namedElement.nameIdentifier
 
             if (nameIdentifier != null) {
-                val text = ApplicationManager.getApplication().runReadAction(Computable { nameIdentifier.text })
-                unquoteName(namedElement, text)
+                unquoteName(namedElement, nameIdentifier.text)
             } else {
                 if (namedElement is Call) {
                     val call = namedElement as Call

--- a/src/org/elixir_lang/psi/impl/call/CallImpl.kt
+++ b/src/org/elixir_lang/psi/impl/call/CallImpl.kt
@@ -1,14 +1,11 @@
 package org.elixir_lang.psi.impl.call
 
-import com.intellij.openapi.application.ApplicationManager
-import com.intellij.openapi.util.Computable
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiReference
 import com.intellij.psi.tree.TokenSet
 import com.intellij.psi.util.CachedValueProvider
 import com.intellij.psi.util.CachedValuesManager
 import org.elixir_lang.errorreport.Logger
-import org.elixir_lang.mix.project.computeReadAction
 import org.elixir_lang.psi.*
 import org.elixir_lang.psi.call.Call
 import org.elixir_lang.psi.call.StubBased
@@ -20,7 +17,8 @@ import org.elixir_lang.psi.call.name.Function.__MODULE__
 import org.elixir_lang.psi.call.name.Module.KERNEL
 import org.elixir_lang.psi.call.name.Module.stripElixirPrefix
 import org.elixir_lang.psi.impl.*
-import org.elixir_lang.psi.impl.ElixirPsiImplUtil.*
+import org.elixir_lang.psi.impl.ElixirPsiImplUtil.ARROW_OPERATOR_TOKEN_SET
+import org.elixir_lang.psi.impl.ElixirPsiImplUtil.moduleAttributeName
 import org.elixir_lang.psi.operation.*
 import org.elixir_lang.psi.qualification.Qualified
 import org.elixir_lang.psi.qualification.Unqualified
@@ -144,8 +142,8 @@ private fun Call.computeCallableReference(): PsiReference? =
  */
 fun Call.finalArguments(): Array<PsiElement>? = try {
     (secondaryArguments() ?: primaryArguments())?.map { it!! }?.toTypedArray()
-} catch (e: NullPointerException) {
-    Logger.error(this.javaClass, "NullPointerException getting Call.finalArguments()", this);
+} catch (_: NullPointerException) {
+    Logger.error(this.javaClass, "NullPointerException getting Call.finalArguments()", this)
     null
 }
 
@@ -353,9 +351,7 @@ object CallImpl {
     @Contract(pure = true)
     @JvmStatic
     fun functionName(call: Call): String? =
-        call.functionNameElement()?.let { element ->
-            computeReadAction(Computable<String> { element.text })
-        }
+        call.functionNameElement()?.text
 
     /**
      * @return `null` because the `IDENTIFIER`, `foo` in `@foo 1` is not the local name of a function, but the name of a
@@ -537,7 +533,7 @@ object CallImpl {
     // TODO handle more complex qualifiers besides Aliases
     @Contract(pure = true)
     @JvmStatic
-    fun moduleName(qualified: Qualified): String = computeReadAction(Computable<String> { qualified.firstChild.text })
+    fun moduleName(qualified: Qualified): String = qualified.firstChild.text
 
     @Contract(pure = true)
     @JvmStatic
@@ -720,11 +716,7 @@ object CallImpl {
     @Suppress("UNCHECKED_CAST")
     @JvmStatic
     fun resolvedModuleName(unqualified: Unqualified): String =
-        (unqualified as? StubBased<Stub<*>>)?.let { stubBased ->
-            ApplicationManager.getApplication().runReadAction(Computable {
-                stubBased.stub
-            })?.resolvedModuleName()
-        } ?: KERNEL
+        (unqualified as? StubBased<Stub<*>>)?.stub?.resolvedModuleName() ?: KERNEL
 
     // TODO handle `import`s and determine whether actually a local variable
     @Contract(pure = true)
@@ -746,7 +738,7 @@ object CallImpl {
                 resolvedPrimaryArity = (resolvedPrimaryArity ?: 0) + 1
             }
 
-            val parent = computeReadAction(Computable<PsiElement> { call.parent })
+            val parent = call.parent
 
             if (parent.isPipe()) {
                 val parentPipeOperation = parent as Arrow
@@ -809,4 +801,3 @@ object CallImpl {
      */
     private fun PsiElement.isPipe(): Boolean = (this as? Arrow)?.isPipe() ?: false
 }
-

--- a/src/org/elixir_lang/psi/impl/call/CallImpl.kt
+++ b/src/org/elixir_lang/psi/impl/call/CallImpl.kt
@@ -28,6 +28,7 @@ import org.elixir_lang.psi.scope.isTypeSpecPseudoFunction
 import org.elixir_lang.psi.stub.call.Stub
 import org.elixir_lang.reference.Callable
 import org.elixir_lang.reference.Callable.Companion.isBitStreamSegmentOption
+import org.elixir_lang.util.AccumulatorContinue
 import org.jetbrains.annotations.Contract
 import java.util.*
 import org.elixir_lang.psi.impl.macroChildCallList as psiElementToMacroChildCallList

--- a/src/org/elixir_lang/reference/module/UnaliasedName.kt
+++ b/src/org/elixir_lang/reference/module/UnaliasedName.kt
@@ -89,7 +89,8 @@ object UnaliasedName {
                     up(element, entrance)
 
                 is QualifiedMultipleAliases ->
-                    up(element, entrance)
+                    entrance.fullyQualifiedName()
+
                 is ElixirAccessExpression,
                 is ElixirNoParenthesesOneArgument,
                 is QuotableArguments,

--- a/src/org/elixir_lang/reference/module/UnaliasedName.kt
+++ b/src/org/elixir_lang/reference/module/UnaliasedName.kt
@@ -20,10 +20,10 @@ object UnaliasedName {
                 ":${namedElement.name}"
             } else if (namedElement is Call && namedElement.isCalling(KERNEL, Function.__MODULE__, 0)) {
                 __MODULE__
-                        .reference(namedElement, useCall = null)
-                        .resolve()
-                        ?.let { it as? PsiNamedElement }
-                        ?.name
+                    .reference(namedElement, useCall = null)
+                    .resolve()
+                    ?.let { it as? PsiNamedElement }
+                    ?.name
             } else {
                 namedElement.name
             }
@@ -32,10 +32,11 @@ object UnaliasedName {
             when (element) {
                 is Call ->
                     element
-                            .maybeModularNameToModulars(null)
-                            .mapNotNull { it.name }
-                            .toSet()
-                            .singleOrNull()
+                        .maybeModularNameToModulars(null)
+                        .mapNotNull { it.name }
+                        .toSet()
+                        .singleOrNull()
+
                 is ElixirAccessExpression -> {
                     val children = element.children
 
@@ -43,13 +44,14 @@ object UnaliasedName {
 
                     down(children[0])
                 }
+
                 is ElixirAtom -> ":${element.name}"
                 is QualifiableAlias -> element.name
                 else -> {
                     Logger.error(
-                            javaClass,
-                            "Don't know how to search down below ${element.javaClass} for unaliased name",
-                            element
+                        javaClass,
+                        "Don't know how to search down below ${element.javaClass} for unaliased name",
+                        element
                     )
 
                     "?"
@@ -74,10 +76,18 @@ object UnaliasedName {
                 entrance.name
             }
 
+    private fun up(element: QuotableKeywordPair, entrance: QualifiableAlias): String? =
+            if (element.hasKeywordKey("as")) {
+                up(element.parent, entrance)
+            } else {
+                null
+            }
+
     private tailrec fun up(element: PsiElement?, entrance: QualifiableAlias): String? =
             when (element) {
                 is Call ->
                     up(element, entrance)
+
                 is QualifiedMultipleAliases ->
                     up(element, entrance)
                 is ElixirAccessExpression,
@@ -85,18 +95,15 @@ object UnaliasedName {
                 is QuotableArguments,
                 is QuotableKeywordList ->
                     up(element.parent, entrance)
+
                 is ElixirMultipleAliases ->
                     entrance.fullyQualifiedName()
+
                 is QuotableKeywordPair ->
                     up(element, entrance)
+
                 else ->
                     null
             }
 
-    private fun up(element: QuotableKeywordPair, entrance: QualifiableAlias): String? =
-            if (element.hasKeywordKey("as")) {
-                up(element.parent, entrance)
-            } else {
-                null
-            }
 }

--- a/src/org/elixir_lang/reference/resolver/Callable.kt
+++ b/src/org/elixir_lang/reference/resolver/Callable.kt
@@ -2,12 +2,14 @@ package org.elixir_lang.reference.resolver
 
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.project.DumbService
+import com.intellij.openapi.util.RecursionManager
 import com.intellij.psi.PsiElementResolveResult
 import com.intellij.psi.ResolveResult
 import com.intellij.psi.ResolveState
 import com.intellij.psi.impl.source.resolve.ResolveCache
 import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.psi.stubs.StubIndex
+import com.intellij.psi.util.PsiUtilCore
 import org.elixir_lang.Arity
 import org.elixir_lang.NameArityInterval
 import org.elixir_lang.errorreport.Logger
@@ -66,8 +68,40 @@ object Callable : ResolveCache.PolyVariantResolver<org.elixir_lang.reference.Cal
                 listOf(terminalResolveResult) + pathResolveResultList
             }
             // deduplicate shared `defdelegate`, `import`, or `use`
-            .groupBy { it.element }
-            .map { (_, resolveResults) -> resolveResults.first() }
+            .groupBy { resolveResultKey(it) }
+            .map { (_, resolveResults) ->
+                resolveResults.maxByOrNull { if (it.isValidResult) 1 else 0 } ?: resolveResults.first()
+            }
+            .let(::deduplicateEquivalentResults)
+
+    private fun deduplicateEquivalentResults(resolveResults: List<PsiElementResolveResult>): List<PsiElementResolveResult> {
+        val deduplicated = mutableListOf<PsiElementResolveResult>()
+
+        for (candidate in resolveResults) {
+            val existingIndex = deduplicated.indexOfFirst { existing ->
+                existing.element.manager.areElementsEquivalent(existing.element, candidate.element)
+            }
+
+            if (existingIndex == -1) {
+                deduplicated.add(candidate)
+            } else if (candidate.isValidResult && !deduplicated[existingIndex].isValidResult) {
+                deduplicated[existingIndex] = candidate
+            }
+        }
+
+        return deduplicated
+    }
+
+    private fun resolveResultKey(resolveResult: PsiElementResolveResult): String {
+        val element = resolveResult.element.navigationElement
+        val filePath = element.containingFile?.virtualFile?.path ?: ""
+        val range = element.textRange
+        val startOffset = range?.startOffset ?: -1
+        val endOffset = range?.endOffset ?: -1
+        val elementType = PsiUtilCore.getElementType(element)?.toString() ?: ""
+
+        return "$filePath#$startOffset:$endOffset:$elementType"
+    }
 
     private fun resolvePreferred(
         element: Call,
@@ -97,18 +131,21 @@ object Callable : ResolveCache.PolyVariantResolver<org.elixir_lang.reference.Cal
         name: String,
         resolvedPrimaryArity: Arity,
         incompleteCode: Boolean
-    ): List<VisitedElementSetResolveResult> =
-        try {
-            if (element is Qualified) {
-                resolveQualified(element, name, resolvedPrimaryArity, incompleteCode)
-            } else {
-                resolveUnqualified(element, name, resolvedPrimaryArity, incompleteCode)
-            }
-        } catch (_: StackOverflowError) {
-            Logger.error(Callable::class.java, "StackOverflowError when annotating Call", element)
+    ): List<VisitedElementSetResolveResult> {
+        return RecursionManager.doPreventingRecursion(element, true) {
+            try {
+                if (element is Qualified) {
+                    resolveQualified(element, name, resolvedPrimaryArity, incompleteCode)
+                } else {
+                    resolveUnqualified(element, name, resolvedPrimaryArity, incompleteCode)
+                }
+            } catch (_: StackOverflowError) {
+                Logger.error(Callable::class.java, "StackOverflowError when annotating Call", element)
 
-            emptyList()
-        }
+                emptyList()
+            }
+        } ?: emptyList()
+    }
 
     private fun resolveUnqualified(
         element: Call,

--- a/src/org/elixir_lang/reference/resolver/Callable.kt
+++ b/src/org/elixir_lang/reference/resolver/Callable.kt
@@ -1,32 +1,18 @@
 package org.elixir_lang.reference.resolver
 
 import com.intellij.openapi.application.ApplicationManager
-import com.intellij.openapi.project.DumbService
 import com.intellij.openapi.util.RecursionManager
 import com.intellij.psi.PsiElementResolveResult
 import com.intellij.psi.ResolveResult
-import com.intellij.psi.ResolveState
 import com.intellij.psi.impl.source.resolve.ResolveCache
-import com.intellij.psi.search.GlobalSearchScope
-import com.intellij.psi.stubs.StubIndex
 import com.intellij.psi.util.PsiUtilCore
 import org.elixir_lang.Arity
-import org.elixir_lang.NameArityInterval
 import org.elixir_lang.errorreport.Logger
 import org.elixir_lang.psi.*
-import org.elixir_lang.psi.CallDefinitionClause
-import org.elixir_lang.psi.CallDefinitionClause.enclosingModularMacroCall
-import org.elixir_lang.psi.CallDefinitionClause.nameArityInterval
-import org.elixir_lang.psi.Module
 import org.elixir_lang.psi.call.Call
-import org.elixir_lang.psi.call.CanonicallyNamed
 import org.elixir_lang.psi.call.qualification.Qualified
 import org.elixir_lang.psi.impl.call.qualification.qualifiedToModulars
-import org.elixir_lang.psi.scope.CallDefinitionClause.Companion.MODULAR_CANONICAL_NAME
 import org.elixir_lang.psi.scope.VisitedElementSetResolveResult
-import org.elixir_lang.psi.stub.index.AllName
-import org.elixir_lang.structure_view.element.CallDefinitionHead
-import org.elixir_lang.structure_view.element.Callback
 import org.elixir_lang.structure_view.element.Delegation
 
 object Callable : ResolveCache.PolyVariantResolver<org.elixir_lang.reference.Callable> {
@@ -123,8 +109,6 @@ object Callable : ResolveCache.PolyVariantResolver<org.elixir_lang.reference.Cal
 
     private fun resolve(element: Call, name: String, resolvedPrimaryArity: Arity, incompleteCode: Boolean) =
         resolveInScope(element, name, resolvedPrimaryArity, incompleteCode)
-            .takeIf { set -> set.any(ResolveResult::isValidResult) }
-            ?: nameArityInAnyModule(element, name, resolvedPrimaryArity, incompleteCode)
 
     private fun resolveInScope(
         element: Call,
@@ -201,104 +185,6 @@ object Callable : ResolveCache.PolyVariantResolver<org.elixir_lang.reference.Cal
             }
         } else {
             emptyList()
-        }
-    }
-
-    private fun nameArityInAnyModule(
-        element: Call,
-        name: String,
-        arity: Arity,
-        incompleteCode: Boolean
-    ): List<VisitedElementSetResolveResult> {
-        val project = element.project
-        val resolveResults = mutableListOf<VisitedElementSetResolveResult>()
-
-        if (!DumbService.isDumb(project)) {
-            val keys = mutableListOf<String>()
-            val stubIndex = StubIndex.getInstance()
-
-            stubIndex.processAllKeys(AllName.KEY, project) { key ->
-                if ((incompleteCode && key.startsWith(name)) || key == name) {
-                    keys.add(key)
-                }
-
-                true
-            }
-
-            val scope = GlobalSearchScope.allScope(project)
-            // results are never valid because the qualifier is unknown
-            val validResult = false
-
-            for (key in keys) {
-                try {
-                    stubIndex
-                        .processElements(AllName.KEY, key, project, scope, NamedElement::class.java) { namedElement ->
-                            if (namedElement is Call) {
-                                if (CallDefinitionClause.`is`(namedElement)) {
-                                    if (incompleteCode ||
-                                        nameArityInterval(namedElement, resolveState(namedElement, key))
-                                            ?.arityInterval?.contains(arity) == true
-                                    ) {
-                                        resolveResults.add(
-                                            VisitedElementSetResolveResult(
-                                                namedElement,
-                                                validResult,
-                                                emptySet()
-                                            )
-                                        )
-                                    }
-                                } else if (Callback.`is`(namedElement)) {
-                                    if (incompleteCode ||
-                                        Callback
-                                            .headCall(namedElement as AtUnqualifiedNoParenthesesCall<*>)
-                                            ?.let {
-                                                CallDefinitionHead.nameArityInterval(
-                                                    it,
-                                                    resolveState(namedElement, key)
-                                                )
-                                            }
-                                            ?.arityInterval?.contains(arity) == true
-                                    ) {
-                                        resolveResults.add(
-                                            VisitedElementSetResolveResult(
-                                                namedElement,
-                                                validResult,
-                                                emptySet()
-                                            )
-                                        )
-                                    }
-                                }
-                            }
-
-                            true
-                        }
-                } catch (throwable: Throwable) {
-                    // ignore "Stub ids not found for key" as in #2945
-                    if (throwable.message?.contains("Stub ids not found for key") != true) {
-                        throw throwable
-                    }
-                }
-            }
-        }
-
-        return resolveResults
-    }
-
-    private fun resolveState(call: Call, name: String): ResolveState {
-        val initial = ResolveState.initial()
-
-        return if (NameArityInterval.nameIsAdjusted(name)) {
-            enclosingModularMacroCall(call)?.let { modular ->
-                if (Module.`is`(modular)) {
-                    modular.let { it as CanonicallyNamed }.canonicalName()?.let { modularCanonicalName ->
-                        initial.put(MODULAR_CANONICAL_NAME, modularCanonicalName)
-                    }
-                } else {
-                    null
-                }
-            } ?: initial
-        } else {
-            initial
         }
     }
 }

--- a/src/org/elixir_lang/reference/resolver/Module.kt
+++ b/src/org/elixir_lang/reference/resolver/Module.kt
@@ -28,10 +28,21 @@ object Module : ResolveCache.PolyVariantResolver<org.elixir_lang.reference.Modul
     ): Array<ResolveResult> {
         ApplicationManager.getApplication().assertReadAccessAllowed()
         val element = module.element
-        val name = element.fullyQualifiedName()
+        val name = element.fullyQualifiedName().removeElixirPrefix()
 
         return resolve(element, name, incompleteCode)
     }
+
+    /**
+     * In Elixir, every module `Foo.Bar` is internally named `:Elixir.Foo.Bar` in the
+     * Erlang VM.  Source code can reference modules with the explicit `Elixir.` prefix
+     * (e.g. `Elixir.Enum.map/2`), but the [ModularName] stub index stores modules by
+     * their Elixir-source name (`Enum`, not `Elixir.Enum`).  Strip the prefix so that
+     * resolution, completion, go-to-definition, and all other code insight features work
+     * uniformly for both `Enum.map()` and `Elixir.Enum.map()`.
+     */
+    private fun String.removeElixirPrefix(): String =
+        if (startsWith("Elixir.")) removePrefix("Elixir.") else this
 
     fun resolve(element: PsiElement, name: String, incompleteCode: Boolean): Array<ResolveResult> {
         val preferred = resolvePreferred(element, name, incompleteCode)

--- a/src/org/elixir_lang/util/AccumulatorContinue.kt
+++ b/src/org/elixir_lang/util/AccumulatorContinue.kt
@@ -1,0 +1,3 @@
+package org.elixir_lang.util
+
+data class AccumulatorContinue<out R>(val accumulator: R, val `continue`: Boolean)

--- a/src/org/elixir_lang/util/FoldWhile.kt
+++ b/src/org/elixir_lang/util/FoldWhile.kt
@@ -1,0 +1,41 @@
+package org.elixir_lang.util
+
+fun <T, R> Array<out T>.foldWhile(
+    initial: R,
+    folder: (element: T, accumulator: R) -> AccumulatorContinue<R>
+): AccumulatorContinue<R> =
+    asIterable().foldWhile(initial, folder)
+
+fun <T, R> Sequence<T>.foldWhile(
+    initial: R,
+    folder: (element: T, accumulator: R) -> AccumulatorContinue<R>
+): AccumulatorContinue<R> {
+    var accumulatorContinue = AccumulatorContinue(initial, true)
+
+    for (element in this) {
+        accumulatorContinue = folder(element, accumulatorContinue.accumulator)
+
+        if (!accumulatorContinue.`continue`) {
+            break
+        }
+    }
+
+    return accumulatorContinue
+}
+
+fun <T, R> Iterable<T>.foldWhile(
+    initial: R,
+    folder: (element: T, accumulator: R) -> AccumulatorContinue<R>
+): AccumulatorContinue<R> {
+    var accumulatorContinue = AccumulatorContinue(initial, true)
+
+    for (element in this) {
+        accumulatorContinue = folder(element, accumulatorContinue.accumulator)
+
+        if (!accumulatorContinue.`continue`) {
+            break
+        }
+    }
+
+    return accumulatorContinue
+}

--- a/testData/org/elixir_lang/code_insight/completion/contributor/call_definition_clause/bare_head_preferred_declaration.ex
+++ b/testData/org/elixir_lang/code_insight/completion/contributor/call_definition_clause/bare_head_preferred_declaration.ex
@@ -1,0 +1,11 @@
+defmodule Prefix.BareHeadPreferredDeclaration do
+  def map_every(enumerable, nth, fun)
+
+  def map_every(enumerable, 1, fun), do: {enumerable, fun}
+  def map_every(enumerable, 0, _fun), do: enumerable
+  def map_every([], nth, _fun) when is_integer(nth) and nth > 1, do: []
+
+  def map_every(enumerable, nth, fun) when is_integer(nth) and nth > 1 do
+    {enumerable, nth, fun}
+  end
+end

--- a/testData/org/elixir_lang/code_insight/completion/contributor/call_definition_clause/bare_head_preferred_usage.ex
+++ b/testData/org/elixir_lang/code_insight/completion/contributor/call_definition_clause/bare_head_preferred_usage.ex
@@ -1,0 +1,5 @@
+defmodule Prefix.BareHeadPreferredUsage do
+  alias Prefix.BareHeadPreferredDeclaration
+
+  BareHeadPreferredDeclaration.<caret>
+end

--- a/testData/org/elixir_lang/code_insight/completion/contributor/call_definition_clause/no_bare_head_fallback_declaration.ex
+++ b/testData/org/elixir_lang/code_insight/completion/contributor/call_definition_clause/no_bare_head_fallback_declaration.ex
@@ -1,0 +1,4 @@
+defmodule Prefix.NoBareHeadFallbackDeclaration do
+  def normalize(value, fallback) when is_binary(value), do: value
+  def normalize([], fallback), do: fallback
+end

--- a/testData/org/elixir_lang/code_insight/completion/contributor/call_definition_clause/no_bare_head_fallback_usage.ex
+++ b/testData/org/elixir_lang/code_insight/completion/contributor/call_definition_clause/no_bare_head_fallback_usage.ex
@@ -1,0 +1,5 @@
+defmodule Prefix.NoBareHeadFallbackUsage do
+  alias Prefix.NoBareHeadFallbackDeclaration
+
+  NoBareHeadFallbackDeclaration.<caret>
+end

--- a/testData/org/elixir_lang/code_insight/completion/contributor/call_definition_clause/same_name_different_arity_declaration.ex
+++ b/testData/org/elixir_lang/code_insight/completion/contributor/call_definition_clause/same_name_different_arity_declaration.ex
@@ -1,0 +1,4 @@
+defmodule Prefix.SameNameDifferentArityDeclaration do
+  def process(item), do: item
+  def process(item, opts), do: {item, opts}
+end

--- a/testData/org/elixir_lang/code_insight/completion/contributor/call_definition_clause/same_name_different_arity_usage.ex
+++ b/testData/org/elixir_lang/code_insight/completion/contributor/call_definition_clause/same_name_different_arity_usage.ex
@@ -1,0 +1,5 @@
+defmodule Prefix.SameNameDifferentArityUsage do
+  alias Prefix.SameNameDifferentArityDeclaration
+
+  SameNameDifferentArityDeclaration.<caret>
+end

--- a/testData/org/elixir_lang/code_insight/line_marker_provider/call_definition/leaf_element_contract.ex
+++ b/testData/org/elixir_lang/code_insight/line_marker_provider/call_definition/leaf_element_contract.ex
@@ -1,0 +1,46 @@
+# Extracted from Elixir 1.11.3 kernel.ex — tests that line markers are anchored to leaf elements.
+# The CallDefinition LineMarkerProvider must return LineMarkerInfo only when invoked with leaf
+# elements, not composite Call or AtUnqualifiedNoParenthesesCall elements.
+defmodule LeafElementContract do
+  @doc """
+  Returns the absolute value of `number`.
+  """
+  @doc guard: true
+  @spec abs(number) :: number
+  def abs(number) do
+    :erlang.abs(number)
+  end
+
+  @doc """
+  Returns the smallest integer greater than or equal to `number`.
+  """
+  @doc since: "1.8.0", guard: true
+  @spec ceil(number) :: integer
+  def ceil(number) do
+    :erlang.ceil(number)
+  end
+
+  @doc """
+  Performs an integer division.
+  """
+  @doc guard: true
+  @spec div(integer, neg_integer | pos_integer) :: integer
+  def div(dividend, divisor) do
+    :erlang.div(dividend, divisor)
+  end
+
+  @doc """
+  A private helper function.
+  """
+  defp helper(x) do
+    x + 1
+  end
+
+  @doc """
+  Another function to test separators between different function groups.
+  """
+  @spec other_function(any) :: any
+  def other_function(x) do
+    helper(x)
+  end
+end

--- a/testData/org/elixir_lang/code_insight/line_marker_provider/protocol_implementation/leaf_element_contract.ex
+++ b/testData/org/elixir_lang/code_insight/line_marker_provider/protocol_implementation/leaf_element_contract.ex
@@ -1,0 +1,13 @@
+# Exercises defprotocol/defimpl macro calls and callback definitions for line marker providers.
+defprotocol ProtocolImplementationLeafContract do
+  @spec run(term()) :: term()
+  def run(value)
+end
+
+defimpl ProtocolImplementationLeafContract, for: List do
+  def run(value), do: value
+end
+
+defimpl ProtocolImplementationLeafContract, for: Map do
+  def run(value), do: value
+end

--- a/testData/org/elixir_lang/code_insight/parameter_info/bare_head_declaration.ex
+++ b/testData/org/elixir_lang/code_insight/parameter_info/bare_head_declaration.ex
@@ -1,0 +1,10 @@
+defmodule ParameterInfo.BareHeadDeclaration do
+  def map_every(enumerable, nth, fun)
+
+  def map_every(enumerable, 1, fun), do: {enumerable, fun}
+  def map_every([], nth, _fun) when is_integer(nth) and nth > 1, do: []
+
+  def map_every(enumerable, nth, fun) when is_integer(nth) and nth > 1 do
+    {enumerable, nth, fun}
+  end
+end

--- a/testData/org/elixir_lang/code_insight/parameter_info/bare_head_usage.ex
+++ b/testData/org/elixir_lang/code_insight/parameter_info/bare_head_usage.ex
@@ -1,0 +1,5 @@
+defmodule ParameterInfo.BareHeadUsage do
+  alias ParameterInfo.BareHeadDeclaration
+
+  BareHeadDeclaration.map_every(<caret>)
+end

--- a/testData/org/elixir_lang/code_insight/parameter_info/different_arity_declaration.ex
+++ b/testData/org/elixir_lang/code_insight/parameter_info/different_arity_declaration.ex
@@ -1,0 +1,4 @@
+defmodule ParameterInfo.DifferentArityDeclaration do
+  def process(item), do: item
+  def process(item, opts), do: {item, opts}
+end

--- a/testData/org/elixir_lang/code_insight/parameter_info/different_arity_usage.ex
+++ b/testData/org/elixir_lang/code_insight/parameter_info/different_arity_usage.ex
@@ -1,0 +1,5 @@
+defmodule ParameterInfo.DifferentArityUsage do
+  alias ParameterInfo.DifferentArityDeclaration
+
+  DifferentArityDeclaration.process(<caret>)
+end

--- a/testData/org/elixir_lang/psi/impl/qualifiable_alias/item_presentation/qualifier_in_qualified_multiple_aliases.ex
+++ b/testData/org/elixir_lang/psi/impl/qualifiable_alias/item_presentation/qualifier_in_qualified_multiple_aliases.ex
@@ -1,0 +1,3 @@
+defmodule Test do
+  alias Pre<caret>fix.{SubModule}
+end

--- a/testData/org/elixir_lang/reference/module/unaliased_name/as_option.ex
+++ b/testData/org/elixir_lang/reference/module/unaliased_name/as_option.ex
@@ -1,0 +1,3 @@
+defmodule Test do
+  alias Prefix.Suffix, as: A<caret>s
+end

--- a/testData/org/elixir_lang/reference/module/unaliased_name/defmodule_argument.ex
+++ b/testData/org/elixir_lang/reference/module/unaliased_name/defmodule_argument.ex
@@ -1,0 +1,2 @@
+defmodule My.Mo<caret>dule do
+end

--- a/testData/org/elixir_lang/reference/module/unaliased_name/multiple_alias_leaf.ex
+++ b/testData/org/elixir_lang/reference/module/unaliased_name/multiple_alias_leaf.ex
@@ -1,0 +1,3 @@
+defmodule Test do
+  alias Prefix.{Suf<caret>fix}
+end

--- a/testData/org/elixir_lang/reference/module/unaliased_name/multiple_alias_qualifier.ex
+++ b/testData/org/elixir_lang/reference/module/unaliased_name/multiple_alias_qualifier.ex
@@ -1,0 +1,3 @@
+defmodule Test do
+  alias Pre<caret>fix.{Suffix}
+end

--- a/testData/org/elixir_lang/reference/module/unaliased_name/simple_alias.ex
+++ b/testData/org/elixir_lang/reference/module/unaliased_name/simple_alias.ex
@@ -1,0 +1,3 @@
+defmodule Test do
+  alias Prefix.Suf<caret>fix
+end

--- a/tests/org/elixir_lang/code_insight/ParameterInfoTest.java
+++ b/tests/org/elixir_lang/code_insight/ParameterInfoTest.java
@@ -1,0 +1,77 @@
+package org.elixir_lang.code_insight;
+
+import com.intellij.lang.parameterInfo.CreateParameterInfoContext;
+import com.intellij.testFramework.utils.parameterInfo.MockCreateParameterInfoContext;
+import com.intellij.testFramework.utils.parameterInfo.MockParameterInfoUIContext;
+import org.elixir_lang.PlatformTestCase;
+import org.elixir_lang.psi.Arguments;
+import org.elixir_lang.psi.call.Call;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class ParameterInfoTest extends PlatformTestCase {
+
+    public void testBareHeadPreferredOverImplementationClauses() {
+        myFixture.configureByFiles("bare_head_usage.ex", "bare_head_declaration.ex");
+
+        ParameterInfo handler = new ParameterInfo();
+        CreateParameterInfoContext context = new MockCreateParameterInfoContext(myFixture.getEditor(), myFixture.getFile());
+        Arguments args = handler.findElementForParameterInfo(context);
+
+        assertNotNull("Should find Arguments element at caret", args);
+
+        handler.showParameterInfo(args, context);
+        Object[] items = context.getItemsToShow();
+
+        assertNotNull("Should have parameter info items", items);
+        assertEquals("Multiple clause heads should be deduplicated to one entry", 1, items.length);
+
+        // Render the single item and verify it shows the bare head's canonical parameters
+        Call call = assertInstanceOf(items[0], Call.class);
+        MockParameterInfoUIContext<Arguments> uiContext = new MockParameterInfoUIContext<>(args);
+        uiContext.setCurrentParameterIndex(0);
+        handler.updateUI(call, uiContext);
+
+        assertEquals("enumerable, nth, fun", uiContext.getText());
+    }
+
+    public void testDifferentAritiesPreservedAsSeparateHints() {
+        myFixture.configureByFiles("different_arity_usage.ex", "different_arity_declaration.ex");
+
+        ParameterInfo handler = new ParameterInfo();
+        CreateParameterInfoContext context = new MockCreateParameterInfoContext(myFixture.getEditor(), myFixture.getFile());
+        Arguments args = handler.findElementForParameterInfo(context);
+
+        assertNotNull("Should find Arguments element at caret", args);
+
+        handler.showParameterInfo(args, context);
+        Object[] items = context.getItemsToShow();
+
+        assertNotNull("Should have parameter info items", items);
+        assertEquals("Different arities (process/1, process/2) should produce separate hints", 2, items.length);
+
+        // Render both items and collect their parameter text
+        Set<String> paramTexts = Arrays.stream(items)
+                .map(item -> {
+                    Call call = assertInstanceOf(item, Call.class);
+                    MockParameterInfoUIContext<Arguments> uiContext = new MockParameterInfoUIContext<>(args);
+                    uiContext.setCurrentParameterIndex(0);
+                    handler.updateUI(call, uiContext);
+                    return uiContext.getText();
+                })
+                .collect(Collectors.toSet());
+
+        assertTrue("Should include process/1 parameters", paramTexts.contains("item"));
+        assertTrue("Should include process/2 parameters", paramTexts.contains("item, opts"));
+    }
+
+    /*
+     * Protected Instance Methods
+     */
+
+    @Override
+    protected String getTestDataPath() {
+        return "testData/org/elixir_lang/code_insight/parameter_info";
+    }
+}

--- a/tests/org/elixir_lang/code_insight/completion/contributor/CallDefinitionClauseTest.java
+++ b/tests/org/elixir_lang/code_insight/completion/contributor/CallDefinitionClauseTest.java
@@ -6,6 +6,7 @@ import com.intellij.codeInsight.lookup.LookupElementPresentation;
 import org.elixir_lang.PlatformTestCase;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.Arrays;
 import java.util.List;
 
 public class CallDefinitionClauseTest extends PlatformTestCase {
@@ -180,6 +181,52 @@ public class CallDefinitionClauseTest extends PlatformTestCase {
         assertEquals("(assigns)", lookupElementPresentation.getTailText());
     }
 
+    public void testPrefersBareFunctionHeadSignature() {
+        myFixture.configureByFiles("bare_head_preferred_usage.ex", "bare_head_preferred_declaration.ex");
+        myFixture.complete(CompletionType.BASIC, 1);
+
+        List<String> strings = myFixture.getLookupElementStrings();
+        assertNotNull("Completion lookup not shown", strings);
+        assertCompletion("map_every", strings);
+        assertEquals("Wrong number of completions", 1, strings.size());
+
+        LookupElement mapEvery = lookupElementByItemText("map_every");
+        assertNotNull("No lookup element for map_every", mapEvery);
+
+        LookupElementPresentation lookupElementPresentation = new LookupElementPresentation();
+        mapEvery.renderElement(lookupElementPresentation);
+        assertEquals("map_every", lookupElementPresentation.getItemText());
+        assertEquals("(enumerable, nth, fun) (/src/bare_head_preferred_declaration.ex defmodule Prefix.BareHeadPreferredDeclaration)", lookupElementPresentation.getTailText());
+    }
+
+    public void testSameNameDifferentArityCollapsedToOneCompletion() {
+        myFixture.configureByFiles("same_name_different_arity_usage.ex", "same_name_different_arity_declaration.ex");
+        myFixture.complete(CompletionType.BASIC, 1);
+
+        List<String> strings = myFixture.getLookupElementStrings();
+        assertNotNull("Completion lookup not shown", strings);
+        assertCompletion("process", strings);
+        assertEquals("Completion should collapse same-name different-arity into one entry", 1, strings.size());
+    }
+
+    public void testFallsBackToFirstClauseWhenNoBareHeadExists() {
+        myFixture.configureByFiles("no_bare_head_fallback_usage.ex", "no_bare_head_fallback_declaration.ex");
+        myFixture.complete(CompletionType.BASIC, 1);
+
+        List<String> strings = myFixture.getLookupElementStrings();
+        assertNotNull("Completion lookup not shown", strings);
+        assertCompletion("normalize", strings);
+        assertEquals("Wrong number of completions", 1, strings.size());
+
+        LookupElement normalize = lookupElementByItemText("normalize");
+        assertNotNull("No lookup element for normalize", normalize);
+
+        LookupElementPresentation lookupElementPresentation = new LookupElementPresentation();
+        normalize.renderElement(lookupElementPresentation);
+        assertEquals("normalize", lookupElementPresentation.getItemText());
+        assertEquals("(value, fallback) when is_binary(value) (/src/no_bare_head_fallback_declaration.ex defmodule Prefix.NoBareHeadFallbackDeclaration)", lookupElementPresentation.getTailText());
+    }
+
     /*
      * Protected Instance Methods
      */
@@ -192,6 +239,20 @@ public class CallDefinitionClauseTest extends PlatformTestCase {
     /*
      * Private Instance Methods
      */
+
+    private LookupElement lookupElementByItemText(@NotNull String expectedItemText) {
+        LookupElement[] lookupElements = myFixture.getLookupElements();
+        assertNotNull("Completion lookup not shown", lookupElements);
+
+        return Arrays.stream(lookupElements)
+                .filter(lookupElement -> {
+                    LookupElementPresentation presentation = new LookupElementPresentation();
+                    lookupElement.renderElement(presentation);
+                    return expectedItemText.equals(presentation.getItemText());
+                })
+                .findFirst()
+                .orElse(null);
+    }
 
     void assertCompletion(@NotNull String expectedCompletion, @NotNull List<String> actualCompletions) {
         assertTrue("Did not complete with \"" + expectedCompletion + "\"", actualCompletions.contains(expectedCompletion));

--- a/tests/org/elixir_lang/code_insight/line_marker_provider/CallDefinitionLeafElementTest.kt
+++ b/tests/org/elixir_lang/code_insight/line_marker_provider/CallDefinitionLeafElementTest.kt
@@ -1,0 +1,166 @@
+package org.elixir_lang.code_insight.line_marker_provider
+
+import com.intellij.codeInsight.daemon.DaemonCodeAnalyzerSettings
+import com.intellij.codeInsight.daemon.LineMarkerInfo
+import com.intellij.codeInsight.daemon.impl.DaemonCodeAnalyzerImpl
+import com.intellij.psi.PsiElement
+import com.intellij.psi.impl.source.tree.LeafPsiElement
+import org.elixir_lang.PlatformTestCase
+
+/**
+ * Verifies that Elixir `CallDefinition` line markers are anchored to **leaf** elements and
+ * that `CallDefinition.getLineMarkerInfo` returns `null` for composite elements.
+ *
+ * See: [the SDK documentation](https://plugins.jetbrains.com/docs/intellij/line-marker-provider.html)
+ *
+ * The fixture is extracted from Elixir 1.11.3 `kernel.ex` which contains multiple `@doc`, `@spec`,
+ * and `def` blocks that trigger `CallDefinition`'s method-separator logic.
+ *
+ * These tests verify that the leaf-element dispatch inversion is correctly implemented.
+ */
+class CallDefinitionLeafElementTest : PlatformTestCase() {
+
+    override fun getTestDataPath(): String =
+        "testData/org/elixir_lang/code_insight/line_marker_provider/call_definition"
+
+    override fun setUp() {
+        super.setUp()
+        // Method separators must be enabled for CallDefinition to produce any LineMarkerInfo
+        DaemonCodeAnalyzerSettings.getInstance().SHOW_METHOD_SEPARATORS = true
+    }
+
+    override fun tearDown() {
+        try {
+            DaemonCodeAnalyzerSettings.getInstance().SHOW_METHOD_SEPARATORS = false
+        } finally {
+            super.tearDown()
+        }
+    }
+
+    /**
+     * Verifies that every [LineMarkerInfo] element returned by `CallDefinition` is a leaf.
+     *
+     * The platform logs `Performance warning: LineMarker is supposed to be registered for leaf
+     * elements only` when a non-leaf element is used. This test fails if any marker is anchored
+     * to a composite element.
+     */
+    fun testAllLineMarkersAnchoredToLeafElements() {
+        myFixture.configureByFile("leaf_element_contract.ex")
+
+        // Run the highlighting passes — this triggers all LineMarkerProviders
+        myFixture.doHighlighting()
+
+        val document = myFixture.editor.document
+        val markers: List<LineMarkerInfo<*>> =
+            DaemonCodeAnalyzerImpl.getLineMarkers(document, myFixture.project)
+
+        // We expect at least some separators for the multiple def groups
+        assertTrue(
+            "Expected at least one method separator line marker, but got none. " +
+                "Is SHOW_METHOD_SEPARATORS enabled?",
+            markers.isNotEmpty()
+        )
+
+        val nonLeafMarkers = markers.filter { marker ->
+            val element = marker.element
+            element != null && element.firstChild != null // non-leaf: has children
+        }
+
+        assertTrue(
+            "Found ${nonLeafMarkers.size} LineMarkerInfo(s) anchored to non-leaf elements. " +
+                "Elements: ${nonLeafMarkers.map { formatElement(it.element!!) }}. " +
+                "All markers must be anchored to leaf (terminal) PSI elements per the " +
+                "LineMarkerProvider contract.",
+            nonLeafMarkers.isEmpty()
+        )
+    }
+
+    /**
+     * Verifies that [CallDefinition.getLineMarkerInfo] returns `null` when called with a
+     * composite (non-leaf) element.
+     *
+     * The `LineMarkerProvider` contract states that the provider should only return marker info
+     * when called with a leaf element. When the platform delivers a composite element, the
+     * provider must return `null`.
+     */
+    fun testGetLineMarkerInfoReturnsNullForCompositeElements() {
+        myFixture.configureByFile("leaf_element_contract.ex")
+
+        val provider = CallDefinition()
+        val psiFile = myFixture.file
+
+        // Collect all composite (non-leaf) elements in the file
+        val compositeElements = mutableListOf<PsiElement>()
+        fun collect(element: PsiElement) {
+            if (element.firstChild != null) { // composite
+                compositeElements.add(element)
+            }
+            element.children.forEach(::collect)
+        }
+        collect(psiFile)
+
+        assertTrue("Expected composite elements in fixture", compositeElements.isNotEmpty())
+
+        val violating = compositeElements.filter { element ->
+            provider.getLineMarkerInfo(element) != null
+        }
+
+        assertTrue(
+            "CallDefinition.getLineMarkerInfo returned non-null for ${violating.size} composite " +
+                "element(s): ${violating.take(5).map { formatElement(it) }}. " +
+                "The provider must return null for non-leaf elements.",
+            violating.isEmpty()
+        )
+    }
+
+    /**
+     * Verifies that `CallDefinition` still produces method separators when given leaf elements.
+     * This guards against the fix breaking the separator functionality.
+     */
+    fun testMethodSeparatorsStillProducedFromLeafElements() {
+        myFixture.configureByFile("leaf_element_contract.ex")
+
+        val provider = CallDefinition()
+        val psiFile = myFixture.file
+
+        // Collect all leaf elements using firstChild/nextSibling traversal
+        // (PsiElement.children may not include LeafPsiElement tokens)
+        val leafElements = mutableListOf<PsiElement>()
+        fun collect(element: PsiElement) {
+            if (element.firstChild == null) { // leaf
+                leafElements.add(element)
+            } else {
+                var child: PsiElement? = element.firstChild
+                while (child != null) {
+                    collect(child)
+                    child = child.nextSibling
+                }
+            }
+        }
+        collect(psiFile)
+
+        val markersFromLeaves = leafElements.mapNotNull { leaf ->
+            provider.getLineMarkerInfo(leaf)
+        }
+
+        assertTrue(
+            "Expected at least one method separator from leaf elements in the fixture, but got none. " +
+                "The leaf-element dispatch must still find enclosing Call/AtUnqualifiedNoParenthesesCall " +
+                "ancestors and produce separators.",
+            markersFromLeaves.isNotEmpty()
+        )
+
+        // All markers produced should be anchored at leaves
+        markersFromLeaves.forEach { marker ->
+            val element = marker.element
+            assertNotNull("LineMarkerInfo.element is null", element)
+            assertTrue(
+                "LineMarkerInfo anchored at non-leaf: ${formatElement(element!!)}",
+                element is LeafPsiElement || element.firstChild == null
+            )
+        }
+    }
+
+    private fun formatElement(element: PsiElement): String =
+        "${element.node.elementType} (${element.javaClass.simpleName}) text='${element.text.take(30)}'"
+}

--- a/tests/org/elixir_lang/code_insight/line_marker_provider/ImplementationLeafElementTest.kt
+++ b/tests/org/elixir_lang/code_insight/line_marker_provider/ImplementationLeafElementTest.kt
@@ -1,0 +1,76 @@
+﻿package org.elixir_lang.code_insight.line_marker_provider
+import com.intellij.codeInsight.daemon.LineMarkerInfo
+import com.intellij.psi.PsiElement
+import org.elixir_lang.PlatformTestCase
+class ImplementationLeafElementTest : PlatformTestCase() {
+    override fun getTestDataPath(): String =
+        "testData/org/elixir_lang/code_insight/line_marker_provider/protocol_implementation"
+    fun testGetLineMarkerInfoReturnsNullForCompositeElements() {
+        myFixture.configureByFile("leaf_element_contract.ex")
+        val provider = Implementation()
+        val violating = compositeElements(myFixture.file).filter { provider.getLineMarkerInfo(it) != null }
+        assertTrue(
+            "Implementation.getLineMarkerInfo returned non-null for ${violating.size} composite element(s): " +
+                "${violating.take(5).map(::formatElement)}.",
+            violating.isEmpty()
+        )
+    }
+    fun testProducesMarkersFromLeafAnchorsOnly() {
+        myFixture.configureByFile("leaf_element_contract.ex")
+        val provider = Implementation()
+        val markersFromLeaves: List<Pair<PsiElement, LineMarkerInfo<*>>> =
+            leafElements(myFixture.file).mapNotNull { leaf ->
+                provider.getLineMarkerInfo(leaf)?.let { leaf to it }
+            }
+        assertTrue(
+            "Expected Implementation markers from leaf elements, but got none.",
+            markersFromLeaves.isNotEmpty()
+        )
+        markersFromLeaves.forEach { (leaf, marker) ->
+            val markerElement = marker.element
+            assertNotNull("LineMarkerInfo.element is null", markerElement)
+            assertSame(
+                "Implementation marker must be anchored to the same leaf element it was queried with",
+                leaf,
+                markerElement
+            )
+            assertTrue(
+                "Implementation marker element is not a leaf: ${formatElement(markerElement!!)}",
+                markerElement.firstChild == null
+            )
+        }
+    }
+    private fun compositeElements(root: PsiElement): List<PsiElement> {
+        val compositeElements = mutableListOf<PsiElement>()
+        fun collect(element: PsiElement) {
+            if (element.firstChild != null) {
+                compositeElements.add(element)
+                var child = element.firstChild
+                while (child != null) {
+                    collect(child)
+                    child = child.nextSibling
+                }
+            }
+        }
+        collect(root)
+        return compositeElements
+    }
+    private fun leafElements(root: PsiElement): List<PsiElement> {
+        val leaves = mutableListOf<PsiElement>()
+        fun collect(element: PsiElement) {
+            if (element.firstChild == null) {
+                leaves.add(element)
+            } else {
+                var child = element.firstChild
+                while (child != null) {
+                    collect(child)
+                    child = child.nextSibling
+                }
+            }
+        }
+        collect(root)
+        return leaves
+    }
+    private fun formatElement(element: PsiElement): String =
+        "${element.node.elementType} (${element.javaClass.simpleName}) text='${element.text.take(30)}'"
+}

--- a/tests/org/elixir_lang/code_insight/line_marker_provider/ProtocolLeafElementTest.kt
+++ b/tests/org/elixir_lang/code_insight/line_marker_provider/ProtocolLeafElementTest.kt
@@ -1,0 +1,76 @@
+﻿package org.elixir_lang.code_insight.line_marker_provider
+import com.intellij.codeInsight.daemon.LineMarkerInfo
+import com.intellij.psi.PsiElement
+import org.elixir_lang.PlatformTestCase
+class ProtocolLeafElementTest : PlatformTestCase() {
+    override fun getTestDataPath(): String =
+        "testData/org/elixir_lang/code_insight/line_marker_provider/protocol_implementation"
+    fun testGetLineMarkerInfoReturnsNullForCompositeElements() {
+        myFixture.configureByFile("leaf_element_contract.ex")
+        val provider = Protocol()
+        val violating = compositeElements(myFixture.file).filter { provider.getLineMarkerInfo(it) != null }
+        assertTrue(
+            "Protocol.getLineMarkerInfo returned non-null for ${violating.size} composite element(s): " +
+                "${violating.take(5).map(::formatElement)}.",
+            violating.isEmpty()
+        )
+    }
+    fun testProducesMarkersFromLeafAnchorsOnly() {
+        myFixture.configureByFile("leaf_element_contract.ex")
+        val provider = Protocol()
+        val markersFromLeaves: List<Pair<PsiElement, LineMarkerInfo<*>>> =
+            leafElements(myFixture.file).mapNotNull { leaf ->
+                provider.getLineMarkerInfo(leaf)?.let { leaf to it }
+            }
+        assertTrue(
+            "Expected Protocol markers from leaf elements, but got none.",
+            markersFromLeaves.isNotEmpty()
+        )
+        markersFromLeaves.forEach { (leaf, marker) ->
+            val markerElement = marker.element
+            assertNotNull("LineMarkerInfo.element is null", markerElement)
+            assertSame(
+                "Protocol marker must be anchored to the same leaf element it was queried with",
+                leaf,
+                markerElement
+            )
+            assertTrue(
+                "Protocol marker element is not a leaf: ${formatElement(markerElement!!)}",
+                markerElement.firstChild == null
+            )
+        }
+    }
+    private fun compositeElements(root: PsiElement): List<PsiElement> {
+        val compositeElements = mutableListOf<PsiElement>()
+        fun collect(element: PsiElement) {
+            if (element.firstChild != null) {
+                compositeElements.add(element)
+                var child = element.firstChild
+                while (child != null) {
+                    collect(child)
+                    child = child.nextSibling
+                }
+            }
+        }
+        collect(root)
+        return compositeElements
+    }
+    private fun leafElements(root: PsiElement): List<PsiElement> {
+        val leaves = mutableListOf<PsiElement>()
+        fun collect(element: PsiElement) {
+            if (element.firstChild == null) {
+                leaves.add(element)
+            } else {
+                var child = element.firstChild
+                while (child != null) {
+                    collect(child)
+                    child = child.nextSibling
+                }
+            }
+        }
+        collect(root)
+        return leaves
+    }
+    private fun formatElement(element: PsiElement): String =
+        "${element.node.elementType} (${element.javaClass.simpleName}) text='${element.text.take(30)}'"
+}

--- a/tests/org/elixir_lang/psi/impl/qualifiable_alias/ItemPresentationTest.kt
+++ b/tests/org/elixir_lang/psi/impl/qualifiable_alias/ItemPresentationTest.kt
@@ -1,0 +1,42 @@
+package org.elixir_lang.psi.impl.qualifiable_alias
+
+import org.elixir_lang.PlatformTestCase
+import org.elixir_lang.psi.ElixirAlias
+
+/**
+ * Tests for [ItemPresentation].
+ */
+class ItemPresentationTest : PlatformTestCase() {
+
+    /**
+     * Regression test for an infinite loop in [org.elixir_lang.reference.module.UnaliasedName.up] when a
+     * [org.elixir_lang.psi.QualifiableAlias] is used as the qualifier in a
+     * [org.elixir_lang.psi.QualifiedMultipleAliases] expression (e.g. `alias Prefix.{SubModule}`).
+     *
+     * The qualifier `Prefix` has parent chain:
+     *   `ElixirAlias` → `ElixirAccessExpression` → `QualifiedMultipleAliases` → `alias` Call
+     *
+     * Before the fix, `UnaliasedName.up(QualifiedMultipleAliases, entrance)` called itself with the same
+     * `QualifiedMultipleAliases`, causing an infinite tail-recursive loop that froze IntelliJ.
+     */
+    fun testGetPresentableTextForQualifierInQualifiedMultipleAliases() {
+        myFixture.configureByFile("qualifier_in_qualified_multiple_aliases.ex")
+
+        val elementAtCaret = myFixture.file.findElementAt(myFixture.caretOffset)
+        assertNotNull("Expected an element at the caret", elementAtCaret)
+
+        // The token's parent is the ElixirAlias PSI element for `Prefix`
+        val qualifiableAlias = elementAtCaret!!.parent
+        assertInstanceOf(qualifiableAlias, ElixirAlias::class.java)
+        val elixirAlias = qualifiableAlias as ElixirAlias
+
+        // getPresentableText() must terminate (not infinite-loop) and return the alias presentation
+        val presentation = elixirAlias.presentation
+        assertNotNull("Expected a non-null ItemPresentation for ElixirAlias", presentation)
+        val presentableText = presentation!!.presentableText
+        assertEquals("alias Prefix", presentableText)
+    }
+
+    override fun getTestDataPath(): String =
+        "testData/org/elixir_lang/psi/impl/qualifiable_alias/item_presentation"
+}

--- a/tests/org/elixir_lang/reference/callable/IntramoduleTest.kt
+++ b/tests/org/elixir_lang/reference/callable/IntramoduleTest.kt
@@ -88,7 +88,7 @@ class IntramoduleTest : PlatformTestCase() {
         Assert.assertNotEquals("Resolved to both clauses instead of selected clause", 2, resolveResults.size.toLong())
         assertEquals("Resolves to self", 1, resolveResults.size)
 
-        val resolved = reference!!.resolve()
+        val resolved = reference.resolve()
         assertNotNull("Reference not resolved", resolved)
         assertEquals("def referenced(true) do\n  end", resolved!!.text)
     }

--- a/tests/org/elixir_lang/reference/callable/Issue463Test.kt
+++ b/tests/org/elixir_lang/reference/callable/Issue463Test.kt
@@ -121,18 +121,11 @@ class Issue463Test : PlatformTestCase() {
         assertInstanceOf(reference, PsiPolyVariantReference::class.java)
         val psiPolyVariantReference = reference as PsiPolyVariantReference
 
+        // An unresolvable qualifier (no alias, no module definition) should produce
+        // zero results — not a global search across every module in the project.
+        // The standard unresolved-reference highlight will inform the user.
         val resolveResults = psiPolyVariantReference.multiResolve(false)
-        assertEquals(1, resolveResults.size)
-
-        val firstResolveResult = resolveResults[0]
-        assertFalse(firstResolveResult.isValidResult)
-        val firstElement = firstResolveResult.element
-        assertNotNull(firstElement)
-        assertEquals(firstElement!!.text, """def changeset(params) do
-    %__MODULE__{}
-    |> cast(params, ~w(name))
-    |> validate_required(:name)
-  end""")
+        assertEquals(0, resolveResults.size)
     }
 
     override fun getTestDataPath(): String = "testData/org/elixir_lang/reference/callable/issue_463"

--- a/tests/org/elixir_lang/reference/callable/Issue480Test.kt
+++ b/tests/org/elixir_lang/reference/callable/Issue480Test.kt
@@ -43,7 +43,7 @@ class Issue480Test : PlatformTestCase() {
 
     fun testUnresolvedAliasQualifier() {
         myFixture.configureByFiles("unresolved_alias_qualifier.ex", "referenced.ex")
-        assertReferenceAndResolvedNameArityRange("changeset", 1)
+        assertUnresolvableReferenceNameArityRange("changeset", 1)
     }
 
     override fun getTestDataPath(): String = "testData/org/elixir_lang/reference/callable/issue_480"
@@ -92,17 +92,18 @@ class Issue480Test : PlatformTestCase() {
         val psiPolyVariantReference = reference as PsiPolyVariantReference
 
         val resolveResults = psiPolyVariantReference.multiResolve(false)
-        for (resolveResult in resolveResults) {
-            if (resolveResult.isValidResult) {
-                val resolved = resolveResult.element
-                assertInstanceOf(resolved, Call::class.java)
-                val maybeDefCall = resolved as Call?
-                assertTrue(`is`(maybeDefCall!!))
-                assertEquals(
-                        NameArityInterval(name, ArityInterval(arity, arity)),
-                        nameArityInterval(maybeDefCall, ResolveState.initial())
-                )
-            }
+        val validResults = resolveResults.filter { it.isValidResult }
+        assertTrue("Expected at least one valid resolve result, but got none", validResults.isNotEmpty())
+
+        for (resolveResult in validResults) {
+            val resolved = resolveResult.element
+            assertInstanceOf(resolved, Call::class.java)
+            val maybeDefCall = resolved as Call?
+            assertTrue(`is`(maybeDefCall!!))
+            assertEquals(
+                    NameArityInterval(name, ArityInterval(arity, arity)),
+                    nameArityInterval(maybeDefCall, ResolveState.initial())
+            )
         }
     }
 }

--- a/tests/org/elixir_lang/reference/module/UnaliasedNameTest.kt
+++ b/tests/org/elixir_lang/reference/module/UnaliasedNameTest.kt
@@ -1,0 +1,154 @@
+package org.elixir_lang.reference.module
+
+import org.elixir_lang.PlatformTestCase
+import org.elixir_lang.psi.ElixirAlias
+import org.elixir_lang.psi.QualifiedAlias
+import org.elixir_lang.reference.module.UnaliasedName.unaliasedName
+
+/**
+ * Tests for [UnaliasedName.unaliasedName], covering all branches of both [UnaliasedName.up] and
+ * [UnaliasedName.down].
+ *
+ * ## Branch map
+ *
+ * ### `up(element: PsiElement?, entrance: QualifiableAlias)`
+ * | Branch | Elixir | Test |
+ * |---|---|---|
+ * | `is Call` → delegates to `up(Call, entrance)` | any alias | all tests |
+ * | `is QualifiedMultipleAliases → entrance.fullyQualifiedName()` | `alias Prefix.{Suffix}`, qualifier | [testMultipleAliasQualifier] |
+ * | `is ElixirAccessExpression / …NoParentheses… / QuotableArguments / QuotableKeywordList → up(parent)` | traversal step | all multi-level tests |
+ * | `is ElixirMultipleAliases → entrance.fullyQualifiedName()` | `alias Prefix.{Suffix}`, leaf | [testMultipleAliasLeaf] |
+ * | `is QuotableKeywordPair` → delegates to `up(QuotableKeywordPair, entrance)` | `alias …, as: X` | [testAsOptionValue] |
+ * | `else → null` | non-alias non-recognized parent | [testNonAliasCallReturnsEntranceName] (never hits `else`; Call takes over first) |
+ *
+ * ### `up(call: Call, entrance: QualifiableAlias)`
+ * | Branch | Test |
+ * |---|---|
+ * | alias call with args → `down(firstArg)` | [testSimpleAlias], [testAsOptionValue] |
+ * | non-alias call → `entrance.name` | [testNonAliasCallReturnsEntranceName] |
+ *
+ * ### `up(element: QuotableKeywordPair, entrance: QualifiableAlias)`
+ * | Branch | Test |
+ * |---|---|
+ * | has key "as" → continue up | [testAsOptionValue] |
+ * | no "as" key → null | (aliased value for non-`as` keyword; difficult to reach naturally) |
+ *
+ * ### `down(element: PsiElement)`
+ * | Branch | Test |
+ * |---|---|
+ * | `is QualifiableAlias → element.name` | [testSimpleAlias] |
+ * | `is ElixirAccessExpression` → recurse into child | all `ElixirAccessExpression` traversal cases |
+ * | `is ElixirAtom → ":name"` | (atom aliases; not exercised here) |
+ * | `is Call` → `maybeModularNameToModulars` resolution | (macro-generated aliases; not exercised here) |
+ * | `else → "?"` + Logger.error | (unexpected element type; not exercised here) |
+ */
+class UnaliasedNameTest : PlatformTestCase() {
+
+    // -------------------------------------------------------------------------
+    // `is QualifiedMultipleAliases` branch - the regression/bug-fix case
+    // -------------------------------------------------------------------------
+
+    /**
+     * `Prefix` in `alias Prefix.{Suffix}`.
+     *
+     * Parent chain: `ElixirAlias(Prefix)` → `ElixirAccessExpression` → `QualifiedMultipleAliases` → `alias` Call.
+     *
+     * Before the fix this caused an infinite loop in [UnaliasedName.up]; after the fix it short-circuits
+     * to `entrance.fullyQualifiedName()` = "Prefix".
+     */
+    fun testMultipleAliasQualifier() {
+        myFixture.configureByFile("multiple_alias_qualifier.ex")
+        val prefix = caretElixirAlias()
+        assertEquals("Prefix", unaliasedName(prefix))
+    }
+
+    // -------------------------------------------------------------------------
+    // `is ElixirMultipleAliases` branch
+    // -------------------------------------------------------------------------
+
+    /**
+     * `Suffix` in `alias Prefix.{Suffix}`.
+     *
+     * Parent chain: `ElixirAlias(Suffix)` → `ElixirMultipleAliases` → `QualifiedMultipleAliases` → `alias` Call.
+     *
+     * `up(ElixirMultipleAliases, entrance)` short-circuits to `entrance.fullyQualifiedName()`.
+     * `fullyQualifiedName()` walks UP the PSI tree to prepend the qualifier, so for `Suffix` inside `Prefix.{Suffix}`
+     * it returns "Prefix.Suffix" - the fully-qualified module name, not the bare leaf name.
+     */
+    fun testMultipleAliasLeaf() {
+        myFixture.configureByFile("multiple_alias_leaf.ex")
+        val suffix = caretElixirAlias()
+        assertEquals("Prefix.Suffix", unaliasedName(suffix))
+    }
+
+    // -------------------------------------------------------------------------
+    // `is Call` (alias) → `down(QualifiableAlias → element.name)` branch
+    // -------------------------------------------------------------------------
+
+    /**
+     * `Prefix.Suffix` in `alias Prefix.Suffix`.
+     *
+     * The [QualifiedAlias] text ("Prefix.Suffix") is the name returned by the `down` function when it encounters a
+     * [org.elixir_lang.psi.QualifiableAlias].
+     */
+    fun testSimpleAlias() {
+        myFixture.configureByFile("simple_alias.ex")
+        // caret is inside "Suffix" - one parent up gives ElixirAlias("Suffix"),
+        // one more gives the QualifiedAlias spanning the whole "Prefix.Suffix".
+        val qualifiedAlias = caretElixirAlias().parent
+        assertInstanceOf(qualifiedAlias, QualifiedAlias::class.java)
+        assertEquals("Prefix.Suffix", unaliasedName(qualifiedAlias as QualifiedAlias))
+    }
+
+    // -------------------------------------------------------------------------
+    // `is QuotableKeywordPair` with "as" → continue up → eventually alias Call → `down`
+    // -------------------------------------------------------------------------
+
+    /**
+     * `As` (the alias name) in `alias Prefix.Suffix, as: As`.
+     *
+     * Parent chain: `ElixirAlias(As)` → `ElixirAccessExpression`? → `QuotableKeywordPair(as: …)` →
+     * `QuotableKeywordList` → `ElixirNoParenthesesOneArgument` → `alias` Call.
+     *
+     * `up(QuotableKeywordPair)` detects the "as" key and continues upward; the alias Call then sends
+     * execution to `down(Prefix.Suffix)`, which returns "Prefix.Suffix".
+     */
+    fun testAsOptionValue() {
+        myFixture.configureByFile("as_option.ex")
+        val asAlias = caretElixirAlias()
+        assertEquals("Prefix.Suffix", unaliasedName(asAlias))
+    }
+
+    // -------------------------------------------------------------------------
+    // `is Call` (non-alias) → `entrance.name`
+    // -------------------------------------------------------------------------
+
+    /**
+     * `My.Module` in `defmodule My.Module do end`.
+     *
+     * The [QualifiedAlias] reaches a `defmodule` Call that is not `Kernel.alias/2`, so `up(Call, entrance)`
+     * falls through to `entrance.name` = "My.Module" ([QualifiedAlias.getName] returns the full text).
+     */
+    fun testNonAliasCallReturnsEntranceName() {
+        myFixture.configureByFile("defmodule_argument.ex")
+        val qualifiedAlias = caretElixirAlias().parent
+        assertInstanceOf(qualifiedAlias, QualifiedAlias::class.java)
+        assertEquals("My.Module", unaliasedName(qualifiedAlias as QualifiedAlias))
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    /** Navigates from the caret token to the immediately enclosing [ElixirAlias]. */
+    private fun caretElixirAlias(): ElixirAlias {
+        val element = myFixture.file.findElementAt(myFixture.caretOffset)
+        assertNotNull("Expected an element at the caret", element)
+        val alias = element!!.parent
+        assertInstanceOf(alias, ElixirAlias::class.java)
+        return alias as ElixirAlias
+    }
+
+    override fun getTestDataPath(): String =
+        "testData/org/elixir_lang/reference/module/unaliased_name"
+}


### PR DESCRIPTION
﻿Part of the safer-background-threads split. See #3808 for full context.
### Overview
Fixes resolver safety (recursion guard, removal of the `nameArityInAnyModule` global fallback), line markers, search cancellation, completion deduplication, read-action hot-path cleanup, and miscellaneous PSI fixes.
### Key changes
#### ⚠️ Breaking change — resolver global fallback removed
When `resolveInScope` found no valid results for a call, the resolver previously fell back to `nameArityInAnyModule`, a global stub-index search returning every function with a matching name from every module in the project. All results were marked `validResult=false`, but they still polluted IDE features:
- **Parameter hints** showed params from completely unrelated modules (e.g. hovering `Enum.map()` showed hints from `Stream.Reducers`, `Ecto`, `Phoenix`)
- **Go-to-Definition** could navigate to wrong-module definitions
- Resolution cache filled with irrelevant cross-module results
The fallback is now removed. `resolveInScope` already handles qualified calls (via `qualifiedToModulars`) and unqualified calls (via tree walk through imports, local defs, and Kernel). If neither finds the function, the correct answer is "unresolved reference" — not every function with that name across the project.
Also includes transitive alias fallback in module scope resolution: when a stub-index lookup finds nothing for a module name that is itself a `QualifiableAlias`, resolution now follows alias chains transitively.
#### PSI reliability fixes
- Prevented infinite recursion and NPE in PSI resolve/tree-walk paths.
- Fixed `@spec` line marker grouping to check name equality before arity.
- Anchored gutter icons to leaf `PsiElement`s to avoid stale/misplaced markers after edits.
#### Code insight — completion and parameter info deduplication
- Completion entries no longer show one entry per clause head for functions with multiple clauses/guards (e.g. `Enum.map_every` was appearing 5 times). Introduced shared `PreferFunctionHead` logic that groups by name and selects bare function heads over implementation clauses.
- Parameter info deduplicates by `(name, arity)` so separate arities still show distinct hints.
- Completion prefers source-defined modulars over BEAM stubs to avoid duplicates when both are available.
#### Search — cancellation and early-exit
- Added cancellation checks and early-exit handling to `DefinitionsScopedSearch` to prevent hangs during large-project searches.
#### Threading — read-action hot-path fixes
- Removed redundant `computeReadAction`/`runReadAction` wrappers from `CallImpl` getters (`functionName`, `moduleName`, `resolvedPrimaryArity`) — these perform trivial PSI reads on paths already holding a read lock. Under 2025.3+ writer-preference locking, re-acquiring a held read lock blocks the EDT when a write action is pending.
- Same cleanup applied to `PsiNamedElementImpl` name getters.
### Test coverage
- `tests/org/elixir_lang/code_insight/ParameterInfoTest.java` — parameter info deduplication
- `tests/org/elixir_lang/completion/contributor/CallDefinitionClauseTest.java` — completion deduplication
- Updated resolver tests: `Issue463Test.kt` now expects 0 results for unresolvable qualifier; `Issue480Test.kt` tightened assertions.
### Risk / compatibility notes
- **⚠️ Breaking change:** Calls that were previously "resolved" to functions in unrelated modules (with `validResult=false`) will now appear as unresolved references. Parameter hints for such calls will be empty rather than showing hints from wrong modules. Go-to-definition on unresolvable calls will no longer navigate anywhere. This is a correctness improvement.
### Suggested validation
- In a file with an unresolvable qualified call (e.g. a module name that is not aliased), verify parameter hints are empty rather than showing hints from unrelated modules.
- Trigger completion on a multi-clause function (e.g. `Enum.map_every`) and verify it appears once, not once per clause.
Partially fixes: #3790 (read-action starvation in CallImpl/PsiNamedElementImpl/DefinitionsScopedSearch)
Possibly addresses: #1806
