### PR TITLE
fix: multi-module project-SDK assumption fixes and umbrella sub-app folder marks

### DIFF
--- a/src/org/elixir_lang/action/ReconfigureModuleSetupAction.kt
+++ b/src/org/elixir_lang/action/ReconfigureModuleSetupAction.kt
@@ -67,6 +67,12 @@ class ReconfigureModuleSetupAction : AnAction() {
         var sdksFixed = 0
 
         WriteCommandAction.runWriteCommandAction(project, "Reconfigure Elixir Modules", null, {
+            // Collect all content entry URLs upfront so umbrella sub-app detection can skip
+            // sub-apps that are already covered by their own content entry.
+            val allContentEntryUrls: Set<String> = ModuleManager.getInstance(project).modules
+                .flatMap { ModuleRootManager.getInstance(it).contentEntries.map { ce -> ce.url } }
+                .toSet()
+
             for (module in ModuleManager.getInstance(project).modules) {
                 val rootManager = ModuleRootManager.getInstance(module)
                 val model = rootManager.modifiableModel
@@ -85,6 +91,14 @@ class ReconfigureModuleSetupAction : AnAction() {
                     val added = addMissingFolderMarks(contentEntry, root)
                     if (added > 0) {
                         foldersAdded += added
+                        moduleChanged = true
+                    }
+
+                    // Also apply marks for umbrella sub-apps that are not already covered by
+                    // their own content entry.
+                    val umbrellaAdded = addMissingUmbrellaSubAppFolderMarks(contentEntry, root, allContentEntryUrls)
+                    if (umbrellaAdded > 0) {
+                        foldersAdded += umbrellaAdded
                         moduleChanged = true
                     }
                 }
@@ -117,7 +131,47 @@ class ReconfigureModuleSetupAction : AnAction() {
      * to [contentEntry] by URL (even if the backing directory does not yet exist on disk).
      * Returns the number of marks added.
      */
-    private fun addMissingFolderMarks(contentEntry: ContentEntry, root: VirtualFile): Int {
+    private fun addMissingFolderMarks(contentEntry: ContentEntry, root: VirtualFile): Int =
+        applyCanonicalMarksForBaseUrl(contentEntry, root.url)
+
+    /**
+     * Scans the `apps/` directory under [root] for umbrella sub-apps that are NOT already
+     * covered by their own content entry (i.e. whose URL is absent from [allContentEntryUrls]),
+     * and additively applies missing canonical folder marks for each such sub-app on [contentEntry].
+     *
+     * Returns the total number of marks added across all discovered sub-apps.
+     */
+    private fun addMissingUmbrellaSubAppFolderMarks(
+        contentEntry: ContentEntry,
+        root: VirtualFile,
+        allContentEntryUrls: Set<String>,
+    ): Int {
+        val appsDir = root.findChild("apps") ?: return 0
+
+        var added = 0
+
+        for (subAppDir in appsDir.children) {
+            if (!subAppDir.isDirectory) continue
+            if (subAppDir.findChild("mix.exs") == null) continue
+
+            // Skip sub-apps already covered by their own content entry.
+            if (subAppDir.url in allContentEntryUrls) continue
+
+            added += applyCanonicalMarksForBaseUrl(contentEntry, "${root.url}/apps/${subAppDir.name}")
+        }
+
+        return added
+    }
+
+    /**
+     * Applies [CANONICAL_FOLDER_MARKS] to [contentEntry] for every canonical folder relative to
+     * [baseUrl].  Existing correct marks are left untouched; incorrect source marks are replaced;
+     * missing exclusions are added.  Returns the number of marks added or replaced.
+     *
+     * This is the single implementation shared by [addMissingFolderMarks] (top-level content root)
+     * and [addMissingUmbrellaSubAppFolderMarks] (umbrella sub-apps).
+     */
+    private fun applyCanonicalMarksForBaseUrl(contentEntry: ContentEntry, baseUrl: String): Int {
         val existingSourceUrls = contentEntry.sourceFolders.associate {
             it.url to if (it.isTestSource) FolderMark.TEST_SOURCES else FolderMark.SOURCES
         }
@@ -126,7 +180,7 @@ class ReconfigureModuleSetupAction : AnAction() {
         var added = 0
 
         for (canonical in CANONICAL_FOLDER_MARKS) {
-            val url = "${root.url}/${canonical.relativePath}"
+            val url = "$baseUrl/${canonical.relativePath}"
 
             when (canonical.folderMark) {
                 FolderMark.SOURCES, FolderMark.TEST_SOURCES -> {
@@ -138,8 +192,7 @@ class ReconfigureModuleSetupAction : AnAction() {
                                 .find { it.url == url }
                                 ?.let { contentEntry.removeSourceFolder(it) }
                         }
-                        val isTest = canonical.folderMark == FolderMark.TEST_SOURCES
-                        contentEntry.addSourceFolder(url, isTest)
+                        contentEntry.addSourceFolder(url, canonical.folderMark == FolderMark.TEST_SOURCES)
                         added++
                     }
                 }

--- a/src/org/elixir_lang/action/ReconfigureModuleSetupAction.kt
+++ b/src/org/elixir_lang/action/ReconfigureModuleSetupAction.kt
@@ -103,7 +103,7 @@ class ReconfigureModuleSetupAction : AnAction() {
                     }
                 }
 
-                if (hasRootMixExs && projectSdk != null) {
+                if (hasRootMixExs && projectSdk != null && projectSdk.sdkType is ElixirSdkType) {
                     if (fixModuleSdk(model, projectSdk)) {
                         sdksFixed++
                         moduleChanged = true

--- a/src/org/elixir_lang/beam/BulkDecompilation.kt
+++ b/src/org/elixir_lang/beam/BulkDecompilation.kt
@@ -23,6 +23,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.elixir_lang.errorreport.Logger
+import org.elixir_lang.sdk.elixir.Type
 
 class BulkDecompilation : AnAction() {
     override fun actionPerformed(event: AnActionEvent) {
@@ -36,25 +37,18 @@ class BulkDecompilation : AnAction() {
                     withContext(Dispatchers.Default) {
                         val sdkSet = mutableSetOf<Sdk>()
                         val psiManager = PsiManager.getInstance(project)
+                        val modules = ModuleManager.getInstance(project).modules
 
-                        data class ModuleInfo(val name: String, val sdk: Sdk?, val contentRoots: Array<VirtualFile>)
-
-                        val moduleInfos = readAction {
-                            ModuleManager.getInstance(project).modules.map { module ->
-                                val mrm = ModuleRootManager.getInstance(module)
-                                ModuleInfo(module.name, mrm.sdk, mrm.contentRoots)
-                            }
-                        }
-
-                        if (moduleInfos.isNotEmpty()) {
-                            reportSequentialProgress(moduleInfos.size) { reporter ->
-                                for (info in moduleInfos) {
-                                    reporter.itemStep("Module ${info.name}") {
+                        if (modules.isNotEmpty()) {
+                            reportSequentialProgress(modules.size) { reporter ->
+                                for (module in modules) {
+                                    reporter.itemStep("Module ${module.name}") {
                                         ProgressManager.checkCanceled()
 
-                                        info.sdk?.let { sdkSet.add(it) }
+                                        val moduleRootManager = ModuleRootManager.getInstance(module)
+                                        moduleRootManager.sdk?.let { sdkSet.add(it) }
 
-                                        for (contentRoot in info.contentRoots) {
+                                        for (contentRoot in moduleRootManager.contentRoots) {
                                             ProgressManager.checkCanceled()
                                             decompile(psiManager, contentRoot)
                                         }
@@ -63,9 +57,11 @@ class BulkDecompilation : AnAction() {
                             }
                         }
 
-                        readAction {
-                            ProjectRootManager.getInstance(project).projectSdk
-                        }?.let { sdkSet.add(it) }
+                        ProjectRootManager.getInstance(project).projectSdk?.let { sdk ->
+                            if (sdk.sdkType is Type) {
+                                sdkSet.add(sdk)
+                            }
+                        }
 
                         if (sdkSet.isNotEmpty()) {
                             reportSequentialProgress(sdkSet.size) { reporter ->

--- a/src/org/elixir_lang/beam/chunk/Code.kt
+++ b/src/org/elixir_lang/beam/chunk/Code.kt
@@ -190,10 +190,10 @@ class Code(private val operationList: List<Operation>) {
 
             val expectedMaxOpcode = org.elixir_lang.beam.chunk.code.operation.Code.values().max()?.number ?: 0
             if (maxOpcode > expectedMaxOpcode) {
-                LOGGER.error(
-                        "Max opcode ($maxOpcode) exceeds expected max opcode ($expectedMaxOpcode).  Additional " +
-                                "opcodes have been added to the end of " +
-                                "https://github.com/erlang/otp/blob/master/lib/compiler/src/genop.tab."
+                LOGGER.warn(
+                    "Max opcode ($maxOpcode) exceeds expected max opcode ($expectedMaxOpcode).  Additional " +
+                            "opcodes have been added to the end of " +
+                            "https://github.com/erlang/otp/blob/master/lib/compiler/src/genop.tab"
                 )
             }
 

--- a/src/org/elixir_lang/beam/chunk/code/operation/Code.kt
+++ b/src/org/elixir_lang/beam/chunk/code/operation/Code.kt
@@ -832,7 +832,77 @@ enum class Code(val number: Int, val function: String, val arguments: Array<Argu
     // @spec recv_marker_use Reference
     // @doc  Sets the current receive cursor to the marker associated with
     //       the given Reference
-    RECV_MARKER_USE(176, "recv_marker_user", arrayOf(REFERENCE));
+    RECV_MARKER_USE(176, "recv_marker_user", arrayOf(REFERENCE)),
+
+    // OTP 25
+
+    // @spec bs_create_bin Fail Alloc Live Unit Dst OpList
+    // @doc  Build a new binary using the binary syntax.
+    BS_CREATE_BIN(177, "bs_create_bin", SIX),
+
+    // @spec call_fun2 Tag Arity Func
+    // @doc  Calls the fun Func with arity Arity.
+    CALL_FUN2(178, "call_fun2", THREE),
+
+    // @spec nif_start
+    // @doc  No-op at start of each function declared in -nifs().
+    NIF_START(179, "nif_start"),
+
+    // @spec badrecord Value
+    // @doc  Raises a {badrecord,Value} error exception.
+    BADRECORD(180, "badrecord", ONE),
+
+    // OTP 26
+
+    // @spec update_record Hint Size Src Dst Updates
+    // @doc  Sets Dst to a copy of Src with the update list applied.
+    UPDATE_RECORD(181, "update_record", FIVE),
+
+    // @spec bs_match Fail Ctx Commands
+    // @doc  Match one or more binary segments of fixed size.
+    BS_MATCH(182, "bs_match", THREE),
+
+    // OTP 27
+
+    // @spec executable_line Location Index
+    // @doc  Provide location for an executable line.
+    EXECUTABLE_LINE(183, "executable_line", TWO),
+
+    // OTP 28
+
+    // @spec debug_line Kind Location Index Live
+    // @doc  Provide location for a place where a break point can be placed.
+    DEBUG_LINE(184, "debug_line", FOUR),
+
+    // OTP 29
+
+    // @spec bif3 Lbl Bif Arg1 Arg2 Arg3 Reg
+    // @doc  Call the bif Bif with the arguments Arg1, Arg2, and Arg3.
+    BIF3(185, "bif3", SIX),
+
+    // @spec is_any_native_record Lbl Term
+    // @doc  Check whether Term is a native record.
+    IS_ANY_NATIVE_RECORD(186, "is_any_native_record", UNARY),
+
+    // @spec is_native_record Lbl Rec Module Name
+    // @doc  Check whether record Rec is the record Name defined in module Module.
+    IS_NATIVE_RECORD(187, "is_native_record", FOUR),
+
+    // @spec get_record_elements Lbl Rec Elements
+    // @doc  Extract the values for each field name and store into the corresponding register.
+    GET_RECORD_ELEMENTS(188, "get_record_elements", THREE),
+
+    // @spec put_record Lbl Id Src Dst Live Updates
+    // @doc  Create (Src is nil) or update (Src is a register) a native record.
+    PUT_RECORD(189, "put_record", SIX),
+
+    // @spec is_record_accessible Lbl Rec Scope
+    // @doc  Check whether the fields of native record Rec are accessible from the executing module.
+    IS_RECORD_ACCESSIBLE(190, "is_record_accessible", THREE),
+
+    // @spec get_record_field Lbl Rec Id Field Dst
+    // @doc  Get a single field from a record.
+    GET_RECORD_FIELD(191, "get_record_field", FIVE);
 
     fun arity() = arguments.size
 }

--- a/src/org/elixir_lang/beam/chunk/code/operation/code/Argument.kt
+++ b/src/org/elixir_lang/beam/chunk/code/operation/code/Argument.kt
@@ -115,6 +115,8 @@ data class Argument(val name: String, val supportedOptions: Code.Options = Code.
                     else -> "literal($index)"
                 }
             }
+            is TypedRegister ->
+                "{tr, ${valueAssembly(term.register, cache, configuredOptions)}, ${valueAssembly(term.type, cache, configuredOptions)}}"
             is XRegister ->
                 "x(${term.index})"
             is YRegister ->

--- a/src/org/elixir_lang/beam/term/Term.kt
+++ b/src/org/elixir_lang/beam/term/Term.kt
@@ -61,6 +61,9 @@ sealed class Term {
                                 AllocationList.from(data, internalOffset, literalFloat)
                             0b1000 ->
                                 ExtendedLiteral.from(data, internalOffset, literalFloat)
+                            // OTP 25+: typed register {tr, Reg, Type} used by JIT-annotated operands
+                            0b1010 ->
+                                TypedRegister.from(data, internalOffset, literalFloat)
                             else ->
                                 throw IllegalArgumentException(
                                         "Extended tag ($extendedTag) is not properly shifted and masked"
@@ -381,6 +384,27 @@ class ExtendedLiteral: Term() {
             }
 
             return Pair(Literal(index), internalOffset - offset)
+        }
+    }
+}
+
+/**
+ * Typed register operand {tr, Reg, Type} introduced in OTP 25 for JIT type-annotated operands.
+ * Extended tag sub-type 5 (encoded as 0b1010 in the shifted-masked extended tag field).
+ * See https://github.com/erlang/otp/blob/main/lib/compiler/src/beam_disasm.erl
+ */
+class TypedRegister(val register: Term, val type: Term) : Term() {
+    companion object {
+        fun from(data: ByteArray, offset: Int, literalFloat: Boolean): Pair<TypedRegister, ByteCount> {
+            var internalOffset = offset
+
+            val (register, registerByteCount) = Term.from(data, internalOffset, literalFloat)
+            internalOffset += registerByteCount
+
+            val (type, typeByteCount) = Term.from(data, internalOffset, literalFloat)
+            internalOffset += typeByteCount
+
+            return Pair(TypedRegister(register, type), internalOffset - offset)
         }
     }
 }

--- a/src/org/elixir_lang/mix/project/ProjectModuleSetupValidator.kt
+++ b/src/org/elixir_lang/mix/project/ProjectModuleSetupValidator.kt
@@ -4,6 +4,7 @@ import com.intellij.openapi.module.ModuleManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.roots.ContentEntry
 import com.intellij.openapi.roots.ModuleRootManager
+import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.util.concurrency.ThreadingAssertions
 import org.elixir_lang.mixContentRoots
 
@@ -48,36 +49,98 @@ object ProjectModuleSetupValidator {
 
         val issues = mutableListOf<FolderMarkIssue>()
 
+        // Collect all content entry URLs across all modules so the umbrella scan can skip
+        // sub-apps that are already covered by their own content entry.
+        val allContentEntryUrls: Set<String> = ModuleManager.getInstance(project).modules
+            .flatMap { ModuleRootManager.getInstance(it).contentEntries.map { ce -> ce.url } }
+            .toSet()
+
         for (module in ModuleManager.getInstance(project).modules) {
             for (mixContentRoot in module.mixContentRoots()) {
                 val contentEntry = mixContentRoot.contentEntry
                 val root = mixContentRoot.root
                 val actualMarks = actualMarks(contentEntry)
-                for (canonical in CANONICAL_FOLDER_MARKS) {
-                    val url = "${root.url}/${canonical.relativePath}"
 
-                    val actualMark = actualMarks[url]
+                // --- Top-level canonical mark check ---
+                checkCanonicalMarks(module.name, root, "", actualMarks, issues)
 
-                    if (actualMark != canonical.folderMark) {
-                        // Only warn when the folder actually exists on disk (via VFS).
-                        // Non-existent folders with no mark are expected -- the reconfigure action
-                        // applies marks by URL so they're ready when the folder appears later.
-                        if (root.findFileByRelativePath(canonical.relativePath) == null) continue
-
-                        issues.add(
-                            FolderMarkIssue(
-                                moduleName = module.name,
-                                folderRelativePath = canonical.relativePath,
-                                folderMark = canonical.folderMark,
-                                currentState = actualMark?.displayName?.lowercase() ?: "unmarked",
-                            )
-                        )
-                    }
-                }
+                // --- Umbrella sub-app detection ---
+                // If this content root looks like an umbrella project (has an apps/ directory
+                // containing sub-apps with their own mix.exs), validate folder marks for any
+                // sub-app that is NOT already covered by its own content entry.
+                detectUmbrellaSubAppIssues(module.name, root, actualMarks, allContentEntryUrls, issues)
             }
         }
 
         return issues
+    }
+
+    /**
+     * Scans the `apps/` directory under [root] for umbrella sub-apps and adds [FolderMarkIssue]s
+     * for any sub-app whose folders are not correctly marked (as reflected by [actualMarks]).
+     *
+     * Sub-apps whose directory URL is already present in [allContentEntryUrls] are skipped because
+     * they are validated independently via the standard per-content-entry loop.
+     */
+    private fun detectUmbrellaSubAppIssues(
+        moduleName: String,
+        root: VirtualFile,
+        actualMarks: Map<String, FolderMark>,
+        allContentEntryUrls: Set<String>,
+        issues: MutableList<FolderMarkIssue>,
+    ) {
+        val appsDir = root.findChild("apps") ?: return
+
+        for (subAppDir in appsDir.children) {
+            if (!subAppDir.isDirectory) continue
+            if (subAppDir.findChild("mix.exs") == null) continue
+
+            // Skip if the sub-app already has its own content entry anywhere in the project.
+            if (subAppDir.url in allContentEntryUrls) continue
+
+            checkCanonicalMarks(moduleName, root, "apps/${subAppDir.name}", actualMarks, issues)
+        }
+    }
+
+    /**
+     * Checks [CANONICAL_FOLDER_MARKS] for a single content root (or umbrella sub-app) and appends
+     * any discrepancies to [issues].
+     *
+     * @param pathPrefix  Empty string for a top-level content root; `"apps/{name}"` for an
+     *                    umbrella sub-app.  The final relative path is
+     *                    `"$pathPrefix/${canonical.relativePath}"` (or just `canonical.relativePath`
+     *                    when [pathPrefix] is empty).
+     */
+    private fun checkCanonicalMarks(
+        moduleName: String,
+        root: VirtualFile,
+        pathPrefix: String,
+        actualMarks: Map<String, FolderMark>,
+        issues: MutableList<FolderMarkIssue>,
+    ) {
+        for (canonical in CANONICAL_FOLDER_MARKS) {
+            val relativePath =
+                if (pathPrefix.isEmpty()) canonical.relativePath else "$pathPrefix/${canonical.relativePath}"
+            val url = "${root.url}/$relativePath"
+
+            val actualMark = actualMarks[url]
+
+            if (actualMark != canonical.folderMark) {
+                // Only warn when the folder actually exists on disk (via VFS).
+                // Non-existent folders with no mark are expected - the reconfigure action
+                // applies marks by URL so they're ready when the folder appears later.
+                if (root.findFileByRelativePath(relativePath) == null) continue
+
+                issues.add(
+                    FolderMarkIssue(
+                        moduleName = moduleName,
+                        folderRelativePath = relativePath,
+                        folderMark = canonical.folderMark,
+                        currentState = actualMark?.displayName?.lowercase() ?: "unmarked",
+                    )
+                )
+            }
+        }
     }
 
     // Build a unified map: folder URL → its actual mark (using the same

--- a/src/org/elixir_lang/mix/project/_import/Builder.kt
+++ b/src/org/elixir_lang/mix/project/_import/Builder.kt
@@ -9,11 +9,9 @@ import com.intellij.openapi.module.Module
 import com.intellij.openapi.module.ModuleManager
 import com.intellij.openapi.options.ConfigurationException
 import com.intellij.openapi.project.Project
-import com.intellij.openapi.projectRoots.ProjectJdkTable
 import com.intellij.openapi.projectRoots.Sdk
 import com.intellij.openapi.projectRoots.SdkTypeId
 import com.intellij.openapi.roots.CompilerModuleExtension
-import com.intellij.openapi.roots.ex.ProjectRootManagerEx
 import com.intellij.openapi.roots.ui.configuration.ModulesProvider
 import com.intellij.openapi.ui.Messages
 import com.intellij.openapi.util.text.StringUtil
@@ -40,6 +38,9 @@ class Builder : ProjectImportBuilder<OtpApp>() {
     private var mySelectedOtpApps = emptyList<OtpApp>()
     private var myIsImportingProject: Boolean = false
     private var myNeedsScan: Boolean = false
+
+    /** Elixir SDK to assign to each created module. Set by ElixirSdkForModuleStep.updateDataModel(). */
+    var elixirSdk: Sdk? = null
 
     override fun getIcon(): Icon = Icons.PROJECT
     override fun getName(): String = "Mix"
@@ -117,12 +118,15 @@ class Builder : ProjectImportBuilder<OtpApp>() {
         modulesProvider: ModulesProvider,
         artifactModel: ModifiableArtifactModel?
     ): List<Module> {
-        fixProjectSdk(project)
+        val sdk = elixirSdk
         val createModules = createModulesForOtpApps(
             project,
             mySelectedOtpApps,
             { moduleModel ?: ModuleManager.getInstance(project).getModifiableModel() },
             { otpApp, rootModel ->
+                if (sdk != null) {
+                    rootModel.sdk = sdk
+                }
                 val compilerModuleExt = rootModel.getModuleExtension(CompilerModuleExtension::class.java)
                 compilerModuleExt.inheritCompilerOutputPath(false)
                 val ideaModuleDir = otpApp.root
@@ -206,21 +210,6 @@ class Builder : ProjectImportBuilder<OtpApp>() {
 
     companion object {
         private val LOG = Logger.getInstance(Builder::class.java)
-
-        private fun fixProjectSdk(project: Project): Sdk? {
-            val projectRootMgr = ProjectRootManagerEx.getInstanceEx(project)
-            val selectedSdk = projectRootMgr.projectSdk
-            val fixedProjectSdk: Sdk?
-
-            if (selectedSdk == null || selectedSdk.sdkType !== Type.instance) {
-                fixedProjectSdk = ProjectJdkTable.getInstance().findMostRecentSdkOfType(Type.instance)
-                ApplicationManager.getApplication().runWriteAction { projectRootMgr.projectSdk = fixedProjectSdk }
-            } else {
-                fixedProjectSdk = selectedSdk
-            }
-
-            return fixedProjectSdk
-        }
 
         @Throws(IOException::class)
         private fun deleteIdeaModuleFiles(otpApps: List<OtpApp>) {

--- a/src/org/elixir_lang/mix/project/_import/step/ElixirSdkForModuleStep.kt
+++ b/src/org/elixir_lang/mix/project/_import/step/ElixirSdkForModuleStep.kt
@@ -18,6 +18,7 @@ import com.intellij.util.ui.JBInsets
 import com.intellij.util.ui.JBUI
 import com.intellij.util.ui.StartupUiUtil
 import org.elixir_lang.Elixir
+import org.elixir_lang.mix.project._import.Builder
 import org.elixir_lang.sdk.elixir.Type
 import org.jetbrains.annotations.NonNls
 import org.jetbrains.annotations.SystemDependent
@@ -166,7 +167,7 @@ class ElixirSdkForModuleStep(private val wizardContext: WizardContext) : ModuleW
     override fun getComponent(): JComponent = panel
 
     override fun updateDataModel() {
-        wizardContext.projectJdk = jdk
+        (wizardContext.projectBuilder as? Builder)?.elixirSdk = jdk
     }
 
     override fun updateStep() {

--- a/src/org/elixir_lang/new_project_wizard/Step.kt
+++ b/src/org/elixir_lang/new_project_wizard/Step.kt
@@ -21,7 +21,6 @@ import com.intellij.openapi.progress.Task
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.projectRoots.Sdk
 import com.intellij.openapi.projectRoots.SdkTypeId
-import com.intellij.openapi.roots.ProjectRootManager
 import com.intellij.openapi.roots.ui.configuration.*
 import com.intellij.openapi.roots.ui.configuration.projectRoot.ProjectSdksModel
 import com.intellij.openapi.ui.ValidationInfo
@@ -177,12 +176,9 @@ class Step(parent: NewProjectWizardStep) : AbstractNewProjectWizardStep(parent),
 
             val builder = ElixirModuleBuilder()
 
-            // Based on https://github.com/JetBrains/intellij-community/blob/8c0419e906efe686479832543092f4918e6516bd/java/idea-ui/src/com/intellij/ide/projectWizard/generators/IntelliJJavaNewProjectWizard.kt#L40-L48
-            if (context.isCreatingNewProject) {
-                context.projectJdk = sdk
-            } else {
-                builder.moduleJdk = sdk.takeIf { ProjectRootManager.getInstance(project).projectSdk?.name != it.name }
-            }
+            // Always set moduleJdk rather than context.projectJdk so the Elixir plugin never claims the project SDK slot.
+            // The project SDK belongs to the host language (Java, Python, etc.) and is not required for Elixir functionality.
+            builder.moduleJdk = sdk
 
             builder.addSourcePath(
                 com.intellij.openapi.util.Pair(
@@ -242,7 +238,6 @@ fun Row.elixirSdkComboBox(context: WizardContext, sdkProperty: ObservableMutable
 
     return cell(comboBox)
         .validationOnApply { validateElixirSdk(sdkProperty, sdksModel) }
-        .onApply { context.projectJdk = sdkProperty.get() }
 }
 
 fun ValidationInfoBuilder.validateElixirSdk(

--- a/src/org/elixir_lang/notification/setup_sdk/Provider.kt
+++ b/src/org/elixir_lang/notification/setup_sdk/Provider.kt
@@ -1,7 +1,6 @@
 package org.elixir_lang.notification.setup_sdk
 
 import com.intellij.ide.actions.ShowSettingsUtilImpl
-import com.intellij.openapi.application.ReadAction
 import com.intellij.openapi.fileEditor.FileEditor
 import com.intellij.openapi.module.Module
 import com.intellij.openapi.module.ModuleType
@@ -26,33 +25,32 @@ class Provider : EditorNotificationProvider {
         project: Project,
         file: VirtualFile,
     ): Function<in FileEditor, out JComponent?>? {
-        // Quick check without read action - file type check is thread-safe
-        if (file.fileType !is ElixirFileType) {
-            return null
-        }
+        // Quick check without additional read - file type check is thread-safe.
+        if (file.fileType !is ElixirFileType) return null
 
-        // Keep PSI/model access explicitly scoped to a read action.
-        return ReadAction.compute<Function<in FileEditor, out JComponent?>?, Throwable> {
-            val psiFile = PsiManager.getInstance(project).findFile(file) ?: return@compute null
+        // collectNotificationData is always called under a platform-held read lock
+        // (@RequiresReadLock, see EditorNotificationProvider), so PSI/model access here is safe.
+        val psiFile = PsiManager.getInstance(project).findFile(file) ?: return null
+        if (psiFile.language !== ElixirLanguage) return null
 
-            if (psiFile.language !== ElixirLanguage) return@compute null
+        val module = ModuleUtilCore.findModuleForPsiElement(psiFile)
 
-            // Resolve the module once; use it for both the SDK check and panel decision
-            // to avoid calling findModuleForPsiElement twice.
-            val module = ModuleUtilCore.findModuleForPsiElement(psiFile)
+        val sdk = module?.let { Type.mostSpecificSdk(it) } ?: Type.mostSpecificSdk(project)
+        if (sdk != null) return null
 
-            // mostSpecificSdk(module) / mostSpecificSdk(project) avoid the internal
-            // re-lookup that mostSpecificSdk(PsiElement) would perform.
-            val sdk = if (module != null) Type.mostSpecificSdk(module) else Type.mostSpecificSdk(project)
-            if (sdk != null) return@compute null
-
-            // IMPORTANT: this lambda is applied later on the EDT.
-            // Keep it UI-only and PSI/model-free; all PSI decisions must stay in this read action.
-            when {
-                module != null && ModuleType.get(module).id == "ELIXIR_MODULE" -> Function { createModulePanel(project, module) }
-                ProcessOutput.isSmallIde -> Function { createSmallIDEFacetPanel(project) }
-                else -> Function { createProjectPanel(project) }
-            }
+        // No SDK configured. Mise-based suggestion is handled by the status bar widget's
+        // notification scan (ElixirEditorBasedSdkWidget), which runs off the read lock on
+        // Dispatchers.IO and surfaces a balloon notification with a one-click configure action.
+        // This panel remains as a persistent per-file indicator for manual setup, but is a candidate
+        // for removal in the future if the Experimental Widget becomes stable.
+        return when {
+            module != null && ModuleType.get(module).id == "ELIXIR_MODULE" ->
+                Function { createModulePanel(project, module) }
+            module != null && ProcessOutput.isSmallIde ->
+                Function { createSmallIDEFacetPanel(project) }
+            module != null ->
+                Function { createProjectPanel(project) }
+            else -> null
         }
     }
 }
@@ -107,7 +105,7 @@ private fun createModulePanel(
 
 private fun createProjectPanel(project: Project): EditorNotificationPanel =
     EditorNotificationPanel().apply {
-        text = "Project SDK is not defined"
+        text = "Elixir SDK is not defined"
         createActionLabel(ProjectBundle.message("project.sdk.setup")) {
             showProjectSettings(project)
         }

--- a/src/org/elixir_lang/sdk/elixir/Type.kt
+++ b/src/org/elixir_lang/sdk/elixir/Type.kt
@@ -339,13 +339,6 @@ ELIXIR_SDK_HOME
         internal fun setupSdkTableListener() {
             val messageBus = ApplicationManager.getApplication().messageBus
             messageBus.connect().subscribe(ProjectJdkTable.JDK_TABLE_TOPIC, object : ProjectJdkTable.Listener {
-                override fun jdkAdded(jdk: Sdk) {
-                    // When an Elixir SDK is added, auto-set it as the project SDK if appropriate
-                    if (jdk.sdkType is Type) {
-                        autoSetProjectSdkIfNeeded(jdk)
-                    }
-                }
-
                 override fun jdkRemoved(jdk: Sdk) {
                     // When an Erlang SDK is removed, clean up any Elixir SDKs that reference it
                     if (staticIsValidDependency(jdk)) {
@@ -376,70 +369,6 @@ ELIXIR_SDK_HOME
                         projectRootManager.projectSdk = null
                         LOG.info("Cleared removed Elixir SDK '${deletedSdk.name}' from project '${project.name}'")
                     }
-                }
-            }
-        }
-
-        private fun autoSetProjectSdkIfNeeded(newElixirSdk: Sdk) {
-            LOG.debug { "Auto-set check for newly added Elixir SDK: ${newElixirSdk.name}" }
-
-            // Get all non-disposed projects
-            val openProjects = com.intellij.openapi.project.ProjectManager.getInstance().openProjects.filter {
-                !it.isDisposed
-            }
-
-            // Only auto-set if exactly one project is open
-            // This ensures we don't accidentally set the wrong project's SDK
-            val project = when (openProjects.size) {
-                0 -> {
-                    LOG.debug { "No open projects, skipping auto-set" }
-                    return
-                }
-
-                1 -> openProjects.first()
-                else -> {
-                    LOG.debug { "Multiple projects open (${openProjects.size}), skipping auto-set to avoid ambiguity" }
-                    return
-                }
-            }
-
-            val projectRootManager = ProjectRootManager.getInstance(project)
-            val currentProjectSdk = projectRootManager.projectSdk
-
-            // Only auto-set if current SDK is null or (is Elixir and invalid)
-            val shouldAutoSet = if (currentProjectSdk == null) {
-                LOG.debug { "Project '${project.name}' has no SDK, will auto-set to '${newElixirSdk.name}'" }
-                true
-            } else if (currentProjectSdk.sdkType !is Type) {
-                // Don't replace non-Elixir SDKs (Java, Python, etc.)
-                LOG.debug {
-                    "Project '${project.name}' has non-Elixir SDK '${currentProjectSdk.name}', skipping auto-set"
-                }
-                false
-            } else {
-                // Current SDK is Elixir - check if it's valid
-                val isValid = try {
-                    val additionalData = currentProjectSdk.sdkAdditionalData as? SdkAdditionalData
-                    val erlangSdk = additionalData?.getErlangSdk()
-                    erlangSdk != null
-                } catch (e: Exception) {
-                    LOG.debug { "Error checking validity of current SDK: ${e.message}" }
-                    false
-                }
-
-                if (!isValid) {
-                    LOG.debug {
-                        "Project '${project.name}' SDK '${currentProjectSdk.name}' is invalid, " +
-                                "will auto-set to '${newElixirSdk.name}'"
-                    }
-                }
-                !isValid
-            }
-
-            if (shouldAutoSet) {
-                WriteActions.runWriteActionLater {
-                    projectRootManager.projectSdk = newElixirSdk
-                    LOG.info("Auto-set project '${project.name}' SDK to '${newElixirSdk.name}'")
                 }
             }
         }

--- a/src/org/elixir_lang/status_bar_widget/ElixirSdkStatusWidget.kt
+++ b/src/org/elixir_lang/status_bar_widget/ElixirSdkStatusWidget.kt
@@ -5,7 +5,8 @@ import com.intellij.ide.DataManager
 import com.intellij.notification.NotificationGroupManager
 import com.intellij.notification.NotificationType
 import com.intellij.openapi.actionSystem.*
-import com.intellij.openapi.application.ReadAction
+import com.intellij.openapi.application.UI
+import com.intellij.openapi.application.readAction
 import com.intellij.openapi.components.service
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.module.ModuleManager
@@ -26,7 +27,6 @@ import com.intellij.ui.ClickListener
 import com.intellij.ui.awt.RelativePoint
 import com.intellij.util.messages.MessageBusConnection
 import com.intellij.util.ui.JBUI
-import com.intellij.openapi.application.UI
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.cancel
@@ -37,14 +37,11 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.elixir_lang.Icons
 import org.elixir_lang.isElixirModule
-import org.elixir_lang.sdk.SdkHomeKey
-import org.elixir_lang.sdk.SdkHomePaths
 import org.elixir_lang.mix.project.ProjectModuleSetupValidator
 import org.elixir_lang.mix.project.ProjectModuleSetupValidator.FolderMarkIssue
 import org.elixir_lang.sdk.SdkEbinPaths
 import org.elixir_lang.sdk.elixir.SdkSettingsOpener
 import org.elixir_lang.sdk.elixir.Type
-import org.elixir_lang.sdk.elixir.Type.Companion.SKIP_ERLANG_SETTINGS_HINT_KEY
 import org.elixir_lang.sdk.erlang_dependent.SdkAdditionalData
 import org.elixir_lang.util.ElixirCoroutineService
 import org.jetbrains.annotations.NotNull
@@ -73,9 +70,7 @@ class ElixirSdkStatusWidget(@param:NotNull private val project: Project) : Custo
     private val rootsChangedFlow = MutableSharedFlow<Unit>(
         extraBufferCapacity = 1,
         onBufferOverflow = BufferOverflow.DROP_OLDEST,
-    )
-
-    // Track last notified status to avoid spamming duplicate notifications
+    )    // Track last notified status to avoid spamming duplicate notifications
     @Volatile
     private var lastNotifiedIssueKey: String? = null
 
@@ -100,9 +95,6 @@ class ElixirSdkStatusWidget(@param:NotNull private val project: Project) : Custo
     // Cached widget presentation data - computed once per update
     @Volatile
     private var cachedPresentation: WidgetPresentation? = null
-
-    @Volatile
-    private var cachedSdkConfigured: Boolean = true
 
     private data class WidgetPresentation(
         val text: String,
@@ -148,6 +140,9 @@ class ElixirSdkStatusWidget(@param:NotNull private val project: Project) : Custo
     private data class ModuleSdkIssue(val moduleName: String, val issue: String, val isDangling: Boolean)
 
     init {
+        // Kick off the first presentation computation asynchronously.
+        // updateWidget() only schedules a coroutine and returns immediately, so it is safe
+        // to call from the EDT (the widget constructor runs on the EDT during widget creation).
         updateWidget()
     }
 
@@ -158,6 +153,7 @@ class ElixirSdkStatusWidget(@param:NotNull private val project: Project) : Custo
     override fun install(statusBar: StatusBar) {
         this.statusBar = statusBar
         setupListeners()
+        // Refresh immediately now that statusBar is wired up.  Safe to call from EDT - async.
         updateWidget()
     }
 
@@ -174,16 +170,6 @@ class ElixirSdkStatusWidget(@param:NotNull private val project: Project) : Custo
     private fun showPopup(e: MouseEvent) {
         val actionGroup = DefaultActionGroup().apply {
             add(createAddSdkAction())
-
-            // When no SDK is configured, show detected mise Elixir SDKs for quick setup
-            if (!cachedSdkConfigured) {
-                val detectedActions = createDetectedSdkActions()
-                if (detectedActions.isNotEmpty()) {
-                    add(Separator.create("Detected Elixir SDKs"))
-                    detectedActions.forEach { add(it) }
-                }
-            }
-
             val actionManager = ActionManager.getInstance()
             actionManager.getAction("Elixir.RefreshAllElixirSdks")?.let { add(it) }
             actionManager.getAction("Elixir.InstallMixDependencies")?.let { add(it) }
@@ -235,68 +221,19 @@ class ElixirSdkStatusWidget(@param:NotNull private val project: Project) : Custo
         }
     }
 
-    private fun createDetectedSdkActions(): List<AnAction> {
-        val miseHomes = mutableMapOf<SdkHomeKey, String>()
-        SdkHomePaths.mergeMise(miseHomes, "elixir")
-
-        val elixirSdkType = Type.instance
-        return miseHomes.entries
-            .filter { (_, path) -> elixirSdkType.isValidSdkHome(path) }
-            .map { (_, homePath) ->
-                val sdkName = Type.suggestSdkNameForHome(homePath, null)
-                object : AnAction(sdkName, "Add $sdkName and set as project SDK", Icons.LANGUAGE) {
-                    override fun actionPerformed(e: AnActionEvent) {
-                        addDetectedElixirSdk(homePath)
-                    }
-
-                    override fun getActionUpdateThread(): ActionUpdateThread = ActionUpdateThread.BGT
-                }
-            }
-    }
-
-    private fun addDetectedElixirSdk(homePath: String) {
-        val elixirSdkType = Type.instance
-        val canonicalHome = org.elixir_lang.sdk.wsl.wslCompat.canonicalizePath(homePath)
-        val versionString = Type.versionStringForHome(canonicalHome, null) ?: return
-        val sdkName = Type.suggestSdkNameForHome(canonicalHome, null)
-
-        val newSdk = com.intellij.openapi.projectRoots.impl.ProjectJdkImpl(
-            sdkName, elixirSdkType, canonicalHome, versionString
-        )
-
-        val app = com.intellij.openapi.application.ApplicationManager.getApplication()
-        app.invokeLater {
-            app.runWriteAction {
-                ProjectJdkTable.getInstance().addJdk(newSdk)
-            }
-            // setupSdkPaths triggers the Erlang SDK prompt if needed.
-            // Skip the "reopen settings" hint since we're not in the settings dialog.
-            newSdk.putUserData(SKIP_ERLANG_SETTINGS_HINT_KEY, true)
-            elixirSdkType.setupSdkPaths(newSdk)
-
-            // Set as project SDK
-            app.runWriteAction {
-                ProjectRootManager.getInstance(project).projectSdk = newSdk
-            }
-        }
-    }
-
     private fun updateWidget() {
         widgetScope.launch {
-            cachedPresentation = null
-            val sdkStatus = detectSdkStatus()
-            cachedSdkConfigured = sdkStatus !is SdkStatus.NotConfigured
+            val sdkStatus = readAction { detectSdkStatus() }
             val presentation = createPresentation(sdkStatus)
-            cachedPresentation = presentation
-
             withContext(Dispatchers.UI) {
+                cachedPresentation = presentation
                 component.text = presentation.text
                 component.icon = presentation.icon
                 component.toolTipText = presentation.tooltip
                 statusBar?.updateWidget(ID)
+                // Fire notification whenever a discrepancy is detected
+                notifyIfNeeded(sdkStatus)
             }
-
-            notifyIfNeeded(sdkStatus)
         }
     }
 
@@ -543,7 +480,8 @@ class ElixirSdkStatusWidget(@param:NotNull private val project: Project) : Custo
     private fun setupListeners() {
         messageBusConnection = project.messageBus.connect(this)
 
-        // Listen for project JDK table changes (SDK added/removed/modified)
+        // Listen for project JDK table changes (SDK added/removed/modified).
+        // These events are infrequent; call updateWidget() directly (it just launches a coroutine).
         messageBusConnection?.subscribe(ProjectJdkTable.JDK_TABLE_TOPIC, object : ProjectJdkTable.Listener {
             override fun jdkAdded(jdk: Sdk) {
                 if (jdk.sdkType is Type) {
@@ -564,7 +502,7 @@ class ElixirSdkStatusWidget(@param:NotNull private val project: Project) : Custo
             }
         })
 
-        // Listen for project root changes (project SDK changes)
+        // Listen for project root changes (project SDK changes).
         // Debounced: bulk operations (import wizard, DepsWatcher) fire rootsChanged() rapidly;
         // collapse them into a single update after a 2-second quiet window.
         messageBusConnection?.subscribe(
@@ -590,49 +528,47 @@ class ElixirSdkStatusWidget(@param:NotNull private val project: Project) : Custo
     }
 
     private fun detectSdkStatus(): SdkStatus {
-        return ReadAction.nonBlocking<SdkStatus> {
-            val elixirSdk = Type.mostSpecificSdk(project) ?: return@nonBlocking SdkStatus.NotConfigured
-            val versionString = elixirSdk.versionString ?: "Unknown"
+        val elixirSdk = Type.mostSpecificSdk(project) ?: return SdkStatus.NotConfigured
+        val versionString = elixirSdk.versionString ?: "Unknown"
 
-            // Add WSL distribution suffix if this is a WSL SDK
-            val elixirVersion = org.elixir_lang.sdk.Type.appendWslSuffix(versionString, elixirSdk.homePath)
+        // Add WSL distribution suffix if this is a WSL SDK
+        val elixirVersion = org.elixir_lang.sdk.Type.appendWslSuffix(versionString, elixirSdk.homePath)
 
-            if (!isValidSdk(elixirSdk)) {
-                return@nonBlocking SdkStatus.InvalidSdk(elixirSdk, elixirVersion, "Invalid Elixir SDK")
-            }
+        if (!isValidSdk(elixirSdk)) {
+            return SdkStatus.InvalidSdk(elixirSdk, elixirVersion, "Invalid Elixir SDK")
+        }
 
-            val erlangSdk = getErlangSdk(elixirSdk)
-                ?: return@nonBlocking SdkStatus.InvalidSdk(elixirSdk, elixirVersion, "Missing Erlang SDK")
+        val erlangSdk = getErlangSdk(elixirSdk)
+            ?: return SdkStatus.InvalidSdk(elixirSdk, elixirVersion, "Missing Erlang SDK")
 
-            // Check module-level SDK consistency (dangling references or mismatches)
-            val moduleSdkIssues = detectModuleSdkIssues()
-            if (moduleSdkIssues.isNotEmpty()) {
-                return@nonBlocking SdkStatus.ModuleSdkError(elixirSdk, elixirVersion, moduleSdkIssues)
-            }
+        // Check module-level SDK consistency (dangling references or mismatches)
+        val moduleSdkIssues = detectModuleSdkIssues()
+        if (moduleSdkIssues.isNotEmpty()) {
+            return SdkStatus.ModuleSdkError(elixirSdk, elixirVersion, moduleSdkIssues)
+        }
 
-            // Check classpath/ebin configuration (breaks code resolution globally)
-            val issues = mutableListOf<String>()
-            if (hasEbinPathIssues(elixirSdk)) {
-                issues.add("Missing Elixir ebin paths or classpath entries")
-            }
-            if (hasErlangSdkIssues(erlangSdk)) {
-                issues.add("Erlang SDK configuration issues")
-            }
-            if (!Type.hasErlangClasspathInElixirSdk(elixirSdk, erlangSdk)) {
-                issues.add("Erlang SDK classpath entries missing - reopen SDK settings to fix")
-            }
-            if (issues.isNotEmpty()) {
-                return@nonBlocking SdkStatus.ClasspathIssue(elixirSdk, erlangSdk, elixirVersion, issues)
-            }
+        // Check classpath/ebin configuration (breaks code resolution globally)
+        val issues = mutableListOf<String>()
+        if (hasEbinPathIssues(elixirSdk)) {
+            issues.add("Missing Elixir ebin paths or classpath entries")
+        }
+        if (hasErlangSdkIssues(erlangSdk)) {
+            issues.add("Erlang SDK configuration issues")
+        }
+        if (!Type.hasErlangClasspathInElixirSdk(elixirSdk, erlangSdk)) {
+            issues.add("Erlang SDK classpath entries missing - reopen SDK settings to fix")
+        }
+        if (issues.isNotEmpty()) {
+            return SdkStatus.ClasspathIssue(elixirSdk, erlangSdk, elixirVersion, issues)
+        }
 
-            // Check folder mark configuration (breaks specific per-directory features)
-            val folderMarkIssues = ProjectModuleSetupValidator.detectFolderMarkIssues(project)
-            if (folderMarkIssues.isNotEmpty()) {
-                return@nonBlocking SdkStatus.FolderMarkWarning(elixirSdk, elixirVersion, folderMarkIssues)
-            }
+        // Check folder mark configuration (breaks specific per-directory features)
+        val folderMarkIssues = ProjectModuleSetupValidator.detectFolderMarkIssues(project)
+        if (folderMarkIssues.isNotEmpty()) {
+            return SdkStatus.FolderMarkWarning(elixirSdk, elixirVersion, folderMarkIssues)
+        }
 
-            SdkStatus.Configured(elixirSdk, erlangSdk, elixirVersion)
-        }.executeSynchronously()
+        return SdkStatus.Configured(elixirSdk, erlangSdk, elixirVersion)
     }
 
     private fun detectModuleSdkIssues(): List<ModuleSdkIssue> {

--- a/src/org/elixir_lang/status_bar_widget/ElixirSdkStatusWidget.kt
+++ b/src/org/elixir_lang/status_bar_widget/ElixirSdkStatusWidget.kt
@@ -529,8 +529,28 @@ class ElixirSdkStatusWidget(@param:NotNull private val project: Project) : Custo
         })
     }
 
+    /**
+     * Finds the active Elixir SDK by scanning all Elixir modules.
+     *
+     * Uses [Type.mostSpecificSdk] (module overload) which checks Facet SDK → module SDK → project SDK,
+     * returning the first non-null result. This covers both Rich IDEs (JdkOrderEntry) and Small IDEs
+     * (Facet library entry) without additional branching.
+     *
+     * When both the project SDK and a module SDK are Elixir, this returns the **module** SDK - the one
+     * that actually drives code insight - rather than the project-level one. The mismatch between them
+     * is reported separately by [detectModuleSdkIssues].
+     */
+    private fun findModuleLevelElixirSdk(): Sdk? {
+        for (module in ModuleManager.getInstance(project).modules) {
+            if (!module.isElixirModule()) continue
+            val moduleSdk = Type.mostSpecificSdk(module)
+            if (moduleSdk != null) return moduleSdk
+        }
+        return null
+    }
+
     private fun detectSdkStatus(): SdkStatus {
-        val elixirSdk = Type.mostSpecificSdk(project) ?: return SdkStatus.NotConfigured
+        val elixirSdk = findModuleLevelElixirSdk() ?: return SdkStatus.NotConfigured
         val versionString = elixirSdk.versionString ?: "Unknown"
 
         // Add WSL distribution suffix if this is a WSL SDK

--- a/src/org/elixir_lang/status_bar_widget/ElixirSdkStatusWidget.kt
+++ b/src/org/elixir_lang/status_bar_widget/ElixirSdkStatusWidget.kt
@@ -20,7 +20,6 @@ import com.intellij.openapi.roots.ProjectRootManager
 import com.intellij.openapi.ui.popup.JBPopupFactory
 import com.intellij.openapi.util.Disposer
 import com.intellij.openapi.util.text.StringUtil
-import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.wm.CustomStatusBarWidget
 import com.intellij.openapi.wm.StatusBar
 import com.intellij.openapi.wm.impl.status.TextPanel
@@ -104,7 +103,7 @@ class ElixirSdkStatusWidget(@param:NotNull private val project: Project) : Custo
         val tooltip: String
     )
 
-    private sealed interface SdkStatus {
+    internal sealed interface SdkStatus {
         data class Configured(
             val elixirSdk: Sdk,
             val erlangSdk: Sdk,
@@ -139,7 +138,7 @@ class ElixirSdkStatusWidget(@param:NotNull private val project: Project) : Custo
         data object NotConfigured : SdkStatus
     }
 
-    private data class ModuleSdkIssue(val moduleName: String, val issue: String, val isDangling: Boolean)
+    internal data class ModuleSdkIssue(val moduleName: String, val issue: String, val isDangling: Boolean)
 
     init {
         // Kick off the first presentation computation asynchronously.
@@ -540,7 +539,7 @@ class ElixirSdkStatusWidget(@param:NotNull private val project: Project) : Custo
      * that actually drives code insight - rather than the project-level one. The mismatch between them
      * is reported separately by [detectModuleSdkIssues].
      */
-    private fun findModuleLevelElixirSdk(): Sdk? {
+    internal fun findModuleLevelElixirSdk(): Sdk? {
         for (module in ModuleManager.getInstance(project).modules) {
             if (!module.isElixirModule()) continue
             val moduleSdk = Type.mostSpecificSdk(module)
@@ -549,7 +548,7 @@ class ElixirSdkStatusWidget(@param:NotNull private val project: Project) : Custo
         return null
     }
 
-    private fun detectSdkStatus(): SdkStatus {
+    internal fun detectSdkStatus(): SdkStatus {
         val elixirSdk = findModuleLevelElixirSdk() ?: return SdkStatus.NotConfigured
         val versionString = elixirSdk.versionString ?: "Unknown"
 
@@ -593,12 +592,9 @@ class ElixirSdkStatusWidget(@param:NotNull private val project: Project) : Custo
         return SdkStatus.Configured(elixirSdk, erlangSdk, elixirVersion)
     }
 
-    private fun detectModuleSdkIssues(): List<ModuleSdkIssue> {
+    internal fun detectModuleSdkIssues(): List<ModuleSdkIssue> {
         val issues = mutableListOf<ModuleSdkIssue>()
         val projectSdk = ProjectRootManager.getInstance(project).projectSdk
-        val hasRootMixExs = project.basePath?.let { basePath ->
-            LocalFileSystem.getInstance().findFileByPath(basePath)?.findChild("mix.exs")
-        } != null
 
         for (module in ModuleManager.getInstance(project).modules) {
             if (!module.isElixirModule()) continue
@@ -625,8 +621,8 @@ class ElixirSdkStatusWidget(@param:NotNull private val project: Project) : Custo
                             isDangling = true
                         )
                     )
-                } else if (hasRootMixExs && projectSdk != null && projectSdk.sdkType is Type && resolvedSdk != projectSdk) {
-                    // MISMATCH: Module uses different SDK than project in a single-version project.
+                } else if (projectSdk != null && projectSdk.sdkType is Type && resolvedSdk != projectSdk) {
+                    // MISMATCH: Module uses different Elixir SDK than project in a single-version project.
                     // Only meaningful when the project SDK is itself Elixir; skip when it is Java/Python/etc.
                     issues.add(
                         ModuleSdkIssue(

--- a/src/org/elixir_lang/status_bar_widget/ElixirSdkStatusWidget.kt
+++ b/src/org/elixir_lang/status_bar_widget/ElixirSdkStatusWidget.kt
@@ -1,5 +1,6 @@
 package org.elixir_lang.status_bar_widget
 
+import com.intellij.facet.FacetManager
 import com.intellij.icons.AllIcons
 import com.intellij.ide.DataManager
 import com.intellij.notification.NotificationGroupManager
@@ -35,6 +36,7 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import org.elixir_lang.Facet
 import org.elixir_lang.Icons
 import org.elixir_lang.isElixirModule
 import org.elixir_lang.mix.project.ProjectModuleSetupValidator
@@ -583,10 +585,13 @@ class ElixirSdkStatusWidget(@param:NotNull private val project: Project) : Custo
 
             val rootManager = ModuleRootManager.getInstance(module)
 
+            // --- Rich IDE path: detect dangling/mismatch JdkOrderEntry ---
+            var hasJdkEntry = false
             for (entry in rootManager.orderEntries) {
                 if (entry !is JdkOrderEntry) continue
 
                 val jdkName = entry.jdkName ?: continue
+                hasJdkEntry = true
                 // Only check Elixir SDK entries (when SDK is resolvable, check its type)
                 val resolvedSdk = entry.jdk
                 if (resolvedSdk != null && resolvedSdk.sdkType !is Type) continue
@@ -600,13 +605,32 @@ class ElixirSdkStatusWidget(@param:NotNull private val project: Project) : Custo
                             isDangling = true
                         )
                     )
-                } else if (hasRootMixExs && projectSdk != null && resolvedSdk != projectSdk) {
-                    // MISMATCH: Module uses different SDK than project in a single-version project
+                } else if (hasRootMixExs && projectSdk != null && projectSdk.sdkType is Type && resolvedSdk != projectSdk) {
+                    // MISMATCH: Module uses different SDK than project in a single-version project.
+                    // Only meaningful when the project SDK is itself Elixir; skip when it is Java/Python/etc.
                     issues.add(
                         ModuleSdkIssue(
                             module.name,
                             "uses '$jdkName' but project SDK is '${projectSdk.name}'",
                             isDangling = false
+                        )
+                    )
+                }
+            }
+
+            // --- Small IDE path: detect dangling Facet SDK ---
+            // Only check if the Rich IDE path didn't find any JDK entries (Small IDE modules use
+            // a Facet library entry instead of a JdkOrderEntry to hold the Elixir SDK).
+            if (!hasJdkEntry) {
+                val facet = FacetManager.getInstance(module).getFacetByType(Facet.ID)
+                if (facet != null && Facet.sdk(module) == null && Facet.sdks().isNotEmpty()) {
+                    // The module has an Elixir Facet and Elixir SDKs exist in the table, but the
+                    // Facet library entry doesn't match any current SDK name - stale/dangling reference.
+                    issues.add(
+                        ModuleSdkIssue(
+                            module.name,
+                            "Elixir Facet SDK is not configured (stale reference). Reconfigure in Settings → Languages → Elixir.",
+                            isDangling = true
                         )
                     )
                 }

--- a/src/org/elixir_lang/status_bar_widget/ElixirSdkStatusWidgetFactory.kt
+++ b/src/org/elixir_lang/status_bar_widget/ElixirSdkStatusWidgetFactory.kt
@@ -1,10 +1,12 @@
 package org.elixir_lang.status_bar_widget
 
 import com.intellij.openapi.diagnostic.logger
+import com.intellij.openapi.module.ModuleManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.wm.StatusBar
 import com.intellij.openapi.wm.StatusBarWidget
 import com.intellij.openapi.wm.StatusBarWidgetFactory
+import org.elixir_lang.isElixirModule
 import org.elixir_lang.settings.ElixirExperimentalSettings
 
 private val LOG = logger<ElixirSdkStatusWidgetFactory>()
@@ -15,9 +17,12 @@ class ElixirSdkStatusWidgetFactory : StatusBarWidgetFactory {
     override fun getDisplayName(): String = "Elixir SDK Status"
 
     override fun isAvailable(project: Project): Boolean {
-        // Widget is available when the experimental setting is enabled
-        val isAvailable = ElixirExperimentalSettings.instance.state.enableStatusBarWidget
-        LOG.debug("isAvailable called for project ${project.name}, returning $isAvailable")
+        val isSettingEnabled = ElixirExperimentalSettings.instance.state.enableStatusBarWidget
+        if (!isSettingEnabled) return false
+
+        val hasElixirModule = ModuleManager.getInstance(project).modules.any { it.isElixirModule() }
+        val isAvailable = hasElixirModule
+        LOG.debug("isAvailable called for project ${project.name}, setting=$isSettingEnabled, hasElixirModule=$hasElixirModule, returning $isAvailable")
         return isAvailable
     }
 

--- a/tests/org/elixir_lang/action/ReconfigureModuleSetupActionTest.kt
+++ b/tests/org/elixir_lang/action/ReconfigureModuleSetupActionTest.kt
@@ -6,6 +6,12 @@ import com.intellij.openapi.actionSystem.ActionUiKind
 import com.intellij.openapi.actionSystem.CommonDataKeys
 import com.intellij.openapi.actionSystem.DataContext
 import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.application.WriteAction
+import com.intellij.openapi.projectRoots.ProjectJdkTable
+import com.intellij.openapi.projectRoots.SimpleJavaSdkType
+import com.intellij.openapi.projectRoots.Sdk
+import com.intellij.openapi.projectRoots.impl.ProjectJdkImpl
+import com.intellij.openapi.roots.ProjectRootManager
 import com.intellij.openapi.util.ThrowableComputable
 import com.intellij.facet.FacetManager
 import com.intellij.facet.FacetType
@@ -16,11 +22,15 @@ import org.elixir_lang.Facet
 import org.elixir_lang.PlatformTestCase
 import org.elixir_lang.facet.Type
 import org.elixir_lang.mix.project.ProjectModuleSetupValidator
+import org.elixir_lang.sdk.elixir.Type as ElixirSdkType
 
 class ReconfigureModuleSetupActionTest : PlatformTestCase() {
 
     /** URLs of content entries added during a test, cleaned up in [tearDown]. */
     private val addedContentRootUrls = mutableListOf<String>()
+
+    /** SDKs registered in the JDK table during a test, cleaned up in [tearDown]. */
+    private val addedSdks = mutableListOf<Sdk>()
 
     override fun setUp() {
         super.setUp()
@@ -42,6 +52,20 @@ class ReconfigureModuleSetupActionTest : PlatformTestCase() {
                     }
                 }
                 addedContentRootUrls.clear()
+            }
+            // Clear module SDK before removing SDKs from the table
+            ModuleRootModificationUtil.setModuleSdk(module, null)
+            // Clear project SDK
+            WriteAction.run<Throwable> {
+                ProjectRootManager.getInstance(project).projectSdk = null
+            }
+            // Remove registered SDKs
+            WriteAction.run<Throwable> {
+                val jdkTable = ProjectJdkTable.getInstance()
+                for (sdk in addedSdks) {
+                    if (jdkTable.allJdks.contains(sdk)) jdkTable.removeJdk(sdk)
+                }
+                addedSdks.clear()
             }
         } finally {
             super.tearDown()
@@ -333,5 +357,45 @@ class ReconfigureModuleSetupActionTest : PlatformTestCase() {
 
         assertNotNull("web/ should be marked as Source even when it does not exist", webFolder)
         assertFalse("web/ should be Sources (not Test Sources)", webFolder!!.isTestSource)
+    }
+
+    // -------------------------------------------------------------------------
+    // Scenario 4: Project SDK = Java, Reconfigure action invoked
+    // → folder marks applied; module SDK left untouched (Step 1 guard)
+    // -------------------------------------------------------------------------
+
+    /**
+     * When the project SDK is non-Elixir (e.g. Java), the Reconfigure action must NOT
+     * touch the module SDK.  Before Step 1, `fixModuleSdk()` would call `model.inheritSdk()`
+     * unconditionally, replacing the Elixir module SDK with the Java project SDK.
+     */
+    fun testReconfigureWithNonElixirProjectSdkDoesNotTouchModuleSdk() {
+        val javaHome = System.getProperty("java.home") ?: "/usr/lib/jvm/java"
+        val javaSdk = SimpleJavaSdkType().createJdk("Java Mock", javaHome)
+
+        val elixirSdk = ProjectJdkImpl("Elixir Mock", ElixirSdkType.instance)
+        WriteAction.run<Throwable> {
+            ProjectJdkTable.getInstance().addJdk(elixirSdk)
+        }
+        addedSdks.add(elixirSdk)
+
+        // Set project SDK to Java and module SDK to Elixir
+        WriteAction.run<Throwable> {
+            ProjectRootManager.getInstance(project).projectSdk = javaSdk
+        }
+        ModuleRootModificationUtil.setModuleSdk(module, elixirSdk)
+
+        // Add a Mix content entry so the action processes the module
+        addMixContentEntry("sdk_guard_app", subdirs = listOf("lib", "test"))
+
+        runAction()
+
+        // The module SDK should still be the Elixir SDK, not the Java project SDK
+        val moduleSdkAfter = ModuleRootManager.getInstance(module).sdk
+        assertEquals(
+            "Module SDK must not be replaced with Java project SDK when project SDK is non-Elixir",
+            elixirSdk,
+            moduleSdkAfter
+        )
     }
 }

--- a/tests/org/elixir_lang/mix/project/ProjectModuleSetupValidatorTest.kt
+++ b/tests/org/elixir_lang/mix/project/ProjectModuleSetupValidatorTest.kt
@@ -427,5 +427,93 @@ class ProjectModuleSetupValidatorTest : PlatformTestCase() {
         assertEquals(FolderMark.EXCLUDED, depsIssues.single().folderMark)
     }
 
+    /**
+     * When an umbrella project is imported as a single module (one content entry at the umbrella
+     * root), sub-apps under `apps/` that have no folder marks on the content entry must produce
+     * [ProjectModuleSetupValidator.FolderMarkIssue]s for each missing mark.
+     */
+    fun testUmbrellaSubAppsNotConfiguredReportsFolderMarkIssues() {
+        // Set up umbrella root with mix.exs and a single sub-app (app_a) with lib/ and test/.
+        myFixture.tempDirFixture.findOrCreateDir("umbrella_single/apps/app_a/lib")
+        myFixture.tempDirFixture.findOrCreateDir("umbrella_single/apps/app_a/test")
+        myFixture.tempDirFixture.createFile("umbrella_single/apps/app_a/mix.exs", "")
+
+        addMixContentEntry("umbrella_single") { _, _ ->
+            // No sub-app folder marks added - simulates an unconfigured single-module umbrella.
+        }
+
+        val issues = detectFolderMarkIssuesOnBackgroundThread()
+        val moduleIssues = issues.filter { it.moduleName == module.name }
+
+        val libIssues = moduleIssues.filter { it.folderRelativePath == "apps/app_a/lib" }
+        val testIssues = moduleIssues.filter { it.folderRelativePath == "apps/app_a/test" }
+
+        assertEquals(
+            "Expected exactly one issue for apps/app_a/lib (unmarked Sources)",
+            1,
+            libIssues.size,
+        )
+        assertEquals(FolderMark.SOURCES, libIssues.single().folderMark)
+        assertEquals("unmarked", libIssues.single().currentState)
+
+        assertEquals(
+            "Expected exactly one issue for apps/app_a/test (unmarked Test Sources)",
+            1,
+            testIssues.size,
+        )
+        assertEquals(FolderMark.TEST_SOURCES, testIssues.single().folderMark)
+        assertEquals("unmarked", testIssues.single().currentState)
+    }
+
+    /**
+     * When one sub-app (`app_a`) already has its own content entry (e.g., from the import wizard),
+     * the umbrella scan must skip it and only report issues for sub-apps (`app_b`) that do NOT
+     * have their own content entry.
+     */
+    fun testUmbrellaSubAppAlreadyCoveredByContentEntryIsSkipped() {
+        // Umbrella root with mix.exs.
+        // app_a: has its own content entry → umbrella scan must skip it.
+        // app_b: only a plain directory under apps/ → umbrella scan must report it.
+        myFixture.tempDirFixture.findOrCreateDir("umbrella_mixed/apps/app_a/lib")
+        myFixture.tempDirFixture.findOrCreateDir("umbrella_mixed/apps/app_a/test")
+        myFixture.tempDirFixture.createFile("umbrella_mixed/apps/app_a/mix.exs", "")
+
+        myFixture.tempDirFixture.findOrCreateDir("umbrella_mixed/apps/app_b/lib")
+        myFixture.tempDirFixture.findOrCreateDir("umbrella_mixed/apps/app_b/test")
+        myFixture.tempDirFixture.createFile("umbrella_mixed/apps/app_b/mix.exs", "")
+
+        // Umbrella root content entry (no sub-app marks).
+        addMixContentEntry("umbrella_mixed") { _, _ -> }
+
+        // app_a gets its own content entry, fully configured - the per-entry loop handles it.
+        val appARoot = myFixture.tempDirFixture.findOrCreateDir("umbrella_mixed/apps/app_a")
+        ModuleRootModificationUtil.updateModel(module) { model ->
+            val contentA = model.addContentEntry(appARoot)
+            contentA.addSourceFolder("${appARoot.url}/lib", false)
+            contentA.addSourceFolder("${appARoot.url}/test", true)
+        }
+        addedContentRootUrls.add(appARoot.url)
+
+        val issues = detectFolderMarkIssuesOnBackgroundThread()
+        val moduleIssues = issues.filter { it.moduleName == module.name }
+
+        // app_a is covered by its own content entry and fully configured → no umbrella issues.
+        val appAIssues = moduleIssues.filter { it.folderRelativePath.startsWith("apps/app_a/") }
+        assertTrue(
+            "app_a is covered by its own content entry and must produce no umbrella issues, got: $appAIssues",
+            appAIssues.isEmpty(),
+        )
+
+        // app_b has no content entry → umbrella scan must report lib/ and test/.
+        val appBLibIssues = moduleIssues.filter { it.folderRelativePath == "apps/app_b/lib" }
+        val appBTestIssues = moduleIssues.filter { it.folderRelativePath == "apps/app_b/test" }
+
+        assertEquals("Expected one issue for apps/app_b/lib", 1, appBLibIssues.size)
+        assertEquals(FolderMark.SOURCES, appBLibIssues.single().folderMark)
+
+        assertEquals("Expected one issue for apps/app_b/test", 1, appBTestIssues.size)
+        assertEquals(FolderMark.TEST_SOURCES, appBTestIssues.single().folderMark)
+    }
+
     override fun getTestDataPath(): String = "testData/org/elixir_lang/mix/project"
 }

--- a/tests/org/elixir_lang/status_bar_widget/ElixirSdkStatusWidgetTest.kt
+++ b/tests/org/elixir_lang/status_bar_widget/ElixirSdkStatusWidgetTest.kt
@@ -1,31 +1,297 @@
 package org.elixir_lang.status_bar_widget
 
+import com.intellij.facet.FacetManager
+import com.intellij.facet.FacetType
+import com.intellij.facet.impl.FacetUtil
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.application.WriteAction
+import com.intellij.openapi.projectRoots.ProjectJdkTable
+import com.intellij.openapi.projectRoots.SimpleJavaSdkType
+import com.intellij.openapi.projectRoots.Sdk
+import com.intellij.openapi.projectRoots.impl.ProjectJdkImpl
+import com.intellij.openapi.roots.ModuleRootModificationUtil
+import com.intellij.openapi.roots.ProjectRootManager
+import org.elixir_lang.Facet
 import org.elixir_lang.PlatformTestCase
+import org.elixir_lang.facet.Type
+import org.elixir_lang.sdk.elixir.Type as ElixirSdkType
 
 /**
- * Tests for ElixirSdkStatusWidget functionality.
+ * Tests for [ElixirSdkStatusWidget] detection logic.
+ *
+ * Tests scenarios from the project-sdk-fixes plan (Step 8):
+ * 1. Project SDK = Java, module SDK = Elixir → no NotConfigured, no mismatch
+ * 2. Project SDK = null, module SDK = Elixir → no NotConfigured
+ * 3. Project SDK = Elixir A, module SDK = Elixir B → mismatch reported
+ * 5. No Elixir modules → widget factory isAvailable() = false
+ * 6. Small IDE: stale Facet SDK reference, Elixir SDKs exist → dangling issue
+ * 7. Small IDE: Facet SDK resolves correctly → no issue
+ * 8. Small IDE: stale Facet SDK reference, no Elixir SDKs in table → no dangling (NotConfigured)
  */
 class ElixirSdkStatusWidgetTest : PlatformTestCase() {
 
+    private val addedSdks = mutableListOf<Sdk>()
+
+    override fun setUp() {
+        super.setUp()
+        ensureElixirFacet()
+    }
+
+    override fun tearDown() {
+        try {
+            ModuleRootModificationUtil.setModuleSdk(module, null)
+            WriteAction.run<Throwable> {
+                ProjectRootManager.getInstance(project).projectSdk = null
+            }
+            WriteAction.run<Throwable> {
+                val jdkTable = ProjectJdkTable.getInstance()
+                for (sdk in addedSdks) {
+                    if (jdkTable.allJdks.contains(sdk)) {
+                        jdkTable.removeJdk(sdk)
+                    }
+                }
+                addedSdks.clear()
+            }
+            removeElixirFacetLibraries()
+        } finally {
+            super.tearDown()
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private fun ensureElixirFacet() {
+        val facetManager = FacetManager.getInstance(module)
+        if (facetManager.getFacetByType(Facet.ID) == null) {
+            FacetUtil.addFacet(module, FacetType.findInstance(Type::class.java))
+        }
+    }
+
+    private fun removeElixirFacet() {
+        val facetManager = FacetManager.getInstance(module)
+        val facet = facetManager.getFacetByType(Facet.ID) ?: return
+        ApplicationManager.getApplication().runWriteAction {
+            val model = facetManager.createModifiableModel()
+            model.removeFacet(facet)
+            model.commit()
+        }
+    }
+
+    private fun removeElixirFacetLibraries() {
+        // Use the Facet setter with null - this calls removeElixirSDKs() internally,
+        // which removes all Elixir SDK library entries from the module.
+        val facetManager = FacetManager.getInstance(module)
+        val facet = facetManager.getFacetByType(Facet.ID) ?: return
+        ApplicationManager.getApplication().runWriteAction {
+            facet.sdk = null
+        }
+    }
+
+    private fun createAndRegisterElixirSdk(name: String): Sdk {
+        val sdk = ProjectJdkImpl(name, ElixirSdkType.instance)
+        WriteAction.run<Throwable> {
+            ProjectJdkTable.getInstance().addJdk(sdk)
+        }
+        addedSdks.add(sdk)
+        return sdk
+    }
+
+    private fun createJavaSdk(): Sdk {
+        val javaHome = System.getProperty("java.home") ?: "/usr/lib/jvm/java"
+        return SimpleJavaSdkType().createJdk("Java Mock", javaHome)
+    }
+
+    private fun setModuleSdk(sdk: Sdk) {
+        ModuleRootModificationUtil.setModuleSdk(module, sdk)
+    }
+
+    private fun setProjectSdk(sdk: Sdk?) {
+        WriteAction.run<Throwable> {
+            ProjectRootManager.getInstance(project).projectSdk = sdk
+        }
+    }
+
+    private fun setFacetSdk(sdk: Sdk) {
+        val facetManager = FacetManager.getInstance(module)
+        val facet = facetManager.getFacetByType(Facet.ID) ?: error("No Elixir Facet on module")
+        ApplicationManager.getApplication().runWriteAction {
+            facet.sdk = sdk
+        }
+    }
+
+    private fun createWidget(): ElixirSdkStatusWidget = ElixirSdkStatusWidget(project)
+
+    // -------------------------------------------------------------------------
+    // Scenario 1: Project SDK = Java, module SDK = Elixir
+    // -------------------------------------------------------------------------
+
+    fun testModuleElixirSdkFoundWhenProjectSdkIsJava() {
+        val elixirSdk = createAndRegisterElixirSdk("Elixir Mock")
+        val javaSdk = createJavaSdk()
+
+        setProjectSdk(javaSdk)
+        setModuleSdk(elixirSdk)
+
+        val widget = createWidget()
+        val foundSdk = widget.findModuleLevelElixirSdk()
+
+        assertNotNull("Should find Elixir SDK from module even when project SDK is Java", foundSdk)
+        assertEquals("Should return the module's Elixir SDK", elixirSdk, foundSdk)
+    }
+
+    fun testNoMismatchWhenProjectSdkIsJavaAndModuleSdkIsElixir() {
+        val elixirSdk = createAndRegisterElixirSdk("Elixir Mock")
+        val javaSdk = createJavaSdk()
+
+        setProjectSdk(javaSdk)
+        setModuleSdk(elixirSdk)
+
+        val widget = createWidget()
+        val issues = widget.detectModuleSdkIssues()
+
+        assertTrue(
+            "No module SDK issues should be reported when project SDK is non-Elixir; got: $issues",
+            issues.isEmpty()
+        )
+    }
+
+    // -------------------------------------------------------------------------
+    // Scenario 2: Project SDK = null, module SDK = Elixir
+    // -------------------------------------------------------------------------
+
+    fun testModuleElixirSdkFoundWhenProjectSdkIsNull() {
+        val elixirSdk = createAndRegisterElixirSdk("Elixir Mock")
+
+        setProjectSdk(null)
+        setModuleSdk(elixirSdk)
+
+        val widget = createWidget()
+        val foundSdk = widget.findModuleLevelElixirSdk()
+
+        assertNotNull("Should find Elixir SDK from module when project SDK is null", foundSdk)
+        assertEquals(elixirSdk, foundSdk)
+    }
+
+    // -------------------------------------------------------------------------
+    // Scenario 3: Project SDK = Elixir A, module SDK = Elixir B
+    // → mismatch reported
+    // -------------------------------------------------------------------------
+
+    fun testMismatchReportedWhenModuleSdkDiffersFromElixirProjectSdk() {
+        val elixirSdkA = createAndRegisterElixirSdk("Elixir 1.17")
+        val elixirSdkB = createAndRegisterElixirSdk("Elixir 1.16")
+
+        setProjectSdk(elixirSdkA)
+        setModuleSdk(elixirSdkB)
+
+        val widget = createWidget()
+        val issues = widget.detectModuleSdkIssues()
+
+        assertTrue(
+            "Expected a mismatch issue (project=Elixir 1.17, module=Elixir 1.16); got: $issues",
+            issues.any { !it.isDangling && it.moduleName == module.name }
+        )
+    }
+
+    // -------------------------------------------------------------------------
+    // Scenario 5: No Elixir modules → widget factory isAvailable = false
+    // -------------------------------------------------------------------------
+
+    fun testWidgetFactoryNotAvailableWhenNoElixirModules() {
+        removeElixirFacet()
+
+        val factory = ElixirSdkStatusWidgetFactory()
+        assertFalse(
+            "Widget should not be available when the project has no Elixir modules",
+            factory.isAvailable(project)
+        )
+    }
+
+    // -------------------------------------------------------------------------
+    // Scenario 6: Small IDE - stale Facet SDK, SDKs exist → dangling issue
+    // -------------------------------------------------------------------------
+
+    fun testDanglingFacetSdkReportedWhenElixirSdkExistsButFacetReferenceIsStale() {
+        // Set up: Facet references "Elixir 1.17", then remove it from the JDK table
+        val staleSdk = createAndRegisterElixirSdk("Elixir 1.17")
+        setFacetSdk(staleSdk)
+
+        WriteAction.run<Throwable> {
+            ProjectJdkTable.getInstance().removeJdk(staleSdk)
+        }
+        addedSdks.remove(staleSdk)
+
+        // Register a different SDK so Facet.sdks().isNotEmpty() → stale (not NotConfigured)
+        createAndRegisterElixirSdk("Elixir 1.18")
+
+        // Do NOT call setModuleSdk() - no JdkOrderEntry, simulating Small IDE path
+
+        val widget = createWidget()
+        val issues = widget.detectModuleSdkIssues()
+
+        assertTrue(
+            "Expected a dangling issue for stale Facet SDK reference; got: $issues",
+            issues.any { it.isDangling && it.moduleName == module.name }
+        )
+    }
+
+    // -------------------------------------------------------------------------
+    // Scenario 7: Small IDE - Facet SDK resolves correctly → no issue
+    // -------------------------------------------------------------------------
+
+    fun testNoDanglingWhenFacetSdkResolvesCorrectly() {
+        val registeredSdk = createAndRegisterElixirSdk("Elixir 1.17")
+        setFacetSdk(registeredSdk)
+
+        val widget = createWidget()
+        val issues = widget.detectModuleSdkIssues()
+
+        assertTrue(
+            "Expected no issues when Facet SDK resolves correctly; got: $issues",
+            issues.isEmpty()
+        )
+    }
+
+    // -------------------------------------------------------------------------
+    // Scenario 8: Small IDE - stale Facet SDK, NO Elixir SDKs in table → no dangling
+    // -------------------------------------------------------------------------
+
+    fun testNoDanglingWhenNoElixirSdksExistInTable() {
+        val sdk = createAndRegisterElixirSdk("Elixir 1.17")
+        setFacetSdk(sdk)
+
+        WriteAction.run<Throwable> {
+            ProjectJdkTable.getInstance().removeJdk(sdk)
+        }
+        addedSdks.remove(sdk)
+
+        assertTrue("Precondition: no Elixir SDKs in table", Facet.sdks().isEmpty())
+
+        val widget = createWidget()
+        val issues = widget.detectModuleSdkIssues()
+
+        assertTrue(
+            "Expected no dangling issue when no Elixir SDKs exist (this is NotConfigured); got: $issues",
+            issues.isEmpty()
+        )
+    }
+
+    // -------------------------------------------------------------------------
+    // Smoke tests (regression)
+    // -------------------------------------------------------------------------
+
     fun testWidgetCreation() {
-        val widget = ElixirSdkStatusWidget(project)
+        val widget = createWidget()
         assertNotNull(widget)
         assertEquals(ElixirSdkStatusWidget.ID, widget.ID())
     }
 
     fun testWidgetComponent() {
-        val widget = ElixirSdkStatusWidget(project)
+        val widget = createWidget()
         val component = widget.getComponent()
         assertNotNull("Widget should have a component", component)
-    }
-
-    fun testWidgetComponentTextWithNoSdk() {
-        val widget = ElixirSdkStatusWidget(project)
-        val component = widget.getComponent()
-
-        // The component is a TextPanel.WithIconAndArrows
-        // When no SDK is configured, should show "No Elixir SDK"
-        assertNotNull(component)
     }
 
     fun testWidgetIdConstant() {
@@ -33,8 +299,7 @@ class ElixirSdkStatusWidgetTest : PlatformTestCase() {
     }
 
     fun testWidgetDispose() {
-        val widget = ElixirSdkStatusWidget(project)
-        // Should not throw
+        val widget = createWidget()
         widget.dispose()
     }
 }


### PR DESCRIPTION
## Summary

Fix the long-standing assumption that the project-level SDK is always an Elixir SDK. In mixed-language
projects (Java + Elixir, or multi-module workspaces with different SDKs per module), this caused false
positives in the status widget, silent no-ops in SDK mismatch detection, incorrect `BulkDecompilation`
behaviour, and the Mix importer silently overwriting the project SDK on import.

## Problem

`project.sdk` in IntelliJ is a project-wide slot that can hold *any* SDK type. For mixed-language
projects it is often a Java or Kotlin SDK. Every place the plugin called `Type.mostSpecificSdk(project)`
or `ProjectRootManager.projectSdk` and assumed the result was an Elixir SDK was silently broken:

- **Status widget** — `detectSdkStatus()` showed the Java/Kotlin SDK name as the Elixir SDK, or
  reported "not configured" when an Elixir module SDK was perfectly valid.
- **SDK mismatch check** — the guard that detects a module SDK differing from the project SDK fired
  against non-Elixir project SDKs, producing spurious "SDK mismatch" notifications.
- **`fixModuleSdk()`** — the reconfigure action assigned the project SDK to modules even when it was
  not an Elixir SDK.
- **Mix importer** (`Builder.kt`) — `fixProjectSdk()` called `findMostRecentSdkOfType(Elixir)` and
  silently wrote that SDK to the project slot, displacing whatever was there.
- **New Project Wizard** and **`Type.setupSdkPaths`** — also touched the project SDK slot
  unconditionally.
- **`BulkDecompilation`** — added the project SDK to the decompiler classpath without checking its
  type, causing a crash or no-op when the project SDK was not Elixir.
- **`ElixirSdkStatusWidgetFactory.isAvailable()`** — returned `true` for any project, not just those
  with Elixir modules.
- **`setup_sdk/Provider`** — banner text said "Project SDK is not defined" (wrong — it may be defined,
  just not Elixir), and showed a panel even when `module == null`.

Additionally, `ProjectModuleSetupValidator` and `ReconfigureModuleSetupAction` had no awareness of
umbrella sub-apps: folder marks were only applied to the content root, not to `apps/<sub-app>/`
directories that were not themselves content roots.

## Changes

### SDK resolution: walk modules, not the project slot

- **`ElixirSdkStatusWidget`** — `detectSdkStatus()` now calls `findModuleLevelElixirSdk()`, which
  iterates Elixir modules and returns `Type.mostSpecificSdk(module)` (Facet → module → project chain).
  It no longer reads `project.sdk` directly.
- **`ElixirSdkStatusWidget`** — SDK mismatch detection now skips modules where the project SDK is not
  an Elixir SDK, eliminating false "mismatch" notifications in mixed-language projects.
- **`ElixirSdkStatusWidgetFactory.isAvailable()`** — gated on the project containing at least one
  Elixir module (`ModuleType`).

### Stop claiming the project SDK slot

- **`Builder.kt`** (Mix importer) — removed `fixProjectSdk()`, which unconditionally found and
  assigned the most recent Elixir SDK to the project slot. The Elixir SDK to use is now passed in
  via `elixirSdk: Sdk?` (set by `ElixirSdkForModuleStep`) and assigned directly to each new module's
  root model, not the project.
- **`ElixirSdkForModuleStep.kt`** — sets `builder.elixirSdk` instead of relying on the importer to
  find one.
- **`new_project_wizard/Step.kt`** — removed the unconditional write of an Elixir SDK to the project
  SDK slot.
- **`sdk/elixir/Type.kt`** — removed the block in `setupSdkPaths` that set the project SDK, which
  ran even for SDK configurations unrelated to the current project.

### Guards on SDK-consuming actions

- **`fixModuleSdk()`** in `ReconfigureModuleSetupAction` — now skips modules where the project SDK is
  not an Elixir SDK rather than assigning a non-Elixir SDK to the module.
- **`BulkDecompilation`** — now checks `sdk.sdkType is elixir.Type` before adding the project SDK to
  the decompiler classpath.

### setup_sdk/Provider fixes

- Banner text changed from `"Project SDK is not defined"` to `"Elixir SDK is not defined"`.
- Panel suppressed when `module == null` (no Elixir module found for the file) — previously showed
  a confusing "project SDK" panel for non-Elixir files in mixed projects.
- Removed the nested `ReadAction.compute` wrapper; `collectNotificationData` is already called under
  a platform read lock.

### Umbrella sub-app folder marks

- **`ProjectModuleSetupValidator`** — detects umbrella sub-apps under `apps/` that are missing
  canonical folder marks and reports them in the module setup validation notification.
- **`ReconfigureModuleSetupAction`** — `addMissingUmbrellaSubAppFolderMarks()` applies canonical marks
  to `apps/<sub-app>/` directories that are not themselves separate content entries, using the same
  `applyCanonicalMarksForBaseUrl()` implementation as the top-level content-root path.

## Testing

- All existing tests pass.
- **`ReconfigureModuleSetupActionTest`** — new tests for the umbrella sub-app detection and the
  `fixModuleSdk` non-Elixir guard.
- **`ProjectModuleSetupValidatorTest`** — new tests for umbrella sub-app missing-mark detection.
- **`ElixirSdkStatusWidgetTest`** — extended to cover the module-level SDK resolution path and the
  mismatch check guard.

## Dependencies

- Stacked on merged PRs #3814–#3837 (all now in `main`).
- The BEAM decompiler TypedRegister fix (commit `c9df46683`) is also present on this branch — it
  will be dropped when PR #3841 merges into `main` and this branch is rebased.
