### PR TITLE
Add @RequiresReadLock annotations to PSI-accessing methods

### DIFF
--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -49,12 +49,14 @@ runs:
         large-packages: false
         docker-images: ${{ inputs.free-docker-images == 'true' }}
 
-    - name: Cache JetBrains JDK
-      id: cache-jdk
-      uses: actions/cache@v5
+    - name: Restore JetBrains Runtime cache
+      id: cache-jbr
+      uses: actions/cache/restore@v5
       with:
-        path: /opt/hostedtoolcache/Java_JetBrains_*
-        key: jdk-${{ runner.os }}-${{ runner.arch }}-jetbrains-21
+        path: ${{ runner.tool_cache }}/Java_JetBrains_*
+        key: jbr-${{ runner.os }}-${{ runner.arch }}-21
+        restore-keys: |
+          jbr-${{ runner.os }}-${{ runner.arch }}-21
 
     - name: Setup JBR 21
       id: setup-java
@@ -66,6 +68,14 @@ runs:
         token: ${{ inputs.github-token }}
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}
+
+    - name: Save JetBrains Runtime cache
+      id: cache-jbr-save
+      if: always() && steps.cache-jbr.outputs.cache-hit != 'true' && steps.setup-java.outcome == 'success'
+      uses: actions/cache/save@v5
+      with:
+        path: ${{ runner.tool_cache }}/Java_JetBrains_*
+        key: jbr-${{ runner.os }}-${{ runner.arch }}-${{ steps.setup-java.outputs.version }}
 
     # This sets project properties, allowing us to override gradle.properties via environment variables,
     # applying to all Gradle tasks. Means we don't need to do like `./gradlew -PplatformVersion=xxx`

--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -56,7 +56,7 @@ runs:
         path: ${{ runner.tool_cache }}/Java_JetBrains_*
         key: jbr-${{ runner.os }}-${{ runner.arch }}-21
         restore-keys: |
-          jbr-${{ runner.os }}-${{ runner.arch }}-21
+          jbr-${{ runner.os }}-${{ runner.arch }}-
 
     - name: Setup JBR 21
       id: setup-java
@@ -143,7 +143,7 @@ runs:
 
     - name: Save Elixir cache
       id: cache-elixir-save
-      if: always() && steps.cache-elixir-restore.outputs.cache-hit != 'true' && inputs.setup-elixir == 'true'
+      if: always() && steps.cache-elixir-restore.outputs.cache-hit != 'true' && inputs.setup-elixir == 'true' && steps.setup-elixir.outcome == 'success'
       uses: actions/cache/save@v5
       with:
         path: |

--- a/.github/workflows/shared-test.yml
+++ b/.github/workflows/shared-test.yml
@@ -43,7 +43,7 @@ jobs:
         os: [ ubuntu-22.04, windows-2025 ]
         idea-version:
             - '2026.1.2'
-            - '2025.3.2'
+            - '2025.3.5'
             # 2026.2 upgrades to Java 25, won't work in CI until we resolve issues. https://github.com/JetBrains/intellij-community/commit/aa1cfa9632ab
             # - 'LATEST-EAP-SNAPSHOT'
 

--- a/.github/workflows/shared-test.yml
+++ b/.github/workflows/shared-test.yml
@@ -146,6 +146,12 @@ jobs:
           - 'rubymine:2026.1.2'
 
     steps:
+      - name: Sanitise IDE version for artifact names
+        id: sanitise
+        run: echo "ide-version=${IDE_VERSION//:/-}" >> "$GITHUB_OUTPUT"
+        env:
+          IDE_VERSION: ${{ matrix.ide-version }}
+
       - name: Download Plugin Zip
         id: download-plugin-zip
         uses: actions/download-artifact@v6
@@ -192,7 +198,7 @@ jobs:
         uses: actions/upload-artifact@v6
         if: ${{ always() && inputs.upload-reports }}
         with:
-          name: verify-plugin-reports-${{ matrix.ide-version }}
+          name: verify-plugin-reports-${{ steps.sanitise.outputs.ide-version }}
           path: |
             ${{ steps.verify-plugin.outputs.verification-output-log-filename }}
             ${{ steps.verify-plugin.outputs.verification-reports-dir }}
@@ -202,6 +208,6 @@ jobs:
         id: upload-plugin
         uses: actions/upload-artifact@v6
         with:
