### PR TITLE
Bump IntelliJ 2026.1.x to 2026.1.2

### DIFF
--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -14,7 +14,7 @@ inputs:
   idea-version:
     description: 'IntelliJ IDEA version to test against. Keep in sync with the matrix in shared-test.yml'
     required: false
-    default: '2026.1.1'  # should match first version in shared-test.yml
+    default: '2026.1.2'  # should match first version in shared-test.yml
   github-token:
     description: 'GitHub token for API access (required for setup-java to download JBR)'
     required: true

--- a/.github/workflows/shared-test.yml
+++ b/.github/workflows/shared-test.yml
@@ -40,15 +40,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Note, we use ubuntu-22.04, due to 
         os: [ ubuntu-22.04, windows-2025 ]
         idea-version:
-            - '2026.1.1'
+            - '2026.1.2'
             - '2025.3.2'
             # 2026.2 upgrades to Java 25, won't work in CI until we resolve issues. https://github.com/JetBrains/intellij-community/commit/aa1cfa9632ab
             # - 'LATEST-EAP-SNAPSHOT'
-            # revert to 261 eap instead
-            - '261.24374.34'
 
     steps:
       - name: Checkout
@@ -118,7 +115,7 @@ jobs:
         with:
           setup-elixir: false
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          idea-version: '2026.1.1'
+          idea-version: '2026.1.2'
           free-docker-images: false
 
       - name: Build Plugin
@@ -143,10 +140,10 @@ jobs:
       fail-fast: false
       matrix:
         ide-version:
-          - 'ideaIU:253.30387.90'
-          - 'ideaIU:261.23567.138'
-          - 'rubymine:2025.3.2'
-          - 'rubymine:2026.1'
+          - 'ideaIU:253.33514.17'
+          - 'ideaIU:261.24374.151'
+          - 'rubymine:2025.3.5'
+          - 'rubymine:2026.1.2'
 
     steps:
       - name: Download Plugin Zip

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@ skipSearchableOptions=true
 
 # --- Platform Targets ---
 platformType=IU
-platformVersion=2026.1.1
+platformVersion=2026.1.2
 # Enable this to pull in the latest EAP version.
 useDynamicEapVersion=false
 
@@ -27,24 +27,24 @@ useDynamicEapVersion=false
 enableEAPIDEs=true
 
 # Stable Versions (2025.3)
-platformVersionIntellijIdea=2026.1.1
-platformVersionRubyMine=2026.1.1
-platformVersionPyCharm=2026.1
-platformVersionWebStorm=2026.1.1
+platformVersionIntellijIdea=2026.1.2
+platformVersionRubyMine=2026.1.2
+platformVersionPyCharm=2026.1.2
+platformVersionWebStorm=2026.1.2
 platformVersionRustRover=2026.1.1
 platformVersionCLion=2026.1.1
-platformVersionGoLand=2026.1.1
+platformVersionGoLand=2026.1.2
 platformVersionPhpStorm=2026.1.1
 
 # EAP Versions
-platformVersionIntellijIdeaEAP=261-EAP-SNAPSHOT
-platformVersionRubyMineEAP=261-EAP-SNAPSHOT
-platformVersionPyCharmEAP=261-EAP-SNAPSHOT
-platformVersionWebStormEAP=261-EAP-SNAPSHOT
-platformVersionRustRoverEAP=261-EAP-SNAPSHOT
-platformVersionCLionEAP=261-EAP-SNAPSHOT
-platformVersionGoLandEAP=261-EAP-SNAPSHOT
-platformVersionPhpStormEAP=261-EAP-SNAPSHOT
+platformVersionIntellijIdeaEAP=262-EAP-SNAPSHOT
+platformVersionRubyMineEAP=262-EAP-SNAPSHOT
+platformVersionPyCharmEAP=262-EAP-SNAPSHOT
+platformVersionWebStormEAP=262-EAP-SNAPSHOT
+platformVersionRustRoverEAP=262-EAP-SNAPSHOT
+platformVersionCLionEAP=262-EAP-SNAPSHOT
+platformVersionGoLandEAP=262-EAP-SNAPSHOT
+platformVersionPhpStormEAP=262-EAP-SNAPSHOT
 
 # --- Plugin Verification ---
 # Comma-separated list of IDE types to verify against

--- a/src/org/elixir_lang/mix/project/CanonicalFolderMarks.kt
+++ b/src/org/elixir_lang/mix/project/CanonicalFolderMarks.kt
@@ -10,7 +10,7 @@ import com.intellij.openapi.project.ProjectBundle
  * terminology exactly (e.g. the "Mark Directory as" context menu labels).  This avoids hardcoded
  * strings that could drift if the platform renames these labels.
  *
- * Verified present in platform tags `idea/253.28294.334` (2025.3.2) and `idea/261.23567.138`
+ * Verified present in platform tags `idea/253.28294.334` (2025.3.2) and `idea/261.24374.151`
  * (2026.1.1) on 2026-05-03.
  */
 enum class FolderMark(private val bundleKey: String) {


### PR DESCRIPTION
Curious if this fixes the stuck runners for 2026.x plugin verifier
