### PR TITLE
fix: BEAM decompiler - TypedRegister (OTP 25+) and opcodes 177-191 (OTP 25-29)

### DIFF
--- a/src/org/elixir_lang/beam/chunk/Code.kt
+++ b/src/org/elixir_lang/beam/chunk/Code.kt
@@ -190,10 +190,10 @@ class Code(private val operationList: List<Operation>) {
 
             val expectedMaxOpcode = org.elixir_lang.beam.chunk.code.operation.Code.values().max()?.number ?: 0
             if (maxOpcode > expectedMaxOpcode) {
-                LOGGER.error(
-                        "Max opcode ($maxOpcode) exceeds expected max opcode ($expectedMaxOpcode).  Additional " +
-                                "opcodes have been added to the end of " +
-                                "https://github.com/erlang/otp/blob/master/lib/compiler/src/genop.tab."
+                LOGGER.warn(
+                    "Max opcode ($maxOpcode) exceeds expected max opcode ($expectedMaxOpcode).  Additional " +
+                            "opcodes have been added to the end of " +
+                            "https://github.com/erlang/otp/blob/master/lib/compiler/src/genop.tab"
                 )
             }
 

--- a/src/org/elixir_lang/beam/chunk/code/operation/Code.kt
+++ b/src/org/elixir_lang/beam/chunk/code/operation/Code.kt
@@ -832,7 +832,77 @@ enum class Code(val number: Int, val function: String, val arguments: Array<Argu
     // @spec recv_marker_use Reference
     // @doc  Sets the current receive cursor to the marker associated with
     //       the given Reference
-    RECV_MARKER_USE(176, "recv_marker_user", arrayOf(REFERENCE));
+    RECV_MARKER_USE(176, "recv_marker_user", arrayOf(REFERENCE)),
+
+    // OTP 25
+
+    // @spec bs_create_bin Fail Alloc Live Unit Dst OpList
+    // @doc  Build a new binary using the binary syntax.
+    BS_CREATE_BIN(177, "bs_create_bin", SIX),
+
+    // @spec call_fun2 Tag Arity Func
+    // @doc  Calls the fun Func with arity Arity.
+    CALL_FUN2(178, "call_fun2", THREE),
+
+    // @spec nif_start
+    // @doc  No-op at start of each function declared in -nifs().
+    NIF_START(179, "nif_start"),
+
+    // @spec badrecord Value
+    // @doc  Raises a {badrecord,Value} error exception.
+    BADRECORD(180, "badrecord", ONE),
+
+    // OTP 26
+
+    // @spec update_record Hint Size Src Dst Updates
+    // @doc  Sets Dst to a copy of Src with the update list applied.
+    UPDATE_RECORD(181, "update_record", FIVE),
+
+    // @spec bs_match Fail Ctx Commands
+    // @doc  Match one or more binary segments of fixed size.
+    BS_MATCH(182, "bs_match", THREE),
+
+    // OTP 27
+
+    // @spec executable_line Location Index
+    // @doc  Provide location for an executable line.
+    EXECUTABLE_LINE(183, "executable_line", TWO),
+
+    // OTP 28
+
+    // @spec debug_line Kind Location Index Live
+    // @doc  Provide location for a place where a break point can be placed.
+    DEBUG_LINE(184, "debug_line", FOUR),
+
+    // OTP 29
+
+    // @spec bif3 Lbl Bif Arg1 Arg2 Arg3 Reg
+    // @doc  Call the bif Bif with the arguments Arg1, Arg2, and Arg3.
+    BIF3(185, "bif3", SIX),
+
+    // @spec is_any_native_record Lbl Term
+    // @doc  Check whether Term is a native record.
+    IS_ANY_NATIVE_RECORD(186, "is_any_native_record", UNARY),
+
+    // @spec is_native_record Lbl Rec Module Name
+    // @doc  Check whether record Rec is the record Name defined in module Module.
+    IS_NATIVE_RECORD(187, "is_native_record", FOUR),
+
+    // @spec get_record_elements Lbl Rec Elements
+    // @doc  Extract the values for each field name and store into the corresponding register.
+    GET_RECORD_ELEMENTS(188, "get_record_elements", THREE),
+
+    // @spec put_record Lbl Id Src Dst Live Updates
+    // @doc  Create (Src is nil) or update (Src is a register) a native record.
+    PUT_RECORD(189, "put_record", SIX),
+
+    // @spec is_record_accessible Lbl Rec Scope
+    // @doc  Check whether the fields of native record Rec are accessible from the executing module.
+    IS_RECORD_ACCESSIBLE(190, "is_record_accessible", THREE),
+
+    // @spec get_record_field Lbl Rec Id Field Dst
+    // @doc  Get a single field from a record.
+    GET_RECORD_FIELD(191, "get_record_field", FIVE);
 
     fun arity() = arguments.size
 }

--- a/src/org/elixir_lang/beam/chunk/code/operation/code/Argument.kt
+++ b/src/org/elixir_lang/beam/chunk/code/operation/code/Argument.kt
@@ -115,6 +115,8 @@ data class Argument(val name: String, val supportedOptions: Code.Options = Code.
                     else -> "literal($index)"
                 }
             }
+            is TypedRegister ->
+                "{tr, ${valueAssembly(term.register, cache, configuredOptions)}, ${valueAssembly(term.type, cache, configuredOptions)}}"
             is XRegister ->
                 "x(${term.index})"
             is YRegister ->

--- a/src/org/elixir_lang/beam/term/Term.kt
+++ b/src/org/elixir_lang/beam/term/Term.kt
@@ -61,6 +61,9 @@ sealed class Term {
                                 AllocationList.from(data, internalOffset, literalFloat)
                             0b1000 ->
                                 ExtendedLiteral.from(data, internalOffset, literalFloat)
+                            // OTP 25+: typed register {tr, Reg, Type} used by JIT-annotated operands
+                            0b1010 ->
+                                TypedRegister.from(data, internalOffset, literalFloat)
                             else ->
                                 throw IllegalArgumentException(
                                         "Extended tag ($extendedTag) is not properly shifted and masked"
@@ -381,6 +384,27 @@ class ExtendedLiteral: Term() {
             }
 
             return Pair(Literal(index), internalOffset - offset)
+        }
+    }
+}
+
+/**
+ * Typed register operand {tr, Reg, Type} introduced in OTP 25 for JIT type-annotated operands.
+ * Extended tag sub-type 5 (encoded as 0b1010 in the shifted-masked extended tag field).
+ * See https://github.com/erlang/otp/blob/main/lib/compiler/src/beam_disasm.erl
+ */
+class TypedRegister(val register: Term, val type: Term) : Term() {
+    companion object {
+        fun from(data: ByteArray, offset: Int, literalFloat: Boolean): Pair<TypedRegister, ByteCount> {
+            var internalOffset = offset
+
+            val (register, registerByteCount) = Term.from(data, internalOffset, literalFloat)
+            internalOffset += registerByteCount
+
+            val (type, typeByteCount) = Term.from(data, internalOffset, literalFloat)
+            internalOffset += typeByteCount
+
+            return Pair(TypedRegister(register, type), internalOffset - offset)
         }
     }
 }


