### PR TITLE
Fix DevKit inspections (Rethrow ProcessCanceledException in spell checking Splitter/Fix intention preview for ConvertMatchToTypeOperation)

### DIFF
--- a/src/org/elixir_lang/inspection/MatchOperatorInsteadOfTypeOperator.kt
+++ b/src/org/elixir_lang/inspection/MatchOperatorInsteadOfTypeOperator.kt
@@ -58,7 +58,7 @@ class MatchOperatorInsteadOfTypeOperator : LocalInspectionTool() {
                                             relativeStart + nodeTextLength
                                     )
 
-                                    val localQuickFix = ConvertMatchToTypeOperation(astNode)
+                                    val localQuickFix = ConvertMatchToTypeOperation()
 
                                     problemsHolder.registerProblem(
                                             operator,

--- a/src/org/elixir_lang/local_quick_fix/ConvertMatchToTypeOperation.java
+++ b/src/org/elixir_lang/local_quick_fix/ConvertMatchToTypeOperation.java
@@ -6,19 +6,11 @@ import com.intellij.lang.ASTNode;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.TextRange;
 import com.intellij.psi.text.BlockSupport;
+import org.elixir_lang.psi.Operator;
+import org.elixir_lang.psi.impl.OperatorImplKt;
 import org.jetbrains.annotations.NotNull;
 
 public class ConvertMatchToTypeOperation implements LocalQuickFix {
-    @NotNull
-    private final ASTNode matchOperatorASTNode;
-
-    /*
-     * Constructors
-     */
-
-    public ConvertMatchToTypeOperation(@NotNull ASTNode matchOperatorASTNode) {
-        this.matchOperatorASTNode = matchOperatorASTNode;
-    }
 
     /*
      * Instance Methods
@@ -32,6 +24,7 @@ public class ConvertMatchToTypeOperation implements LocalQuickFix {
      */
     @Override
     public void applyFix(@NotNull Project project, @NotNull ProblemDescriptor descriptor) {
+        ASTNode matchOperatorASTNode = OperatorImplKt.operatorTokenNode((Operator) descriptor.getPsiElement());
         BlockSupport blockSupport = BlockSupport.getInstance(project);
         TextRange textRange = matchOperatorASTNode.getTextRange();
         blockSupport.reparseRange(

--- a/src/org/elixir_lang/spell_checking/Splitter.kt
+++ b/src/org/elixir_lang/spell_checking/Splitter.kt
@@ -1,6 +1,5 @@
 package org.elixir_lang.spell_checking
 
-import com.intellij.openapi.progress.ProcessCanceledException
 import com.intellij.openapi.util.TextRange
 import com.intellij.openapi.util.text.StringUtil
 import com.intellij.spellchecker.inspections.BaseSplitter
@@ -16,19 +15,15 @@ open class Splitter : BaseSplitter() {
     protected open fun wordTextRanges(text: String, range: TextRange): List<TextRange> {
         val startOffset = range.startOffset
 
-        return try {
-                range
-                        .substring(text)
-                        .let { StringUtil.newBombedCharSequence(it, 500) }
-                        .let { WORD_REGEX.findAll(it) }
-                        .toList()
-                        .map { matchResult ->
-                            val matchResultRange = matchResult.range
+        return range
+            .substring(text)
+            .let { StringUtil.newBombedCharSequence(it, 500) }
+            .let { WORD_REGEX.findAll(it) }
+            .toList()
+            .map { matchResult ->
+                val matchResultRange = matchResult.range
 
-                            TextRange(startOffset + matchResultRange.first, startOffset + matchResultRange.last + 1)
-                        }
-            } catch (processCanceledException: ProcessCanceledException) {
-                listOf(range)
+                TextRange(startOffset + matchResultRange.first, startOffset + matchResultRange.last + 1)
             }
     }
 }


### PR DESCRIPTION
- Rethrow ProcessCanceledException in spell checking Splitter
- Fix intention preview for ConvertMatchToTypeOperation