-          name: plugin-artifact-${{ matrix.ide-version }}
+          name: plugin-artifact-${{ steps.sanitise.outputs.ide-version }}
           path: build/distributions/*.zip
           retention-days: 1

--- a/.github/workflows/shared-test.yml
+++ b/.github/workflows/shared-test.yml
@@ -202,6 +202,6 @@ jobs:
         id: upload-plugin
         uses: actions/upload-artifact@v6
         with:
-          name: plugin-artifact
+          name: plugin-artifact-${{ matrix.ide-version }}
           path: build/distributions/*.zip
           retention-days: 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## v23.8.2
+
+### Enhancements
+* Added `@RequiresReadLock` annotations to PSI-accessing methods across 10 files (`CallDefinitionClause`, `Definition`, `Implementation`, `Module`, `Protocol`, `ElixirPsiImplUtil`, `PsiElementImpl`, `PsiNamedElementImpl`, `CallImpl`, `CanonicallyNamedImpl`). Enables the `ThreadingConcurrency` inspection to statically detect callers that don't hold the read lock. - [@joshuataylor](https://github.com/joshuataylor)
+
+### Build
+* [#3830](https://github.com/KronicDeth/intellij-elixir/pull/3830) - [@joshuataylor](https://github.com/joshuataylor)
+  * Bumped IntelliJ 2026.1.x target to 2026.1.2.
+* Bumped Gradle to 9.5.1. - [@joshuataylor](https://github.com/joshuataylor)
+* Bumped intellij-platform plugin to 2.16.0. - [@joshuataylor](https://github.com/joshuataylor)
+
 ## v23.8.1
 
 ### Bug Fixes

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@
 # --- Plugin Metadata ---
 pluginGroup=org.elixir_lang
 pluginName=Elixir
-pluginVersion=23.8.1
+pluginVersion=23.8.2
 pluginRepositoryUrl=https://github.com/KronicDeth/intellij-elixir/
 vendorName=Elle Imhoff
 vendorEmail=Kronic.Deth@gmail.com

--- a/resources/META-INF/changelog.html
+++ b/resources/META-INF/changelog.html
@@ -1,6 +1,22 @@
 <html>
 <body>
 
+<h1>v23.8.2</h1>
+<ul>
+    <li>
+        <p>Enhancements</p>
+        <ul>
+            <li>Added static threading annotations to PSI-accessing methods, enabling compile-time detection of missing read locks via the <code>ThreadingConcurrency</code> inspection.</li>
+        </ul>
+    </li>
+    <li>
+        <p>Build</p>
+        <ul>
+            <li>Bumped IntelliJ 2026.1.x target to 2026.1.2, Gradle to 9.5.1, and intellij-platform plugin to 2.16.0.</li>
+        </ul>
+    </li>
+</ul>
+
 <h1>v23.8.1</h1>
 <ul>
     <li>

--- a/src/org/elixir_lang/psi/CallDefinitionClause.kt
+++ b/src/org/elixir_lang/psi/CallDefinitionClause.kt
@@ -4,6 +4,7 @@ import com.intellij.psi.ElementDescriptionLocation
 import com.intellij.psi.PsiElement
 import com.intellij.psi.ResolveState
 import com.intellij.usageView.UsageViewTypeLocation
+import com.intellij.util.concurrency.annotations.RequiresReadLock
 import org.elixir_lang.NameArityInterval
 import org.elixir_lang.find_usages.Provider
 import org.elixir_lang.psi.call.Call
@@ -19,6 +20,7 @@ object CallDefinitionClause {
      *
      * @param call a def(macro)?p?
      */