### PR DESCRIPTION
## Problem

Two related bugs in the BEAM chunk Code parser that affect all OTP 25+ installations:

### 1. `IllegalArgumentException` when parsing any OTP 25+ BEAM file

`Term.kt`'s extended-tag dispatch was missing sub-type `0b1010` (decimal 10), which OTP 25 introduced for **TypedRegister** — the `{tr, Reg, Type}` operand used by the JIT to carry type annotations alongside a register reference. Every BEAM file compiled by OTP 25 or later contains at least one TypedRegister operand, so attempting to read the Code chunk (e.g. opening the **Code** tab in the BEAM decompiler) threw:

```
IllegalArgumentException: Extended tag (10) is not properly shifted and masked
```

### 2. False `SEVERE` log on every OTP 25+ BEAM open

The max-opcode validator in `Code.kt` compared the highest opcode seen in the file against the highest entry in the `Code` enum. Because opcodes 177–191 (added across OTP 25–29) were absent from the enum, the validator logged a `SEVERE` error for every OTP 25+ file even when parsing succeeded.

## Fix

**`Term.kt`** — add the `0b1010` case to the extended-tag `when` block and implement `TypedRegister.from()` to consume the two sub-terms (register + type):

```kotlin
0b1010 -> TypedRegister.from(data, internalOffset, literalFloat)
```

**`Argument.kt`** — add the `TypedRegister` branch to the exhaustive `when` in `valueAssembly` so it renders as `{tr, <reg>, <type>}`:

```kotlin
is TypedRegister ->
    "{tr, ${valueAssembly(term.register, ...)}, ${valueAssembly(term.type, ...)}}"
```

**`operation/Code.kt`** — add opcodes 177–191 sourced from [`genop.tab`](https://github.com/erlang/otp/blob/master/lib/compiler/src/genop.tab):

| Range | OTP version | New opcodes |
|-------|-------------|-------------|
| 177–180 | OTP 25 | `bs_create_bin`, `call_fun2`, `nif_start`, `badrecord` |
| 181–182 | OTP 26 | `update_record`, `bs_match` |
| 183 | OTP 27 | `executable_line` |
| 184 | OTP 28 | `debug_line` |
| 185–191 | OTP 29 | `bif3`, native-record instructions |

**`chunk/Code.kt`** — downgrade the max-opcode mismatch from `LOGGER.error` to `LOGGER.warn`. New opcodes appended to the end of `genop.tab` are expected with each OTP release; this is not an error condition.

## Testing

Manually verified against OTP 25, 26, 27, and 28 BEAM files. The Code chunk tab now opens without exception and the SEVERE log is gone.

## Notes

This is a prerequisite for PR #3838, which reads the Code chunk of `Elixir.System.beam` to extract the compiled-against OTP release from `System.build_info/0`. That function requires the Code parser to handle OTP 25+ operands correctly.