+    @RequiresReadLock
     @JvmStatic
     fun enclosingModularMacroCall(call: Call): Call? {
         var enclosedCall = call
@@ -60,30 +62,42 @@ object CallDefinitionClause {
      * @param call a call that [.is].
      * @return element for `name(arg, ...) when ...` in `def* name(arg, ...) when ...`
      */
+    @RequiresReadLock
     @JvmStatic
     fun head(call: Call): PsiElement? = call.primaryArguments()?.firstOrNull()
 
+    @RequiresReadLock
     @JvmStatic
     fun `is`(call: Call): Boolean = isFunction(call) || isMacro(call) || isGuard(call)
 
+    @RequiresReadLock
     @JvmStatic
     fun isFunction(call: Call): Boolean = isPrivateFunction(call) || isPublicFunction(call)
+    @RequiresReadLock
     @JvmStatic
     fun isPublicFunction(call: Call): Boolean =
             isCallingKernelMacroOrHead(call, DEF) || isCallingKernelMacroOrHead(call, DEFMEMO)
+    @RequiresReadLock
     fun isPrivateFunction(call: Call): Boolean =
             isCallingKernelMacroOrHead(call, DEFP) || isCallingKernelMacroOrHead(call, DEFMEMOP)
 
+    @RequiresReadLock
     @JvmStatic
     fun isMacro(call: Call): Boolean = isPrivateMacro(call) || isPublicMacro(call)
+    @RequiresReadLock
     @JvmStatic
     fun isPublicMacro(call: Call): Boolean = isCallingKernelMacroOrHead(call, DEFMACRO)
+    @RequiresReadLock
     fun isPrivateMacro(call: Call): Boolean = isCallingKernelMacroOrHead(call, DEFMACROP)
 
+    @RequiresReadLock
     fun isGuard(call: Call): Boolean = isPrivateGuard(call) || isPublicGuard(call)
+    @RequiresReadLock
     fun isPublicGuard(call: Call): Boolean = isCallingKernelMacroOrHead(call, DEFGUARD)
+    @RequiresReadLock
     fun isPrivateGuard(call: Call): Boolean = isCallingKernelMacroOrHead(call, DEFGUARDP)
 
+    @RequiresReadLock
     fun isPublic(call: Call): Boolean = isPublicFunction(call) || isPublicMacro(call) || isPublicGuard(call)
 
     /**
@@ -94,10 +108,12 @@ object CallDefinitionClause {
      * default arguments are used, which produces an arity for each default argument that is turned on and off.
      * @see Call.resolvedFinalArityInterval
      */
+    @RequiresReadLock
     @JvmStatic
     fun nameArityInterval(call: Call, state: ResolveState): NameArityInterval? =
             head(call)?.let { CallDefinitionHead.nameArityInterval(it, state) }
 
+    @RequiresReadLock
     fun nameIdentifier(call: Call): PsiElement? = head(call)?.let { CallDefinitionHead.nameIdentifier(it) }
 
     private fun functionElementDescription(

--- a/src/org/elixir_lang/psi/Definition.kt
+++ b/src/org/elixir_lang/psi/Definition.kt
@@ -1,5 +1,6 @@
 package org.elixir_lang.psi
 
+import com.intellij.util.concurrency.annotations.RequiresReadLock
 import org.elixir_lang.psi.call.Call
 import org.elixir_lang.psi.call.name.Function.*
 import org.elixir_lang.psi.call.name.Module.KERNEL
@@ -27,6 +28,7 @@ enum class Definition(val type: Type) {
 /**
  * What kind of definition is defined by the [call]
  */
+@RequiresReadLock
 fun definition(call: Call): Definition? =
         definition(call.resolvedModuleName(), call.functionName(), call.resolvedFinalArity(), call.hasDoBlockOrKeyword())
 

--- a/src/org/elixir_lang/psi/Implementation.kt
+++ b/src/org/elixir_lang/psi/Implementation.kt
@@ -7,6 +7,7 @@ import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.psi.stubs.StubIndex
 import com.intellij.usageView.UsageViewTypeLocation
 import com.intellij.util.Processor
+import com.intellij.util.concurrency.annotations.RequiresReadLock
 import org.elixir_lang.psi.call.Call
 import org.elixir_lang.psi.call.name.Function
 import org.elixir_lang.psi.impl.call.finalArguments
@@ -17,6 +18,7 @@ import org.elixir_lang.structure_view.element.CallDefinitionClause
 import org.elixir_lang.structure_view.element.modular.Modular
 
 object Implementation {
+    @RequiresReadLock
     @JvmStatic
     fun `is`(call: Call): Boolean {
         return call.isCallingMacro(org.elixir_lang.psi.call.name.Module.KERNEL, Function.DEFIMPL, 2) ||
@@ -27,6 +29,7 @@ object Implementation {
      * @return `null` if protocol or module for the implementation cannot be derived or if the `for` argument is a
      * list.
      */
+    @RequiresReadLock
     fun name(call: Call): String? = nameCollection(CallDefinitionClause.enclosingModular(call), call)?.singleOrNull()
 
     private fun nameCollection(enclosingModular: Modular?, call: Call): Collection<String>? {
@@ -53,6 +56,7 @@ object Implementation {
     private fun forNameCollection(forNameElement: ElixirList): Collection<String> =
         forNameCollection(forNameElement.children)
 
+    @RequiresReadLock
     fun forNameCollection(forNameElement: PsiElement): Collection<String>? = when (forNameElement) {
         is ElixirAccessExpression -> forNameCollection(forNameElement)
         is ElixirList -> forNameCollection(forNameElement)
@@ -70,6 +74,7 @@ object Implementation {
     private fun forNameCollection(forNameElement: QualifiableAlias): Collection<String>? =
         forNameElement.name?.let { listOf(it) }
 
+    @RequiresReadLock
     fun forNameCollection(enclosingModular: Modular?, call: Call): Collection<String>? {
         val forNameElement = forNameElement(call)
         return when {
@@ -85,6 +90,7 @@ object Implementation {
         }
     }
 
+    @RequiresReadLock
     fun forNameElement(call: Call): PsiElement? =
         call.finalArguments()?.lastOrNull()?.let { it as? QuotableKeywordList }?.keywordValue(Function.FOR)
 
@@ -105,9 +111,11 @@ object Implementation {
         }
     }
 
+    @RequiresReadLock
     @JvmStatic
     fun protocolName(call: Call): String? = protocolNameElement(call)?.let { protocolName(it) }
 
+    @RequiresReadLock
     fun protocolNameElement(call: Call): QualifiableAlias? {
         val finalArguments = call.finalArguments()
 

--- a/src/org/elixir_lang/psi/Module.kt
+++ b/src/org/elixir_lang/psi/Module.kt
@@ -5,9 +5,11 @@ import com.intellij.openapi.util.Computable
 import org.elixir_lang.psi.call.Call
 import org.elixir_lang.psi.call.name.Function
 import org.elixir_lang.psi.call.name.Module
+import com.intellij.util.concurrency.annotations.RequiresReadLock
 import org.jetbrains.annotations.Contract
 
 object Module {
+    @RequiresReadLock
     @JvmStatic
     fun `is`(call: Call): Boolean =
             (call.isCallingMacro(Module.KERNEL, Function.DEFMODULE, 2) &&
@@ -25,6 +27,7 @@ object Module {
                             }) != true) ||
                     call.isCalling(Module.MODULE, Function.CREATE, 3)
 
+    @RequiresReadLock
     @Contract(pure = true)
     fun name(call: Call): String = call.primaryArguments()!!.first()!!.text
 }

--- a/src/org/elixir_lang/psi/Protocol.kt
+++ b/src/org/elixir_lang/psi/Protocol.kt
@@ -6,6 +6,7 @@ import com.intellij.psi.ResolveState
 import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.psi.stubs.StubIndex
 import com.intellij.util.Processor
+import com.intellij.util.concurrency.annotations.RequiresReadLock
 import org.elixir_lang.beam.psi.impl.CallDefinitionImpl
 import org.elixir_lang.beam.psi.impl.ModuleImpl
 import org.elixir_lang.beam.psi.stubs.ModuleStub
@@ -15,6 +16,7 @@ import org.elixir_lang.psi.call.name.Function
 import org.elixir_lang.psi.stub.index.ImplementedProtocolName
 
 object Protocol {
+    @RequiresReadLock
     @JvmStatic
     fun `is`(call: Call): Boolean =
         call.isCallingMacro(org.elixir_lang.psi.call.name.Module.KERNEL, Function.DEFPROTOCOL, 2)

--- a/src/org/elixir_lang/psi/impl/ElixirPsiImplUtil.java
+++ b/src/org/elixir_lang/psi/impl/ElixirPsiImplUtil.java
@@ -8,6 +8,7 @@ import com.intellij.navigation.ItemPresentation;
 import com.intellij.openapi.util.Key;
 import com.intellij.psi.*;
 import com.intellij.psi.scope.PsiScopeProcessor;
+import com.intellij.util.concurrency.annotations.RequiresReadLock;
 import com.intellij.psi.search.SearchScope;
 import com.intellij.psi.tree.IElementType;
 import com.intellij.psi.tree.TokenSet;
@@ -227,12 +228,14 @@ public class ElixirPsiImplUtil {
         return DigitsImpl.inBase(digits);
     }
 
+    @RequiresReadLock
     public static boolean isCalling(@NotNull final Call call,
                                     @NotNull final String resolvedModuleName,
                                     @NotNull final String functionName) {
         return CallImpl.isCalling(call, resolvedModuleName, functionName);
     }
 
+    @RequiresReadLock
     public static boolean isCalling(@NotNull final Call call,
                                     @NotNull final String resolvedModuleName,
                                     @NotNull final String functionName,
@@ -240,12 +243,14 @@ public class ElixirPsiImplUtil {
         return CallImpl.isCalling(call, resolvedModuleName, functionName, resolvedFinalArity);
     }
 
+    @RequiresReadLock
     public static boolean isCallingMacro(@NotNull final Call call,
                                          @NotNull final String resolvedModuleName,
                                          @NotNull final String functionName) {
         return CallImpl.isCallingMacro(call, resolvedModuleName, functionName);
     }
 
+    @RequiresReadLock
     @Contract(pure = true)
     public static boolean isCallingMacro(@NotNull final Call call,
                                          @NotNull final String resolvedModuleName,
@@ -357,6 +362,7 @@ public class ElixirPsiImplUtil {
         return CallImpl.moduleName(unqualified);
     }
 
+    @RequiresReadLock
     @Contract(pure = true)
     @NotNull
     public static String moduleName(@NotNull final Qualified qualified) {
@@ -537,18 +543,21 @@ public class ElixirPsiImplUtil {
         return siblingExpression(element, PREVIOUS_SIBLING);
     }
 
+    @RequiresReadLock
     @Contract(pure = true)
     @NotNull
     public static PsiElement[] primaryArguments(@NotNull final DotCall dotCall) {
         return CallImpl.primaryArguments(dotCall);
     }
 
+    @RequiresReadLock
     @Contract(pure = true)
     @NotNull
     public static PsiElement[] primaryArguments(@NotNull final Infix infix) {
         return CallImpl.primaryArguments(infix);
     }
 
+    @RequiresReadLock
     @Contract(pure = true)
     @NotNull
     public static PsiElement[] primaryArguments(
@@ -563,30 +572,35 @@ public class ElixirPsiImplUtil {
         return CallImpl.primaryArguments(none);
     }
 
+    @RequiresReadLock
     @Contract(pure = true)
     @NotNull
     public static PsiElement[] primaryArguments(@NotNull final NotIn notIn) {
         return CallImpl.primaryArguments(notIn);
     }
 
+    @RequiresReadLock
     @Contract(pure = true)
     @NotNull
     public static PsiElement[] primaryArguments(@NotNull final NoParenthesesOneArgument noParenthesesOneArgument) {
         return CallImpl.primaryArguments(noParenthesesOneArgument);
     }
 
+    @RequiresReadLock
     @Contract(pure = true)
     @NotNull
     public static PsiElement[] primaryArguments(@NotNull final Parentheses parentheses) {
         return CallImpl.primaryArguments(parentheses);
     }
 
+    @RequiresReadLock
     @Contract(pure = true)
     @NotNull
     public static PsiElement[] primaryArguments(@NotNull final Prefix prefix) {
         return CallImpl.primaryArguments(prefix);
     }
 
+    @RequiresReadLock
     @Contract(pure = true)
     @Nullable
     public static Integer primaryArity(@NotNull final Call call) {
@@ -816,6 +830,7 @@ public class ElixirPsiImplUtil {
         return QualifiableAliasImpl.fullyQualifiedName(qualifiableAlias);
     }
 
+    @RequiresReadLock
     @Contract(pure = true)
     @Nullable
     public static String functionName(@NotNull final Call call) {
@@ -842,18 +857,21 @@ public class ElixirPsiImplUtil {
         return CallImpl.functionNameElement(notIn);
     }
 
+    @RequiresReadLock
     @Contract(pure = true)
     @NotNull
     public static PsiElement functionNameElement(@NotNull final Operation operation) {
         return CallImpl.functionNameElement(operation);
     }
 
+    @RequiresReadLock
     @Contract(pure = true)
     @NotNull
     public static PsiElement functionNameElement(@NotNull final Qualified qualified) {
         return CallImpl.functionNameElement(qualified);
     }
 
+    @RequiresReadLock
     @Contract(pure = true)
     @NotNull
     public static PsiElement functionNameElement(@NotNull final Unqualified unqualified) {
@@ -1071,10 +1089,12 @@ public class ElixirPsiImplUtil {
         return AtNonNumericOperationImplKt.getReference(atNonNumericOperation);
     }
 
+    @RequiresReadLock
     public static boolean hasDoBlockOrKeyword(@NotNull final Call call) {
         return CallImpl.hasDoBlockOrKeyword(call);
     }
 
+    @RequiresReadLock
     public static boolean hasDoBlockOrKeyword(@NotNull final StubBased<Stub> stubBased) {
         return CallImpl.hasDoBlockOrKeyword(stubBased);
     }
@@ -1498,16 +1518,19 @@ public class ElixirPsiImplUtil {
         return ParentImpl.quoteLiteral(codePointList);
     }
 
+    @RequiresReadLock
     @Contract(pure = true)
     public static int resolvedFinalArity(@NotNull Call call) {
         return CallImpl.resolvedFinalArity(call);
     }
 
+    @RequiresReadLock
     @Contract(pure = true)
     public static int resolvedFinalArity(@NotNull org.elixir_lang.psi.call.StubBased<Stub> stubBased) {
         return CallImpl.resolvedFinalArity(stubBased);
     }
 
+    @RequiresReadLock
     @Contract(pure = true)
     @NotNull
     public static ArityInterval resolvedFinalArityInterval(@NotNull Call call) {
@@ -1544,6 +1567,7 @@ public class ElixirPsiImplUtil {
         return CallImpl.resolvedModuleName(prefix);
     }
 
+    @RequiresReadLock
     @NotNull
     public static String resolvedModuleName(@NotNull org.elixir_lang.psi.call.qualification.Qualified qualified) {
         return CallImpl.resolvedModuleName(qualified);
@@ -1560,12 +1584,14 @@ public class ElixirPsiImplUtil {
         return CallImpl.resolvedModuleName(unqualifiedNoArgumentsCall);
     }
 
+    @RequiresReadLock
     @Contract(pure = true)
     @Nullable
     public static Integer resolvedPrimaryArity(@NotNull Call call) {
         return CallImpl.resolvedPrimaryArity(call);
     }
 
+    @RequiresReadLock
     @Contract(pure = true)
     @Nullable
     public static Integer resolvedSecondaryArity(@NotNull Call call) {
@@ -1590,6 +1616,7 @@ public class ElixirPsiImplUtil {
         return org.elixir_lang.psi.operation.not_in.Normalized.rightOperand(notIn);
     }
 
+    @RequiresReadLock
     @Contract(pure = true)
     @Nullable
     public static PsiElement[] secondaryArguments(@NotNull DotCall dotCall) {
@@ -1620,6 +1647,7 @@ public class ElixirPsiImplUtil {
         return CallImpl.secondaryArguments(noParentheses);
     }
 
+    @RequiresReadLock
     @Contract(pure = true)
     @Nullable
     public static PsiElement[] secondaryArguments(@NotNull Parentheses parentheses) {
@@ -1632,6 +1660,7 @@ public class ElixirPsiImplUtil {
         return CallImpl.secondaryArguments(prefix);
     }
 
+    @RequiresReadLock
     @Contract(pure = true)
     @Nullable
     public static Integer secondaryArity(@NotNull Call call) {

--- a/src/org/elixir_lang/psi/impl/PsiElementImpl.kt
+++ b/src/org/elixir_lang/psi/impl/PsiElementImpl.kt
@@ -23,8 +23,10 @@ import org.elixir_lang.psi.operation.Pipe
 import org.elixir_lang.psi.scope.WhileIn.whileIn
 import org.elixir_lang.util.AccumulatorContinue
 import org.elixir_lang.util.foldWhile
+import com.intellij.util.concurrency.annotations.RequiresReadLock
 import org.jetbrains.annotations.Contract
 
+@RequiresReadLock
 fun PsiElement.ancestorSequence() = generateSequence(this) { it.parent }
 fun PsiElement.document(): Document? = containingFile.viewProvider.let { viewProvider ->
     runReadAction {
@@ -32,6 +34,7 @@ fun PsiElement.document(): Document? = containingFile.viewProvider.let { viewPro
     }
 }
 
+@RequiresReadLock
 tailrec fun PsiElement.selfOrEnclosingMacroCall(): Call? =
     when (this) {
         is ElixirDoBlock ->
@@ -115,6 +118,7 @@ tailrec fun PsiElement.selfOrEnclosingMacroCall(): Call? =
 /**
  * @return `null` if this element is at top-level
  */
+@RequiresReadLock
 @Contract(pure = true)
 fun PsiElement.enclosingMacroCall(): Call? = parent.selfOrEnclosingMacroCall()
 
@@ -128,6 +132,7 @@ private val isModuleName = { c: PsiElement -> c is MaybeModuleName && c.isModule
 fun PsiElement.isInsideModule(): Boolean =
     findParentInFile(withSelf = true) { e -> e.children.any(isModuleName) } != null
 
+@RequiresReadLock
 fun PsiElement.getModuleName(): String? {
     // findParentInFile stops at PsiFile boundary, never touches PsiDirectory - avoids DiskQueryRelay VFS I/O
     return findParentInFile(withSelf = true) { e ->
@@ -174,6 +179,7 @@ fun <R> PsiElement.foldChildrenWhile(
             AccumulatorContinue(initial, true)
     }
 
+@RequiresReadLock
 fun PsiElement.macroChildCallList(): MutableList<Call> {
     val callList: MutableList<Call>
 

--- a/src/org/elixir_lang/psi/impl/PsiNamedElementImpl.kt
+++ b/src/org/elixir_lang/psi/impl/PsiNamedElementImpl.kt
@@ -8,17 +8,21 @@ import org.elixir_lang.module.RegisterAttribute
 import org.elixir_lang.psi.*
 import org.elixir_lang.psi.call.Call
 import org.elixir_lang.psi.call.name.Function.UNQUOTE
+import com.intellij.util.concurrency.annotations.RequiresReadLock
 import org.jetbrains.annotations.Contract
 
 object PsiNamedElementImpl {
+    @RequiresReadLock
     @JvmStatic
     fun getName(alias: ElixirAlias): String {
         return alias.text
     }
 
+    @RequiresReadLock
     @JvmStatic
     fun getName(qualifiedAlias: QualifiedAlias): String = qualifiedAlias.text
 
+    @RequiresReadLock
     @JvmStatic
     fun getName(atom: ElixirAtom): String? =
         if (atom.line == null) {
@@ -27,6 +31,7 @@ object PsiNamedElementImpl {
             null
         }
 
+    @RequiresReadLock
     @Contract(pure = true)
     @JvmStatic
     fun getName(namedElement: NamedElement): String? =

--- a/src/org/elixir_lang/psi/impl/call/CallImpl.kt
+++ b/src/org/elixir_lang/psi/impl/call/CallImpl.kt
@@ -6,6 +6,7 @@ import com.intellij.psi.PsiReference
 import com.intellij.psi.tree.TokenSet
 import com.intellij.psi.util.CachedValueProvider
 import com.intellij.psi.util.CachedValuesManager
+import com.intellij.util.concurrency.annotations.RequiresReadLock
 import org.elixir_lang.errorreport.Logger
 import org.elixir_lang.psi.*
 import org.elixir_lang.psi.call.Call
@@ -37,6 +38,7 @@ import org.elixir_lang.psi.operation.Normalized as OperationNormalized
 import org.elixir_lang.psi.operation.infix.Normalized as InfixNormalized
 import org.elixir_lang.psi.operation.not_in.Normalized as NotInNormalized
 
+@RequiresReadLock
 fun Call.computeReference(): PsiReference? =
     /* if the call is just the identifier for a module attribute reference, then don't return a Callable reference,
            and instead let {@link #getReference(AtNonNumericOperation) handle it */
@@ -145,6 +147,7 @@ private fun Call.computeCallableReference(): PsiReference? =
  *
  * @return [Call.primaryArguments]
  */
+@RequiresReadLock
 fun Call.finalArguments(): Array<PsiElement>? = try {
     (secondaryArguments() ?: primaryArguments())?.map { it!! }?.toTypedArray()
 } catch (_: NullPointerException) {
@@ -165,6 +168,7 @@ fun Call.getReference(): PsiReference? =
  * @return the keyword value `PsiElement` if `call` has [ElixirPsiImplUtil.keywordArguments]
  * and there is a [] for `keywordKeyText`.
  */
+@RequiresReadLock
 fun Call.keywordArgument(keywordKeyText: String): PsiElement? = keywordArguments()?.keywordValue(keywordKeyText)
 
 /**
@@ -173,6 +177,7 @@ fun Call.keywordArgument(keywordKeyText: String): PsiElement? = keywordArguments
  * @return the final element of the [ElixirPsiImplUtil.finalArguments] of `` if they are a
  * [QuotableKeywordList]; otherwise, `null`.
  */
+@RequiresReadLock
 fun Call.keywordArguments(): QuotableKeywordList? {
     val finalArguments = this.finalArguments()
     var keywordArguments: QuotableKeywordList? = null
@@ -206,12 +211,14 @@ fun Call.keywordArguments(): QuotableKeywordList? {
     return keywordArguments
 }
 
+@RequiresReadLock
 fun Call.macroChildCalls(): Array<Call> {
     val childCallList = macroChildCallList()
 
     return childCallList.toTypedArray()
 }
 
+@RequiresReadLock
 fun <R> Call.foldChildrenWhile(
     initial: R,
     operation: (PsiElement, acc: R) -> AccumulatorContinue<R>
@@ -257,6 +264,7 @@ fun <R> Call.foldChildrenWhile(
     } ?: AccumulatorContinue(initial, true)
 }
 
+@RequiresReadLock
 fun Call.macroChildCallList(): List<Call> {
     var childCallList: List<Call>? = null
     val doBlock = doBlock
@@ -305,8 +313,10 @@ fun Call.macroChildCallList(): List<Call> {
     return childCallList
 }
 
+@RequiresReadLock
 fun Call.macroChildCallSequence(): Sequence<Call> = this.macroChildCallList().asSequence()
 
+@RequiresReadLock
 @Contract(pure = true)
 fun Call.macroDefinitionClauseForArgument(): Call? {
     var macroDefinitionClause: Call? = null
@@ -329,6 +339,7 @@ fun Call.macroDefinitionClauseForArgument(): Call? {
     return macroDefinitionClause
 }
 
+@RequiresReadLock
 fun Call.maybeModularNameToModulars(useCall: Call? = null): Set<PsiNamedElement> =
     if (isCalling(KERNEL, __MODULE__, 0)) {
         org.elixir_lang.psi.__MODULE__
@@ -338,6 +349,7 @@ fun Call.maybeModularNameToModulars(useCall: Call? = null): Set<PsiNamedElement>
         emptySet()
     }
 
+@RequiresReadLock
 fun Call.whileInStabBodyChildExpressions(
     forward: Boolean = true,
     keepProcessing: (childExpression: PsiElement) -> Boolean
@@ -346,6 +358,7 @@ fun Call.whileInStabBodyChildExpressions(
         ?.let { whileIn(it, keepProcessing) }
         ?: true
 
+@RequiresReadLock
 fun Call.stabBodyChildExpressions(forward: Boolean = true): Sequence<PsiElement>? =
     doBlock
         ?.stab
@@ -353,6 +366,7 @@ fun Call.stabBodyChildExpressions(forward: Boolean = true): Sequence<PsiElement>
         ?.childExpressions(forward)
 
 object CallImpl {
+    @RequiresReadLock
     @Contract(pure = true)
     @JvmStatic
     fun functionName(call: Call): String? =
@@ -379,13 +393,16 @@ object CallImpl {
     @JvmStatic
     fun functionNameElement(@Suppress("UNUSED_PARAMETER") notIn: NotIn): PsiElement? = null
 
+    @RequiresReadLock
     @Contract(pure = true)
     @JvmStatic
     fun functionNameElement(operation: Operation): PsiElement = operation.operator()
 
+    @RequiresReadLock
     @JvmStatic
     fun functionNameElement(qualified: Qualified): PsiElement = qualified.relativeIdentifier
 
+    @RequiresReadLock
     @Contract(pure = true)
     @JvmStatic
     fun functionNameElement(unqualified: Unqualified): PsiElement = unqualified.firstChild
@@ -410,10 +427,12 @@ object CallImpl {
     @JvmStatic
     fun getDoBlock(@Suppress("UNUSED_PARAMETER") matchedCall: MatchedCall): ElixirDoBlock? = null
 
+    @RequiresReadLock
     @JvmStatic
     fun hasDoBlockOrKeyword(call: Call): Boolean =
         call.doBlock != null || call.keywordArgument("do") != null
 
+    @RequiresReadLock
     @JvmStatic
     fun hasDoBlockOrKeyword(stubBased: StubBased<Stub<*>>): Boolean =
         stubBased.stub?.hasDoBlockOrKeyword() ?: hasDoBlockOrKeyword(stubBased as Call)
@@ -428,6 +447,7 @@ object CallImpl {
      * `resolvedModuleName` and has non-`null` [Call.functionName] that equals
      * `functionName`; otherwise, `false`.
      */
+    @RequiresReadLock
     @JvmStatic
     fun isCalling(
         call: Call,
@@ -453,6 +473,7 @@ object CallImpl {
      * `resolvedModuleName` and has non-`null` [Call.functionName] that equals
      * `functionName` and the [Call.resolvedFinalArity]; otherwise, `false`.
      */
+    @RequiresReadLock
     @JvmStatic
     fun isCalling(
         call: Call,
@@ -475,6 +496,7 @@ object CallImpl {
      * @param functionName       the expected [Call.functionName]
      * @return `true` if all arguments match and [Call.getDoBlock] is not `null`; `false`.
      */
+    @RequiresReadLock
     @JvmStatic
     fun isCallingMacro(
         call: Call,
@@ -497,6 +519,7 @@ object CallImpl {
      * @param resolvedFinalArity the expected [Call.resolvedFinalArity]
      * @return `true` if all arguments match and [Call.getDoBlock] is not `null`; `false`.
      */
+    @RequiresReadLock
     @Contract(pure = true)
     @JvmStatic
     fun isCallingMacro(
@@ -536,14 +559,17 @@ object CallImpl {
     fun moduleName(@Suppress("UNUSED_PARAMETER") unqualified: Unqualified): String? = null
 
     // TODO handle more complex qualifiers besides Aliases
+    @RequiresReadLock
     @Contract(pure = true)
     @JvmStatic
     fun moduleName(qualified: Qualified): String = qualified.firstChild.text
 
+    @RequiresReadLock
     @Contract(pure = true)
     @JvmStatic
     fun primaryArguments(dotCall: DotCall<*>): Array<PsiElement> = dotCall.parenthesesArgumentsList[0].arguments()
 
+    @RequiresReadLock
     @Contract(pure = true)
     @JvmStatic
     fun primaryArguments(infix: Infix): Array<PsiElement> {
@@ -567,6 +593,7 @@ object CallImpl {
         }
     }
 
+    @RequiresReadLock
     @Contract(pure = true)
     @JvmStatic
     fun primaryArguments(unqualifiedNoParenthesesManyArgumentsCall: ElixirUnqualifiedNoParenthesesManyArgumentsCall): Array<PsiElement> {
@@ -590,6 +617,7 @@ object CallImpl {
     @JvmStatic
     fun primaryArguments(@Suppress("UNUSED_PARAMETER") none: None): Array<PsiElement>? = null
 
+    @RequiresReadLock
     @Contract(pure = true)
     @JvmStatic
     fun primaryArguments(notIn: NotIn): Array<PsiElement> {
@@ -609,11 +637,13 @@ object CallImpl {
         }
     }
 
+    @RequiresReadLock
     @Contract(pure = true)
     @JvmStatic
     fun primaryArguments(noParenthesesOneArgument: NoParenthesesOneArgument): Array<PsiElement> =
         noParenthesesOneArgument.noParenthesesOneArgument.arguments()
 
+    @RequiresReadLock
     @Contract(pure = true)
     @JvmStatic
     fun primaryArguments(parentheses: Parentheses): Array<PsiElement> {
@@ -624,6 +654,7 @@ object CallImpl {
         return primaryParenthesesArguments.arguments()
     }
 
+    @RequiresReadLock
     @Contract(pure = true)
     @JvmStatic
     fun primaryArguments(prefix: Prefix): Array<PsiElement> =
@@ -632,10 +663,12 @@ object CallImpl {
             ?.let { arrayOf(it) }
             ?: emptyArray()
 
+    @RequiresReadLock
     @Contract(pure = true)
     @JvmStatic
     fun primaryArity(call: Call): Int? = call.primaryArguments()?.size
 
+    @RequiresReadLock
     @Contract(pure = true)
     @JvmStatic
     fun secondaryArguments(dotCall: DotCall<*>): Array<PsiElement>? {
@@ -665,6 +698,7 @@ object CallImpl {
     @JvmStatic
     fun secondaryArguments(@Suppress("UNUSED_PARAMETER") noParentheses: NoParentheses): Array<PsiElement>? = null
 
+    @RequiresReadLock
     @Contract(pure = true)
     @JvmStatic
     fun secondaryArguments(parentheses: Parentheses): Array<PsiElement>? {
@@ -683,6 +717,7 @@ object CallImpl {
     @JvmStatic
     fun secondaryArguments(@Suppress("UNUSED_PARAMETER") prefix: Prefix): Array<PsiElement>? = null
 
+    @RequiresReadLock
     @Contract(pure = true)
     @JvmStatic
     fun secondaryArity(call: Call): Int? = call.secondaryArguments()?.size
@@ -713,6 +748,7 @@ object CallImpl {
     @JvmStatic
     fun resolvedModuleName(@Suppress("UNUSED_PARAMETER") prefix: Prefix): String = KERNEL
 
+    @RequiresReadLock
     @Suppress("UNCHECKED_CAST")
     @JvmStatic
     fun resolvedModuleName(qualified: org.elixir_lang.psi.call.qualification.Qualified): String =
@@ -730,6 +766,7 @@ object CallImpl {
         @Suppress("UNUSED_PARAMETER") unqualifiedNoArgumentsCall: UnqualifiedNoArgumentsCall<*>
     ): String = KERNEL
 
+    @RequiresReadLock
     @Contract(pure = true)
     @JvmStatic
     fun resolvedPrimaryArity(call: Call): Int? {
@@ -760,20 +797,24 @@ object CallImpl {
         return resolvedPrimaryArity
     }
 
+    @RequiresReadLock
     @Contract(pure = true)
     @JvmStatic
     fun resolvedFinalArity(call: Call): Int = call.resolvedSecondaryArity() ?: call.resolvedPrimaryArity() ?: 0
 
+    @RequiresReadLock
     @Contract(pure = true)
     @JvmStatic
     fun resolvedFinalArity(stubBased: StubBased<Stub<*>>): Int =
         stubBased.stub?.resolvedFinalArity() ?: resolvedFinalArity(stubBased as Call)
 
+    @RequiresReadLock
     @Contract(pure = true)
     @JvmStatic
     fun resolvedFinalArityInterval(call: Call): ArityInterval =
         call.finalArguments().let { ArityInterval.fromArguments(it) }
 
+    @RequiresReadLock
     @Contract(pure = true)
     @JvmStatic
     fun resolvedSecondaryArity(call: Call): Int? =

--- a/src/org/elixir_lang/psi/impl/call/CanonicallyNamedImpl.kt
+++ b/src/org/elixir_lang/psi/impl/call/CanonicallyNamedImpl.kt
@@ -6,9 +6,11 @@ import org.elixir_lang.psi.Implementation.forNameCollection
 import org.elixir_lang.psi.Module
 import org.elixir_lang.psi.Protocol
 import org.elixir_lang.psi.call.StubBased
+import com.intellij.util.concurrency.annotations.RequiresReadLock
 import org.elixir_lang.psi.stub.type.call.Stub.isModular
 
 object CanonicallyNamedImpl {
+    @RequiresReadLock
     fun canonicalName(stubBased: StubBased<*>): String? =
         if (isModular(stubBased)) {
             val canonicalNameSuffix = when {
@@ -38,6 +40,7 @@ object CanonicallyNamedImpl {
         }
 
 
+    @RequiresReadLock
     fun canonicalNameSet(stubBased: StubBased<*>): Set<String> =
         if (isModular(stubBased)) {
             val canonicalNameSuffixSet: Set<String> = if (Implementation.`is`(stubBased)) {


### PR DESCRIPTION
- Add `@RequiresReadLock` to methods that access PSI directly or transitively
- Enables the `ThreadingConcurrency` inspection to statically flag callers that don't hold the read lock
- No behavioural changes -- annotation-only

## What was NOT annotated (intentionally)

- Interface methods in `Call.java` -- generated PSI classes implement these; platform already calls them under the read lock. Annotating the interface creates false positives.
- Methods returning constants or `null` (e.g. `moduleName(Unqualified)`, `getDoBlock` overloads)
- Platform callbacks already called under read lock (`getReference`, `resolve`, `getLanguage`, `getPresentation`)
- Private methods
