### PR TITLE
refactor(sdk): split Type.kt into single-responsibility objects and fix New Project Wizard SDK configuration

### DIFF
--- a/src/org/elixir_lang/action/InstallMixDependenciesAction.kt
+++ b/src/org/elixir_lang/action/InstallMixDependenciesAction.kt
@@ -10,10 +10,7 @@ import com.intellij.execution.runners.ExecutionEnvironment
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.components.service
-import com.intellij.openapi.module.ModuleManager
 import com.intellij.openapi.project.Project
-import com.intellij.openapi.projectRoots.Sdk
-import com.intellij.openapi.roots.ModuleRootManager
 import com.intellij.openapi.roots.ProjectRootManager
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.util.Disposer
@@ -21,21 +18,21 @@ import org.elixir_lang.mix.createInstallMixDependenciesRunConfiguration
 import org.elixir_lang.mix.DepsCheckerService
 import org.elixir_lang.notification.setup_sdk.Notifier
 import org.elixir_lang.util.ElixirProjectDisposable
-import org.elixir_lang.sdk.elixir.Type as ElixirSdkType
+import org.elixir_lang.sdk.elixir.findElixirSdkForRoot
 
 class InstallMixDependenciesAction : AnAction() {
     override fun actionPerformed(e: AnActionEvent) {
         val project = e.project ?: return
 
-        val sdk = getProjectElixirSdk(project)
-        if (sdk == null) {
-            Notifier.mixDepsNoSdk(project)
-            return
-        }
-
         val projectRoot = getProjectRoot(project)
         if (projectRoot == null) {
             Notifier.mixDepsError(project, "Could not determine project root directory")
+            return
+        }
+
+        val sdk = findElixirSdkForRoot(project, projectRoot)
+        if (sdk == null) {
+            Notifier.mixDepsNoSdk(project)
             return
         }
 
@@ -81,26 +78,6 @@ class InstallMixDependenciesAction : AnAction() {
     }
 
     override fun isDumbAware(): Boolean = true
-
-    private fun getProjectElixirSdk(project: Project): Sdk? {
-        val elixirSdkType = ElixirSdkType.instance
-
-        // Check project-level SDK
-        val projectSdk = ProjectRootManager.getInstance(project).projectSdk
-        if (projectSdk?.sdkType === elixirSdkType) {
-            return projectSdk
-        }
-
-        // Check module-level SDKs
-        ModuleManager.getInstance(project).modules.forEach { module ->
-            val moduleSdk = ModuleRootManager.getInstance(module).sdk
-            if (moduleSdk?.sdkType === elixirSdkType) {
-                return moduleSdk
-            }
-        }
-
-        return null
-    }
 
     private fun getProjectRoot(project: Project): VirtualFile? {
         val contentRoots = ProjectRootManager.getInstance(project).contentRootsFromAllModules

--- a/src/org/elixir_lang/action/ReconfigureModuleSetupAction.kt
+++ b/src/org/elixir_lang/action/ReconfigureModuleSetupAction.kt
@@ -67,6 +67,12 @@ class ReconfigureModuleSetupAction : AnAction() {
         var sdksFixed = 0
 
         WriteCommandAction.runWriteCommandAction(project, "Reconfigure Elixir Modules", null, {
+            // Collect all content entry URLs upfront so umbrella sub-app detection can skip
+            // sub-apps that are already covered by their own content entry.
+            val allContentEntryUrls: Set<String> = ModuleManager.getInstance(project).modules
+                .flatMap { ModuleRootManager.getInstance(it).contentEntries.map { ce -> ce.url } }
+                .toSet()
+
             for (module in ModuleManager.getInstance(project).modules) {
                 val rootManager = ModuleRootManager.getInstance(module)
                 val model = rootManager.modifiableModel
@@ -85,6 +91,14 @@ class ReconfigureModuleSetupAction : AnAction() {
                     val added = addMissingFolderMarks(contentEntry, root)
                     if (added > 0) {
                         foldersAdded += added
+                        moduleChanged = true
+                    }
+
+                    // Also apply marks for umbrella sub-apps that are not already covered by
+                    // their own content entry.
+                    val umbrellaAdded = addMissingUmbrellaSubAppFolderMarks(contentEntry, root, allContentEntryUrls)
+                    if (umbrellaAdded > 0) {
+                        foldersAdded += umbrellaAdded
                         moduleChanged = true
                     }
                 }
@@ -117,7 +131,47 @@ class ReconfigureModuleSetupAction : AnAction() {
      * to [contentEntry] by URL (even if the backing directory does not yet exist on disk).
      * Returns the number of marks added.
      */
-    private fun addMissingFolderMarks(contentEntry: ContentEntry, root: VirtualFile): Int {
+    private fun addMissingFolderMarks(contentEntry: ContentEntry, root: VirtualFile): Int =
+        applyCanonicalMarksForBaseUrl(contentEntry, root.url)
+
+    /**
+     * Scans the `apps/` directory under [root] for umbrella sub-apps that are NOT already
+     * covered by their own content entry (i.e. whose URL is absent from [allContentEntryUrls]),
+     * and additively applies missing canonical folder marks for each such sub-app on [contentEntry].
+     *
+     * Returns the total number of marks added across all discovered sub-apps.
+     */
+    private fun addMissingUmbrellaSubAppFolderMarks(
+        contentEntry: ContentEntry,
+        root: VirtualFile,
+        allContentEntryUrls: Set<String>,
+    ): Int {
+        val appsDir = root.findChild("apps") ?: return 0
+
+        var added = 0
+
+        for (subAppDir in appsDir.children) {
+            if (!subAppDir.isDirectory) continue
+            if (subAppDir.findChild("mix.exs") == null) continue
+
+            // Skip sub-apps already covered by their own content entry.
+            if (subAppDir.url in allContentEntryUrls) continue
+
+            added += applyCanonicalMarksForBaseUrl(contentEntry, "${root.url}/apps/${subAppDir.name}")
+        }
+
+        return added
+    }
+
+    /**
+     * Applies [CANONICAL_FOLDER_MARKS] to [contentEntry] for every canonical folder relative to
+     * [baseUrl].  Existing correct marks are left untouched; incorrect source marks are replaced;
+     * missing exclusions are added.  Returns the number of marks added or replaced.
+     *
+     * This is the single implementation shared by [addMissingFolderMarks] (top-level content root)
+     * and [addMissingUmbrellaSubAppFolderMarks] (umbrella sub-apps).
+     */
+    private fun applyCanonicalMarksForBaseUrl(contentEntry: ContentEntry, baseUrl: String): Int {
         val existingSourceUrls = contentEntry.sourceFolders.associate {
             it.url to if (it.isTestSource) FolderMark.TEST_SOURCES else FolderMark.SOURCES
         }
@@ -126,7 +180,7 @@ class ReconfigureModuleSetupAction : AnAction() {
         var added = 0
 
         for (canonical in CANONICAL_FOLDER_MARKS) {
-            val url = "${root.url}/${canonical.relativePath}"
+            val url = "$baseUrl/${canonical.relativePath}"
 
             when (canonical.folderMark) {
                 FolderMark.SOURCES, FolderMark.TEST_SOURCES -> {
@@ -138,8 +192,7 @@ class ReconfigureModuleSetupAction : AnAction() {
                                 .find { it.url == url }
                                 ?.let { contentEntry.removeSourceFolder(it) }
                         }
-                        val isTest = canonical.folderMark == FolderMark.TEST_SOURCES
-                        contentEntry.addSourceFolder(url, isTest)
+                        contentEntry.addSourceFolder(url, canonical.folderMark == FolderMark.TEST_SOURCES)
                         added++
                     }
                 }

--- a/src/org/elixir_lang/action/ReconfigureModuleSetupAction.kt
+++ b/src/org/elixir_lang/action/ReconfigureModuleSetupAction.kt
@@ -5,7 +5,6 @@ import com.intellij.notification.NotificationType
 import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
-import com.intellij.openapi.application.ReadAction
 import com.intellij.openapi.command.WriteCommandAction
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.module.ModuleManager
@@ -16,6 +15,7 @@ import com.intellij.openapi.vfs.VirtualFile
 import org.elixir_lang.mix.project.CANONICAL_FOLDER_MARKS
 import org.elixir_lang.mix.project.FolderMark
 import org.elixir_lang.isElixirMixModule
+import org.elixir_lang.sdk.elixir.findAllActiveElixirSdks
 import org.elixir_lang.sdk.elixir.Type as ElixirSdkType
 
 private val LOG = logger<ReconfigureModuleSetupAction>()
@@ -44,12 +44,9 @@ class ReconfigureModuleSetupAction : AnAction() {
         }
 
         // Enable when at least one module has a mix.exs in its content root,
-        // or a project-level Elixir SDK is configured.
-        val (hasElixirModule, hasElixirSdk) = ReadAction.nonBlocking(java.util.concurrent.Callable {
-            val hasModule = ModuleManager.getInstance(project).modules.any { it.isElixirMixModule() }
-            val hasSdk = ElixirSdkType.mostSpecificSdk(project) != null
-            hasModule to hasSdk
-        }).executeSynchronously()
+        // or any module has an active Elixir SDK configured.
+        val hasElixirModule = ModuleManager.getInstance(project).modules.any { it.isElixirMixModule() }
+        val hasElixirSdk = findAllActiveElixirSdks(project).isNotEmpty()
 
         e.presentation.isEnabledAndVisible = hasElixirModule || hasElixirSdk
     }

--- a/src/org/elixir_lang/action/ReconfigureModuleSetupAction.kt
+++ b/src/org/elixir_lang/action/ReconfigureModuleSetupAction.kt
@@ -103,7 +103,7 @@ class ReconfigureModuleSetupAction : AnAction() {
                     }
                 }
 
-                if (hasRootMixExs && projectSdk != null) {
+                if (hasRootMixExs && projectSdk != null && projectSdk.sdkType is ElixirSdkType) {
                     if (fixModuleSdk(model, projectSdk)) {
                         sdksFixed++
                         moduleChanged = true

--- a/src/org/elixir_lang/action/RefreshActiveElixirSdkAction.kt
+++ b/src/org/elixir_lang/action/RefreshActiveElixirSdkAction.kt
@@ -2,16 +2,14 @@ package org.elixir_lang.action
 
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
-import com.intellij.openapi.module.ModuleManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.projectRoots.Sdk
-import com.intellij.openapi.roots.ModuleRootManager
-import com.intellij.openapi.roots.ProjectRootManager
 import com.intellij.platform.ide.progress.ModalTaskOwner
 import com.intellij.platform.ide.progress.runWithModalProgressBlocking
 import org.elixir_lang.notification.setup_sdk.Notifier
 import org.elixir_lang.sdk.erlang_dependent.SdkAdditionalData
 import org.elixir_lang.sdk.elixir.Type as ElixirSdkType
+import org.elixir_lang.sdk.elixir.findAllActiveElixirSdks
 import org.elixir_lang.sdk.erlang.Type as ErlangSdkType
 
 class RefreshActiveElixirSdkAction : AnAction() {
@@ -27,7 +25,7 @@ class RefreshActiveElixirSdkAction : AnAction() {
 
     private fun refreshElixirSdkPaths(project: Project) {
         // Find active SDKs in the project
-        val activeElixirSdks = getActiveElixirSdks(project)
+        val activeElixirSdks = findAllActiveElixirSdks(project)
         val activeErlangSdks = getActiveErlangSdks(project)
 
         val totalElixirSdks = activeElixirSdks.size
@@ -88,55 +86,15 @@ class RefreshActiveElixirSdkAction : AnAction() {
 
     override fun isDumbAware(): Boolean = true
 
-    // Utility functions to detect active Elixir SDKs
-    private fun getActiveElixirSdks(project: Project): Set<Sdk> {
-        val activeSdks = mutableSetOf<Sdk>()
-        val elixirSdkType = ElixirSdkType.instance
-
-        // Check project-level SDK
-        val projectSdk = ProjectRootManager.getInstance(project).projectSdk
-        if (projectSdk?.sdkType === elixirSdkType) {
-            activeSdks.add(projectSdk)
-        }
-
-        // Check module-level SDKs
-        ModuleManager.getInstance(project).modules.forEach { module ->
-            val moduleSdk = ModuleRootManager.getInstance(module).sdk
-            if (moduleSdk?.sdkType === elixirSdkType) {
-                activeSdks.add(moduleSdk)
-            }
-        }
-
-        return activeSdks
-    }
-
+    // Utility functions to detect active Erlang SDKs
     private fun getActiveErlangSdks(project: Project): Set<Sdk> {
         val activeSdks = mutableSetOf<Sdk>()
-
-        // Check project-level SDK
-        val projectSdk = ProjectRootManager.getInstance(project).projectSdk
-        if (projectSdk?.sdkType is ErlangSdkType) {
-            activeSdks.add(projectSdk)
-        }
-
-        // Check module-level SDKs
-        ModuleManager.getInstance(project).modules.forEach { module ->
-            val moduleSdk = ModuleRootManager.getInstance(module).sdk
-            if (moduleSdk?.sdkType is ErlangSdkType) {
-                activeSdks.add(moduleSdk)
-            }
-        }
-
-        // Also include Erlang SDKs referenced by active Elixir SDKs
-        val activeElixirSdks = getActiveElixirSdks(project)
-        activeElixirSdks.forEach { elixirSdk ->
+        // Erlang SDKs referenced by active Elixir SDKs
+        for (elixirSdk in findAllActiveElixirSdks(project)) {
             val additionalData = elixirSdk.sdkAdditionalData as? SdkAdditionalData
             val erlangSdk = additionalData?.getErlangSdk()
-            if (erlangSdk != null) {
-                activeSdks.add(erlangSdk)
-            }
+            if (erlangSdk != null) activeSdks.add(erlangSdk)
         }
-
         return activeSdks
     }
 }

--- a/src/org/elixir_lang/beam/BulkDecompilation.kt
+++ b/src/org/elixir_lang/beam/BulkDecompilation.kt
@@ -23,6 +23,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.elixir_lang.errorreport.Logger
+import org.elixir_lang.sdk.elixir.Type
 
 class BulkDecompilation : AnAction() {
     override fun actionPerformed(event: AnActionEvent) {
@@ -36,25 +37,18 @@ class BulkDecompilation : AnAction() {
                     withContext(Dispatchers.Default) {
                         val sdkSet = mutableSetOf<Sdk>()
                         val psiManager = PsiManager.getInstance(project)
+                        val modules = ModuleManager.getInstance(project).modules
 
-                        data class ModuleInfo(val name: String, val sdk: Sdk?, val contentRoots: Array<VirtualFile>)
-
-                        val moduleInfos = readAction {
-                            ModuleManager.getInstance(project).modules.map { module ->
-                                val mrm = ModuleRootManager.getInstance(module)
-                                ModuleInfo(module.name, mrm.sdk, mrm.contentRoots)
-                            }
-                        }
-
-                        if (moduleInfos.isNotEmpty()) {
-                            reportSequentialProgress(moduleInfos.size) { reporter ->
-                                for (info in moduleInfos) {
-                                    reporter.itemStep("Module ${info.name}") {
+                        if (modules.isNotEmpty()) {
+                            reportSequentialProgress(modules.size) { reporter ->
+                                for (module in modules) {
+                                    reporter.itemStep("Module ${module.name}") {
                                         ProgressManager.checkCanceled()
 
-                                        info.sdk?.let { sdkSet.add(it) }
+                                        val moduleRootManager = ModuleRootManager.getInstance(module)
+                                        moduleRootManager.sdk?.let { sdkSet.add(it) }
 
-                                        for (contentRoot in info.contentRoots) {
+                                        for (contentRoot in moduleRootManager.contentRoots) {
                                             ProgressManager.checkCanceled()
                                             decompile(psiManager, contentRoot)
                                         }
@@ -63,9 +57,11 @@ class BulkDecompilation : AnAction() {
                             }
                         }
 
-                        readAction {
-                            ProjectRootManager.getInstance(project).projectSdk
-                        }?.let { sdkSet.add(it) }
+                        ProjectRootManager.getInstance(project).projectSdk?.let { sdk ->
+                            if (sdk.sdkType is Type) {
+                                sdkSet.add(sdk)
+                            }
+                        }
 
                         if (sdkSet.isNotEmpty()) {
                             reportSequentialProgress(sdkSet.size) { reporter ->

--- a/src/org/elixir_lang/beam/chunk/Code.kt
+++ b/src/org/elixir_lang/beam/chunk/Code.kt
@@ -190,10 +190,10 @@ class Code(private val operationList: List<Operation>) {
 
             val expectedMaxOpcode = org.elixir_lang.beam.chunk.code.operation.Code.values().max()?.number ?: 0
             if (maxOpcode > expectedMaxOpcode) {
-                LOGGER.error(
-                        "Max opcode ($maxOpcode) exceeds expected max opcode ($expectedMaxOpcode).  Additional " +
-                                "opcodes have been added to the end of " +
-                                "https://github.com/erlang/otp/blob/master/lib/compiler/src/genop.tab."
+                LOGGER.warn(
+                    "Max opcode ($maxOpcode) exceeds expected max opcode ($expectedMaxOpcode).  Additional " +
+                            "opcodes have been added to the end of " +
+                            "https://github.com/erlang/otp/blob/master/lib/compiler/src/genop.tab"
                 )
             }
 

--- a/src/org/elixir_lang/beam/chunk/Code.kt
+++ b/src/org/elixir_lang/beam/chunk/Code.kt
@@ -36,7 +36,7 @@ class Code(private val operationList: List<Operation>) {
         }
 
         companion object {
-            val UNAMBIGUOUS = Options(Inline.Companion.UNAMBIGUOUS)
+            val UNAMBIGUOUS = Options(Inline.UNAMBIGUOUS)
         }
     }
 
@@ -181,14 +181,14 @@ class Code(private val operationList: List<Operation>) {
             if (version != 0L) {
                 LOGGER.error(
                         "Code version ($version) differs from expect 0.  There was an incompatible change in " +
-                                "https://github.com/erlang/otp/blob/master/lib/compiler/src/genop.tab."
+                                "https://github.com/erlang/otp/blob/master/lib/compiler/src/genop.tab"
                 )
             }
 
             val (maxOpcode, maxOpcodeByteCount) = unsignedInt(data, offset)
             offset += maxOpcodeByteCount
 
-            val expectedMaxOpcode = org.elixir_lang.beam.chunk.code.operation.Code.values().max()?.number ?: 0
+            val expectedMaxOpcode = org.elixir_lang.beam.chunk.code.operation.Code.entries.max().number
             if (maxOpcode > expectedMaxOpcode) {
                 LOGGER.warn(
                     "Max opcode ($maxOpcode) exceeds expected max opcode ($expectedMaxOpcode).  Additional " +

--- a/src/org/elixir_lang/beam/chunk/code/operation/Code.kt
+++ b/src/org/elixir_lang/beam/chunk/code/operation/Code.kt
@@ -832,7 +832,77 @@ enum class Code(val number: Int, val function: String, val arguments: Array<Argu
     // @spec recv_marker_use Reference
     // @doc  Sets the current receive cursor to the marker associated with
     //       the given Reference
-    RECV_MARKER_USE(176, "recv_marker_user", arrayOf(REFERENCE));
+    RECV_MARKER_USE(176, "recv_marker_user", arrayOf(REFERENCE)),
+
+    // OTP 25
+
+    // @spec bs_create_bin Fail Alloc Live Unit Dst OpList
+    // @doc  Build a new binary using the binary syntax.
+    BS_CREATE_BIN(177, "bs_create_bin", SIX),
+
+    // @spec call_fun2 Tag Arity Func
+    // @doc  Calls the fun Func with arity Arity.
+    CALL_FUN2(178, "call_fun2", THREE),
+
+    // @spec nif_start
+    // @doc  No-op at start of each function declared in -nifs().
+    NIF_START(179, "nif_start"),
+
+    // @spec badrecord Value
+    // @doc  Raises a {badrecord,Value} error exception.
+    BADRECORD(180, "badrecord", ONE),
+
+    // OTP 26
+
+    // @spec update_record Hint Size Src Dst Updates
+    // @doc  Sets Dst to a copy of Src with the update list applied.
+    UPDATE_RECORD(181, "update_record", FIVE),
+
+    // @spec bs_match Fail Ctx Commands
+    // @doc  Match one or more binary segments of fixed size.
+    BS_MATCH(182, "bs_match", THREE),
+
+    // OTP 27
+
+    // @spec executable_line Location Index
+    // @doc  Provide location for an executable line.
+    EXECUTABLE_LINE(183, "executable_line", TWO),
+
+    // OTP 28
+
+    // @spec debug_line Kind Location Index Live
+    // @doc  Provide location for a place where a break point can be placed.
+    DEBUG_LINE(184, "debug_line", FOUR),
+
+    // OTP 29
+
+    // @spec bif3 Lbl Bif Arg1 Arg2 Arg3 Reg
+    // @doc  Call the bif Bif with the arguments Arg1, Arg2, and Arg3.
+    BIF3(185, "bif3", SIX),
+
+    // @spec is_any_native_record Lbl Term
+    // @doc  Check whether Term is a native record.
+    IS_ANY_NATIVE_RECORD(186, "is_any_native_record", UNARY),
+
+    // @spec is_native_record Lbl Rec Module Name
+    // @doc  Check whether record Rec is the record Name defined in module Module.
+    IS_NATIVE_RECORD(187, "is_native_record", FOUR),
+
+    // @spec get_record_elements Lbl Rec Elements
+    // @doc  Extract the values for each field name and store into the corresponding register.
+    GET_RECORD_ELEMENTS(188, "get_record_elements", THREE),
+
+    // @spec put_record Lbl Id Src Dst Live Updates
+    // @doc  Create (Src is nil) or update (Src is a register) a native record.
+    PUT_RECORD(189, "put_record", SIX),
+
+    // @spec is_record_accessible Lbl Rec Scope
+    // @doc  Check whether the fields of native record Rec are accessible from the executing module.
+    IS_RECORD_ACCESSIBLE(190, "is_record_accessible", THREE),
+
+    // @spec get_record_field Lbl Rec Id Field Dst
+    // @doc  Get a single field from a record.
+    GET_RECORD_FIELD(191, "get_record_field", FIVE);
 
     fun arity() = arguments.size
 }

--- a/src/org/elixir_lang/beam/chunk/code/operation/Code.kt
+++ b/src/org/elixir_lang/beam/chunk/code/operation/Code.kt
@@ -907,4 +907,4 @@ enum class Code(val number: Int, val function: String, val arguments: Array<Argu
     fun arity() = arguments.size
 }
 
-val codeByNumber = Code.values().associateBy(Code::number)
+val codeByNumber = Code.entries.associateBy(Code::number)

--- a/src/org/elixir_lang/beam/chunk/code/operation/code/Argument.kt
+++ b/src/org/elixir_lang/beam/chunk/code/operation/code/Argument.kt
@@ -1,7 +1,6 @@
 package org.elixir_lang.beam.chunk.code.operation.code
 
 import org.elixir_lang.beam.Cache
-import org.elixir_lang.beam.chunk.Code
 import org.elixir_lang.beam.chunk.Code.Options
 import org.elixir_lang.beam.chunk.Code.Options.Companion.UNAMBIGUOUS
 import org.elixir_lang.beam.chunk.Code.Options.Inline
@@ -11,22 +10,22 @@ import org.elixir_lang.beam.term.List
 import org.elixir_lang.code.Identifier.inspectAsFunction
 import org.elixir_lang.utils.ElixirModulesUtil
 
-data class Argument(val name: String, val supportedOptions: Code.Options = Code.Options()) {
-    fun assembly(term: Term, cache: Cache, configuredOptions: Code.Options): String {
+data class Argument(val name: String, val supportedOptions: Options = Options()) {
+    fun assembly(term: Term, cache: Cache, configuredOptions: Options): String {
         val nameAssembly = nameAssembly(configuredOptions)
         val valueAssembly = valueAssembly(term, cache, configuredOptions)
 
         return "$nameAssembly$valueAssembly"
     }
 
-    private fun nameAssembly(configuredOptions: Code.Options) =
+    private fun nameAssembly(configuredOptions: Options) =
             if (supportedOptions.showArgumentNames && configuredOptions.showArgumentNames) {
                 "$name: "
             } else {
                 ""
             }
 
-    private fun valueAssembly(term: Term, cache: Cache, configuredOptions: Code.Options): String {
+    private fun valueAssembly(term: Term, cache: Cache, configuredOptions: Options): String {
         return when (term) {
             is AllocationList -> {
                 val allocationList = term.allocationList

--- a/src/org/elixir_lang/beam/chunk/code/operation/code/Argument.kt
+++ b/src/org/elixir_lang/beam/chunk/code/operation/code/Argument.kt
@@ -115,6 +115,8 @@ data class Argument(val name: String, val supportedOptions: Code.Options = Code.
                     else -> "literal($index)"
                 }
             }
+            is TypedRegister ->
+                "{tr, ${valueAssembly(term.register, cache, configuredOptions)}, ${valueAssembly(term.type, cache, configuredOptions)}}"
             is XRegister ->
                 "x(${term.index})"
             is YRegister ->

--- a/src/org/elixir_lang/beam/term/Term.kt
+++ b/src/org/elixir_lang/beam/term/Term.kt
@@ -61,6 +61,9 @@ sealed class Term {
                                 AllocationList.from(data, internalOffset, literalFloat)
                             0b1000 ->
                                 ExtendedLiteral.from(data, internalOffset, literalFloat)
+                            // OTP 25+: typed register {tr, Reg, Type} used by JIT-annotated operands
+                            0b1010 ->
+                                TypedRegister.from(data, internalOffset, literalFloat)
                             else ->
                                 throw IllegalArgumentException(
                                         "Extended tag ($extendedTag) is not properly shifted and masked"
@@ -381,6 +384,27 @@ class ExtendedLiteral: Term() {
             }
 
             return Pair(Literal(index), internalOffset - offset)
+        }
+    }
+}
+
+/**
+ * Typed register operand {tr, Reg, Type} introduced in OTP 25 for JIT type-annotated operands.
+ * Extended tag sub-type 5 (encoded as 0b1010 in the shifted-masked extended tag field).
+ * See https://github.com/erlang/otp/blob/main/lib/compiler/src/beam_disasm.erl
+ */
+class TypedRegister(val register: Term, val type: Term) : Term() {
+    companion object {
+        fun from(data: ByteArray, offset: Int, literalFloat: Boolean): Pair<TypedRegister, ByteCount> {
+            var internalOffset = offset
+
+            val (register, registerByteCount) = Term.from(data, internalOffset, literalFloat)
+            internalOffset += registerByteCount
+
+            val (type, typeByteCount) = Term.from(data, internalOffset, literalFloat)
+            internalOffset += typeByteCount
+
+            return Pair(TypedRegister(register, type), internalOffset - offset)
         }
     }
 }

--- a/src/org/elixir_lang/beam/term/Term.kt
+++ b/src/org/elixir_lang/beam/term/Term.kt
@@ -130,9 +130,10 @@ fun value(fullTag: UnsignedByte, data: ByteArray, offset: Int): Pair<Any, ByteCo
     val bit3 = fullTag.ushr(3).and(0b1)
 
     return if (bit3 == 0) {
+        // Value is encoded entirely in bits 7-4 of the tag byte; no additional bytes consumed.
         val value = fullTag.ushr(4)
 
-        Pair(value, internalOffset - offset)
+        Pair(value, 0)
     } else {
         val bit4 = fullTag.ushr(4).and(0b1)
         val bits7to5 = fullTag.and(0b1110_0000).shr(5)
@@ -210,7 +211,7 @@ class Character(val codePoint: Int) : Term() {
 class Float : Term() {
     companion object {
         fun from(data: ByteArray, offset: Int): Pair<Float, ByteCount> {
-            TODO("decode $data at offset $offset as Float")
+            TODO("decode ${data.toHexString()} at offset $offset as Float")
         }
     }
 }
@@ -345,7 +346,7 @@ class AllocationList(val allocationList: kotlin.collections.List<Allocation>) : 
     }
 
     companion object {
-        private val typeByNumber = Type.values().associateBy(Type::number)
+        private val typeByNumber = Type.entries.associateBy(Type::number)
 
         // https://github.com/erlang/otp/blob/OTP-20.2.2/lib/compiler/src/beam_disasm.erl#L559-L573
         fun from(data: ByteArray, offset: Int, literalFloat: Boolean): Pair<AllocationList, ByteCount> {

--- a/src/org/elixir_lang/credo/inspection_tool/Global.kt
+++ b/src/org/elixir_lang/credo/inspection_tool/Global.kt
@@ -24,7 +24,7 @@ import org.elixir_lang.isElixirMixModule
 import org.elixir_lang.jps.shared.ParametersList
 import org.elixir_lang.mix.Project
 import org.elixir_lang.notification.setup_sdk.Notifier
-import org.elixir_lang.sdk.elixir.Type.Companion.mostSpecificSdk
+import org.elixir_lang.sdk.elixir.ElixirSdkLookup.mostSpecificSdk
 import java.nio.charset.StandardCharsets
 import java.nio.file.InvalidPathException
 import java.nio.file.Paths

--- a/src/org/elixir_lang/dialyzer/service/DialyzerServiceImpl.kt
+++ b/src/org/elixir_lang/dialyzer/service/DialyzerServiceImpl.kt
@@ -17,7 +17,7 @@ import org.elixir_lang.Mix
 import org.elixir_lang.isElixirMixModule
 import org.elixir_lang.notification.setup_sdk.Notifier
 import org.elixir_lang.run.ensureWorkingDirectory
-import org.elixir_lang.sdk.elixir.Type.Companion.mostSpecificSdk
+import org.elixir_lang.sdk.elixir.ElixirSdkLookup.mostSpecificSdk
 
 data class DialyzerWarn(
     val fileName: String,

--- a/src/org/elixir_lang/espec/configuration/Producer.kt
+++ b/src/org/elixir_lang/espec/configuration/Producer.kt
@@ -14,7 +14,7 @@ import org.elixir_lang.file.containsFileWithSuffix
 import org.elixir_lang.mix.Project
 import org.elixir_lang.psi.ElixirFile
 import org.elixir_lang.sdk.elixir.Type
-import org.elixir_lang.sdk.elixir.Type.Companion.mostSpecificSdk
+import org.elixir_lang.sdk.elixir.ElixirSdkLookup.mostSpecificSdk
 import java.io.File
 
 class MixESpecRunConfigurationProducer :

--- a/src/org/elixir_lang/exunit/configuration/Producer.kt
+++ b/src/org/elixir_lang/exunit/configuration/Producer.kt
@@ -13,7 +13,7 @@ import org.elixir_lang.file.containsFileWithSuffix
 import org.elixir_lang.mix.Project
 import org.elixir_lang.psi.ElixirFile
 import org.elixir_lang.sdk.elixir.Type
-import org.elixir_lang.sdk.elixir.Type.Companion.mostSpecificSdk
+import org.elixir_lang.sdk.elixir.ElixirSdkLookup.mostSpecificSdk
 import java.io.File
 
 class MixExUnitRunConfigurationProducer :

--- a/src/org/elixir_lang/formatter/MixFormatFormattingService.kt
+++ b/src/org/elixir_lang/formatter/MixFormatFormattingService.kt
@@ -18,7 +18,7 @@ import org.elixir_lang.Mix
 import org.elixir_lang.code_style.CodeStyleSettings
 import org.elixir_lang.mix.Project as MixProject
 import org.elixir_lang.psi.ElixirFile
-import org.elixir_lang.sdk.elixir.Type.Companion.mostSpecificSdk
+import org.elixir_lang.sdk.elixir.ElixirSdkLookup.mostSpecificSdk
 import java.io.FileNotFoundException
 import java.nio.charset.StandardCharsets
 

--- a/src/org/elixir_lang/mise/Mise.kt
+++ b/src/org/elixir_lang/mise/Mise.kt
@@ -1,0 +1,165 @@
+package org.elixir_lang.mise
+
+import com.google.gson.FieldNamingPolicy
+import com.google.gson.GsonBuilder
+import com.google.gson.reflect.TypeToken
+import com.intellij.execution.configurations.GeneralCommandLine
+import com.intellij.execution.process.CapturingProcessHandler
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.diagnostic.logger
+import com.intellij.util.concurrency.ThreadingAssertions
+import org.jetbrains.annotations.VisibleForTesting
+import java.nio.file.Path
+
+private val LOG = logger<Mise>()
+
+/**
+ * A single tool entry from `mise ls --json`.
+ */
+data class MiseToolEntry(
+    val version: String,
+    val requestedVersion: String,
+    val installPath: String,
+    val sourceType: String?,
+    val sourcePath: String?,
+    val installed: Boolean,
+    val active: Boolean,
+)
+
+/**
+ * Resolved mise tool versions for the current project directory.
+ */
+data class MiseVersions(
+    val elixir: MiseToolEntry?,
+    val erlang: MiseToolEntry?,
+)
+
+/**
+ * Raw Gson model matching the snake_case JSON output of `mise ls --json`.
+ * Converted to [MiseToolEntry] after parsing.
+ */
+private data class RawMiseEntry(
+    val version: String?,
+    val requested_version: String?,
+    val install_path: String?,
+    val source: RawMiseSource?,
+    val installed: Boolean?,
+    val active: Boolean?,
+)
+
+private data class RawMiseSource(
+    val type: String?,
+    val path: String?,
+)
+
+/**
+ * Integrates with [mise](https://mise.jdx.dev/) to resolve tool versions for the current project.
+ *
+ * Shells out to `mise ls --local --json` using the module content root as the working directory,
+ * which causes mise to apply its normal walk-up resolution rules (.tool-versions, mise.toml, etc.)
+ * for that directory.
+ *
+ * All failures (mise not installed, non-zero exit, unparseable output) are swallowed and return
+ * `null` - the feature simply doesn't activate when mise is unavailable.
+ */
+object Mise {
+    private const val TIMEOUT_MS = 10_000
+
+    /**
+     * Invokes `mise ls --local --json` in [workDir] and parses the result.
+     *
+     * Returns `null` if mise is not on PATH, returns a non-zero exit code, times out, or
+     * produces output that cannot be parsed. Callers should treat `null` as "mise unavailable".
+     *
+     * **Threading**: Must not be called on the EDT or under a read lock. This method spawns
+     * a subprocess and blocks for up to [TIMEOUT_MS]ms. Callers must ensure they are running
+     * on a background thread outside of any read lock (e.g. inside `withContext(Dispatchers.IO)`
+     * after releasing any read lock).
+     */
+    fun resolveVersions(workDir: Path): MiseVersions? {
+        // `assertBackgroundThread()` only checks EDT, NOT holdsReadLock - both guards are needed.
+        ThreadingAssertions.assertBackgroundThread()
+        check(!ApplicationManager.getApplication().holdsReadLock()) {
+            "Mise.resolveVersions() must not be called under a read lock - " +
+            "it spawns a subprocess that blocks for up to ${TIMEOUT_MS}ms"
+        }
+        return try {
+            val commandLine = GeneralCommandLine("mise", "ls", "--local", "--json")
+                .withWorkDirectory(workDir.toFile())
+            val handler = CapturingProcessHandler(commandLine)
+            val output = handler.runProcess(TIMEOUT_MS)
+
+            if (output.exitCode != 0) {
+                LOG.debug("mise ls --local --json exited with ${output.exitCode} in $workDir: ${output.stderr.take(200)}")
+                return null
+            }
+
+            parseOutput(output.stdout)
+        } catch (e: Exception) {
+            LOG.debug("mise ls --local --json failed in $workDir: ${e.message}")
+            null
+        }
+    }
+
+    /**
+     * Parses the JSON output of `mise ls --local --json` into a [MiseVersions] result.
+     *
+     * Takes the first entry for each tool key where `installed == true && active == true`.
+     *
+     * `internal` for testing - use [resolveVersions] in production code.
+     */
+    @VisibleForTesting
+    internal fun parseOutput(json: String): MiseVersions? {
+        return try {
+            val gson = GsonBuilder()
+                .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
+                .create()
+            val type = object : TypeToken<Map<String, List<RawMiseEntry>>>() {}.type
+            // fromJson returns a platform type (T!) which can be null for empty/invalid JSON.
+            @Suppress("UNCHECKED_CAST")
+            val allTools = gson.fromJson(json, type) as? Map<String, List<RawMiseEntry>>
+                ?: return null
+
+            val elixir = allTools["elixir"]
+                ?.firstOrNull { it.installed == true && it.active == true }
+                ?.toMiseToolEntry()
+
+            val erlang = allTools["erlang"]
+                ?.firstOrNull { it.installed == true && it.active == true }
+                ?.toMiseToolEntry()
+
+            MiseVersions(elixir, erlang)
+        } catch (e: Exception) {
+            LOG.debug("Failed to parse mise ls output: ${e.message}")
+            null
+        }
+    }
+
+    private fun RawMiseEntry.toMiseToolEntry(): MiseToolEntry? {
+        val v = version ?: return null
+        val ip = install_path ?: return null
+        return MiseToolEntry(
+            version = v,
+            requestedVersion = requested_version ?: v,
+            installPath = ip,
+            sourceType = source?.type,
+            sourcePath = source?.path,
+            installed = installed ?: false,
+            active = active ?: false,
+        )
+    }
+
+    /**
+     * Strips the `-otp-XX` suffix that mise appends to Elixir version strings
+     * (e.g. `"1.13.4-otp-24"` → `"1.13.4"`).
+     *
+     * **Note**: this is a temporary workaround. Once `ElixirVersionDetector` reads
+     * the `vsn` field from `elixir.app` directly, both sides of the version comparison
+     * will be bare version strings and this function can be removed.
+     */
+    @VisibleForTesting
+    internal fun stripElixirOtpSuffix(version: String): String {
+        val idx = version.indexOf("-otp-")
+        return if (idx >= 0) version.substring(0, idx) else version
+    }
+}

--- a/src/org/elixir_lang/mix/DepsCheckerService.kt
+++ b/src/org/elixir_lang/mix/DepsCheckerService.kt
@@ -2,13 +2,10 @@ package org.elixir_lang.mix
 
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.application.ApplicationManager
-import com.intellij.openapi.application.ReadAction
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.diagnostic.logger
-import com.intellij.openapi.module.ModuleManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.projectRoots.Sdk
-import com.intellij.openapi.roots.ModuleRootManager
 import com.intellij.openapi.roots.ProjectRootManager
 import com.intellij.openapi.util.io.FileUtil
 import com.intellij.openapi.vfs.VirtualFile
@@ -20,7 +17,7 @@ import org.elixir_lang.notification.setup_sdk.Notifier
 import org.elixir_lang.package_manager.DepsStatusResult
 import org.elixir_lang.package_manager.virtualFile
 import org.elixir_lang.settings.ElixirExperimentalSettings
-import org.elixir_lang.sdk.elixir.Type as ElixirSdkType
+import org.elixir_lang.sdk.elixir.findElixirSdkForRoot
 import java.util.concurrent.atomic.AtomicBoolean
 
 @Service(Service.Level.PROJECT)
@@ -81,21 +78,13 @@ class DepsCheckerService(private val project: Project) : Disposable {
             }
 
             LOG.debug("DepsCheckerService: Checking Mix deps ($reason)")
-            val (sdk, projectRoots) = ReadAction.nonBlocking(java.util.concurrent.Callable {
-                val sdk = findElixirSdk(project)
-                val roots = selectTopLevelMixRoots(ProjectRootManager.getInstance(project).contentRootsFromAllModules)
-                sdk to roots
-            }).executeSynchronously()
-
-            if (sdk == null) {
-                LOG.debug("DepsCheckerService: Skipping mix deps check, no Elixir SDK configured")
-                return
-            }
+            val projectRoots = selectTopLevelMixRoots(ProjectRootManager.getInstance(project).contentRootsFromAllModules)
 
             var sawSupported = false
             var sawNonOk = false
 
             for (root in projectRoots) {
+                val sdk = findElixirSdkForRoot(project, root)
                 when (val statusResult = depsStatusResult(project, root, sdk)) {
                     is DepsStatusResult.Available -> {
                         sawSupported = true
@@ -134,24 +123,6 @@ class DepsCheckerService(private val project: Project) : Disposable {
             ?: return DepsStatusResult.Unsupported
         val (packageManager, packageVirtualFile) = packageManagerVirtualFile
         return packageManager.depsStatus(project, packageVirtualFile, sdk)
-    }
-
-    private fun findElixirSdk(project: Project): Sdk? {
-        val elixirSdkType = ElixirSdkType.instance
-
-        val projectSdk = ProjectRootManager.getInstance(project).projectSdk
-        if (projectSdk?.sdkType === elixirSdkType) {
-            return projectSdk
-        }
-
-        ModuleManager.getInstance(project).modules.forEach { module ->
-            val moduleSdk = ModuleRootManager.getInstance(module).sdk
-            if (moduleSdk?.sdkType === elixirSdkType) {
-                return moduleSdk
-            }
-        }
-
-        return null
     }
 
     private fun isDepsChange(event: VFileEvent): Boolean {

--- a/src/org/elixir_lang/mix/State.kt
+++ b/src/org/elixir_lang/mix/State.kt
@@ -15,7 +15,7 @@ import org.elixir_lang.console.ElixirConsoleUtil
 import org.elixir_lang.notification.setup_sdk.Notifier
 import org.elixir_lang.run.ElixirProcessHandler
 import org.elixir_lang.run.WslSafeCommandLineState
-import org.elixir_lang.sdk.elixir.Type.Companion.mostSpecificSdk
+import org.elixir_lang.sdk.elixir.ElixirSdkLookup.mostSpecificSdk
 
 fun ensureMostSpecificSdk(module: Module): Sdk = mostSpecificSdk(module) ?: throw MissingSdk(module)
 

--- a/src/org/elixir_lang/mix/project/ProjectModuleSetupValidator.kt
+++ b/src/org/elixir_lang/mix/project/ProjectModuleSetupValidator.kt
@@ -4,6 +4,7 @@ import com.intellij.openapi.module.ModuleManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.roots.ContentEntry
 import com.intellij.openapi.roots.ModuleRootManager
+import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.util.concurrency.ThreadingAssertions
 import org.elixir_lang.mixContentRoots
 
@@ -48,36 +49,98 @@ object ProjectModuleSetupValidator {
 
         val issues = mutableListOf<FolderMarkIssue>()
 
+        // Collect all content entry URLs across all modules so the umbrella scan can skip
+        // sub-apps that are already covered by their own content entry.
+        val allContentEntryUrls: Set<String> = ModuleManager.getInstance(project).modules
+            .flatMap { ModuleRootManager.getInstance(it).contentEntries.map { ce -> ce.url } }
+            .toSet()
+
         for (module in ModuleManager.getInstance(project).modules) {
             for (mixContentRoot in module.mixContentRoots()) {
                 val contentEntry = mixContentRoot.contentEntry
                 val root = mixContentRoot.root
                 val actualMarks = actualMarks(contentEntry)
-                for (canonical in CANONICAL_FOLDER_MARKS) {
-                    val url = "${root.url}/${canonical.relativePath}"
 
-                    val actualMark = actualMarks[url]
+                // --- Top-level canonical mark check ---
+                checkCanonicalMarks(module.name, root, "", actualMarks, issues)
 
-                    if (actualMark != canonical.folderMark) {
-                        // Only warn when the folder actually exists on disk (via VFS).
-                        // Non-existent folders with no mark are expected -- the reconfigure action
-                        // applies marks by URL so they're ready when the folder appears later.
-                        if (root.findFileByRelativePath(canonical.relativePath) == null) continue
-
-                        issues.add(
-                            FolderMarkIssue(
-                                moduleName = module.name,
-                                folderRelativePath = canonical.relativePath,
-                                folderMark = canonical.folderMark,
-                                currentState = actualMark?.displayName?.lowercase() ?: "unmarked",
-                            )
-                        )
-                    }
-                }
+                // --- Umbrella sub-app detection ---
+                // If this content root looks like an umbrella project (has an apps/ directory
+                // containing sub-apps with their own mix.exs), validate folder marks for any
+                // sub-app that is NOT already covered by its own content entry.
+                detectUmbrellaSubAppIssues(module.name, root, actualMarks, allContentEntryUrls, issues)
             }
         }
 
         return issues
+    }
+
+    /**
+     * Scans the `apps/` directory under [root] for umbrella sub-apps and adds [FolderMarkIssue]s
+     * for any sub-app whose folders are not correctly marked (as reflected by [actualMarks]).
+     *
+     * Sub-apps whose directory URL is already present in [allContentEntryUrls] are skipped because
+     * they are validated independently via the standard per-content-entry loop.
+     */
+    private fun detectUmbrellaSubAppIssues(
+        moduleName: String,
+        root: VirtualFile,
+        actualMarks: Map<String, FolderMark>,
+        allContentEntryUrls: Set<String>,
+        issues: MutableList<FolderMarkIssue>,
+    ) {
+        val appsDir = root.findChild("apps") ?: return
+
+        for (subAppDir in appsDir.children) {
+            if (!subAppDir.isDirectory) continue
+            if (subAppDir.findChild("mix.exs") == null) continue
+
+            // Skip if the sub-app already has its own content entry anywhere in the project.
+            if (subAppDir.url in allContentEntryUrls) continue
+
+            checkCanonicalMarks(moduleName, root, "apps/${subAppDir.name}", actualMarks, issues)
+        }
+    }
+
+    /**
+     * Checks [CANONICAL_FOLDER_MARKS] for a single content root (or umbrella sub-app) and appends
+     * any discrepancies to [issues].
+     *
+     * @param pathPrefix  Empty string for a top-level content root; `"apps/{name}"` for an
+     *                    umbrella sub-app.  The final relative path is
+     *                    `"$pathPrefix/${canonical.relativePath}"` (or just `canonical.relativePath`
+     *                    when [pathPrefix] is empty).
+     */
+    private fun checkCanonicalMarks(
+        moduleName: String,
+        root: VirtualFile,
+        pathPrefix: String,
+        actualMarks: Map<String, FolderMark>,
+        issues: MutableList<FolderMarkIssue>,
+    ) {
+        for (canonical in CANONICAL_FOLDER_MARKS) {
+            val relativePath =
+                if (pathPrefix.isEmpty()) canonical.relativePath else "$pathPrefix/${canonical.relativePath}"
+            val url = "${root.url}/$relativePath"
+
+            val actualMark = actualMarks[url]
+
+            if (actualMark != canonical.folderMark) {
+                // Only warn when the folder actually exists on disk (via VFS).
+                // Non-existent folders with no mark are expected - the reconfigure action
+                // applies marks by URL so they're ready when the folder appears later.
+                if (root.findFileByRelativePath(relativePath) == null) continue
+
+                issues.add(
+                    FolderMarkIssue(
+                        moduleName = moduleName,
+                        folderRelativePath = relativePath,
+                        folderMark = canonical.folderMark,
+                        currentState = actualMark?.displayName?.lowercase() ?: "unmarked",
+                    )
+                )
+            }
+        }
     }
 
     // Build a unified map: folder URL → its actual mark (using the same

--- a/src/org/elixir_lang/mix/project/ProjectModuleSetupValidator.kt
+++ b/src/org/elixir_lang/mix/project/ProjectModuleSetupValidator.kt
@@ -12,7 +12,7 @@ import org.elixir_lang.mixContentRoots
  * Validates each Elixir Mix module's folder marks against the canonical specification defined in
  * [CANONICAL_FOLDER_MARKS] (which mirrors [org.elixir_lang.mix.Project.addFolders]).
  *
- * Threading: follows the same contract as `detectModuleSdkIssues()` in `ElixirSdkStatusWidget` -
+ * Threading: follows the same contract as `detectModuleSdkIssues()` in `ElixirEditorBasedSdkWidget` -
  * accesses [ModuleRootManager] which requires read access.  Callers must either hold a read lock
  * or call this inside a `readAction { }` block.
  */
@@ -41,8 +41,8 @@ object ProjectModuleSetupValidator {
      * **Threading**: must be called off the EDT (background thread).  The method accesses
      * [ModuleRootManager] which requires read access; the caller must either hold a read lock or
      * call this inside a `readAction { }` block.  The current call site in
-     * `ElixirSdkStatusWidget.detectSdkStatus()` follows the same contract as
-     * `detectModuleSdkIssues()` - both run in the widget's update cycle.
+     * `ElixirEditorBasedSdkWidget` follows the same contract as `detectModuleSdkIssues()` -
+     * both run in the background notification job triggered by rootsChanged.
      */
     fun detectFolderMarkIssues(project: Project): List<FolderMarkIssue> {
         ThreadingAssertions.assertBackgroundThread()

--- a/src/org/elixir_lang/mix/project/_import/Builder.kt
+++ b/src/org/elixir_lang/mix/project/_import/Builder.kt
@@ -9,11 +9,9 @@ import com.intellij.openapi.module.Module
 import com.intellij.openapi.module.ModuleManager
 import com.intellij.openapi.options.ConfigurationException
 import com.intellij.openapi.project.Project
-import com.intellij.openapi.projectRoots.ProjectJdkTable
 import com.intellij.openapi.projectRoots.Sdk
 import com.intellij.openapi.projectRoots.SdkTypeId
 import com.intellij.openapi.roots.CompilerModuleExtension
-import com.intellij.openapi.roots.ex.ProjectRootManagerEx
 import com.intellij.openapi.roots.ui.configuration.ModulesProvider
 import com.intellij.openapi.ui.Messages
 import com.intellij.openapi.util.text.StringUtil
@@ -40,6 +38,9 @@ class Builder : ProjectImportBuilder<OtpApp>() {
     private var mySelectedOtpApps = emptyList<OtpApp>()
     private var myIsImportingProject: Boolean = false
     private var myNeedsScan: Boolean = false
+
+    /** Elixir SDK to assign to each created module. Set by ElixirSdkForModuleStep.updateDataModel(). */
+    var elixirSdk: Sdk? = null
 
     override fun getIcon(): Icon = Icons.PROJECT
     override fun getName(): String = "Mix"
@@ -117,12 +118,15 @@ class Builder : ProjectImportBuilder<OtpApp>() {
         modulesProvider: ModulesProvider,
         artifactModel: ModifiableArtifactModel?
     ): List<Module> {
-        fixProjectSdk(project)
+        val sdk = elixirSdk
         val createModules = createModulesForOtpApps(
             project,
             mySelectedOtpApps,
             { moduleModel ?: ModuleManager.getInstance(project).getModifiableModel() },
             { otpApp, rootModel ->
+                if (sdk != null) {
+                    rootModel.sdk = sdk
+                }
                 val compilerModuleExt = rootModel.getModuleExtension(CompilerModuleExtension::class.java)
                 compilerModuleExt.inheritCompilerOutputPath(false)
                 val ideaModuleDir = otpApp.root
@@ -206,21 +210,6 @@ class Builder : ProjectImportBuilder<OtpApp>() {
 
     companion object {
         private val LOG = Logger.getInstance(Builder::class.java)
-
-        private fun fixProjectSdk(project: Project): Sdk? {
-            val projectRootMgr = ProjectRootManagerEx.getInstanceEx(project)
-            val selectedSdk = projectRootMgr.projectSdk
-            val fixedProjectSdk: Sdk?
-
-            if (selectedSdk == null || selectedSdk.sdkType !== Type.instance) {
-                fixedProjectSdk = ProjectJdkTable.getInstance().findMostRecentSdkOfType(Type.instance)
-                ApplicationManager.getApplication().runWriteAction { projectRootMgr.projectSdk = fixedProjectSdk }
-            } else {
-                fixedProjectSdk = selectedSdk
-            }
-
-            return fixedProjectSdk
-        }
 
         @Throws(IOException::class)
         private fun deleteIdeaModuleFiles(otpApps: List<OtpApp>) {

--- a/src/org/elixir_lang/mix/project/_import/step/ElixirSdkForModuleStep.kt
+++ b/src/org/elixir_lang/mix/project/_import/step/ElixirSdkForModuleStep.kt
@@ -18,6 +18,7 @@ import com.intellij.util.ui.JBInsets
 import com.intellij.util.ui.JBUI
 import com.intellij.util.ui.StartupUiUtil
 import org.elixir_lang.Elixir
+import org.elixir_lang.mix.project._import.Builder
 import org.elixir_lang.sdk.elixir.Type
 import org.jetbrains.annotations.NonNls
 import org.jetbrains.annotations.SystemDependent
@@ -166,7 +167,7 @@ class ElixirSdkForModuleStep(private val wizardContext: WizardContext) : ModuleW
     override fun getComponent(): JComponent = panel
 
     override fun updateDataModel() {
-        wizardContext.projectJdk = jdk
+        (wizardContext.projectBuilder as? Builder)?.elixirSdk = jdk
     }
 
     override fun updateStep() {

--- a/src/org/elixir_lang/new_project_wizard/Step.kt
+++ b/src/org/elixir_lang/new_project_wizard/Step.kt
@@ -21,7 +21,6 @@ import com.intellij.openapi.progress.Task
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.projectRoots.Sdk
 import com.intellij.openapi.projectRoots.SdkTypeId
-import com.intellij.openapi.roots.ProjectRootManager
 import com.intellij.openapi.roots.ui.configuration.*
 import com.intellij.openapi.roots.ui.configuration.projectRoot.ProjectSdksModel
 import com.intellij.openapi.ui.ValidationInfo
@@ -177,12 +176,9 @@ class Step(parent: NewProjectWizardStep) : AbstractNewProjectWizardStep(parent),
 
             val builder = ElixirModuleBuilder()
 
-            // Based on https://github.com/JetBrains/intellij-community/blob/8c0419e906efe686479832543092f4918e6516bd/java/idea-ui/src/com/intellij/ide/projectWizard/generators/IntelliJJavaNewProjectWizard.kt#L40-L48
-            if (context.isCreatingNewProject) {
-                context.projectJdk = sdk
-            } else {
-                builder.moduleJdk = sdk.takeIf { ProjectRootManager.getInstance(project).projectSdk?.name != it.name }
-            }
+            // Always set moduleJdk rather than context.projectJdk so the Elixir plugin never claims the project SDK slot.
+            // The project SDK belongs to the host language (Java, Python, etc.) and is not required for Elixir functionality.
+            builder.moduleJdk = sdk
 
             builder.addSourcePath(
                 com.intellij.openapi.util.Pair(
@@ -242,7 +238,6 @@ fun Row.elixirSdkComboBox(context: WizardContext, sdkProperty: ObservableMutable
 
     return cell(comboBox)
         .validationOnApply { validateElixirSdk(sdkProperty, sdksModel) }
-        .onApply { context.projectJdk = sdkProperty.get() }
 }
 
 fun ValidationInfoBuilder.validateElixirSdk(

--- a/src/org/elixir_lang/new_project_wizard/Step.kt
+++ b/src/org/elixir_lang/new_project_wizard/Step.kt
@@ -11,6 +11,7 @@ import com.intellij.ide.wizard.NewProjectWizardBaseData.Companion.baseData
 import com.intellij.ide.wizard.NewProjectWizardStep
 import com.intellij.notification.NotificationGroupManager
 import com.intellij.notification.NotificationType
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.observable.properties.ObservableMutableProperty
 import com.intellij.openapi.observable.properties.ObservableProperty
@@ -19,9 +20,12 @@ import com.intellij.openapi.progress.ProgressIndicator
 import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.progress.Task
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.projectRoots.ProjectJdkTable
 import com.intellij.openapi.projectRoots.Sdk
 import com.intellij.openapi.projectRoots.SdkTypeId
-import com.intellij.openapi.roots.ui.configuration.*
+import com.intellij.openapi.roots.ui.configuration.JdkComboBox
+import com.intellij.openapi.roots.ui.configuration.SdkListItem
+import com.intellij.openapi.roots.ui.configuration.createSdkComboBox
 import com.intellij.openapi.roots.ui.configuration.projectRoot.ProjectSdksModel
 import com.intellij.openapi.ui.ValidationInfo
 import com.intellij.openapi.util.Disposer
@@ -34,6 +38,7 @@ import org.elixir_lang.Mix
 import org.elixir_lang.module.ElixirModuleBuilder
 import org.elixir_lang.module.ElixirModuleType
 import org.elixir_lang.sdk.elixir.Type
+import org.elixir_lang.sdk.erlang_dependent.ErlangSdkResolver
 import java.io.IOException
 import java.nio.file.Paths
 import java.util.concurrent.TimeUnit
@@ -49,6 +54,12 @@ class Step(parent: NewProjectWizardStep) : AbstractNewProjectWizardStep(parent),
     override val mixNewSupProperty = propertyGraph.property(false)
     override val mixNewUmbrellaProperty = propertyGraph.property(false)
 
+    // Stored in newSdkCallback so setupProject can ensure the Erlang SDK is in
+    // ProjectJdkTable at mix-command time, even if the workspace-model sync has
+    // already wiped it out (IJ 2026+). setupProject runs on the EDT so no sync
+    // can fire between addJdk and the resolver call.
+    private var erlangSdkForSetup: Sdk? = null
+
     override var sdk by sdkProperty
     override var mixNewApp by mixNewAppProperty
     override var mixNewModule by mixNewModuleProperty
@@ -59,21 +70,22 @@ class Step(parent: NewProjectWizardStep) : AbstractNewProjectWizardStep(parent),
     override fun setupUI(builder: Panel) {
         with(builder) {
             row("Elixir SDK:") {
-                elixirSdkComboBox(context, sdkProperty)
+                elixirSdkComboBox(context, sdkProperty) { erlangSdkForSetup = it }
                     .columns(COLUMNS_MEDIUM)
             }
+            @Suppress("DialogTitleCapitalization")
             collapsibleGroup("mix new Options") {
                 row("--app") {
                     textField()
                         .bindText(mixNewAppProperty)
                         .align(AlignX.FILL)
                         .validationOnApply {
-                            if (mixNewApp.isNullOrBlank()) {
+                            if (mixNewApp.isBlank()) {
                                 val name = this@Step.name
 
                                 if (!name.matches(APPLICATION_NAME_REGEX)) {
                                     error(
-                                        "Application name ust start with a lowercase ASCII letter, followed by " +
+                                        "Application name must start with a lowercase ASCII letter, followed by " +
                                                 "lowercase ASCII letters, numbers, or underscores, got: \"${name}\"" +
                                                 ". The application name is inferred from the path, if you'd like to" +
                                                 " explicitly name the application set --app"
@@ -84,7 +96,7 @@ class Step(parent: NewProjectWizardStep) : AbstractNewProjectWizardStep(parent),
                             } else {
                                 if (!mixNewApp.matches(APPLICATION_NAME_REGEX)) {
                                     error(
-                                        "Application name ust start with a lowercase ASCII letter, followed by " +
+                                        "Application name must start with a lowercase ASCII letter, followed by " +
                                                 "lowercase ASCII letters, numbers, or underscores."
                                     )
                                 } else {
@@ -115,6 +127,24 @@ class Step(parent: NewProjectWizardStep) : AbstractNewProjectWizardStep(parent),
             val sdk = this.sdk!!
             val workingDirectory = Paths.get(".").toAbsolutePath().normalize().toString()
             val projectDirectory = context.projectDirectory.toString()
+
+            // Re-register both SDKs if the workspace-model sync has wiped them from
+            // ProjectJdkTable. This sync fires ~5s after IDE start (delayLoadGlobalWorkspaceModel
+            // in JpsGlobalModelSynchronizerImpl) and replaces in-memory SDKs with whatever was
+            // on disk at that moment - before our SDKs were registered. setupProject runs on
+            // the EDT so no sync can interleave between addJdk and the resolver call.
+            ApplicationManager.getApplication().runWriteAction {
+                val jdkTable = ProjectJdkTable.getInstance()
+                if (jdkTable.findJdk(sdk.name) == null) {
+                    jdkTable.addJdk(sdk)
+                }
+                erlangSdkForSetup?.let { erlangSdk ->
+                    if (jdkTable.findJdk(erlangSdk.name) == null) {
+                        jdkTable.addJdk(erlangSdk)
+                    }
+                }
+            }
+            erlangSdkForSetup = null  // Clear after use; Step is wizard-scoped so no leak, but signals intent
 
             val commandLine = Mix.commandLine(emptyMap(), workingDirectory, sdk, project = project)
             commandLine.addParameters("new", projectDirectory)
@@ -162,6 +192,7 @@ class Step(parent: NewProjectWizardStep) : AbstractNewProjectWizardStep(parent),
             } else if (processOutput.exitCode != 0) {
                 val stderrWithoutColorCodes = processOutput.stderr.replace(Regex("\u001B\\[[;\\d]*m"), "")
 
+                @Suppress("DialogTitleCapitalization")
                 NotificationGroupManager
                     .getInstance()
                     .getNotificationGroup("Elixir")
@@ -214,17 +245,46 @@ private val ELIXIR_SDK_TYPE_FILTER = { it: SdkTypeId -> it == Type.instance; }
 private val ANY_SDK_FILTER: ((Sdk) -> Boolean) = { true }
 private val ANY_SDK_TYPE_FILTER: ((SdkTypeId) -> Boolean) = { true }
 private val ANY_SUGGESTED_SDK_FILTER: ((SdkListItem.SuggestedItem) -> Boolean) = { true }
-private val NEW_SDK_CALLBACK_DEFAULT: ((Sdk) -> Unit) = {}
 private val APPLICATION_NAME_REGEX: Regex = Regex("[a-z]([a-z0-9_])*")
 
-fun Row.elixirSdkComboBox(context: WizardContext, sdkProperty: ObservableMutableProperty<Sdk?>): Cell<JdkComboBox> {
+fun Row.elixirSdkComboBox(
+    context: WizardContext,
+    sdkProperty: ObservableMutableProperty<Sdk?>,
+    onErlangSdkRegistered: (Sdk) -> Unit = {},
+): Cell<JdkComboBox> {
     val sdksModel = ProjectSdksModel()
 
     Disposer.register(context.disposable) {
         sdksModel.disposeUIResources()
     }
 
-    val comboBox = createSdkComboBox(
+    // After setupSdkPaths runs on a newly created Elixir SDK, verify it has a linked Erlang SDK.
+    // If not (e.g. user cancelled the Erlang SDK selection dialog), remove it from the staged model
+    // and clear the combo box selection so the wizard returns to "No SDK".
+    // comboBox is assigned after this lambda but will be initialised by the time the callback fires.
+    lateinit var comboBox: JdkComboBox
+    val newSdkCallback: (Sdk) -> Unit = { sdk ->
+        val erlangSdk = Elixir.elixirSdkToErlangSdk(sdk)
+        if (erlangSdk == null) {
+            sdksModel.removeSdk(sdk)
+            comboBox.reloadModel()
+            comboBox.setSelectedJdk(null)
+        } else {
+            // The Erlang SDK was registered into ProjectJdkTable by registerErlangSdk /
+            // SdkRegistrar. Add the Elixir SDK to sdksModel (not yet in JdkTable) so that
+            // sdksModel.apply() on wizard commit can commit it cleanly.
+            // ErlangSdkResolver checks both sdksModel and ProjectJdkTable, so the Erlang
+            // SDK is found during validation without requiring a model reset.
+            // Note: this does NOT prevent the workspace-model sync from wiping the SDKs
+            // later - that is handled in setupProject via runWriteAction re-registration.
+            sdksModel.addSdk(sdk)
+            comboBox.reloadModel()
+            comboBox.setSelectedJdk(sdk)
+            onErlangSdkRegistered(erlangSdk)
+        }
+    }
+
+    comboBox = createSdkComboBox(
         context.project,
         sdksModel,
         sdkProperty,
@@ -233,7 +293,7 @@ fun Row.elixirSdkComboBox(context: WizardContext, sdkProperty: ObservableMutable
         ANY_SDK_FILTER,
         ANY_SUGGESTED_SDK_FILTER,
         ANY_SDK_TYPE_FILTER,
-        NEW_SDK_CALLBACK_DEFAULT
+        newSdkCallback
     )
 
     return cell(comboBox)
@@ -247,30 +307,23 @@ fun ValidationInfoBuilder.validateElixirSdk(
 
 private fun validateAndGetSdkValidationMessage(
     sdkProperty: ObservableProperty<Sdk?>,
-    sdkModel: ProjectSdksModel
+    sdkModel: ProjectSdksModel,
 ): @NlsContexts.DialogMessage String? {
-    val sdk = sdkProperty.get()
+    val sdk = sdkProperty.get() ?: return JavaUiBundle.message("title.no.jdk.specified")
 
-    return if (sdk == null) {
-        JavaUiBundle.message("title.no.jdk.specified")
-    } else {
-        val internalErlangSdk = Elixir.elixirSdkToErlangSdk(sdk)
+    val internalErlangSdk = ErlangSdkResolver.getInstance().resolveErlangSdk(sdk, sdkModel)
+        ?: return "Internal Erlang SDK is not configured. Set it before picking this Elixir SDK."
 
-        if (internalErlangSdk != null) {
-            if (internalErlangSdk.homeDirectory != null) {
-                try {
-                    sdkModel.apply(null, true)
+    if (internalErlangSdk.homeDirectory == null) {
+        return "Internal Erlang SDK (${internalErlangSdk.name}) home directory" +
+                " (${internalErlangSdk.homePath}) does not exist. Did you uninstall it?"
+    }
 
-                    null
-                } catch (e: ConfigurationException) {
-                    e.message ?: e.title
-                }
-            } else {
-                "Internal Erlang SDK (${internalErlangSdk.name} home directory (${internalErlangSdk.homePath}) " +
-                        "does not exists.  Did you uninstall it?"
-            }
-        } else {
-            "Internal Erlang SDK is not in Elixir SDK.  Set it before picking this Elixir SDK."
-        }
+    return try {
+        sdkModel.apply(null, true)
+        null
+    } catch (e: ConfigurationException) {
+        @Suppress("DEPRECATION")
+        e.message ?: e.title
     }
 }

--- a/src/org/elixir_lang/notification/mix_deps/ShowStatusAction.kt
+++ b/src/org/elixir_lang/notification/mix_deps/ShowStatusAction.kt
@@ -11,10 +11,7 @@ import com.intellij.notification.Notification
 import com.intellij.notification.NotificationAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.components.service
-import com.intellij.openapi.module.ModuleManager
 import com.intellij.openapi.project.Project
-import com.intellij.openapi.projectRoots.Sdk
-import com.intellij.openapi.roots.ModuleRootManager
 import com.intellij.openapi.roots.ProjectRootManager
 import com.intellij.openapi.util.Disposer
 import com.intellij.openapi.vfs.VirtualFile
@@ -22,7 +19,7 @@ import org.elixir_lang.mix.DepsCheckerService
 import org.elixir_lang.mix.createMixDepsStatusRunConfiguration
 import org.elixir_lang.notification.setup_sdk.Notifier
 import org.elixir_lang.util.ElixirProjectDisposable
-import org.elixir_lang.sdk.elixir.Type as ElixirSdkType
+import org.elixir_lang.sdk.elixir.findElixirSdkForRoot
 
 class ShowStatusAction : NotificationAction("Run mix deps") {
     override fun actionPerformed(e: AnActionEvent, notification: Notification) {
@@ -34,15 +31,15 @@ class ShowStatusAction : NotificationAction("Run mix deps") {
             return
         }
 
-        val sdk = getProjectElixirSdk(project)
-        if (sdk == null) {
-            Notifier.mixDepsNoSdk(project)
-            return
-        }
-
         val projectRoot = getProjectRoot(project)
         if (projectRoot == null) {
             Notifier.mixDepsError(project, "Could not determine project root directory")
+            return
+        }
+
+        val sdk = findElixirSdkForRoot(project, projectRoot)
+        if (sdk == null) {
+            Notifier.mixDepsNoSdk(project)
             return
         }
 
@@ -81,24 +78,6 @@ class ShowStatusAction : NotificationAction("Run mix deps") {
         } catch (e: Exception) {
             Notifier.mixDepsError(project, e.message ?: "Unknown error")
         }
-    }
-
-    private fun getProjectElixirSdk(project: Project): Sdk? {
-        val elixirSdkType = ElixirSdkType.instance
-
-        val projectSdk = ProjectRootManager.getInstance(project).projectSdk
-        if (projectSdk?.sdkType === elixirSdkType) {
-            return projectSdk
-        }
-
-        ModuleManager.getInstance(project).modules.forEach { module ->
-            val moduleSdk = ModuleRootManager.getInstance(module).sdk
-            if (moduleSdk?.sdkType === elixirSdkType) {
-                return moduleSdk
-            }
-        }
-
-        return null
     }
 
     private fun getProjectRoot(project: Project): VirtualFile? {

--- a/src/org/elixir_lang/notification/setup_sdk/Provider.kt
+++ b/src/org/elixir_lang/notification/setup_sdk/Provider.kt
@@ -1,7 +1,6 @@
 package org.elixir_lang.notification.setup_sdk
 
 import com.intellij.ide.actions.ShowSettingsUtilImpl
-import com.intellij.openapi.application.ReadAction
 import com.intellij.openapi.fileEditor.FileEditor
 import com.intellij.openapi.module.Module
 import com.intellij.openapi.module.ModuleType
@@ -26,33 +25,32 @@ class Provider : EditorNotificationProvider {
         project: Project,
         file: VirtualFile,
     ): Function<in FileEditor, out JComponent?>? {
-        // Quick check without read action - file type check is thread-safe
-        if (file.fileType !is ElixirFileType) {
-            return null
-        }
+        // Quick check without additional read - file type check is thread-safe.
+        if (file.fileType !is ElixirFileType) return null
 
-        // Keep PSI/model access explicitly scoped to a read action.
-        return ReadAction.compute<Function<in FileEditor, out JComponent?>?, Throwable> {
-            val psiFile = PsiManager.getInstance(project).findFile(file) ?: return@compute null
+        // collectNotificationData is always called under a platform-held read lock
+        // (@RequiresReadLock, see EditorNotificationProvider), so PSI/model access here is safe.
+        val psiFile = PsiManager.getInstance(project).findFile(file) ?: return null
+        if (psiFile.language !== ElixirLanguage) return null
 
-            if (psiFile.language !== ElixirLanguage) return@compute null
+        val module = ModuleUtilCore.findModuleForPsiElement(psiFile)
 
-            // Resolve the module once; use it for both the SDK check and panel decision
-            // to avoid calling findModuleForPsiElement twice.
-            val module = ModuleUtilCore.findModuleForPsiElement(psiFile)
+        val sdk = module?.let { Type.mostSpecificSdk(it) } ?: Type.mostSpecificSdk(project)
+        if (sdk != null) return null
 
-            // mostSpecificSdk(module) / mostSpecificSdk(project) avoid the internal
-            // re-lookup that mostSpecificSdk(PsiElement) would perform.
-            val sdk = if (module != null) Type.mostSpecificSdk(module) else Type.mostSpecificSdk(project)
-            if (sdk != null) return@compute null
-
-            // IMPORTANT: this lambda is applied later on the EDT.
-            // Keep it UI-only and PSI/model-free; all PSI decisions must stay in this read action.
-            when {
-                module != null && ModuleType.get(module).id == "ELIXIR_MODULE" -> Function { createModulePanel(project, module) }
-                ProcessOutput.isSmallIde -> Function { createSmallIDEFacetPanel(project) }
-                else -> Function { createProjectPanel(project) }
-            }
+        // No SDK configured. Mise-based suggestion is handled by the status bar widget's
+        // notification scan (ElixirEditorBasedSdkWidget), which runs off the read lock on
+        // Dispatchers.IO and surfaces a balloon notification with a one-click configure action.
+        // This panel remains as a persistent per-file indicator for manual setup, but is a candidate
+        // for removal in the future if the Experimental Widget becomes stable.
+        return when {
+            module != null && ModuleType.get(module).id == "ELIXIR_MODULE" ->
+                Function { createModulePanel(project, module) }
+            module != null && ProcessOutput.isSmallIde ->
+                Function { createSmallIDEFacetPanel(project) }
+            module != null ->
+                Function { createProjectPanel(project) }
+            else -> null
         }
     }
 }
@@ -107,7 +105,7 @@ private fun createModulePanel(
 
 private fun createProjectPanel(project: Project): EditorNotificationPanel =
     EditorNotificationPanel().apply {
-        text = "Project SDK is not defined"
+        text = "Elixir SDK is not defined"
         createActionLabel(ProjectBundle.message("project.sdk.setup")) {
             showProjectSettings(project)
         }

--- a/src/org/elixir_lang/notification/setup_sdk/Provider.kt
+++ b/src/org/elixir_lang/notification/setup_sdk/Provider.kt
@@ -16,6 +16,7 @@ import com.intellij.ui.EditorNotificationProvider
 import org.elixir_lang.ElixirFileType
 import org.elixir_lang.ElixirLanguage
 import org.elixir_lang.sdk.ProcessOutput
+import org.elixir_lang.sdk.elixir.ElixirSdkLookup
 import org.elixir_lang.sdk.elixir.Type
 import java.util.function.Function
 import javax.swing.JComponent
@@ -35,7 +36,7 @@ class Provider : EditorNotificationProvider {
 
         val module = ModuleUtilCore.findModuleForPsiElement(psiFile)
 
-        val sdk = module?.let { Type.mostSpecificSdk(it) } ?: Type.mostSpecificSdk(project)
+        val sdk = module?.let { ElixirSdkLookup.mostSpecificSdk(it) } ?: ElixirSdkLookup.mostSpecificSdk(project)
         if (sdk != null) return null
 
         // No SDK configured. Mise-based suggestion is handled by the status bar widget's

--- a/src/org/elixir_lang/sdk/SdkProcessUtils.kt
+++ b/src/org/elixir_lang/sdk/SdkProcessUtils.kt
@@ -1,0 +1,18 @@
+package org.elixir_lang.sdk
+
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.platform.ide.progress.ModalTaskOwner
+import com.intellij.platform.ide.progress.runWithModalProgressBlocking
+
+/**
+ * Runs [block] directly if off-EDT, or wraps it in [runWithModalProgressBlocking] if on EDT.
+ * Use this to guard any blocking subprocess or I/O call that may be triggered from the EDT.
+ */
+fun <T> runWithEdtGuard(title: String, block: () -> T): T {
+    val app = ApplicationManager.getApplication()
+    return if (app.isDispatchThread) {
+        runWithModalProgressBlocking(ModalTaskOwner.guess(), title) { block() }
+    } else {
+        block()
+    }
+}

--- a/src/org/elixir_lang/sdk/SdkRegistrar.kt
+++ b/src/org/elixir_lang/sdk/SdkRegistrar.kt
@@ -12,21 +12,35 @@ import org.elixir_lang.sdk.elixir.Type as ElixirSdkType
 import org.elixir_lang.sdk.erlang.Type as ErlangSdkType
 import org.elixir_lang.sdk.erlang_dependent.Type as ErlangDependentType
 
+/** Holds the pre-computed parts for registering or updating an Erlang SDK. */
+internal data class ErlangSdkPreparation(
+    val existing: Sdk?,
+    val template: ProjectJdkImpl,
+)
+
 object SdkRegistrar {
+    /**
+     * Canonicalises [homePath], resolves the version string and SDK name, and looks up any
+     * already-registered SDK at that home. Returns null if the path or version cannot be resolved.
+     * Shared by both the suspend ([registerOrUpdateErlangSdk]) and synchronous
+     * ([org.elixir_lang.sdk.elixir.ElixirInternalErlangSdkSetup.registerErlangSdk]) registration paths.
+     */
+    internal fun prepareErlangSdk(homePath: String, resolvedVersion: String? = null): ErlangSdkPreparation? {
+        val canonicalHomePath = canonicalHomePath(homePath) ?: return null
+        val sdkType = ErlangSdkType.instance
+        val versionString = ErlangSdkType.versionStringForHome(canonicalHomePath, resolvedVersion) ?: return null
+        val sdkName = ErlangSdkType.suggestSdkNameForHome(canonicalHomePath, resolvedVersion)
+        val existing = findSdkByHomePath(sdkType, canonicalHomePath)
+        return ErlangSdkPreparation(existing, ProjectJdkImpl(sdkName, sdkType, canonicalHomePath, versionString))
+    }
+
     suspend fun registerOrUpdateErlangSdk(
         homePath: String,
         resolvedVersion: String? = null,
     ): Sdk? {
-        val canonicalHomePath = canonicalHomePath(homePath) ?: return null
-        val sdkType = ErlangSdkType.instance
-        val versionString = ErlangSdkType.versionStringForHome(canonicalHomePath, resolvedVersion) ?: return null
-        val existing = findSdkByHomePath(sdkType, canonicalHomePath)
-        val sdkName = ErlangSdkType.suggestSdkNameForHome(canonicalHomePath, resolvedVersion)
-
-        val updatedSdk = ProjectJdkImpl(sdkName, sdkType, canonicalHomePath, versionString)
-        val registeredSdk = registerOrUpdate(existing, updatedSdk)
-
-        sdkType.setupSdkPaths(registeredSdk)
+        val prep = prepareErlangSdk(homePath, resolvedVersion) ?: return null
+        val registeredSdk = registerOrUpdate(prep.existing, prep.template)
+        ErlangSdkType.instance.setupSdkPaths(registeredSdk)
         return registeredSdk
     }
 

--- a/src/org/elixir_lang/sdk/SdkTableListenerStartupActivity.kt
+++ b/src/org/elixir_lang/sdk/SdkTableListenerStartupActivity.kt
@@ -26,7 +26,7 @@ class SdkTableListenerInitializationService {
                 if (!initialized) {
                     LOG.debug("Setting up SDK table listeners")
                     org.elixir_lang.sdk.elixir.Type.setupSdkTableListener()
-                    org.elixir_lang.sdk.erlang.Type.setupSdkTableListener()
+                    org.elixir_lang.sdk.erlang.ErlangSdkTableListener.setup()
                     initialized = true
                     LOG.debug("SDK table listeners initialized successfully")
                 }

--- a/src/org/elixir_lang/sdk/elixir/ElixirErlangClasspath.kt
+++ b/src/org/elixir_lang/sdk/elixir/ElixirErlangClasspath.kt
@@ -1,0 +1,100 @@
+package org.elixir_lang.sdk.elixir
+
+import com.intellij.openapi.projectRoots.Sdk
+import com.intellij.openapi.projectRoots.SdkModificator
+import com.intellij.openapi.projectRoots.SdkType
+import com.intellij.openapi.roots.OrderRootType
+import com.intellij.openapi.vfs.VirtualFile
+import org.elixir_lang.sdk.SdkEbinPaths
+import org.elixir_lang.sdk.Type.ebinPathChainVirtualFile
+import java.nio.file.Path
+import java.nio.file.Paths
+
+object ElixirErlangClasspath {
+    fun addNewCodePathsFromInternErlangSdk(
+        elixirSdk: Sdk,
+        internalErlangSdk: Sdk,
+        elixirSdkModificator: SdkModificator,
+    ) {
+        codePathsFromInternalErlangSdk(
+            elixirSdk,
+            internalErlangSdk,
+            elixirSdkModificator
+        ) { sdkModificator, configuredRoots, expandedInternalRoot, type ->
+            if (expandedInternalRoot !in configuredRoots) {
+                sdkModificator.addRoot(expandedInternalRoot, type)
+            }
+        }
+    }
+
+    fun removeCodePathsFromInternalErlangSdk(
+        elixirSdk: Sdk,
+        internalErlangSdk: Sdk,
+        elixirSdkModificator: SdkModificator,
+    ) {
+        codePathsFromInternalErlangSdk(
+            elixirSdk,
+            internalErlangSdk,
+            elixirSdkModificator
+        ) { sdkModificator, _, expandedInternalRoot, type ->
+            sdkModificator.removeRoot(expandedInternalRoot, type)
+        }
+    }
+
+    private fun codePathsFromInternalErlangSdk(
+        elixirSdk: Sdk,
+        internalErlangSdk: Sdk,
+        elixirSdkModificator: SdkModificator,
+        sdkModificatorRootTypeConsumer: (SdkModificator, Array<VirtualFile>, VirtualFile, OrderRootType) -> Unit,
+    ) {
+        val internalSdkType = internalErlangSdk.sdkType as SdkType
+        val elixirSdkType = elixirSdk.sdkType as SdkType
+        for (type in OrderRootType.getAllTypes()) {
+            if (internalSdkType.isRootTypeApplicable(type) && elixirSdkType.isRootTypeApplicable(type)) {
+                val internalRoots = internalErlangSdk.sdkModificator.getRoots(type)
+                val configuredRoots = elixirSdkModificator.getRoots(type)
+                for (internalRoot in internalRoots) {
+                    for (expandedInternalRoot in expandInternalErlangSdkRoot(internalRoot, type)) {
+                        sdkModificatorRootTypeConsumer(
+                            elixirSdkModificator,
+                            configuredRoots,
+                            expandedInternalRoot,
+                            type
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    private fun expandInternalErlangSdkRoot(
+        internalRoot: VirtualFile,
+        type: OrderRootType,
+    ): Iterable<VirtualFile> {
+        val expandedInternalRootList: List<VirtualFile>
+        if (type === OrderRootType.CLASSES) {
+            val path = internalRoot.path
+
+            /* Erlang SDK from intellij-erlang uses lib/erlang/lib as class path, but intellij-elixir needs the ebin
+               directories under lib/erlang/lib/APP-VERSION/ebin that works as a code path used by `-pa` argument to
+               `erl.exe`
+
+               For ASDF the path ends in erlang/VERSION/lib, in both cases, going to the parent directory will get the
+               right ebin paths from `eachEbinPath` */
+            if (path.endsWith("lib")) {
+                expandedInternalRootList = ArrayList()
+                val parentPath = Paths.get(path).parent.toString()
+                SdkEbinPaths.eachEbinPath(parentPath) { ebinPath: Path ->
+                    ebinPathChainVirtualFile(ebinPath) { virtualFile: VirtualFile? ->
+                        virtualFile?.let { expandedInternalRootList.add(it) }
+                    }
+                }
+            } else {
+                expandedInternalRootList = listOf(internalRoot)
+            }
+        } else {
+            expandedInternalRootList = listOf(internalRoot)
+        }
+        return expandedInternalRootList
+    }
+}

--- a/src/org/elixir_lang/sdk/elixir/ElixirInternalErlangSdkSetup.kt
+++ b/src/org/elixir_lang/sdk/elixir/ElixirInternalErlangSdkSetup.kt
@@ -1,0 +1,166 @@
+package org.elixir_lang.sdk.elixir
+
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.diagnostic.trace
+import com.intellij.openapi.projectRoots.ProjectJdkTable
+import com.intellij.openapi.projectRoots.Sdk
+import com.intellij.openapi.projectRoots.SdkModificator
+import com.intellij.openapi.projectRoots.impl.ProjectJdkImpl
+import com.intellij.openapi.ui.Messages
+import org.elixir_lang.jps.shared.sdk.SdkPaths
+import org.elixir_lang.sdk.SdkHomeKey
+import org.elixir_lang.sdk.SdkHomePaths
+import org.elixir_lang.sdk.erlang_dependent.ErlangSdkResolver
+import org.elixir_lang.sdk.erlang_dependent.SdkAdditionalData
+import org.elixir_lang.sdk.erlang_dependent.Type.Companion.ERLANG_SDK_KEY
+import org.elixir_lang.sdk.wsl.wslCompat
+import org.elixir_lang.sdk.erlang.Type as ErlangSdkType
+
+/**
+ * Handles the internal Erlang SDK setup path for Elixir SDKs.
+ *
+ * This covers the wizard-driven flow: auto-linking an already-registered Erlang SDK,
+ * prompting the user to pick a mise-installed Erlang SDK when none is registered, and
+ * registering the selected one. Separated from Type.kt so that the OTP compatibility
+ * validation added later can be focused here.
+ */
+object ElixirInternalErlangSdkSetup {
+
+    private val LOG = Logger.getInstance(ElixirInternalErlangSdkSetup::class.java)
+
+    /**
+     * Finds or prompts for an Erlang SDK and links it to the given Elixir SDK.
+     *
+     * Resolution order:
+     * 1. Explicit SDK stored in UserData (set by the wizard when creating Erlang + Elixir together)
+     * 2. Already-linked SDK from existing SdkAdditionalData
+     * 3. Any registered Erlang SDK in ProjectJdkTable
+     * 4. Prompt the user to pick a mise-installed Erlang SDK (mise Elixir SDKs only)
+     */
+    internal fun configureInternalErlangSdk(
+        elixirSdk: Sdk,
+        elixirSdkModificator: SdkModificator,
+    ): Sdk? {
+        val existingAdditionalData = elixirSdk.sdkAdditionalData as? SdkAdditionalData
+        val existingErlangSdk = existingAdditionalData?.getErlangSdk()
+        val explicitErlangSdk = elixirSdk.getUserData(ERLANG_SDK_KEY)
+
+        LOG.trace { "[${elixirSdk.name}] configureInternalErlangSdk: explicitErlangSdk=${explicitErlangSdk?.name}, existingErlangSdk=${existingErlangSdk?.name}" }
+
+        val erlangSdk = explicitErlangSdk
+            ?: existingErlangSdk
+            ?: ErlangSdkResolver.findAnyRegistered()?.also { LOG.trace { "[${elixirSdk.name}] Resolution: found via findAnyRegistered: '${it.name}'" } }
+            ?: promptForMiseErlangSdk(elixirSdk)?.also { LOG.trace { "[${elixirSdk.name}] Resolution: found via promptForMiseErlangSdk: '${it.name}'" } }
+
+        if (erlangSdk != null) {
+            LOG.trace { "[${elixirSdk.name}] Using Erlang SDK '${erlangSdk.name}' (identity: ${System.identityHashCode(erlangSdk)})" }
+            if (explicitErlangSdk == null && existingErlangSdk == null) {
+                LOG.info("Auto-linked Erlang SDK '${erlangSdk.name}' to Elixir SDK '${elixirSdk.name}'")
+            }
+
+            if (existingAdditionalData == null || existingErlangSdk == null) {
+                val sdkAdditionData: com.intellij.openapi.projectRoots.SdkAdditionalData =
+                    SdkAdditionalData(erlangSdk, elixirSdk)
+                elixirSdkModificator.sdkAdditionalData = sdkAdditionData
+            }
+
+            ElixirErlangClasspath.addNewCodePathsFromInternErlangSdk(elixirSdk, erlangSdk, elixirSdkModificator)
+
+            elixirSdk.putUserData(ERLANG_SDK_KEY, null)
+        } else {
+            LOG.warn("No Erlang SDK found, Elixir SDK will be incomplete")
+        }
+        return erlangSdk
+    }
+
+    /**
+     * For mise Elixir SDKs only: finds mise-installed Erlang SDK homes,
+     * presents a chooser dialog, and registers the selected one.
+     */
+    internal fun promptForMiseErlangSdk(elixirSdk: Sdk): Sdk? {
+        val homePath = elixirSdk.homePath ?: return null
+        if (SdkPaths.detectSource(homePath) != SdkPaths.SOURCE_NAME_MISE) return null
+
+        val erlangSdkType = ErlangSdkType.instance
+        val miseHomes = java.util.TreeMap<SdkHomeKey, String>()
+        SdkHomePaths.mergeMise(miseHomes, "erlang")
+
+        val validHomes = miseHomes.entries.filter { (_, path) ->
+            erlangSdkType.isValidSdkHome(path)
+        }
+        if (validHomes.isEmpty()) return null
+
+        val displayNames = validHomes.map { (_, path) ->
+            ErlangSdkType.suggestSdkNameForHome(path, null)
+        }.toTypedArray()
+
+        // Build a reverse map from display name → home path for lookup after dialog
+        val nameToHome = validHomes.associate { (_, path) ->
+            ErlangSdkType.suggestSdkNameForHome(path, null) to path
+        }
+
+        val validator = object : com.intellij.openapi.ui.InputValidator {
+            override fun checkInput(inputString: String) = inputString in nameToHome
+            override fun canClose(inputString: String) = inputString in nameToHome
+        }
+
+        var selectedName: String? = null
+        val app = ApplicationManager.getApplication()
+        val showDialog = Runnable {
+            selectedName = Messages.showEditableChooseDialog(
+                "No Erlang SDK is configured. Select one to use with this Elixir SDK:",
+                "Select Erlang SDK",
+                Messages.getQuestionIcon(),
+                displayNames,
+                displayNames[0],
+                validator
+            )
+        }
+
+        if (app.isDispatchThread) {
+            showDialog.run()
+        } else {
+            app.invokeAndWait(showDialog)
+        }
+
+        val selectedHome = selectedName?.let { nameToHome[it] } ?: return null
+
+        val erlangSdk = registerErlangSdk(selectedHome) ?: return null
+
+        return erlangSdk
+    }
+
+    internal fun registerErlangSdk(homePath: String): Sdk? {
+        val erlangSdkType = ErlangSdkType.instance
+        val canonicalHome = wslCompat.canonicalizePath(homePath)
+        val versionString = ErlangSdkType.versionStringForHome(canonicalHome, null)
+            ?: return null
+        val sdkName = ErlangSdkType.suggestSdkNameForHome(canonicalHome, null)
+
+        val newSdk = ProjectJdkImpl(sdkName, erlangSdkType, canonicalHome, versionString)
+        LOG.trace { "registerErlangSdk: created SDK '$sdkName' (identity: ${System.identityHashCode(newSdk)})" }
+
+        val app = ApplicationManager.getApplication()
+        val addSdk = Runnable {
+            app.runWriteAction {
+                ProjectJdkTable.getInstance().addJdk(newSdk)
+                val tableEntry = ProjectJdkTable.getInstance().findJdk(sdkName)
+                LOG.trace { "registerErlangSdk: after addJdk, findJdk('$sdkName') = ${tableEntry?.let { "'${it.name}' (identity: ${System.identityHashCode(it)})" } ?: "NOT FOUND"}" }
+            }
+        }
+
+        if (app.isDispatchThread) {
+            addSdk.run()
+        } else {
+            app.invokeAndWait(addSdk)
+        }
+
+        LOG.trace { "registerErlangSdk: before setupSdkPaths, findJdk('$sdkName') = ${ProjectJdkTable.getInstance().findJdk(sdkName)?.let { "found (identity: ${System.identityHashCode(it)})" } ?: "NOT FOUND"}" }
+        erlangSdkType.setupSdkPaths(newSdk)
+        LOG.trace { "registerErlangSdk: after setupSdkPaths, findJdk('$sdkName') = ${ProjectJdkTable.getInstance().findJdk(sdkName)?.let { "found (identity: ${System.identityHashCode(it)})" } ?: "NOT FOUND"}" }
+
+        LOG.info("Registered Erlang SDK '${newSdk.name}' from $canonicalHome")
+        return newSdk
+    }
+}

--- a/src/org/elixir_lang/sdk/elixir/ElixirInternalErlangSdkSetup.kt
+++ b/src/org/elixir_lang/sdk/elixir/ElixirInternalErlangSdkSetup.kt
@@ -1,20 +1,23 @@
 package org.elixir_lang.sdk.elixir
 
 import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.application.ModalityState
+import com.intellij.openapi.application.asContextElement
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.diagnostic.trace
 import com.intellij.openapi.projectRoots.ProjectJdkTable
 import com.intellij.openapi.projectRoots.Sdk
 import com.intellij.openapi.projectRoots.SdkModificator
-import com.intellij.openapi.projectRoots.impl.ProjectJdkImpl
 import com.intellij.openapi.ui.Messages
+import kotlinx.coroutines.runBlocking
 import org.elixir_lang.jps.shared.sdk.SdkPaths
 import org.elixir_lang.sdk.SdkHomeKey
 import org.elixir_lang.sdk.SdkHomePaths
+import org.elixir_lang.sdk.SdkRegistrar
 import org.elixir_lang.sdk.erlang_dependent.ErlangSdkResolver
 import org.elixir_lang.sdk.erlang_dependent.SdkAdditionalData
 import org.elixir_lang.sdk.erlang_dependent.Type.Companion.ERLANG_SDK_KEY
-import org.elixir_lang.sdk.wsl.wslCompat
+import org.elixir_lang.util.WriteActions
 import org.elixir_lang.sdk.erlang.Type as ErlangSdkType
 
 /**
@@ -75,8 +78,20 @@ object ElixirInternalErlangSdkSetup {
     }
 
     /**
-     * For mise Elixir SDKs only: finds mise-installed Erlang SDK homes,
-     * presents a chooser dialog, and registers the selected one.
+     * For mise Elixir SDKs only: finds mise-installed Erlang SDK homes, presents a chooser dialog, and registers the
+     * selected one.
+     *
+     * This is normally called from within `setupSdkPaths`, which IntelliJ runs inside its own "Configuring SDK…" modal
+     * (see `ProjectSdksModel.doAdd`). In that context the EDT loop is pumping at the modal modality level.
+     *
+     * When on a background thread we capture [ModalityState.defaultModalityState] - which, from a `ProgressManager`
+     * background thread, returns the modality of the enclosing progress dialog - and pass it as a coroutine context
+     * element so that [com.intellij.openapi.application.edtWriteAction] inside [SdkRegistrar] dispatches at the correct
+     * modality level and is processed by the modal loop.
+     *
+     * When already on the EDT we cannot use [runBlocking] (it would deadlock), so we fall back to the classical
+     * [com.intellij.openapi.application.Application.invokeAndWait] + [com.intellij.openapi.application.runWriteAction]
+     * path via [org.elixir_lang.sdk.elixir.ElixirInternalErlangSdkSetup.registerErlangSdk].
      */
     internal fun promptForMiseErlangSdk(elixirSdk: Sdk): Sdk? {
         val homePath = elixirSdk.homePath ?: return null
@@ -95,7 +110,6 @@ object ElixirInternalErlangSdkSetup {
             ErlangSdkType.suggestSdkNameForHome(path, null)
         }.toTypedArray()
 
-        // Build a reverse map from display name → home path for lookup after dialog
         val nameToHome = validHomes.associate { (_, path) ->
             ErlangSdkType.suggestSdkNameForHome(path, null) to path
         }
@@ -117,50 +131,45 @@ object ElixirInternalErlangSdkSetup {
                 validator
             )
         }
-
-        if (app.isDispatchThread) {
-            showDialog.run()
-        } else {
-            app.invokeAndWait(showDialog)
-        }
+        if (app.isDispatchThread) showDialog.run() else app.invokeAndWait(showDialog)
 
         val selectedHome = selectedName?.let { nameToHome[it] } ?: return null
 
-        val erlangSdk = registerErlangSdk(selectedHome) ?: return null
-
-        return erlangSdk
-    }
-
-    internal fun registerErlangSdk(homePath: String): Sdk? {
-        val erlangSdkType = ErlangSdkType.instance
-        val canonicalHome = wslCompat.canonicalizePath(homePath)
-        val versionString = ErlangSdkType.versionStringForHome(canonicalHome, null)
-            ?: return null
-        val sdkName = ErlangSdkType.suggestSdkNameForHome(canonicalHome, null)
-
-        val newSdk = ProjectJdkImpl(sdkName, erlangSdkType, canonicalHome, versionString)
-        LOG.trace { "registerErlangSdk: created SDK '$sdkName' (identity: ${System.identityHashCode(newSdk)})" }
-
-        val app = ApplicationManager.getApplication()
-        val addSdk = Runnable {
-            app.runWriteAction {
-                ProjectJdkTable.getInstance().addJdk(newSdk)
-                val tableEntry = ProjectJdkTable.getInstance().findJdk(sdkName)
-                LOG.trace { "registerErlangSdk: after addJdk, findJdk('$sdkName') = ${tableEntry?.let { "'${it.name}' (identity: ${System.identityHashCode(it)})" } ?: "NOT FOUND"}" }
+        return if (app.isDispatchThread) {
+            // Can't use runBlocking on EDT - fall back to modal-aware invokeAndWait + runWriteAction.
+            registerErlangSdk(selectedHome)
+        } else {
+            // Capture the current ProgressManager modality (the "Configuring SDK…" modal) so that
+            // edtWriteAction inside SdkRegistrar dispatches at the correct modality level.
+            //
+            // Safety invariant: ErlangSdkType.setupSdkPaths (called inside registerOrUpdateErlangSdk)
+            // must not block waiting for this background thread. Any invokeAndWait it issues dispatches
+            // to the EDT, which is safe because we are not holding any lock the EDT needs. If
+            // setupSdkPaths ever changed to block on the calling thread, this runBlocking would deadlock.
+            val modality = ModalityState.defaultModalityState()
+            runBlocking(modality.asContextElement()) {
+                SdkRegistrar.registerOrUpdateErlangSdk(selectedHome)
             }
         }
+    }
 
-        if (app.isDispatchThread) {
-            addSdk.run()
+    /**
+     * Registers an Erlang SDK using [com.intellij.openapi.application.Application.invokeAndWait] +
+     * [com.intellij.openapi.application.runWriteAction], which is modal-aware and works whether called from the EDT or
+     * from a background thread inside a modal context.
+     *
+     * Reuses an already-registered SDK at the same home path rather than creating a duplicate.
+     */
+    internal fun registerErlangSdk(homePath: String): Sdk? {
+        val prep = SdkRegistrar.prepareErlangSdk(homePath) ?: return null
+        val sdk = if (prep.existing != null) {
+            prep.existing
         } else {
-            app.invokeAndWait(addSdk)
+            WriteActions.runWriteAction { ProjectJdkTable.getInstance().addJdk(prep.template) }
+            prep.template
         }
-
-        LOG.trace { "registerErlangSdk: before setupSdkPaths, findJdk('$sdkName') = ${ProjectJdkTable.getInstance().findJdk(sdkName)?.let { "found (identity: ${System.identityHashCode(it)})" } ?: "NOT FOUND"}" }
-        erlangSdkType.setupSdkPaths(newSdk)
-        LOG.trace { "registerErlangSdk: after setupSdkPaths, findJdk('$sdkName') = ${ProjectJdkTable.getInstance().findJdk(sdkName)?.let { "found (identity: ${System.identityHashCode(it)})" } ?: "NOT FOUND"}" }
-
-        LOG.info("Registered Erlang SDK '${newSdk.name}' from $canonicalHome")
-        return newSdk
+        ErlangSdkType.instance.setupSdkPaths(sdk)
+        LOG.info("${if (prep.existing != null) "Reused" else "Registered"} Erlang SDK '${sdk.name}' from ${sdk.homePath}")
+        return sdk
     }
 }

--- a/src/org/elixir_lang/sdk/elixir/ElixirSdkLookup.kt
+++ b/src/org/elixir_lang/sdk/elixir/ElixirSdkLookup.kt
@@ -1,0 +1,43 @@
+package org.elixir_lang.sdk.elixir
+
+import com.intellij.facet.FacetManager
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.module.Module
+import com.intellij.openapi.module.ModuleUtilCore
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.projectRoots.Sdk
+import com.intellij.openapi.roots.ModuleRootManager
+import com.intellij.openapi.roots.ProjectRootManager
+import com.intellij.psi.PsiElement
+import org.elixir_lang.Facet
+
+object ElixirSdkLookup {
+    fun mostSpecificSdk(module: Module): Sdk? =
+        FacetManager.getInstance(module).getFacetByType(Facet.ID)?.sdk
+            ?: moduleSdk(module)
+            ?: mostSpecificSdk(module.project)
+
+    fun mostSpecificSdk(psiElement: PsiElement): Sdk? {
+        val project = psiElement.project
+        if (project.isDisposed) return null
+
+        val module = ApplicationManager.getApplication().runReadAction<Module?> {
+            ModuleUtilCore.findModuleForPsiElement(psiElement)
+        }
+
+        return if (module != null) mostSpecificSdk(module) else mostSpecificSdk(project)
+    }
+
+    fun mostSpecificSdk(project: Project): Sdk? = projectSdk(project)
+
+    private fun moduleSdk(module: Module): Sdk? = sdk(ModuleRootManager.getInstance(module).sdk)
+
+    private fun projectSdk(project: Project): Sdk? = sdk(ProjectRootManager.getInstance(project).projectSdk)
+
+    private fun sdk(sdk: Sdk?): Sdk? =
+        if (sdk != null && sdk.sdkType === Type.instance) {
+            sdk
+        } else {
+            null
+        }
+}

--- a/src/org/elixir_lang/sdk/elixir/ElixirSdkPathConfigurator.kt
+++ b/src/org/elixir_lang/sdk/elixir/ElixirSdkPathConfigurator.kt
@@ -1,13 +1,14 @@
 package org.elixir_lang.sdk.elixir
 
-import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.diagnostic.debug
+import com.intellij.openapi.projectRoots.ProjectJdkTable
 import com.intellij.openapi.projectRoots.Sdk
 import com.intellij.openapi.projectRoots.SdkModificator
 import com.intellij.openapi.roots.OrderRootType
 import com.intellij.openapi.vfs.VfsUtil
 import org.elixir_lang.sdk.SdkEbinPaths
+import org.elixir_lang.util.WriteActions
 import java.io.File
 import java.nio.file.Path
 import java.nio.file.Paths
@@ -28,29 +29,26 @@ object ElixirSdkPathConfigurator {
         // is registered to consume JavadocOrderRootType roots.
         addSourcePaths(sdkModificator)
 
-        // Configure internal Erlang SDK - this will now create and fully setup the Erlang SDK synchronously
-        val erlangSdk = Type.configureInternalErlangSdk(sdk, sdkModificator)
-
-        // Commit changes - check if we're already in a write action to avoid deadlock
-        val app = ApplicationManager.getApplication()
-        if (app.isWriteAccessAllowed) {
-            LOG.debug { "Committing SDK changes for ${sdk.name} (already in write action)" }
-            sdkModificator.commitChanges()
-        } else {
-            val runnable = Runnable {
-                app.runWriteAction {
-                    LOG.debug { "Committing SDK changes for ${sdk.name}" }
-                    sdkModificator.commitChanges()
-                    LOG.debug { "Committed SDK changes for ${sdk.name}" }
-                }
-            }
-            if (app.isDispatchThread) {
-                runnable.run()
+        val erlangSdk = ElixirInternalErlangSdkSetup.configureInternalErlangSdk(sdk, sdkModificator)
+        if (erlangSdk == null) {
+            // Only remove SDKs that are not yet in ProjectJdkTable (wizard/new-SDK path).
+            // An existing SDK that temporarily can't resolve its Erlang pairing must not be removed -
+            // the caller (e.g. SdkRegistrar.registerOrUpdateElixirSdk) owns the SDK's lifecycle.
+            if (ProjectJdkTable.getInstance().findJdk(sdk.name) == null) {
+                LOG.warn("No Erlang SDK found for new Elixir SDK '${sdk.name}'; removing incomplete SDK")
+                WriteActions.runWriteAction { ProjectJdkTable.getInstance().removeJdk(sdk) }
             } else {
-                app.invokeAndWait(runnable)
+                LOG.warn("No Erlang SDK found for Elixir SDK '${sdk.name}'; leaving existing SDK in table")
             }
+            return
         }
-        LOG.info("SDK paths configured for ${sdk.name} (Erlang SDK: ${erlangSdk?.name ?: "none"})")
+
+        WriteActions.runWriteAction {
+            LOG.debug { "Committing SDK changes for ${sdk.name}" }
+            sdkModificator.commitChanges()
+            LOG.debug { "Committed SDK changes for ${sdk.name}" }
+        }
+        LOG.info("SDK paths configured for ${sdk.name} (Erlang SDK: ${erlangSdk.name})")
     }
 
     private fun addSourcePaths(sdkModificator: SdkModificator) {

--- a/src/org/elixir_lang/sdk/elixir/ElixirSdkPathConfigurator.kt
+++ b/src/org/elixir_lang/sdk/elixir/ElixirSdkPathConfigurator.kt
@@ -1,0 +1,84 @@
+package org.elixir_lang.sdk.elixir
+
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.diagnostic.debug
+import com.intellij.openapi.projectRoots.Sdk
+import com.intellij.openapi.projectRoots.SdkModificator
+import com.intellij.openapi.roots.OrderRootType
+import com.intellij.openapi.vfs.VfsUtil
+import org.elixir_lang.sdk.SdkEbinPaths
+import java.io.File
+import java.nio.file.Path
+import java.nio.file.Paths
+
+object ElixirSdkPathConfigurator {
+    private val LOG = Logger.getInstance(ElixirSdkPathConfigurator::class.java)
+
+    fun configure(sdk: Sdk) {
+        LOG.info("Configuring SDK paths for ${sdk.name}")
+        val sdkModificator = sdk.sdkModificator
+
+        // Configure base paths
+        org.elixir_lang.sdk.Type.addCodePaths(sdkModificator)
+        sdkModificator.removeRoots(OrderRootType.SOURCES)
+        org.elixir_lang.sdk.Type.documentationRootType()?.let { sdkModificator.removeRoots(it) }
+        // addDocumentationPaths removed: VirtualFileManager.findFileByUrl returns null for HTTP URLs,
+        // the hostname was wrong (hexdoc.pm vs hexdocs.pm), and no ExternalDocumentationProvider
+        // is registered to consume JavadocOrderRootType roots.
+        addSourcePaths(sdkModificator)
+
+        // Configure internal Erlang SDK - this will now create and fully setup the Erlang SDK synchronously
+        val erlangSdk = Type.configureInternalErlangSdk(sdk, sdkModificator)
+
+        // Commit changes - check if we're already in a write action to avoid deadlock
+        val app = ApplicationManager.getApplication()
+        if (app.isWriteAccessAllowed) {
+            LOG.debug { "Committing SDK changes for ${sdk.name} (already in write action)" }
+            sdkModificator.commitChanges()
+        } else {
+            val runnable = Runnable {
+                app.runWriteAction {
+                    LOG.debug { "Committing SDK changes for ${sdk.name}" }
+                    sdkModificator.commitChanges()
+                    LOG.debug { "Committed SDK changes for ${sdk.name}" }
+                }
+            }
+            if (app.isDispatchThread) {
+                runnable.run()
+            } else {
+                app.invokeAndWait(runnable)
+            }
+        }
+        LOG.info("SDK paths configured for ${sdk.name} (Erlang SDK: ${erlangSdk?.name ?: "none"})")
+    }
+
+    private fun addSourcePaths(sdkModificator: SdkModificator) {
+        val homePath = sdkModificator.homePath ?: return
+        SdkEbinPaths.eachEbinPath(
+            homePath,
+        ) { ebinPath: Path -> addSourcePath(sdkModificator, ebinPath) }
+    }
+
+    private fun addSourcePath(
+        sdkModificator: SdkModificator,
+        libFile: File,
+    ) {
+        val sourcePath = VfsUtil.findFileByIoFile(libFile, true)
+        if (sourcePath != null) {
+            sdkModificator.addRoot(sourcePath, OrderRootType.SOURCES)
+        }
+    }
+
+    private fun addSourcePath(
+        sdkModificator: SdkModificator,
+        ebinPath: Path,
+    ) {
+        val parentPath = ebinPath.parent
+        val libPath = Paths.get(parentPath.toString(), "lib")
+        val libFile = libPath.toFile()
+        if (libFile.exists()) {
+            addSourcePath(sdkModificator, libFile)
+        }
+    }
+}

--- a/src/org/elixir_lang/sdk/elixir/ElixirSdkUtil.kt
+++ b/src/org/elixir_lang/sdk/elixir/ElixirSdkUtil.kt
@@ -1,0 +1,37 @@
+package org.elixir_lang.sdk.elixir
+
+import com.intellij.openapi.module.ModuleManager
+import com.intellij.openapi.module.ModuleUtilCore
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.projectRoots.Sdk
+import com.intellij.openapi.vfs.VirtualFile
+
+/**
+ * Finds the Elixir SDK for a specific content root by resolving the owning module.
+ *
+ * Uses [Type.mostSpecificSdk] (module overload) which checks Facet SDK → module SDK → project SDK,
+ * covering both Rich IDEs (JdkOrderEntry) and Small IDEs (Facet library entry).
+ *
+ * Falls back to the first module's SDK when no module owns [root] (e.g., external content roots).
+ */
+fun findElixirSdkForRoot(project: Project, root: VirtualFile): Sdk? {
+    val module = ModuleUtilCore.findModuleForFile(root, project)
+        ?: ModuleManager.getInstance(project).modules.firstOrNull()
+        ?: return null
+    return Type.mostSpecificSdk(module)
+}
+
+/**
+ * Collects all distinct active Elixir SDKs across all modules in the project.
+ *
+ * Uses [Type.mostSpecificSdk] per module, covering Facet SDKs in Small IDEs.
+ * Useful for SDK refresh actions and "does any Elixir SDK exist?" guards.
+ */
+fun findAllActiveElixirSdks(project: Project): Set<Sdk> {
+    val sdks = mutableSetOf<Sdk>()
+    for (module in ModuleManager.getInstance(project).modules) {
+        val sdk = Type.mostSpecificSdk(module)
+        if (sdk != null) sdks.add(sdk)
+    }
+    return sdks
+}

--- a/src/org/elixir_lang/sdk/elixir/ElixirVersionDetector.kt
+++ b/src/org/elixir_lang/sdk/elixir/ElixirVersionDetector.kt
@@ -10,8 +10,8 @@ import com.intellij.util.concurrency.annotations.RequiresBackgroundThread
 import org.elixir_lang.cli.getExecutableFilepathWslSafe
 import org.elixir_lang.jps.shared.cli.CliTool
 import org.elixir_lang.sdk.ProcessOutput
-import org.elixir_lang.sdk.runWithEdtGuard
 import org.elixir_lang.sdk.wsl.wslCompat
+import org.elixir_lang.util.runWithEdtGuard
 import org.jetbrains.annotations.Contract
 import java.io.File
 import java.util.concurrent.ConcurrentHashMap
@@ -81,7 +81,7 @@ object ElixirVersionDetector {
      *
      * The result is cached on the [sdk] instance via [UserDataHolderEx] after the first call.
      * On a cold start (after IDE restart, before any SDK setup has run), the backing
-     * [elixirVersion] may shell out to `elixir --short-version`.  That subprocess call
+     * [ElixirVersionDetector.elixirVersion] may shell out to `elixir --short-version`.  That subprocess call
      * **must not** happen while a read lock is held - doing so blocks write actions and
      * triggers a platform SEVERE.  Always call this from a background thread or an IO
      * coroutine dispatcher, never from inside `readAction { }`.
@@ -117,14 +117,14 @@ object ElixirVersionDetector {
      * release cannot be determined.
      *
      * This method is read-lock-safe and may be called from any thread, including the EDT
-     * and under a read action.  It uses only the pre-cached [ELIXIR_VERSION_KEY] user data
-     * (populated by a prior [canonicalVersion] call from an IO phase) and falls back to
+     * and under a read action.  It uses only the pre-cached [ElixirVersionDetector.ELIXIR_VERSION_KEY] user data
+     * (populated by a prior [ElixirVersionDetector.canonicalVersion] call from an IO phase) and falls back to
      * parsing the SDK home directory name.  It deliberately does **not** call
-     * [canonicalVersion] - that would spawn `elixir --short-version` on a cold start and
+     * [ElixirVersionDetector.canonicalVersion] - that would spawn `elixir --short-version` on a cold start and
      * is forbidden under a read lock.
      *
      * Callers that need a guaranteed-accurate version at the cost of a subprocess on cold
-     * start should call [canonicalVersion] from a background/IO thread instead.
+     * start should call [ElixirVersionDetector.canonicalVersion] from a background/IO thread instead.
      */
     @Contract("null -> null")
     fun getRelease(sdk: Sdk?): Release? =

--- a/src/org/elixir_lang/sdk/elixir/ElixirVersionDetector.kt
+++ b/src/org/elixir_lang/sdk/elixir/ElixirVersionDetector.kt
@@ -1,0 +1,140 @@
+package org.elixir_lang.sdk.elixir
+
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.projectRoots.Sdk
+import com.intellij.openapi.util.Key
+import com.intellij.openapi.util.UserDataHolderEx
+import com.intellij.util.concurrency.ThreadingAssertions
+import com.intellij.util.concurrency.annotations.RequiresBackgroundThread
+import org.elixir_lang.cli.getExecutableFilepathWslSafe
+import org.elixir_lang.jps.shared.cli.CliTool
+import org.elixir_lang.sdk.ProcessOutput
+import org.elixir_lang.sdk.runWithEdtGuard
+import org.elixir_lang.sdk.wsl.wslCompat
+import org.jetbrains.annotations.Contract
+import java.io.File
+import java.util.concurrent.ConcurrentHashMap
+
+object ElixirVersionDetector {
+    val ELIXIR_VERSION_KEY = Key.create<String>("ELIXIR_CANONICAL_VERSION")
+    private val LOG = Logger.getInstance(ElixirVersionDetector::class.java)
+    private val versionByHomePath: MutableMap<String, String> = ConcurrentHashMap()
+
+    internal fun elixirVersion(sdkHome: String, resolvedVersion: String?): String? {
+        if (!resolvedVersion.isNullOrBlank()) {
+            return resolvedVersion
+        }
+
+        val canonicalHome = wslCompat.canonicalizePath(sdkHome)
+        val exePath = CliTool.ELIXIR.getExecutableFilepathWslSafe(canonicalHome)
+        val exeFile = File(exePath)
+        val lastModified = exeFile.lastModified()
+        if (lastModified == 0L) {
+            LOG.debug("Elixir executable missing or unreadable: $exePath")
+            return elixirVersionFromHomePath(canonicalHome)
+        }
+
+        val cacheKey = "$canonicalHome@$lastModified"
+        val cached = versionByHomePath[cacheKey]
+        if (cached != null || versionByHomePath.containsKey(cacheKey)) {
+            return cached
+        }
+
+        return runWithEdtGuard("Detecting Elixir SDK version...") {
+            elixirVersionBackground(canonicalHome, exePath, cacheKey)
+        }
+    }
+
+    private fun elixirVersionBackground(canonicalHome: String, exePath: String, cacheKey: String): String? {
+        return try {
+            val output =
+                ProcessOutput.getProcessOutput(
+                    ProcessOutput.STANDARD_TIMEOUT,
+                    canonicalHome,
+                    exePath,
+                    "--short-version"
+                )
+            val version =
+                if (output.exitCode == 0 && !output.isTimeout && !output.isCancelled) {
+                    output.stdoutLines.firstOrNull { it.isNotBlank() }?.trim()
+                } else {
+                    LOG.debug("Failed to read Elixir version from $exePath (exitCode=${output.exitCode})")
+                    elixirVersionFromHomePath(canonicalHome)
+                }
+            if (version != null) {
+                versionByHomePath[cacheKey] = version
+            }
+            version
+        } catch (e: Exception) {
+            LOG.debug("Failed to read Elixir version from $exePath", e)
+            elixirVersionFromHomePath(canonicalHome)
+        }
+    }
+
+    private fun elixirVersionFromHomePath(homePath: String) =
+        homePath.let { Release.fromString(File(it).name) }?.version()
+
+    /**
+     * Returns the bare canonical Elixir version string for [sdk] (e.g. `"1.15.7"`), or `null`
+     * if the SDK is not an Elixir SDK or the version cannot be determined.
+     *
+     * The result is cached on the [sdk] instance via [UserDataHolderEx] after the first call.
+     * On a cold start (after IDE restart, before any SDK setup has run), the backing
+     * [elixirVersion] may shell out to `elixir --short-version`.  That subprocess call
+     * **must not** happen while a read lock is held - doing so blocks write actions and
+     * triggers a platform SEVERE.  Always call this from a background thread or an IO
+     * coroutine dispatcher, never from inside `readAction { }`.
+     */
+    @RequiresBackgroundThread
+    fun canonicalVersion(sdk: Sdk): String? {
+        ThreadingAssertions.assertBackgroundThread()
+
+        if (sdk.sdkType !== Type.instance) return null
+
+        sdk.getUserData(ELIXIR_VERSION_KEY)?.let { return it }
+
+        // Cold path: may shell out to `elixir --short-version`.
+        // Calling elixirVersion() under a read lock blocks write actions - assert early.
+        check(!ApplicationManager.getApplication().holdsReadLock()) {
+            "canonicalVersion() may shell out to `elixir --short-version` and must not be called under a read lock"
+        }
+
+        val homePath = sdk.homePath ?: return null
+        val version = elixirVersion(homePath, null) ?: return null
+
+        val existing = (sdk as? UserDataHolderEx)?.putUserDataIfAbsent(ELIXIR_VERSION_KEY, version)
+        if (existing != null) {
+            return existing
+        }
+
+        sdk.putUserData(ELIXIR_VERSION_KEY, version)
+        return version
+    }
+
+    /**
+     * Returns the [Release] for [sdk], or `null` if the SDK is not an Elixir SDK or the
+     * release cannot be determined.
+     *
+     * This method is read-lock-safe and may be called from any thread, including the EDT
+     * and under a read action.  It uses only the pre-cached [ELIXIR_VERSION_KEY] user data
+     * (populated by a prior [canonicalVersion] call from an IO phase) and falls back to
+     * parsing the SDK home directory name.  It deliberately does **not** call
+     * [canonicalVersion] - that would spawn `elixir --short-version` on a cold start and
+     * is forbidden under a read lock.
+     *
+     * Callers that need a guaranteed-accurate version at the cost of a subprocess on cold
+     * start should call [canonicalVersion] from a background/IO thread instead.
+     */
+    @Contract("null -> null")
+    fun getRelease(sdk: Sdk?): Release? =
+        if (sdk != null && sdk.sdkType === Type.instance) {
+            // Prefer the pre-cached bare version (set by canonicalVersion() in IO phase).
+            // Fall back to directory name parsing - never spawn a subprocess here.
+            val cachedVersion = sdk.getUserData(ELIXIR_VERSION_KEY)
+            cachedVersion?.let { Release.fromString(it) }
+                ?: sdk.homePath?.let { Release.fromString(File(it).name) }
+        } else {
+            null
+        }
+}

--- a/src/org/elixir_lang/sdk/elixir/Type.kt
+++ b/src/org/elixir_lang/sdk/elixir/Type.kt
@@ -339,13 +339,6 @@ ELIXIR_SDK_HOME
         internal fun setupSdkTableListener() {
             val messageBus = ApplicationManager.getApplication().messageBus
             messageBus.connect().subscribe(ProjectJdkTable.JDK_TABLE_TOPIC, object : ProjectJdkTable.Listener {
-                override fun jdkAdded(jdk: Sdk) {
-                    // When an Elixir SDK is added, auto-set it as the project SDK if appropriate
-                    if (jdk.sdkType is Type) {
-                        autoSetProjectSdkIfNeeded(jdk)
-                    }
-                }
-
                 override fun jdkRemoved(jdk: Sdk) {
                     // When an Erlang SDK is removed, clean up any Elixir SDKs that reference it
                     if (staticIsValidDependency(jdk)) {
@@ -376,70 +369,6 @@ ELIXIR_SDK_HOME
                         projectRootManager.projectSdk = null
                         LOG.info("Cleared removed Elixir SDK '${deletedSdk.name}' from project '${project.name}'")
                     }
-                }
-            }
-        }
-
-        private fun autoSetProjectSdkIfNeeded(newElixirSdk: Sdk) {
-            LOG.debug { "Auto-set check for newly added Elixir SDK: ${newElixirSdk.name}" }
-
-            // Get all non-disposed projects
-            val openProjects = com.intellij.openapi.project.ProjectManager.getInstance().openProjects.filter {
-                !it.isDisposed
-            }
-
-            // Only auto-set if exactly one project is open
-            // This ensures we don't accidentally set the wrong project's SDK
-            val project = when (openProjects.size) {
-                0 -> {
-                    LOG.debug { "No open projects, skipping auto-set" }
-                    return
-                }
-
-                1 -> openProjects.first()
-                else -> {
-                    LOG.debug { "Multiple projects open (${openProjects.size}), skipping auto-set to avoid ambiguity" }
-                    return
-                }
-            }
-
-            val projectRootManager = ProjectRootManager.getInstance(project)
-            val currentProjectSdk = projectRootManager.projectSdk
-
-            // Only auto-set if current SDK is null or (is Elixir and invalid)
-            val shouldAutoSet = if (currentProjectSdk == null) {
-                LOG.debug { "Project '${project.name}' has no SDK, will auto-set to '${newElixirSdk.name}'" }
-                true
-            } else if (currentProjectSdk.sdkType !is Type) {
-                // Don't replace non-Elixir SDKs (Java, Python, etc.)
-                LOG.debug {
-                    "Project '${project.name}' has non-Elixir SDK '${currentProjectSdk.name}', skipping auto-set"
-                }
-                false
-            } else {
-                // Current SDK is Elixir - check if it's valid
-                val isValid = try {
-                    val additionalData = currentProjectSdk.sdkAdditionalData as? SdkAdditionalData
-                    val erlangSdk = additionalData?.getErlangSdk()
-                    erlangSdk != null
-                } catch (e: Exception) {
-                    LOG.debug { "Error checking validity of current SDK: ${e.message}" }
-                    false
-                }
-
-                if (!isValid) {
-                    LOG.debug {
-                        "Project '${project.name}' SDK '${currentProjectSdk.name}' is invalid, " +
-                                "will auto-set to '${newElixirSdk.name}'"
-                    }
-                }
-                !isValid
-            }
-
-            if (shouldAutoSet) {
-                WriteActions.runWriteActionLater {
-                    projectRootManager.projectSdk = newElixirSdk
-                    LOG.info("Auto-set project '${project.name}' SDK to '${newElixirSdk.name}'")
                 }
             }
         }

--- a/src/org/elixir_lang/sdk/elixir/Type.kt
+++ b/src/org/elixir_lang/sdk/elixir/Type.kt
@@ -3,7 +3,6 @@ package org.elixir_lang.sdk.elixir
 import com.intellij.facet.FacetManager
 import com.intellij.notification.NotificationAction
 import com.intellij.openapi.application.ApplicationManager
-import com.intellij.openapi.application.ReadAction
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.diagnostic.debug
 import com.intellij.openapi.fileChooser.FileChooserDescriptor
@@ -18,6 +17,10 @@ import com.intellij.openapi.roots.ModuleRootManager
 import com.intellij.openapi.roots.OrderRootType
 import com.intellij.openapi.roots.ProjectRootManager
 import com.intellij.openapi.util.InvalidDataException
+import com.intellij.openapi.util.Key
+import com.intellij.openapi.util.UserDataHolderEx
+import com.intellij.util.concurrency.ThreadingAssertions
+import com.intellij.util.concurrency.annotations.RequiresBackgroundThread
 import com.intellij.openapi.util.WriteExternalException
 import com.intellij.openapi.util.io.FileUtil
 import com.intellij.openapi.vfs.LocalFileSystem
@@ -241,6 +244,7 @@ ELIXIR_SDK_HOME
         private val SDK_HOME_CHILD_BASE_NAME_SET: Set<String> = setOf("lib", "src")
         private const val WINDOWS_32BIT_DEFAULT_HOME_PATH = "C:\\Program Files\\Elixir"
         private const val WINDOWS_64BIT_DEFAULT_HOME_PATH = "C:\\Program Files (x86)\\Elixir"
+        private val ELIXIR_VERSION_KEY = Key.create<String>("ELIXIR_CANONICAL_VERSION")
         private val versionByHomePath: MutableMap<String, String> = ConcurrentHashMap()
 
         @JvmStatic
@@ -450,7 +454,7 @@ ELIXIR_SDK_HOME
         }
 
         private fun releaseVersion(sdkModificator: SdkModificator): String? =
-            sdkModificator.versionString?.let { Release.fromString(it) }?.version()
+            sdkModificator.homePath?.let { elixirVersion(it, null) }
 
         private fun addDocumentationPath(
             sdkModificator: SdkModificator,
@@ -822,11 +826,66 @@ ELIXIR_SDK_HOME
             return classRoots.any { root -> VfsUtilCore.isAncestor(erlangHomePathVf, root, true) }
         }
 
+        /**
+         * Returns the bare canonical Elixir version string for [sdk] (e.g. `"1.15.7"`), or `null`
+         * if the SDK is not an Elixir SDK or the version cannot be determined.
+         *
+         * The result is cached on the [sdk] instance via [UserDataHolderEx] after the first call.
+         * On a cold start (after IDE restart, before any SDK setup has run), the backing
+         * [elixirVersion] may shell out to `elixir --short-version`.  That subprocess call
+         * **must not** happen while a read lock is held - doing so blocks write actions and
+         * triggers a platform SEVERE.  Always call this from a background thread or an IO
+         * coroutine dispatcher, never from inside `readAction { }`.
+         */
+        @JvmStatic
+        @RequiresBackgroundThread
+        fun canonicalVersion(sdk: Sdk): String? {
+            ThreadingAssertions.assertBackgroundThread()
+
+            if (sdk.sdkType !== instance) return null
+
+            sdk.getUserData(ELIXIR_VERSION_KEY)?.let { return it }
+
+            // Cold path: may shell out to `elixir --short-version`.
+            // Calling elixirVersion() under a read lock blocks write actions - assert early.
+            check(!ApplicationManager.getApplication().holdsReadLock()) {
+                "canonicalVersion() may shell out to `elixir --short-version` and must not be called under a read lock"
+            }
+
+            val homePath = sdk.homePath ?: return null
+            val version = elixirVersion(homePath, null) ?: return null
+
+            val existing = (sdk as? UserDataHolderEx)?.putUserDataIfAbsent(ELIXIR_VERSION_KEY, version)
+            if (existing != null) {
+                return existing
+            }
+
+            sdk.putUserData(ELIXIR_VERSION_KEY, version)
+            return version
+        }
+
+        /**
+         * Returns the [Release] for [sdk], or `null` if the SDK is not an Elixir SDK or the
+         * release cannot be determined.
+         *
+         * This method is read-lock-safe and may be called from any thread, including the EDT
+         * and under a read action.  It uses only the pre-cached [ELIXIR_VERSION_KEY] user data
+         * (populated by a prior [canonicalVersion] call from an IO phase) and falls back to
+         * parsing the SDK home directory name.  It deliberately does **not** call
+         * [canonicalVersion] - that would spawn `elixir --short-version` on a cold start and
+         * is forbidden under a read lock.
+         *
+         * Callers that need a guaranteed-accurate version at the cost of a subprocess on cold
+         * start should call [canonicalVersion] from a background/IO thread instead.
+         */
         @JvmStatic
         @Contract("null -> null")
         fun getRelease(sdk: Sdk?): Release? =
             if (sdk != null && sdk.sdkType === instance) {
-                Release.fromString(sdk.versionString)
+                // Prefer the pre-cached bare version (set by canonicalVersion() in IO phase).
+                // Fall back to directory name parsing - never spawn a subprocess here.
+                val cachedVersion = sdk.getUserData(ELIXIR_VERSION_KEY)
+                cachedVersion?.let { Release.fromString(it) }
                     ?: sdk.homePath?.let { Release.fromString(File(it).name) }
             } else {
                 null
@@ -853,7 +912,7 @@ ELIXIR_SDK_HOME
             val project = psiElement.project
             if (project.isDisposed) return null
 
-            val module = ReadAction.compute<Module?, Throwable> {
+            val module = ApplicationManager.getApplication().runReadAction<Module?> {
                 ModuleUtilCore.findModuleForPsiElement(psiElement)
             }
 

--- a/src/org/elixir_lang/sdk/elixir/Type.kt
+++ b/src/org/elixir_lang/sdk/elixir/Type.kt
@@ -1,47 +1,30 @@
 package org.elixir_lang.sdk.elixir
 
-import com.intellij.facet.FacetManager
 import com.intellij.notification.NotificationAction
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.diagnostic.Logger
-import com.intellij.openapi.diagnostic.debug
 import com.intellij.openapi.fileChooser.FileChooserDescriptor
 import com.intellij.openapi.module.Module
-import com.intellij.openapi.module.ModuleUtilCore
-import com.intellij.platform.ide.progress.ModalTaskOwner
-import com.intellij.platform.ide.progress.runWithModalProgressBlocking
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.project.guessProjectDir
 import com.intellij.openapi.projectRoots.*
-import com.intellij.openapi.roots.ModuleRootManager
 import com.intellij.openapi.roots.OrderRootType
 import com.intellij.openapi.roots.ProjectRootManager
 import com.intellij.openapi.util.InvalidDataException
-import com.intellij.openapi.util.Key
-import com.intellij.openapi.util.UserDataHolderEx
-import com.intellij.util.concurrency.ThreadingAssertions
-import com.intellij.util.concurrency.annotations.RequiresBackgroundThread
 import com.intellij.openapi.util.WriteExternalException
 import com.intellij.openapi.util.io.FileUtil
-import com.intellij.openapi.vfs.LocalFileSystem
-import com.intellij.openapi.vfs.VfsUtil
-import com.intellij.openapi.vfs.VfsUtilCore
-import com.intellij.openapi.vfs.VirtualFile
-import com.intellij.openapi.vfs.VirtualFileManager
-import com.intellij.openapi.vfs.toNioPathOrNull
+import com.intellij.openapi.vfs.*
 import com.intellij.psi.PsiElement
+import com.intellij.util.concurrency.annotations.RequiresBackgroundThread
 import org.apache.commons.io.FilenameUtils
-import org.elixir_lang.Facet
 import org.elixir_lang.Icons
 import org.elixir_lang.cli.getExecutableFilepathWslSafe
 import org.elixir_lang.jps.shared.ElixirSdkTypeId
 import org.elixir_lang.jps.shared.cli.CliTool
 import org.elixir_lang.jps.shared.sdk.SdkPaths
-import org.elixir_lang.sdk.SdkHomeKey
-import org.elixir_lang.sdk.SdkHomePaths
 import org.elixir_lang.sdk.*
-import org.elixir_lang.sdk.Type.ebinPathChainVirtualFile
 import org.elixir_lang.sdk.erlang_dependent.AdditionalDataConfigurable
+import org.elixir_lang.sdk.erlang_dependent.ErlangSdkResolver
 import org.elixir_lang.sdk.erlang_dependent.SdkAdditionalData
 import org.elixir_lang.sdk.wsl.wslCompat
 import org.elixir_lang.util.WriteActions
@@ -50,9 +33,8 @@ import org.jetbrains.annotations.Contract
 import org.jetbrains.annotations.Unmodifiable
 import java.io.File
 import java.nio.file.Path
-import java.nio.file.Paths
-import java.util.concurrent.ConcurrentHashMap
 import javax.swing.Icon
+
 
 class Type : org.elixir_lang.sdk.erlang_dependent.Type(ElixirSdkTypeId.ELIXIR_SDK_TYPE_ID) {
     /**
@@ -168,7 +150,7 @@ ELIXIR_SDK_HOME
     }
 
     override fun setupSdkPaths(sdk: Sdk) {
-        configureSdkPaths(sdk)
+        ElixirSdkPathConfigurator.configure(sdk)
     }
 
     @Deprecated("Deprecated in Java")
@@ -244,12 +226,10 @@ ELIXIR_SDK_HOME
         private val SDK_HOME_CHILD_BASE_NAME_SET: Set<String> = setOf("lib", "src")
         private const val WINDOWS_32BIT_DEFAULT_HOME_PATH = "C:\\Program Files\\Elixir"
         private const val WINDOWS_64BIT_DEFAULT_HOME_PATH = "C:\\Program Files (x86)\\Elixir"
-        private val ELIXIR_VERSION_KEY = Key.create<String>("ELIXIR_CANONICAL_VERSION")
-        private val versionByHomePath: MutableMap<String, String> = ConcurrentHashMap()
 
         @JvmStatic
         internal fun versionStringForHome(sdkHome: String, resolvedVersion: String?): String? {
-            val version = elixirVersion(sdkHome, resolvedVersion) ?: return null
+            val version = ElixirVersionDetector.elixirVersion(sdkHome, resolvedVersion) ?: return null
             val source = SdkPaths.detectSource(sdkHome)
             return buildString {
                 if (source != null) {
@@ -262,7 +242,7 @@ ELIXIR_SDK_HOME
         @JvmStatic
         internal fun suggestSdkNameForHome(sdkHome: String, resolvedVersion: String?): String {
             val source = SdkPaths.detectSource(sdkHome)
-            val version = elixirVersion(sdkHome, resolvedVersion)
+            val version = ElixirVersionDetector.elixirVersion(sdkHome, resolvedVersion)
             val base = buildString {
                 if (source != null) {
                     append(source).append(" ")
@@ -277,67 +257,13 @@ ELIXIR_SDK_HOME
             return org.elixir_lang.sdk.Type.appendWslSuffix(base, sdkHome)
         }
 
-        private fun elixirVersion(sdkHome: String, resolvedVersion: String?): String? {
-            if (!resolvedVersion.isNullOrBlank()) {
-                return resolvedVersion
-            }
+        @JvmStatic
+        @RequiresBackgroundThread
+        fun canonicalVersion(sdk: Sdk): String? = ElixirVersionDetector.canonicalVersion(sdk)
 
-            val canonicalHome = wslCompat.canonicalizePath(sdkHome)
-            val exePath = CliTool.ELIXIR.getExecutableFilepathWslSafe(canonicalHome)
-            val exeFile = File(exePath)
-            val lastModified = exeFile.lastModified()
-            if (lastModified == 0L) {
-                LOG.debug("Elixir executable missing or unreadable: $exePath")
-                return elixirVersionFromHomePath(canonicalHome)
-            }
-
-            val cacheKey = "$canonicalHome@$lastModified"
-            val cached = versionByHomePath[cacheKey]
-            if (cached != null || versionByHomePath.containsKey(cacheKey)) {
-                return cached
-            }
-
-            val app = ApplicationManager.getApplication()
-            if (app.isDispatchThread) {
-                return runWithModalProgressBlocking(
-                    ModalTaskOwner.guess(),
-                    "Detecting Elixir SDK version..."
-                ) {
-                    elixirVersionBackground(canonicalHome, exePath, cacheKey)
-                }
-            }
-
-            return elixirVersionBackground(canonicalHome, exePath, cacheKey)
-        }
-
-        private fun elixirVersionBackground(canonicalHome: String, exePath: String, cacheKey: String): String? {
-            return try {
-                val output =
-                    ProcessOutput.getProcessOutput(
-                        ProcessOutput.STANDARD_TIMEOUT,
-                        canonicalHome,
-                        exePath,
-                        "--short-version"
-                    )
-                val version =
-                    if (output.exitCode == 0 && !output.isTimeout && !output.isCancelled) {
-                        output.stdoutLines.firstOrNull { it.isNotBlank() }?.trim()
-                    } else {
-                        LOG.debug("Failed to read Elixir version from $exePath (exitCode=${output.exitCode})")
-                        elixirVersionFromHomePath(canonicalHome)
-                    }
-                if (version != null) {
-                    versionByHomePath[cacheKey] = version
-                }
-                version
-            } catch (e: Exception) {
-                LOG.debug("Failed to read Elixir version from $exePath", e)
-                elixirVersionFromHomePath(canonicalHome)
-            }
-        }
-
-        private fun elixirVersionFromHomePath(homePath: String) =
-            homePath.let { Release.fromString(File(it).name) }?.version()
+        @JvmStatic
+        @Contract("null -> null")
+        fun getRelease(sdk: Sdk?): Release? = ElixirVersionDetector.getRelease(sdk)
 
         @JvmStatic
         internal fun setupSdkTableListener() {
@@ -453,112 +379,7 @@ ELIXIR_SDK_HOME
             }
         }
 
-        private fun releaseVersion(sdkModificator: SdkModificator): String? =
-            sdkModificator.homePath?.let { elixirVersion(it, null) }
-
-        private fun addDocumentationPath(
-            sdkModificator: SdkModificator,
-            releaseVersion: String?,
-            appName: String,
-        ) {
-            val hexdocUrlBuilder = StringBuilder("https://hexdoc.pm/").append(appName)
-            if (releaseVersion != null) {
-                hexdocUrlBuilder.append('/').append(releaseVersion)
-            }
-            val hexdocUrlVirtualFile = VirtualFileManager.getInstance().findFileByUrl(hexdocUrlBuilder.toString())
-            if (hexdocUrlVirtualFile != null) {
-                val documentationRootType =
-                    org.elixir_lang.sdk.Type
-                        .documentationRootType()
-                if (documentationRootType != null) {
-                    sdkModificator.addRoot(hexdocUrlVirtualFile, documentationRootType)
-                }
-            }
-        }
-
-        private fun addDocumentationPath(
-            sdkModificator: SdkModificator,
-            releaseVersion: String?,
-            ebinPath: Path,
-        ) {
-            val appName = ebinPath.parent.fileName.toString()
-            addDocumentationPath(sdkModificator, releaseVersion, appName)
-        }
-
-        private fun addDocumentationPaths(sdkModificator: SdkModificator) {
-            val releaseVersion = releaseVersion(sdkModificator)
-            val homePath = sdkModificator.homePath ?: return
-            SdkEbinPaths.eachEbinPath(
-                homePath,
-            ) { ebinPath: Path -> addDocumentationPath(sdkModificator, releaseVersion, ebinPath) }
-        }
-
-        private fun addSourcePaths(sdkModificator: SdkModificator) {
-            val homePath = sdkModificator.homePath ?: return
-            SdkEbinPaths.eachEbinPath(
-                homePath,
-            ) { ebinPath: Path -> addSourcePath(sdkModificator, ebinPath) }
-        }
-
-        private fun addSourcePath(
-            sdkModificator: SdkModificator,
-            libFile: File,
-        ) {
-            val sourcePath = VfsUtil.findFileByIoFile(libFile, true)
-            if (sourcePath != null) {
-                sdkModificator.addRoot(sourcePath, OrderRootType.SOURCES)
-            }
-        }
-
-        private fun addSourcePath(
-            sdkModificator: SdkModificator,
-            ebinPath: Path,
-        ) {
-            val parentPath = ebinPath.parent
-            val libPath = Paths.get(parentPath.toString(), "lib")
-            val libFile = libPath.toFile()
-            if (libFile.exists()) {
-                addSourcePath(sdkModificator, libFile)
-            }
-        }
-
-        private fun configureSdkPaths(sdk: Sdk) {
-            LOG.info("Configuring SDK paths for ${sdk.name}")
-            val sdkModificator = sdk.sdkModificator
-
-            // Configure base paths
-            org.elixir_lang.sdk.Type.addCodePaths(sdkModificator)
-            sdkModificator.removeRoots(OrderRootType.SOURCES)
-            org.elixir_lang.sdk.Type.documentationRootType()?.let { sdkModificator.removeRoots(it) }
-            addDocumentationPaths(sdkModificator)
-            addSourcePaths(sdkModificator)
-
-            // Configure internal Erlang SDK - this will now create and fully setup the Erlang SDK synchronously
-            val erlangSdk = configureInternalErlangSdk(sdk, sdkModificator)
-
-            // Commit changes - check if we're already in a write action to avoid deadlock
-            val app = ApplicationManager.getApplication()
-            if (app.isWriteAccessAllowed) {
-                LOG.debug { "Committing SDK changes for ${sdk.name} (already in write action)" }
-                sdkModificator.commitChanges()
-            } else {
-                val runnable = Runnable {
-                    app.runWriteAction {
-                        LOG.debug { "Committing SDK changes for ${sdk.name}" }
-                        sdkModificator.commitChanges()
-                        LOG.debug { "Committed SDK changes for ${sdk.name}" }
-                    }
-                }
-                if (app.isDispatchThread) {
-                    runnable.run()
-                } else {
-                    app.invokeAndWait(runnable)
-                }
-            }
-            LOG.info("SDK paths configured for ${sdk.name} (Erlang SDK: ${erlangSdk?.name ?: "none"})")
-        }
-
-        private fun configureInternalErlangSdk(
+        internal fun configureInternalErlangSdk(
             elixirSdk: Sdk,
             elixirSdkModificator: SdkModificator,
         ): Sdk? {
@@ -572,7 +393,7 @@ ELIXIR_SDK_HOME
 
             val erlangSdk = explicitErlangSdk
                 ?: existingErlangSdk
-                ?: findRegisteredErlangSdk()
+                ?: ErlangSdkResolver.findAnyRegistered()
                 ?: promptForMiseErlangSdk(elixirSdk)
 
             if (erlangSdk != null) {
@@ -587,7 +408,7 @@ ELIXIR_SDK_HOME
                     elixirSdkModificator.sdkAdditionalData = sdkAdditionData
                 }
 
-                addNewCodePathsFromInternErlangSdk(elixirSdk, erlangSdk, elixirSdkModificator)
+                ElixirErlangClasspath.addNewCodePathsFromInternErlangSdk(elixirSdk, erlangSdk, elixirSdkModificator)
 
                 // Clear the UserData after use
                 elixirSdk.putUserData(ERLANG_SDK_KEY, null)
@@ -595,13 +416,6 @@ ELIXIR_SDK_HOME
                 LOG.warn("No Erlang SDK found, Elixir SDK will be incomplete")
             }
             return erlangSdk
-        }
-
-        internal fun findRegisteredErlangSdk(): Sdk? {
-            val erlangSdkType = org.elixir_lang.sdk.erlang.Type.instance
-            return ProjectJdkTable.getInstance()
-                .getSdksOfType(erlangSdkType)
-                .firstOrNull { it.homePath != null }
         }
 
         /**
@@ -698,95 +512,6 @@ ELIXIR_SDK_HOME
         }
 
 
-        @JvmStatic
-        fun addNewCodePathsFromInternErlangSdk(
-            elixirSdk: Sdk,
-            internalErlangSdk: Sdk,
-            elixirSdkModificator: SdkModificator,
-        ) {
-            codePathsFromInternalErlangSdk(
-                elixirSdk,
-                internalErlangSdk,
-                elixirSdkModificator
-            ) { sdkModificator, configuredRoots, expandedInternalRoot, type ->
-                if (expandedInternalRoot !in configuredRoots) {
-                    sdkModificator.addRoot(expandedInternalRoot, type)
-                }
-            }
-        }
-
-        @JvmStatic
-        fun removeCodePathsFromInternalErlangSdk(
-            elixirSdk: Sdk,
-            internalErlangSdk: Sdk,
-            elixirSdkModificator: SdkModificator,
-        ) {
-            codePathsFromInternalErlangSdk(
-                elixirSdk,
-                internalErlangSdk,
-                elixirSdkModificator
-            ) { sdkModificator, _, expandedInternalRoot, type ->
-                sdkModificator.removeRoot(expandedInternalRoot, type)
-            }
-        }
-
-        private fun codePathsFromInternalErlangSdk(
-            elixirSdk: Sdk,
-            internalErlangSdk: Sdk,
-            elixirSdkModificator: SdkModificator,
-            sdkModificatorRootTypeConsumer: (SdkModificator, Array<VirtualFile>, VirtualFile, OrderRootType) -> Unit,
-        ) {
-            val internalSdkType = internalErlangSdk.sdkType as SdkType
-            val elixirSdkType = elixirSdk.sdkType as SdkType
-            for (type in OrderRootType.getAllTypes()) {
-                if (internalSdkType.isRootTypeApplicable(type) && elixirSdkType.isRootTypeApplicable(type)) {
-                    val internalRoots = internalErlangSdk.sdkModificator.getRoots(type)
-                    val configuredRoots = elixirSdkModificator.getRoots(type)
-                    for (internalRoot in internalRoots) {
-                        for (expandedInternalRoot in expandInternalErlangSdkRoot(internalRoot, type)) {
-                            sdkModificatorRootTypeConsumer(
-                                elixirSdkModificator,
-                                configuredRoots,
-                                expandedInternalRoot,
-                                type
-                            )
-                        }
-                    }
-                }
-            }
-        }
-
-        private fun expandInternalErlangSdkRoot(
-            internalRoot: VirtualFile,
-            type: OrderRootType,
-        ): Iterable<VirtualFile> {
-            val expandedInternalRootList: List<VirtualFile>
-            if (type === OrderRootType.CLASSES) {
-                val path = internalRoot.path
-
-                /* Erlang SDK from intellij-erlang uses lib/erlang/lib as class path, but intellij-elixir needs the ebin
-               directories under lib/erlang/lib/APP-VERSION/ebin that works as a code path used by `-pa` argument to
-               `erl.exe`
-
-               For ASDF the path ends in erlang/VERSION/lib, in both cases, going to the parent directory will get the
-               right ebin paths from `eachEbinPath` */
-                if (path.endsWith("lib")) {
-                    expandedInternalRootList = ArrayList()
-                    val parentPath = Paths.get(path).parent.toString()
-                    SdkEbinPaths.eachEbinPath(parentPath) { ebinPath: Path ->
-                        ebinPathChainVirtualFile(ebinPath) { virtualFile: VirtualFile? ->
-                            virtualFile?.let { expandedInternalRootList.add(it) }
-                        }
-                    }
-                } else {
-                    expandedInternalRootList = listOf(internalRoot)
-                }
-            } else {
-                expandedInternalRootList = listOf(internalRoot)
-            }
-            return expandedInternalRootList
-        }
-
         private fun getDefaultDocumentationUrl(version: Release?): String? =
             if (version == null) null else "https://elixir-lang.org/docs/stable/elixir/"
 
@@ -826,100 +551,12 @@ ELIXIR_SDK_HOME
             return classRoots.any { root -> VfsUtilCore.isAncestor(erlangHomePathVf, root, true) }
         }
 
-        /**
-         * Returns the bare canonical Elixir version string for [sdk] (e.g. `"1.15.7"`), or `null`
-         * if the SDK is not an Elixir SDK or the version cannot be determined.
-         *
-         * The result is cached on the [sdk] instance via [UserDataHolderEx] after the first call.
-         * On a cold start (after IDE restart, before any SDK setup has run), the backing
-         * [elixirVersion] may shell out to `elixir --short-version`.  That subprocess call
-         * **must not** happen while a read lock is held - doing so blocks write actions and
-         * triggers a platform SEVERE.  Always call this from a background thread or an IO
-         * coroutine dispatcher, never from inside `readAction { }`.
-         */
         @JvmStatic
-        @RequiresBackgroundThread
-        fun canonicalVersion(sdk: Sdk): String? {
-            ThreadingAssertions.assertBackgroundThread()
+        fun mostSpecificSdk(module: Module): Sdk? = ElixirSdkLookup.mostSpecificSdk(module)
 
-            if (sdk.sdkType !== instance) return null
-
-            sdk.getUserData(ELIXIR_VERSION_KEY)?.let { return it }
-
-            // Cold path: may shell out to `elixir --short-version`.
-            // Calling elixirVersion() under a read lock blocks write actions - assert early.
-            check(!ApplicationManager.getApplication().holdsReadLock()) {
-                "canonicalVersion() may shell out to `elixir --short-version` and must not be called under a read lock"
-            }
-
-            val homePath = sdk.homePath ?: return null
-            val version = elixirVersion(homePath, null) ?: return null
-
-            val existing = (sdk as? UserDataHolderEx)?.putUserDataIfAbsent(ELIXIR_VERSION_KEY, version)
-            if (existing != null) {
-                return existing
-            }
-
-            sdk.putUserData(ELIXIR_VERSION_KEY, version)
-            return version
-        }
-
-        /**
-         * Returns the [Release] for [sdk], or `null` if the SDK is not an Elixir SDK or the
-         * release cannot be determined.
-         *
-         * This method is read-lock-safe and may be called from any thread, including the EDT
-         * and under a read action.  It uses only the pre-cached [ELIXIR_VERSION_KEY] user data
-         * (populated by a prior [canonicalVersion] call from an IO phase) and falls back to
-         * parsing the SDK home directory name.  It deliberately does **not** call
-         * [canonicalVersion] - that would spawn `elixir --short-version` on a cold start and
-         * is forbidden under a read lock.
-         *
-         * Callers that need a guaranteed-accurate version at the cost of a subprocess on cold
-         * start should call [canonicalVersion] from a background/IO thread instead.
-         */
-        @JvmStatic
-        @Contract("null -> null")
-        fun getRelease(sdk: Sdk?): Release? =
-            if (sdk != null && sdk.sdkType === instance) {
-                // Prefer the pre-cached bare version (set by canonicalVersion() in IO phase).
-                // Fall back to directory name parsing - never spawn a subprocess here.
-                val cachedVersion = sdk.getUserData(ELIXIR_VERSION_KEY)
-                cachedVersion?.let { Release.fromString(it) }
-                    ?: sdk.homePath?.let { Release.fromString(File(it).name) }
-            } else {
-                null
-            }
-
-        private fun moduleSdk(module: Module): Sdk? = sdk(ModuleRootManager.getInstance(module).sdk)
-
-        private fun projectSdk(project: Project): Sdk? = sdk(ProjectRootManager.getInstance(project).projectSdk)
-
-        private fun sdk(sdk: Sdk?): Sdk? =
-            if (sdk != null && sdk.sdkType === instance) {
-                sdk
-            } else {
-                null
-            }
+        fun mostSpecificSdk(psiElement: PsiElement): Sdk? = ElixirSdkLookup.mostSpecificSdk(psiElement)
 
         @JvmStatic
-        fun mostSpecificSdk(module: Module): Sdk? =
-            FacetManager.getInstance(module).getFacetByType(Facet.ID)?.sdk
-                ?: moduleSdk(module)
-                ?: mostSpecificSdk(module.project)
-
-        fun mostSpecificSdk(psiElement: PsiElement): Sdk? {
-            val project = psiElement.project
-            if (project.isDisposed) return null
-
-            val module = ApplicationManager.getApplication().runReadAction<Module?> {
-                ModuleUtilCore.findModuleForPsiElement(psiElement)
-            }
-
-            return if (module != null) mostSpecificSdk(module) else mostSpecificSdk(project)
-        }
-
-        @JvmStatic
-        fun mostSpecificSdk(project: Project): Sdk? = projectSdk(project)
+        fun mostSpecificSdk(project: Project): Sdk? = ElixirSdkLookup.mostSpecificSdk(project)
     }
 }

--- a/src/org/elixir_lang/sdk/elixir/Type.kt
+++ b/src/org/elixir_lang/sdk/elixir/Type.kt
@@ -13,7 +13,10 @@ import com.intellij.openapi.roots.ProjectRootManager
 import com.intellij.openapi.util.InvalidDataException
 import com.intellij.openapi.util.WriteExternalException
 import com.intellij.openapi.util.io.FileUtil
-import com.intellij.openapi.vfs.*
+import com.intellij.openapi.vfs.LocalFileSystem
+import com.intellij.openapi.vfs.VfsUtilCore
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.openapi.vfs.toNioPathOrNull
 import com.intellij.psi.PsiElement
 import com.intellij.util.concurrency.annotations.RequiresBackgroundThread
 import org.apache.commons.io.FilenameUtils
@@ -24,9 +27,7 @@ import org.elixir_lang.jps.shared.cli.CliTool
 import org.elixir_lang.jps.shared.sdk.SdkPaths
 import org.elixir_lang.sdk.*
 import org.elixir_lang.sdk.erlang_dependent.AdditionalDataConfigurable
-import org.elixir_lang.sdk.erlang_dependent.ErlangSdkResolver
 import org.elixir_lang.sdk.erlang_dependent.SdkAdditionalData
-import org.elixir_lang.sdk.wsl.wslCompat
 import org.elixir_lang.util.WriteActions
 import org.jdom.Element
 import org.jetbrains.annotations.Contract
@@ -217,8 +218,6 @@ ELIXIR_SDK_HOME
     }
 
     companion object {
-        val SKIP_ERLANG_SETTINGS_HINT_KEY = com.intellij.openapi.util.Key.create<Boolean>("SKIP_ERLANG_SETTINGS_HINT")
-
         private const val LINUX_DEFAULT_HOME_PATH = SdkHomePaths.LINUX_DEFAULT_HOME_PATH + "/elixir"
         private const val LINUX_MINT_HOME_PATH = SdkHomePaths.LINUX_MINT_HOME_PATH + "/elixir"
         private val LOG = Logger.getInstance(Type::class.java)
@@ -378,139 +377,6 @@ ELIXIR_SDK_HOME
                 }
             }
         }
-
-        internal fun configureInternalErlangSdk(
-            elixirSdk: Sdk,
-            elixirSdkModificator: SdkModificator,
-        ): Sdk? {
-            // Check if additional data is already set (happens when SDK was just created)
-            val existingAdditionalData = elixirSdk.sdkAdditionalData as? SdkAdditionalData
-            val existingErlangSdk = existingAdditionalData?.getErlangSdk()
-
-            // First, check if an Erlang SDK was explicitly set via UserData
-            // This happens when creating a new Elixir SDK right after creating its Erlang SDK
-            val explicitErlangSdk = elixirSdk.getUserData(ERLANG_SDK_KEY)
-
-            val erlangSdk = explicitErlangSdk
-                ?: existingErlangSdk
-                ?: ErlangSdkResolver.findAnyRegistered()
-                ?: promptForMiseErlangSdk(elixirSdk)
-
-            if (erlangSdk != null) {
-                if (explicitErlangSdk == null && existingErlangSdk == null) {
-                    LOG.info("Auto-linked Erlang SDK '${erlangSdk.name}' to Elixir SDK '${elixirSdk.name}'")
-                }
-
-                // Only set additional data if it's not already set
-                if (existingAdditionalData == null || existingErlangSdk == null) {
-                    val sdkAdditionData: com.intellij.openapi.projectRoots.SdkAdditionalData =
-                        SdkAdditionalData(erlangSdk, elixirSdk)
-                    elixirSdkModificator.sdkAdditionalData = sdkAdditionData
-                }
-
-                ElixirErlangClasspath.addNewCodePathsFromInternErlangSdk(elixirSdk, erlangSdk, elixirSdkModificator)
-
-                // Clear the UserData after use
-                elixirSdk.putUserData(ERLANG_SDK_KEY, null)
-            } else {
-                LOG.warn("No Erlang SDK found, Elixir SDK will be incomplete")
-            }
-            return erlangSdk
-        }
-
-        /**
-         * For mise Elixir SDKs only: finds mise-installed Erlang SDK homes,
-         * presents a chooser dialog, and registers the selected one.
-         */
-        internal fun promptForMiseErlangSdk(elixirSdk: Sdk): Sdk? {
-            val homePath = elixirSdk.homePath ?: return null
-            if (SdkPaths.detectSource(homePath) != SdkPaths.SOURCE_NAME_MISE) return null
-
-            val erlangSdkType = org.elixir_lang.sdk.erlang.Type.instance
-            val miseHomes = java.util.TreeMap<SdkHomeKey, String>()
-            SdkHomePaths.mergeMise(miseHomes, "erlang")
-
-            // Filter to valid Erlang homes only (erl binary must exist and be executable)
-            val validHomes = miseHomes.entries.filter { (_, path) ->
-                erlangSdkType.isValidSdkHome(path)
-            }
-            if (validHomes.isEmpty()) return null
-
-            val displayNames = validHomes.map { (_, path) ->
-                org.elixir_lang.sdk.erlang.Type.suggestSdkNameForHome(path, null)
-            }.toTypedArray()
-
-            var selectedIndex = -1
-            val app = ApplicationManager.getApplication()
-            val showDialog = Runnable {
-                selectedIndex = com.intellij.openapi.ui.Messages.showChooseDialog(
-                    "No Erlang SDK is configured. Select one to use with this Elixir SDK:",
-                    "Select Erlang SDK",
-                    displayNames,
-                    displayNames[0],
-                    null
-                )
-            }
-
-            if (app.isDispatchThread) {
-                showDialog.run()
-            } else {
-                app.invokeAndWait(showDialog)
-            }
-
-            if (selectedIndex < 0) return null
-
-            val erlangSdk = registerErlangSdk(validHomes[selectedIndex].value)
-            if (erlangSdk != null && elixirSdk.getUserData(SKIP_ERLANG_SETTINGS_HINT_KEY) != true) {
-                val sdkName = erlangSdk.name
-                val showInfo = Runnable {
-                    com.intellij.openapi.ui.Messages.showInfoMessage(
-                        "Erlang SDK '$sdkName' has been registered.\n\n" +
-                            "Please save settings and reopen this dialog to see it in the Internal Erlang SDK dropdown.",
-                        "Erlang SDK Added"
-                    )
-                }
-                if (app.isDispatchThread) {
-                    showInfo.run()
-                } else {
-                    app.invokeAndWait(showInfo)
-                }
-            }
-            elixirSdk.putUserData(SKIP_ERLANG_SETTINGS_HINT_KEY, null)
-            return erlangSdk
-        }
-
-        internal fun registerErlangSdk(homePath: String): Sdk? {
-            val erlangSdkType = org.elixir_lang.sdk.erlang.Type.instance
-            val canonicalHome = wslCompat.canonicalizePath(homePath)
-            val versionString = org.elixir_lang.sdk.erlang.Type.versionStringForHome(canonicalHome, null)
-                ?: return null
-            val sdkName = org.elixir_lang.sdk.erlang.Type.suggestSdkNameForHome(canonicalHome, null)
-
-            val newSdk = com.intellij.openapi.projectRoots.impl.ProjectJdkImpl(
-                sdkName, erlangSdkType, canonicalHome, versionString
-            )
-
-            val app = ApplicationManager.getApplication()
-            val table = ProjectJdkTable.getInstance()
-
-            val addSdk = Runnable {
-                app.runWriteAction {
-                    table.addJdk(newSdk)
-                }
-            }
-
-            if (app.isDispatchThread) {
-                addSdk.run()
-            } else {
-                app.invokeAndWait(addSdk)
-            }
-
-            erlangSdkType.setupSdkPaths(newSdk)
-            LOG.info("Registered Erlang SDK '${newSdk.name}' from $canonicalHome")
-            return newSdk
-        }
-
 
         private fun getDefaultDocumentationUrl(version: Release?): String? =
             if (version == null) null else "https://elixir-lang.org/docs/stable/elixir/"

--- a/src/org/elixir_lang/sdk/erlang/ErlangSdkTableListener.kt
+++ b/src/org/elixir_lang/sdk/erlang/ErlangSdkTableListener.kt
@@ -1,0 +1,37 @@
+package org.elixir_lang.sdk.erlang
+
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.projectRoots.ProjectJdkTable
+import com.intellij.openapi.projectRoots.Sdk
+import com.intellij.openapi.roots.ProjectRootManager
+import org.elixir_lang.util.WriteActions
+
+object ErlangSdkTableListener {
+    private val LOGGER = Logger.getInstance(ErlangSdkTableListener::class.java)
+
+    fun setup() {
+        val messageBus = ApplicationManager.getApplication().messageBus
+        messageBus.connect().subscribe(ProjectJdkTable.JDK_TABLE_TOPIC,
+            object : ProjectJdkTable.Listener {
+                override fun jdkRemoved(jdk: Sdk) {
+                    if (jdk.sdkType is Type) {
+                        cleanupProjectReferences(jdk)
+                    }
+                }
+            })
+    }
+
+    private fun cleanupProjectReferences(deletedSdk: Sdk) {
+        LOGGER.warn("Erlang SDK removed: ${deletedSdk.name}, cleaning up project references")
+        com.intellij.openapi.project.ProjectManager.getInstance().openProjects.forEach { project ->
+            val projectRootManager = ProjectRootManager.getInstance(project)
+            if (projectRootManager.projectSdk == deletedSdk) {
+                WriteActions.runWriteActionLater {
+                    projectRootManager.projectSdk = null
+                    LOGGER.warn("Cleared removed Erlang SDK '${deletedSdk.name}' from project '${project.name}'")
+                }
+            }
+        }
+    }
+}

--- a/src/org/elixir_lang/sdk/erlang/ErlangVersionDetector.kt
+++ b/src/org/elixir_lang/sdk/erlang/ErlangVersionDetector.kt
@@ -1,0 +1,130 @@
+package org.elixir_lang.sdk.erlang
+
+import com.intellij.execution.ExecutionException
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.platform.ide.progress.ModalTaskOwner
+import com.intellij.platform.ide.progress.runWithModalProgressBlocking
+import org.elixir_lang.cli.getExecutableFilepathWslSafe
+import org.elixir_lang.jps.shared.cli.CliTool
+import org.elixir_lang.sdk.ProcessOutput
+import org.elixir_lang.sdk.wsl.wslCompat
+import java.io.File
+import java.util.Collections
+import java.util.WeakHashMap
+
+object ErlangVersionDetector {
+    private const val OTP_RELEASE_PREFIX_LINE = "org.elixir_lang.sdk.erlang.Type OTP_RELEASE:"
+    private const val ERTS_VERSION_PREFIX_LINE = "org.elixir_lang.sdk.erlang.Type ERTS_VERSION:"
+    private const val PRINT_VERSION_INFO_EXPRESSION =
+        "io:format(\"~n~s~n~s~n~s~n~s~n\",[" +
+                "\"$OTP_RELEASE_PREFIX_LINE\"," +
+                "erlang:system_info(otp_release)," +
+                "\"$ERTS_VERSION_PREFIX_LINE\"," +
+                "erlang:system_info(version)" +
+                "]),erlang:halt()."
+
+    private val LOGGER = Logger.getInstance(ErlangVersionDetector::class.java)
+    // Weak keys so entries for old "$canonicalHome@$mtime" cache keys are collected after
+    // the erl binary is updated. Synchronized because this object is shared across threads.
+    private val releaseBySdkHome: MutableMap<String, Release> =
+        Collections.synchronizedMap(WeakHashMap())
+
+    fun detectSdkVersion(sdkHome: String): Release? {
+        val canonicalHomePath = wslCompat.canonicalizePath(sdkHome)
+        val cachedRelease = getVersionCacheKey(canonicalHomePath)?.let { releaseBySdkHome[it] }
+        if (cachedRelease != null) {
+            return cachedRelease
+        }
+
+        val erl = erlExecutable(canonicalHomePath)
+        LOGGER.debug("=== ERLANG SDK: Erl executable path: ${erl.absolutePath}")
+        if (!erl.canExecute()) {
+            val message =
+                buildString {
+                    append("Can't detect Erlang version: ${erl.path}")
+                    if (erl.exists()) append(" is not executable.") else append(" is missing.")
+                }
+            LOGGER.warn(message)
+            return null
+        }
+
+        // runBlockingMaybeCancellable can be reached transitively in WSL/Eel process startup,
+        // and that path is forbidden on EDT. Guard EDT callers with modal progress.
+        val app = ApplicationManager.getApplication()
+        if (app.isDispatchThread) {
+            return runWithModalProgressBlocking(
+                ModalTaskOwner.guess(),
+                "Detecting Erlang SDK version..."
+            ) {
+                detectSdkVersionBackground(sdkHome, erl)
+            }
+        }
+
+        return detectSdkVersionBackground(sdkHome, erl)
+    }
+
+    private fun detectSdkVersionBackground(sdkHome: String, erl: File): Release? {
+        LOGGER.debug("=== ERLANG SDK: Executing erl to detect version")
+        return try {
+            val erlPath = erl.absolutePath
+            LOGGER.debug("=== ERLANG SDK: Calling getProcessOutput with workDir: $sdkHome, exe: $erlPath")
+            val output =
+                ProcessOutput.getProcessOutput(
+                    10 * 1000,
+                    sdkHome,
+                    erlPath,
+                    "-noshell",
+                    "-eval",
+                    PRINT_VERSION_INFO_EXPRESSION,
+                )
+
+            if (output.exitCode == 0 && !output.isCancelled && !output.isTimeout) {
+                parseSdkVersion(output.stdoutLines)?.also { detectedRelease ->
+                    LOGGER.debug("=== ERLANG SDK: Detected release: ${detectedRelease.otpRelease}")
+                    getVersionCacheKey(sdkHome)?.let { key ->
+                        releaseBySdkHome[key] = detectedRelease
+                    }
+                }
+            } else {
+                LOGGER.warn(
+                    "=== ERLANG SDK: Failed to detect Erlang version. Workdir: '$sdkHome' " +
+                        "ErlPath: '$erlPath' Exit Code: ${output.exitCode}\nStdOut: ${output.stdout}\n" +
+                        "StdErr: ${output.stderr}"
+                )
+                null
+            }
+        } catch (e: ExecutionException) {
+            LOGGER.warn("=== ERLANG SDK: Exception during version detection", e)
+            null
+        }
+    }
+
+    private fun parseSdkVersion(printVersionInfoOutput: List<String>): Release? {
+        var otpRelease: String? = null
+        var ertsVersion: String? = null
+
+        val iterator = printVersionInfoOutput.listIterator()
+        while (iterator.hasNext()) {
+            when (iterator.next()) {
+                OTP_RELEASE_PREFIX_LINE -> if (iterator.hasNext()) otpRelease = iterator.next()
+                ERTS_VERSION_PREFIX_LINE -> if (iterator.hasNext()) ertsVersion = iterator.next()
+            }
+        }
+
+        return if (otpRelease != null && ertsVersion != null) Release(otpRelease, ertsVersion) else null
+    }
+
+    private fun getVersionCacheKey(sdkHome: String?): String? {
+        val homePath = sdkHome ?: return null
+        val canonicalHomePath = wslCompat.canonicalizePath(homePath)
+        val erlPath = CliTool.ERL.getExecutableFilepathWslSafe(canonicalHomePath)
+        val lastModified = File(erlPath).lastModified()
+        if (lastModified == 0L) {
+            return null
+        }
+        return "$canonicalHomePath@$lastModified"
+    }
+
+    private fun erlExecutable(sdkHome: String): File = File(CliTool.ERL.getExecutableFilepathWslSafe(sdkHome))
+}

--- a/src/org/elixir_lang/sdk/erlang/Type.kt
+++ b/src/org/elixir_lang/sdk/erlang/Type.kt
@@ -1,8 +1,6 @@
 package org.elixir_lang.sdk.erlang
 
-import com.intellij.execution.ExecutionException
 import com.intellij.openapi.application.ApplicationManager
-import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.fileChooser.FileChooserDescriptor
 import com.intellij.platform.ide.progress.ModalTaskOwner
 import com.intellij.platform.ide.progress.runWithModalProgressBlocking
@@ -17,7 +15,6 @@ import com.intellij.openapi.projectRoots.SdkType
 import com.intellij.openapi.roots.OrderRootType
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.vfs.toNioPathOrNull
-import com.intellij.util.containers.ContainerUtil
 import org.elixir_lang.cli.getExecutableFilepathWslSafe
 import org.elixir_lang.jps.shared.ErlangSdkTypeId
 import org.elixir_lang.jps.shared.cli.CliTool
@@ -26,30 +23,16 @@ import org.elixir_lang.sdk.SdkHomeKey
 import org.elixir_lang.sdk.SdkHomePaths
 import org.elixir_lang.sdk.SdkHomeScan
 import org.elixir_lang.sdk.erlang_dependent.AdditionalDataConfigurable
-import org.elixir_lang.sdk.wsl.wslCompat
-import org.elixir_lang.util.WriteActions
 import org.jdom.Element
 import java.io.File
 import java.nio.file.Path
 
 class Type : SdkType(ErlangSdkTypeId.ERLANG_SDK_TYPE_ID) {
-    private val releaseBySdkHome: MutableMap<String, Release> = ContainerUtil.createWeakMap()
-
     companion object {
-        private const val OTP_RELEASE_PREFIX_LINE = "org.elixir_lang.sdk.erlang.Type OTP_RELEASE:"
-        private const val ERTS_VERSION_PREFIX_LINE = "org.elixir_lang.sdk.erlang.Type ERTS_VERSION:"
-        private const val PRINT_VERSION_INFO_EXPRESSION =
-            "io:format(\"~n~s~n~s~n~s~n~s~n\",[" +
-                    "\"$OTP_RELEASE_PREFIX_LINE\"," +
-                    "erlang:system_info(otp_release)," +
-                    "\"$ERTS_VERSION_PREFIX_LINE\"," +
-                    "erlang:system_info(version)" +
-                    "]),erlang:halt()."
         private const val WINDOWS_DEFAULT_HOME_PATH = "C:\\Program Files\\erl9.0"
         private val NIX_PATTERN = SdkHomePaths.nixPattern("erlang")
         private const val LINUX_MINT_HOME_PATH = "${SdkHomePaths.LINUX_MINT_HOME_PATH}/erlang"
         private const val LINUX_DEFAULT_HOME_PATH = "${SdkHomePaths.LINUX_DEFAULT_HOME_PATH}/erlang"
-        private val LOGGER = Logger.getInstance(Type::class.java)
 
         @JvmStatic
         val instance: Type
@@ -69,33 +52,6 @@ class Type : SdkType(ErlangSdkTypeId.ERLANG_SDK_TYPE_ID) {
             kerlTransform = { it },
             travisCIKerlTransform = { it }
         )
-
-        @JvmStatic
-        internal fun setupSdkTableListener() {
-            val messageBus = ApplicationManager.getApplication().messageBus
-            messageBus.connect().subscribe(com.intellij.openapi.projectRoots.ProjectJdkTable.JDK_TABLE_TOPIC,
-                object : com.intellij.openapi.projectRoots.ProjectJdkTable.Listener {
-                    override fun jdkRemoved(jdk: Sdk) {
-                        // When an Erlang SDK is removed, clean up project references
-                        if (jdk.sdkType is Type) {
-                            cleanupProjectReferences(jdk)
-                        }
-                    }
-                })
-        }
-
-        private fun cleanupProjectReferences(deletedSdk: Sdk) {
-            LOGGER.warn("Erlang SDK removed: ${deletedSdk.name}, cleaning up project references")
-            com.intellij.openapi.project.ProjectManager.getInstance().openProjects.forEach { project ->
-                val projectRootManager = com.intellij.openapi.roots.ProjectRootManager.getInstance(project)
-                if (projectRootManager.projectSdk == deletedSdk) {
-                    WriteActions.runWriteActionLater {
-                        projectRootManager.projectSdk = null
-                        LOGGER.warn("Cleared removed Erlang SDK '${deletedSdk.name}' from project '${project.name}'")
-                    }
-                }
-            }
-        }
 
         @JvmStatic
         fun getDefaultSdkName(
@@ -126,7 +82,7 @@ class Type : SdkType(ErlangSdkTypeId.ERLANG_SDK_TYPE_ID) {
             val normalizedVersion = resolvedVersion?.takeIf { it.isNotBlank() }
             val baseName =
                 if (normalizedVersion == null) {
-                    getDefaultSdkName(sdkHome, instance.detectSdkVersion(sdkHome))
+                    getDefaultSdkName(sdkHome, ErlangVersionDetector.detectSdkVersion(sdkHome))
                 } else {
                     val source = SdkPaths.detectSource(sdkHome)
                     val dirVersion = File(sdkHome).name
@@ -149,8 +105,7 @@ class Type : SdkType(ErlangSdkTypeId.ERLANG_SDK_TYPE_ID) {
             resolvedVersion: String?,
         ): String? {
             val normalizedVersion = resolvedVersion?.takeIf { it.isNotBlank() }
-            val version = normalizedVersion ?: instance.detectSdkVersion(sdkHome)?.otpRelease ?: return null
-            val source = SdkPaths.detectSource(sdkHome)
+            val version = normalizedVersion ?: ErlangVersionDetector.detectSdkVersion(sdkHome)?.otpRelease ?: return null
             val displayVersion =
                 if (normalizedVersion == null) {
                     val dirVersion = File(sdkHome).name
@@ -158,38 +113,12 @@ class Type : SdkType(ErlangSdkTypeId.ERLANG_SDK_TYPE_ID) {
                 } else {
                     version
                 }
-            return buildString {
-                if (source != null) {
-                    append(source).append(" ")
-                }
-                append("Erlang ").append(displayVersion)
-            }
+            return erlangDisplayString(SdkPaths.detectSource(sdkHome), displayVersion)
         }
 
-        private fun getVersionCacheKey(sdkHome: String?): String? {
-            val homePath = sdkHome ?: return null
-            val canonicalHomePath = wslCompat.canonicalizePath(homePath)
-            val erlPath = CliTool.ERL.getExecutableFilepathWslSafe(canonicalHomePath)
-            val lastModified = File(erlPath).lastModified()
-            if (lastModified == 0L) {
-                return null
-            }
-            return "$canonicalHomePath@$lastModified"
-        }
-
-        private fun parseSdkVersion(printVersionInfoOutput: List<String>): Release? {
-            var otpRelease: String? = null
-            var ertsVersion: String? = null
-
-            val iterator = printVersionInfoOutput.listIterator()
-            while (iterator.hasNext()) {
-                when (iterator.next()) {
-                    OTP_RELEASE_PREFIX_LINE -> if (iterator.hasNext()) otpRelease = iterator.next()
-                    ERTS_VERSION_PREFIX_LINE -> if (iterator.hasNext()) ertsVersion = iterator.next()
-                }
-            }
-
-            return if (otpRelease != null && ertsVersion != null) Release(otpRelease, ertsVersion) else null
+        private fun erlangDisplayString(source: String?, version: String): String = buildString {
+            source?.let { append(it).append(" ") }
+            append("Erlang ").append(version)
         }
 
         @JvmStatic
@@ -275,7 +204,7 @@ class Type : SdkType(ErlangSdkTypeId.ERLANG_SDK_TYPE_ID) {
     }
 
     override fun isValidSdkHome(path: String): Boolean {
-        val erlExe = erlExecutable(path)
+        val erlExe = File(CliTool.ERL.getExecutableFilepathWslSafe(path))
         return erlExe.canExecute()
     }
 
@@ -287,17 +216,10 @@ class Type : SdkType(ErlangSdkTypeId.ERLANG_SDK_TYPE_ID) {
     }
 
     override fun getVersionString(sdkHome: String): String? {
-        val detectedVersion = detectSdkVersion(sdkHome)?.otpRelease ?: return null
-        val source = SdkPaths.detectSource(sdkHome)
-        // Use directory name for version if it's more specific (e.g., "28.3" vs "28")
+        val detectedVersion = ErlangVersionDetector.detectSdkVersion(sdkHome)?.otpRelease ?: return null
         val dirVersion = File(sdkHome).name
         val displayVersion = if (dirVersion.startsWith(detectedVersion)) dirVersion else detectedVersion
-        return buildString {
-            if (source != null) {
-                append(source).append(" ")
-            }
-            append("Erlang ").append(displayVersion)
-        }
+        return erlangDisplayString(SdkPaths.detectSource(sdkHome), displayVersion)
     }
 
     override fun createAdditionalDataConfigurable(
@@ -313,76 +235,4 @@ class Type : SdkType(ErlangSdkTypeId.ERLANG_SDK_TYPE_ID) {
     ) {
         // Intentionally left blank
     }
-
-    private fun detectSdkVersion(sdkHome: String): Release? {
-        val canonicalHomePath = wslCompat.canonicalizePath(sdkHome)
-        val cachedRelease = getVersionCacheKey(canonicalHomePath)?.let { releaseBySdkHome[it] }
-        if (cachedRelease != null) {
-            return cachedRelease
-        }
-
-        val erl = erlExecutable(canonicalHomePath)
-        LOGGER.debug("=== ERLANG SDK: Erl executable path: ${erl.absolutePath}")
-        if (!erl.canExecute()) {
-            val message =
-                buildString {
-                    append("Can't detect Erlang version: ${erl.path}")
-                    if (erl.exists()) append(" is not executable.") else append(" is missing.")
-                }
-            LOGGER.warn(message)
-            return null
-        }
-
-        // runBlockingMaybeCancellable can be reached transitively in WSL/Eel process startup,
-        // and that path is forbidden on EDT. Guard EDT callers with modal progress.
-        val app = ApplicationManager.getApplication()
-        if (app.isDispatchThread) {
-            return runWithModalProgressBlocking(
-                ModalTaskOwner.guess(),
-                "Detecting Erlang SDK version..."
-            ) {
-                detectSdkVersionBackground(sdkHome, erl)
-            }
-        }
-
-        return detectSdkVersionBackground(sdkHome, erl)
-    }
-
-    private fun detectSdkVersionBackground(sdkHome: String, erl: File): Release? {
-        LOGGER.debug("=== ERLANG SDK: Executing erl to detect version")
-        return try {
-            val erlPath = erl.absolutePath
-            LOGGER.debug("=== ERLANG SDK: Calling getProcessOutput with workDir: $sdkHome, exe: $erlPath")
-            val output =
-                org.elixir_lang.sdk.ProcessOutput.getProcessOutput(
-                    10 * 1000,
-                    sdkHome,
-                    erlPath,
-                    "-noshell",
-                    "-eval",
-                    PRINT_VERSION_INFO_EXPRESSION,
-                )
-
-            if (output.exitCode == 0 && !output.isCancelled && !output.isTimeout) {
-                parseSdkVersion(output.stdoutLines)?.also { detectedRelease ->
-                    LOGGER.debug("=== ERLANG SDK: Detected release: ${detectedRelease.otpRelease}")
-                    getVersionCacheKey(sdkHome)?.let { key ->
-                        releaseBySdkHome[key] = detectedRelease
-                    }
-                }
-            } else {
-                LOGGER.warn(
-                    "=== ERLANG SDK: Failed to detect Erlang version. Workdir: '$sdkHome' " +
-                        "ErlPath: '$erlPath' Exit Code: ${output.exitCode}\nStdOut: ${output.stdout}\n" +
-                        "StdErr: ${output.stderr}"
-                )
-                null
-            }
-        } catch (e: ExecutionException) {
-            LOGGER.warn("=== ERLANG SDK: Exception during version detection", e)
-            null
-        }
-    }
-
-    private fun erlExecutable(sdkHome: String): File = File(CliTool.ERL.getExecutableFilepathWslSafe(sdkHome))
 }

--- a/src/org/elixir_lang/sdk/erlang_dependent/AdditionalDataConfigurable.kt
+++ b/src/org/elixir_lang/sdk/erlang_dependent/AdditionalDataConfigurable.kt
@@ -15,9 +15,9 @@ import com.intellij.openapi.util.Comparing
 import com.intellij.ui.SimpleListCellRenderer
 import com.intellij.util.ui.JBUI
 import org.elixir_lang.debug
-import org.elixir_lang.sdk.elixir.Type.Companion.addNewCodePathsFromInternErlangSdk
+import org.elixir_lang.sdk.elixir.ElixirErlangClasspath.addNewCodePathsFromInternErlangSdk
+import org.elixir_lang.sdk.elixir.ElixirErlangClasspath.removeCodePathsFromInternalErlangSdk
 import org.elixir_lang.sdk.elixir.Type.Companion.hasErlangClasspathInRoots
-import org.elixir_lang.sdk.elixir.Type.Companion.removeCodePathsFromInternalErlangSdk
 import java.awt.GridBagConstraints
 import java.awt.GridBagLayout
 import java.awt.event.ItemEvent

--- a/src/org/elixir_lang/sdk/erlang_dependent/ErlangSdkResolver.kt
+++ b/src/org/elixir_lang/sdk/erlang_dependent/ErlangSdkResolver.kt
@@ -27,6 +27,16 @@ interface ErlangSdkResolver {
     companion object {
         fun getInstance(): ErlangSdkResolver =
             ApplicationManager.getApplication().getService(ErlangSdkResolver::class.java)
+
+        /**
+         * Returns the first registered Erlang SDK that has a non-null home path, or null if none
+         * are registered. Used as a fallback when no Erlang SDK has been explicitly paired with an
+         * Elixir SDK.
+         */
+        fun findAnyRegistered(): Sdk? =
+            ProjectJdkTable.getInstance()
+                .getSdksOfType(org.elixir_lang.sdk.erlang.Type.instance)
+                .firstOrNull { it.homePath != null }
     }
 }
 

--- a/src/org/elixir_lang/status_bar_widget/ElixirEditorBasedSdkWidget.kt
+++ b/src/org/elixir_lang/status_bar_widget/ElixirEditorBasedSdkWidget.kt
@@ -6,10 +6,14 @@ import com.intellij.notification.NotificationGroupManager
 import com.intellij.notification.NotificationType
 import com.intellij.openapi.actionSystem.*
 import com.intellij.openapi.application.readAction
+import com.intellij.openapi.application.edtWriteAction
+import com.intellij.platform.ide.progress.ModalTaskOwner
+import com.intellij.platform.ide.progress.runWithModalProgressBlocking
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.module.ModuleManager
 import com.intellij.openapi.module.ModuleUtilCore
 import com.intellij.openapi.project.Project
+import com.intellij.ui.EditorNotifications
 import com.intellij.openapi.projectRoots.ProjectJdkTable
 import com.intellij.openapi.projectRoots.Sdk
 import com.intellij.openapi.roots.JdkOrderEntry
@@ -21,24 +25,31 @@ import com.intellij.openapi.ui.popup.ListPopup
 import com.intellij.openapi.util.Disposer
 import com.intellij.openapi.util.text.StringUtil
 import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.openapi.vfs.toNioPathOrNull
 import com.intellij.openapi.wm.StatusBarWidget
 import com.intellij.openapi.wm.impl.status.EditorBasedStatusBarPopup
 import com.intellij.util.concurrency.ThreadingAssertions
 import com.intellij.util.concurrency.annotations.RequiresBackgroundThread
 import com.intellij.util.messages.MessageBusConnection
+import java.nio.file.Path
 import java.util.concurrent.CancellationException
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.elixir_lang.Facet
 import org.elixir_lang.Icons
 import org.elixir_lang.isElixirModule
+import org.elixir_lang.mise.Mise
+import org.elixir_lang.mise.MiseVersions
 import org.elixir_lang.mix.project.ProjectModuleSetupValidator
 import org.elixir_lang.mix.project.ProjectModuleSetupValidator.FolderMarkIssue
 import org.elixir_lang.sdk.SdkEbinPaths
+import org.elixir_lang.sdk.SdkRegistrar
 import org.elixir_lang.sdk.elixir.SdkSettingsOpener
 import org.elixir_lang.sdk.elixir.Type
 import org.elixir_lang.sdk.erlang_dependent.SdkAdditionalData
@@ -85,6 +96,12 @@ internal sealed interface SdkStatus {
     ) : SdkStatus
 
     data object NotConfigured : SdkStatus
+
+    /**
+     * No Elixir SDK is configured, but mise has an installed Elixir version for the module's
+     * content root. Surfaces a notification with a one-click "Configure from mise" action.
+     */
+    data class NotConfiguredMiseAvailable(val miseVersions: MiseVersions) : SdkStatus
 }
 
 internal data class ModuleSdkIssue(val moduleName: String, val issue: String, val isDangling: Boolean)
@@ -144,9 +161,25 @@ class ElixirEditorBasedSdkWidget(
                 // a partially-complete scan and restart, wasting work - safe but inefficient since
                 // the notification outcome is idempotent (duplicate issueKeys are suppressed).
                 .collect {
-                    val sdkIssues = readAction { detectModuleSdkIssues() }
-                    val folderIssues = readAction { ProjectModuleSetupValidator.detectFolderMarkIssues(project) }
-                    notifyIfNeeded(sdkIssues, folderIssues)
+                    val modelData = readAction { collectNotificationScanModelData() }
+                    val ioData = withContext(Dispatchers.IO) { collectNotificationScanIoData(modelData) }
+
+                    val miseIssues = detectMiseSdkMismatchIssues(
+                        modelData.moduleMiseCheckData,
+                        ioData.elixirVersionBySdk,
+                        ioData.miseByContentRoot,
+                    )
+                    val miseSuggestion = detectMiseSdkForUnconfiguredModules(
+                        modelData.moduleMiseCheckData,
+                        ioData.miseByContentRoot,
+                    )
+                    notifyIfNeeded(
+                        moduleSdkIssues = modelData.moduleSdkIssues + miseIssues,
+                        folderMarkIssues = modelData.folderMarkIssues,
+                        miseSuggestion = miseSuggestion,
+                        projectSdkSnapshot = modelData.projectSdkSnapshot,
+                        classpathIssues = ioData.classpathIssues,
+                    )
                 }
         }
         // Bind job lifecycle to widget disposal using only public Disposer API.
@@ -321,55 +354,32 @@ class ElixirEditorBasedSdkWidget(
      * ([findModuleLevelElixirSdk], [getErlangSdk]) which also requires read access, so
      * it wraps that access in its own `readAction` call.
      */
-    private suspend fun notifyIfNeeded(moduleSdkIssues: List<ModuleSdkIssue>, folderMarkIssues: List<FolderMarkIssue>) {
-        // Build a composite SdkStatus for notification purposes.
-        // Model access (module iteration, SDK resolution) requires a read lock.
-        val sdkStatus: SdkStatus = readAction {
-            val elixirSdk = findModuleLevelElixirSdk()
-            when {
-                moduleSdkIssues.isNotEmpty() -> {
-                    val versionString = elixirSdk?.versionString
-                    val elixirVersion = if (elixirSdk != null && versionString != null)
-                        org.elixir_lang.sdk.Type.appendWslSuffix(versionString, elixirSdk.homePath)
-                    else
-                        null
-                    SdkStatus.ModuleSdkError(elixirSdk, elixirVersion, moduleSdkIssues)
-                }
-                folderMarkIssues.isNotEmpty() && elixirSdk != null -> {
-                    val versionString = elixirSdk.versionString ?: "Unknown"
-                    val elixirVersion = org.elixir_lang.sdk.Type.appendWslSuffix(versionString, elixirSdk.homePath)
-                    SdkStatus.FolderMarkWarning(elixirSdk, elixirVersion, folderMarkIssues)
-                }
-                elixirSdk == null -> SdkStatus.NotConfigured
-                else -> {
-                    val versionString = elixirSdk.versionString ?: "Unknown"
-                    val elixirVersion = org.elixir_lang.sdk.Type.appendWslSuffix(versionString, elixirSdk.homePath)
-                    val erlangSdk = getErlangSdk(elixirSdk)
-                    if (erlangSdk == null) {
-                        // Missing Erlang SDK is an actionable misconfiguration - report it rather
-                        // than silently exiting (the old code did `?: return` here, which bypassed
-                        // issue-key handling and notification lifecycle).
-                        SdkStatus.InvalidSdk(elixirSdk, elixirVersion, "Missing internal Erlang SDK dependency")
-                    } else {
-                        // Check classpath/ebin configuration (breaks code resolution globally)
-                        val classpathIssues = mutableListOf<String>()
-                        if (hasEbinPathIssues(elixirSdk)) {
-                            classpathIssues.add("Missing Elixir ebin paths or classpath entries")
-                        }
-                        if (hasErlangSdkIssues(erlangSdk)) {
-                            classpathIssues.add("Erlang SDK configuration issues")
-                        }
-                        if (!Type.hasErlangClasspathInElixirSdk(elixirSdk, erlangSdk)) {
-                            classpathIssues.add("Erlang SDK classpath entries missing - reopen SDK settings to fix")
-                        }
-                        if (classpathIssues.isNotEmpty()) {
-                            SdkStatus.ClasspathIssue(elixirSdk, erlangSdk, elixirVersion, classpathIssues)
-                        } else {
-                            SdkStatus.Configured(elixirSdk, erlangSdk, elixirVersion)
-                        }
-                    }
-                }
-            }
+    private fun notifyIfNeeded(
+        moduleSdkIssues: List<ModuleSdkIssue>,
+        folderMarkIssues: List<FolderMarkIssue>,
+        miseSuggestion: MiseVersions? = null,
+        projectSdkSnapshot: ProjectSdkSnapshot,
+        classpathIssues: List<String>,
+    ) {
+        val elixirSdk = projectSdkSnapshot.elixirSdk
+        val erlangSdk = projectSdkSnapshot.erlangSdk
+        val elixirVersion = projectSdkSnapshot.elixirVersion ?: "Unknown"
+
+        val sdkStatus: SdkStatus = when {
+            moduleSdkIssues.isNotEmpty() ->
+                SdkStatus.ModuleSdkError(elixirSdk, projectSdkSnapshot.elixirVersion, moduleSdkIssues)
+            folderMarkIssues.isNotEmpty() && elixirSdk != null ->
+                SdkStatus.FolderMarkWarning(elixirSdk, elixirVersion, folderMarkIssues)
+            elixirSdk == null && miseSuggestion != null ->
+                SdkStatus.NotConfiguredMiseAvailable(miseSuggestion)
+            elixirSdk == null ->
+                SdkStatus.NotConfigured
+            erlangSdk == null ->
+                SdkStatus.InvalidSdk(elixirSdk, elixirVersion, "Missing internal Erlang SDK dependency")
+            classpathIssues.isNotEmpty() ->
+                SdkStatus.ClasspathIssue(elixirSdk, erlangSdk, elixirVersion, classpathIssues)
+            else ->
+                SdkStatus.Configured(elixirSdk, erlangSdk, elixirVersion)
         }
 
         val issueKey = computeIssueKey(sdkStatus)
@@ -402,10 +412,24 @@ class ElixirEditorBasedSdkWidget(
                 notification.addAction(object : AnAction("Reconfigure Now") {
                     override fun actionPerformed(e: AnActionEvent) {
                         reconfigureAction.actionPerformed(e)
+                        // Allow the same issue to be shown again if reconfigure did not resolve it.
+                        lastNotifiedIssueKey = null
+                        activeNotification = null
+                        notificationScanRequests.tryEmit(Unit)
                         notification.expire()
                     }
                 })
             }
+        }
+
+        // For mise-available case, offer one-click SDK configuration from mise install paths.
+        if (sdkStatus is SdkStatus.NotConfiguredMiseAvailable) {
+            notification.addAction(object : AnAction("Configure from Mise") {
+                override fun actionPerformed(e: AnActionEvent) {
+                    notification.expire()
+                    configureSdkFromMise(project, sdkStatus.miseVersions)
+                }
+            })
         }
 
         notification.addAction(object : AnAction("Open Project Structure") {
@@ -435,6 +459,8 @@ class ElixirEditorBasedSdkWidget(
         return when (status) {
             is SdkStatus.Configured -> null
             is SdkStatus.NotConfigured -> "not-configured"
+            is SdkStatus.NotConfiguredMiseAvailable ->
+                "not-configured-mise:${status.miseVersions.elixir?.let { Mise.stripElixirOtpSuffix(it.version) }}"
             is SdkStatus.InvalidSdk -> "partial:${status.issue}"
             is SdkStatus.ClasspathIssue -> "warning:${status.issues.sorted().joinToString(",")}"
             is SdkStatus.ModuleSdkError -> "module-error:${status.moduleSdkIssues.map { "${it.moduleName}:${it.isDangling}:${it.issue}" }.sorted().joinToString(",")}"
@@ -453,6 +479,17 @@ class ElixirEditorBasedSdkWidget(
                 "No Elixir SDK is configured for this project. Code insight will not work.",
                 NotificationType.WARNING
             )
+
+            is SdkStatus.NotConfiguredMiseAvailable -> {
+                val displayVersion = status.miseVersions.elixir?.let {
+                    Mise.stripElixirOtpSuffix(it.version)
+                } ?: "unknown"
+                NotificationContent(
+                    "Elixir SDK Not Configured",
+                    "No Elixir SDK configured, but Elixir $displayVersion is available via mise.",
+                    NotificationType.WARNING
+                )
+            }
 
             is SdkStatus.InvalidSdk -> NotificationContent(
                 "Elixir SDK Issue",
@@ -592,6 +629,264 @@ class ElixirEditorBasedSdkWidget(
                 }
             }
         }
+        return issues
+    }
+
+    // -------------------------------------------------------------------------
+    // Mise version mismatch detection (Features B & C)
+    // -------------------------------------------------------------------------
+
+    /**
+     * Data gathered from the module model (requires a read lock) that is later used by
+     * [detectMiseSdkMismatchIssues] to compare against mise's resolved versions.
+     */
+    private data class ModuleMiseCheckData(
+        val moduleName: String,
+        /** Elixir SDK configured for the module (if any). */
+        val elixirSdk: Sdk?,
+        /** OTP major release reported by the Internal Erlang SDK (e.g. `"25"`). */
+        val erlangOtpRelease: String?,
+        /** First content root of the module, used as the working directory for `mise ls`. */
+        val contentRoot: Path?,
+    )
+
+    private data class ProjectSdkSnapshot(
+        val elixirSdk: Sdk?,
+        val elixirVersion: String?,
+        val erlangSdk: Sdk?,
+    )
+
+    private data class NotificationScanModelData(
+        val moduleSdkIssues: List<ModuleSdkIssue>,
+        val folderMarkIssues: List<FolderMarkIssue>,
+        val moduleMiseCheckData: List<ModuleMiseCheckData>,
+        val projectSdkSnapshot: ProjectSdkSnapshot,
+    )
+
+    private data class NotificationScanIoData(
+        val miseByContentRoot: Map<Path, MiseVersions?>,
+        val elixirVersionBySdk: Map<Sdk, String?>,
+        val classpathIssues: List<String>,
+    )
+
+    private fun collectNotificationScanModelData(): NotificationScanModelData {
+        val moduleSdkIssues = detectModuleSdkIssues()
+        val folderMarkIssues = ProjectModuleSetupValidator.detectFolderMarkIssues(project)
+        val moduleMiseCheckData = collectModuleMiseCheckData()
+        val projectSdkSnapshot = collectProjectSdkSnapshot()
+
+        return NotificationScanModelData(
+            moduleSdkIssues = moduleSdkIssues,
+            folderMarkIssues = folderMarkIssues,
+            moduleMiseCheckData = moduleMiseCheckData,
+            projectSdkSnapshot = projectSdkSnapshot,
+        )
+    }
+
+    private fun collectProjectSdkSnapshot(): ProjectSdkSnapshot {
+        val elixirSdk = findModuleLevelElixirSdk()
+        val elixirVersion = elixirSdk?.versionString?.let {
+            org.elixir_lang.sdk.Type.appendWslSuffix(it, elixirSdk.homePath)
+        }
+        val erlangSdk = elixirSdk?.let { getErlangSdk(it) }
+
+        return ProjectSdkSnapshot(
+            elixirSdk = elixirSdk,
+            elixirVersion = elixirVersion,
+            erlangSdk = erlangSdk,
+        )
+    }
+
+    private fun collectNotificationScanIoData(modelData: NotificationScanModelData): NotificationScanIoData {
+        val miseByContentRoot = modelData.moduleMiseCheckData
+            .mapNotNull { it.contentRoot }
+            .distinct()
+            .associateWith { contentRoot -> Mise.resolveVersions(contentRoot) }
+
+        val elixirVersionBySdk = modelData.moduleMiseCheckData
+            .mapNotNull { it.elixirSdk }
+            .distinct()
+            .associateWith { sdk -> Type.canonicalVersion(sdk) }
+
+        val classpathIssues = detectClasspathIssues(modelData.projectSdkSnapshot)
+
+        return NotificationScanIoData(
+            miseByContentRoot = miseByContentRoot,
+            elixirVersionBySdk = elixirVersionBySdk,
+            classpathIssues = classpathIssues,
+        )
+    }
+
+    private fun detectClasspathIssues(projectSdkSnapshot: ProjectSdkSnapshot): List<String> {
+        val elixirSdk = projectSdkSnapshot.elixirSdk ?: return emptyList()
+        val erlangSdk = projectSdkSnapshot.erlangSdk ?: return emptyList()
+        val classpathIssues = mutableListOf<String>()
+
+        if (hasEbinPathIssues(elixirSdk)) {
+            classpathIssues.add("Missing Elixir ebin paths or classpath entries")
+        }
+        if (hasErlangSdkIssues(erlangSdk)) {
+            classpathIssues.add("Erlang SDK configuration issues")
+        }
+        if (!Type.hasErlangClasspathInElixirSdk(elixirSdk, erlangSdk)) {
+            classpathIssues.add("Erlang SDK classpath entries missing - reopen SDK settings to fix")
+        }
+
+        return classpathIssues
+    }
+
+    /**
+     * Gathers module SDK info needed for mise version-mismatch checks.
+     *
+     * Must be called inside a read action (accesses [ModuleRootManager]).
+     */
+    private fun collectModuleMiseCheckData(): List<ModuleMiseCheckData> {
+        return ModuleManager.getInstance(project).modules
+            .filter { it.isElixirModule() }
+            .map { module ->
+                val elixirSdk = Type.mostSpecificSdk(module)
+                val erlangSdk = elixirSdk?.let { getErlangSdk(it) }
+                val contentRoot = ModuleRootManager.getInstance(module)
+                    .contentRoots
+                    .firstOrNull()
+                    ?.toNioPathOrNull()
+                ModuleMiseCheckData(
+                    moduleName = module.name,
+                    elixirSdk = elixirSdk,
+                    erlangOtpRelease = erlangSdk?.versionString
+                        ?.let { org.elixir_lang.sdk.erlang.Release.fromString(it)?.otpRelease },
+                    contentRoot = contentRoot,
+                )
+            }
+    }
+
+    /**
+     * Feature A: for Elixir modules with no SDK configured, checks if mise has an installed
+     * Elixir version for that module's content root.
+     *
+     * Returns the first [MiseVersions] with an installed Elixir entry, or null if no unconfigured
+     * module has mise data available.
+     *
+     * Must NOT be called under a read lock - runs `mise ls` as a subprocess.
+     */
+    private fun detectMiseSdkForUnconfiguredModules(
+        moduleDataList: List<ModuleMiseCheckData>,
+        miseByContentRoot: Map<Path, MiseVersions?>,
+    ): MiseVersions? {
+        for (moduleData in moduleDataList) {
+            if (moduleData.elixirSdk != null) continue
+            val contentRoot = moduleData.contentRoot ?: continue
+            val versions = miseByContentRoot[contentRoot] ?: continue
+            if (versions.elixir?.installed == true) {
+                return versions
+            }
+        }
+        return null
+    }
+
+    /**
+     * Registers Erlang and Elixir SDKs from mise install paths, pairs them, and assigns the
+     * Elixir SDK to the first unconfigured Elixir module.
+     *
+     * Called from the EDT (notification action click handler). Uses
+     * [runWithModalProgressBlocking] so the user sees a modal progress dialog while SDKs are
+     * being registered. Write-action mutations use [edtWriteAction].
+     */
+    private fun configureSdkFromMise(project: Project, miseVersions: MiseVersions) {
+        runWithModalProgressBlocking(ModalTaskOwner.project(project), "Configuring Elixir SDK from mise") {
+            val erlangSdk = miseVersions.erlang?.let { erlang ->
+                SdkRegistrar.registerOrUpdateErlangSdk(erlang.installPath)
+            }
+
+            val elixirSdk = miseVersions.elixir?.let { elixir ->
+                SdkRegistrar.registerOrUpdateElixirSdk(
+                    homePath = elixir.installPath,
+                    erlangSdk = erlangSdk,
+                    project = project,
+                )
+            } ?: return@runWithModalProgressBlocking
+
+            // Assign to the first unconfigured Elixir module.
+            val module = readAction {
+                ModuleManager.getInstance(project).modules
+                    .firstOrNull { it.isElixirModule() && Type.mostSpecificSdk(it) == null }
+            } ?: return@runWithModalProgressBlocking
+
+            edtWriteAction {
+                val modifiableModel = ModuleRootManager.getInstance(module).modifiableModel
+                modifiableModel.sdk = elixirSdk
+                modifiableModel.commit()
+            }
+
+            EditorNotifications.getInstance(project).updateAllNotifications()
+        }
+    }
+
+    /**
+     * Feature B: warns when the configured Elixir SDK version differs from the version mise
+     * resolves for the module directory.
+     *
+     * Feature C: warns when the Internal Erlang SDK OTP major release differs from the OTP major
+     * in the mise-resolved erlang version string.
+     *
+     * Runs `mise ls --local --json` (a subprocess) for each module. Must NOT be called inside a
+     * read lock - use [collectModuleMiseCheckData] first to extract what you need, then call this.
+     */
+    private fun detectMiseSdkMismatchIssues(
+        moduleDataList: List<ModuleMiseCheckData>,
+        elixirVersionBySdk: Map<Sdk, String?>,
+        miseByContentRoot: Map<Path, MiseVersions?>,
+    ): List<ModuleSdkIssue> {
+        val issues = mutableListOf<ModuleSdkIssue>()
+
+        for (data in moduleDataList) {
+            val contentRoot = data.contentRoot ?: continue
+            val miseVersions = miseByContentRoot[contentRoot] ?: continue
+
+            // Feature B: Elixir version mismatch
+            val miseElixir = miseVersions.elixir
+            if (miseElixir != null) {
+                val configuredVersion = data.elixirSdk?.let { elixirVersionBySdk[it] }
+                val miseVersion = Mise.stripElixirOtpSuffix(miseElixir.version)
+                if (configuredVersion != null && configuredVersion != miseVersion) {
+                    LOG.info(
+                        "Mise version mismatch in module '${data.moduleName}': " +
+                        "SDK=$configuredVersion, mise=$miseVersion"
+                    )
+                    issues.add(
+                        ModuleSdkIssue(
+                            moduleName = data.moduleName,
+                            issue = "Module '${data.moduleName}' uses Elixir $configuredVersion " +
+                                    "but mise resolves ${miseElixir.version}. " +
+                                    "Run 'Refresh Active Elixir SDKs' or reconfigure.",
+                            isDangling = false,
+                        )
+                    )
+                }
+            }
+
+            // Feature C: OTP version mismatch between Internal Erlang SDK and mise erlang
+            val miseErlang = miseVersions.erlang
+            if (miseErlang != null && data.erlangOtpRelease != null) {
+                val miseErlangMajor = miseErlang.version.substringBefore(".")
+                if (miseErlangMajor != data.erlangOtpRelease) {
+                    LOG.info(
+                        "Mise OTP mismatch in module '${data.moduleName}': " +
+                        "SDK OTP=${data.erlangOtpRelease}, mise=${miseErlang.version}"
+                    )
+                    issues.add(
+                        ModuleSdkIssue(
+                            moduleName = data.moduleName,
+                            issue = "Internal Erlang SDK OTP ${data.erlangOtpRelease} does not " +
+                                    "match mise (${miseErlang.version}). " +
+                                    "Run 'Refresh Active Elixir SDKs' or reconfigure.",
+                            isDangling = false,
+                        )
+                    )
+                }
+            }
+        }
+
         return issues
     }
 

--- a/src/org/elixir_lang/status_bar_widget/ElixirEditorBasedSdkWidget.kt
+++ b/src/org/elixir_lang/status_bar_widget/ElixirEditorBasedSdkWidget.kt
@@ -1,0 +1,680 @@
+package org.elixir_lang.status_bar_widget
+
+import com.intellij.facet.FacetManager
+import com.intellij.icons.AllIcons
+import com.intellij.notification.NotificationGroupManager
+import com.intellij.notification.NotificationType
+import com.intellij.openapi.actionSystem.*
+import com.intellij.openapi.application.readAction
+import com.intellij.openapi.diagnostic.logger
+import com.intellij.openapi.module.ModuleManager
+import com.intellij.openapi.module.ModuleUtilCore
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.projectRoots.ProjectJdkTable
+import com.intellij.openapi.projectRoots.Sdk
+import com.intellij.openapi.roots.JdkOrderEntry
+import com.intellij.openapi.roots.ModuleRootListener
+import com.intellij.openapi.roots.ModuleRootManager
+import com.intellij.openapi.roots.ProjectRootManager
+import com.intellij.openapi.ui.popup.JBPopupFactory
+import com.intellij.openapi.ui.popup.ListPopup
+import com.intellij.openapi.util.Disposer
+import com.intellij.openapi.util.text.StringUtil
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.openapi.wm.StatusBarWidget
+import com.intellij.openapi.wm.impl.status.EditorBasedStatusBarPopup
+import com.intellij.util.concurrency.ThreadingAssertions
+import com.intellij.util.concurrency.annotations.RequiresBackgroundThread
+import com.intellij.util.messages.MessageBusConnection
+import java.util.concurrent.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.launch
+import org.elixir_lang.Facet
+import org.elixir_lang.Icons
+import org.elixir_lang.isElixirModule
+import org.elixir_lang.mix.project.ProjectModuleSetupValidator
+import org.elixir_lang.mix.project.ProjectModuleSetupValidator.FolderMarkIssue
+import org.elixir_lang.sdk.SdkEbinPaths
+import org.elixir_lang.sdk.elixir.SdkSettingsOpener
+import org.elixir_lang.sdk.elixir.Type
+import org.elixir_lang.sdk.erlang_dependent.SdkAdditionalData
+import kotlin.time.Duration.Companion.milliseconds
+
+private val LOG = logger<ElixirEditorBasedSdkWidget>()
+
+/**
+ * Aggregated project-level SDK health status for driving notifications.
+ * NOT used for widget display - the widget uses platform [EditorBasedStatusBarPopup.WidgetState]
+ * via [ElixirEditorBasedSdkWidget.getWidgetState]. This sealed interface exists solely to power
+ * the background notification scan triggered by rootsChanged events.
+ */
+internal sealed interface SdkStatus {
+    data class Configured(
+        val elixirSdk: Sdk,
+        val erlangSdk: Sdk,
+        val elixirVersion: String
+    ) : SdkStatus
+
+    data class ClasspathIssue(
+        val elixirSdk: Sdk,
+        val erlangSdk: Sdk,
+        val elixirVersion: String,
+        val issues: List<String>
+    ) : SdkStatus
+
+    data class InvalidSdk(
+        val elixirSdk: Sdk?,
+        val elixirVersion: String?,
+        val issue: String
+    ) : SdkStatus
+
+    data class ModuleSdkError(
+        val elixirSdk: Sdk?,
+        val elixirVersion: String?,
+        val moduleSdkIssues: List<ModuleSdkIssue>
+    ) : SdkStatus
+
+    data class FolderMarkWarning(
+        val elixirSdk: Sdk,
+        val elixirVersion: String,
+        val folderMarkIssues: List<FolderMarkIssue>
+    ) : SdkStatus
+
+    data object NotConfigured : SdkStatus
+}
+
+internal data class ModuleSdkIssue(val moduleName: String, val issue: String, val isDangling: Boolean)
+
+@OptIn(FlowPreview::class)
+class ElixirEditorBasedSdkWidget(
+    project: Project,
+    scope: CoroutineScope,
+) : EditorBasedStatusBarPopup(project, isWriteableFileRequired = false, scope = scope) {
+
+    companion object {
+        const val ID = "ElixirSdkStatus"
+    }
+
+    // Track last notified status to avoid spamming duplicate notifications
+    @Volatile
+    private var lastNotifiedIssueKey: String? = null
+
+    // The currently displayed notification - expired when the issue resolves or changes
+    @Volatile
+    private var activeNotification: com.intellij.notification.Notification? = null
+
+    // Cached count of Elixir modules in the project.  Updated on rootsChanged (which is the
+    // only event that can add/remove modules) so that getWidgetState() remains O(1) and does
+    // not iterate all modules on every editor switch.  Initialised to -1 (unknown) so the
+    // first getWidgetState() call computes it lazily; subsequent rootsChanged events refresh it.
+    @Volatile
+    private var cachedElixirModuleCount: Int = -1
+
+    /**
+     * Debounced flow for the project-wide notification scan.  The platform already debounces
+     * getWidgetState via its own MutableSharedFlow (300ms), but the notification scan is a
+     * separate heavier path (O(modules × orderEntries)) that we debounce independently to
+     * avoid redundant work during bulk rootsChanged events.
+     *
+     * Primary trigger: `mix deps.get` → VFS detects new files under `deps/` and `_build/` →
+     * [org.elixir_lang.DepsWatcher] syncs libraries → each per-dep `libraryModifiableModel.commit()` and
+     * `ModuleRootManager.modifiableModel.commit()` fires a separate rootsChanged event.
+     * A Phoenix project with 30 deps can easily generate 60–90+ events in quick succession.
+     */
+    private val notificationScanRequests = MutableSharedFlow<Unit>(
+        extraBufferCapacity = 1,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST
+    )
+
+    init {
+        // Cancel the notification scan collector when this widget instance is disposed.
+        // This mirrors the semantics of the platform's own debounce collector in
+        // EditorBasedStatusBarPopup (which uses @Internal cancelOnDispose).  Without this,
+        // multiframe widget instances would leave behind active collectors until project close.
+        val notificationScanJob = scope.launch {
+            notificationScanRequests
+                .debounce(500.milliseconds)  // slightly longer than widget debounce since notifications are less urgent
+                // Use `collect` (not `collectLatest`) deliberately: if events arrive while a scan
+                // is running, they queue in the debounce operator and trigger one follow-up scan
+                // after the current one completes + 500ms of quiet.  `collectLatest` would cancel
+                // a partially-complete scan and restart, wasting work - safe but inefficient since
+                // the notification outcome is idempotent (duplicate issueKeys are suppressed).
+                .collect {
+                    val sdkIssues = readAction { detectModuleSdkIssues() }
+                    val folderIssues = readAction { ProjectModuleSetupValidator.detectFolderMarkIssues(project) }
+                    notifyIfNeeded(sdkIssues, folderIssues)
+                }
+        }
+        // Bind job lifecycle to widget disposal using only public Disposer API.
+        // When dispose() is called on this widget, the registered child cancels the job.
+        // When the job completes naturally, it disposes the child to avoid leaking Disposer entries.
+        val jobDisposable = Disposer.newDisposable("ElixirEditorBasedSdkWidget.notificationScanJob")
+        Disposer.register(this, jobDisposable)
+        notificationScanJob.invokeOnCompletion { Disposer.dispose(jobDisposable) }
+        Disposer.register(jobDisposable) {
+            notificationScanJob.cancel(CancellationException("ElixirEditorBasedSdkWidget disposed"))
+        }
+    }
+
+    override fun ID(): String = ID
+
+    // -------------------------------------------------------------------------
+    // EditorBasedStatusBarPopup required overrides
+    // -------------------------------------------------------------------------
+
+    /**
+     * Returns the widget state for the currently open file.
+     *
+     * This method is called by the platform inside a readAction on a background thread
+     * (see EditorBasedStatusBarPopup.doUpdate). Do NOT nest another readAction here.
+     * Performs only O(1) SDK lookups - no project-wide scans or notifications.
+     */
+    @RequiresBackgroundThread
+    override fun getWidgetState(file: VirtualFile?): WidgetState {
+        if (file == null) return WidgetState.HIDDEN
+        val module = ModuleUtilCore.findModuleForFile(file, project)
+            ?: return WidgetState.HIDDEN
+        if (!module.isElixirModule()) return WidgetState.HIDDEN
+        return buildModuleWidgetState(module)
+    }
+
+    override fun createPopup(context: DataContext): ListPopup {
+        val actionGroup = DefaultActionGroup().apply {
+            add(createAddSdkAction())
+            val actionManager = ActionManager.getInstance()
+            actionManager.getAction("Elixir.RefreshAllElixirSdks")?.let { add(it) }
+            actionManager.getAction("Elixir.InstallMixDependencies")?.let { add(it) }
+            add(Separator.getInstance())
+            actionManager.getAction("Elixir.ReconfigureModuleSetup")?.let { add(it) }
+        }
+        return JBPopupFactory.getInstance().createActionGroupPopup(
+            "Elixir SDK",
+            actionGroup,
+            context,
+            JBPopupFactory.ActionSelectionAid.SPEEDSEARCH,
+            false
+        )
+    }
+
+    override fun createInstance(project: Project): StatusBarWidget =
+        ElixirEditorBasedSdkWidget(project, scope)
+
+    override fun registerCustomListeners(connection: MessageBusConnection) {
+        // JDK table changes (SDK added/removed/renamed) - affects both widget display and
+        // project-wide notifications (e.g. SDK removal creates dangling references).
+        connection.subscribe(ProjectJdkTable.JDK_TABLE_TOPIC, object : ProjectJdkTable.Listener {
+            override fun jdkAdded(jdk: Sdk) {
+                if (jdk.sdkType is Type) {
+                    update()
+                    notificationScanRequests.tryEmit(Unit)
+                }
+            }
+
+            override fun jdkRemoved(jdk: Sdk) {
+                if (jdk.sdkType is Type) {
+                    update()
+                    notificationScanRequests.tryEmit(Unit)
+                }
+            }
+
+            override fun jdkNameChanged(jdk: Sdk, previousName: String) {
+                if (jdk.sdkType is Type) {
+                    update()
+                    notificationScanRequests.tryEmit(Unit)
+                }
+            }
+        })
+
+        // Module root changes - update the widget (platform debounces at 300ms) and
+        // request a project-wide notification scan via the debounced flow.
+        connection.subscribe(ModuleRootListener.TOPIC, object : ModuleRootListener {
+            override fun rootsChanged(event: com.intellij.openapi.roots.ModuleRootEvent) {
+                cachedElixirModuleCount = -1  // invalidate; recomputed lazily in getWidgetState()
+                update()  // triggers getWidgetState for per-file widget display
+                notificationScanRequests.tryEmit(Unit)  // debounced notification scan
+            }
+        })
+
+        // SDK refresh (from RefreshAllElixirSdksAction) - re-scan notifications since SDK
+        // validity may have changed (e.g. Erlang SDK path restored).
+        connection.subscribe(ElixirSdkRefreshListener.TOPIC, ElixirSdkRefreshListener {
+            update()
+            notificationScanRequests.tryEmit(Unit)
+        })
+    }
+
+    // -------------------------------------------------------------------------
+    // Per-module widget state
+    // -------------------------------------------------------------------------
+
+    private fun buildModuleWidgetState(module: com.intellij.openapi.module.Module): WidgetState {
+        val elixirSdk = Type.mostSpecificSdk(module)
+
+        // Determine whether to show module name in tooltip (only in multi-module projects).
+        // Uses the cached count (refreshed on rootsChanged) to keep getWidgetState() O(1).
+        var count = cachedElixirModuleCount
+        if (count < 0) {
+            // First call before any rootsChanged - compute lazily and cache.
+            count = ModuleManager.getInstance(project).modules.count { it.isElixirModule() }
+            cachedElixirModuleCount = count
+        }
+        val showModuleName = count > 1
+
+        if (elixirSdk == null) {
+            val state = WidgetState(
+                toolTip = if (showModuleName) "No Elixir SDK configured for module '${module.name}'" else "No Elixir SDK configured",
+                text = "No Elixir SDK",
+                isActionEnabled = true
+            )
+            return state
+        }
+
+        val versionString = elixirSdk.versionString ?: "Unknown"
+        val elixirVersion = org.elixir_lang.sdk.Type.appendWslSuffix(versionString, elixirSdk.homePath)
+
+        if (!isValidSdk(elixirSdk)) {
+            val state = WidgetState(
+                toolTip = if (showModuleName) "Elixir SDK: $elixirVersion - Invalid SDK (module '${module.name}')" else "Elixir SDK: $elixirVersion - Invalid SDK",
+                text = "Elixir: SDK Error",
+                isActionEnabled = true
+            )
+            state.icon = AllIcons.General.Error
+            return state
+        }
+
+        val erlangSdk = getErlangSdk(elixirSdk)
+        if (erlangSdk == null) {
+            val state = WidgetState(
+                toolTip = if (showModuleName) "Elixir SDK: $elixirVersion - Missing Erlang SDK (module '${module.name}')" else "Elixir SDK: $elixirVersion - Missing Erlang SDK",
+                text = "Elixir: SDK Error",
+                isActionEnabled = true
+            )
+            state.icon = AllIcons.General.Error
+            return state
+        }
+
+        val tooltipBase = if (showModuleName) "Elixir SDK: $elixirVersion (module '${module.name}')" else "Elixir SDK: $elixirVersion"
+        val state = WidgetState(
+            toolTip = tooltipBase,
+            text = "Elixir $elixirVersion",
+            isActionEnabled = true
+        )
+        state.icon = Icons.LANGUAGE
+        return state
+    }
+
+    // -------------------------------------------------------------------------
+    // Project-wide notification scan (triggered from rootsChanged background job)
+    // -------------------------------------------------------------------------
+
+    /**
+     * Runs the project-wide notification scan. Called from the debounced collector -
+     * never from getWidgetState(). This is O(modules) for SDK resolution and should not run
+     * per-editor-switch.
+     *
+     * **Threading**: the [moduleSdkIssues] and [folderMarkIssues] parameters are pre-computed
+     * inside `readAction` by the caller. This method performs additional model access
+     * ([findModuleLevelElixirSdk], [getErlangSdk]) which also requires read access, so
+     * it wraps that access in its own `readAction` call.
+     */
+    private suspend fun notifyIfNeeded(moduleSdkIssues: List<ModuleSdkIssue>, folderMarkIssues: List<FolderMarkIssue>) {
+        // Build a composite SdkStatus for notification purposes.
+        // Model access (module iteration, SDK resolution) requires a read lock.
+        val sdkStatus: SdkStatus = readAction {
+            val elixirSdk = findModuleLevelElixirSdk()
+            when {
+                moduleSdkIssues.isNotEmpty() -> {
+                    val versionString = elixirSdk?.versionString
+                    val elixirVersion = if (elixirSdk != null && versionString != null)
+                        org.elixir_lang.sdk.Type.appendWslSuffix(versionString, elixirSdk.homePath)
+                    else
+                        null
+                    SdkStatus.ModuleSdkError(elixirSdk, elixirVersion, moduleSdkIssues)
+                }
+                folderMarkIssues.isNotEmpty() && elixirSdk != null -> {
+                    val versionString = elixirSdk.versionString ?: "Unknown"
+                    val elixirVersion = org.elixir_lang.sdk.Type.appendWslSuffix(versionString, elixirSdk.homePath)
+                    SdkStatus.FolderMarkWarning(elixirSdk, elixirVersion, folderMarkIssues)
+                }
+                elixirSdk == null -> SdkStatus.NotConfigured
+                else -> {
+                    val versionString = elixirSdk.versionString ?: "Unknown"
+                    val elixirVersion = org.elixir_lang.sdk.Type.appendWslSuffix(versionString, elixirSdk.homePath)
+                    val erlangSdk = getErlangSdk(elixirSdk)
+                    if (erlangSdk == null) {
+                        // Missing Erlang SDK is an actionable misconfiguration - report it rather
+                        // than silently exiting (the old code did `?: return` here, which bypassed
+                        // issue-key handling and notification lifecycle).
+                        SdkStatus.InvalidSdk(elixirSdk, elixirVersion, "Missing internal Erlang SDK dependency")
+                    } else {
+                        // Check classpath/ebin configuration (breaks code resolution globally)
+                        val classpathIssues = mutableListOf<String>()
+                        if (hasEbinPathIssues(elixirSdk)) {
+                            classpathIssues.add("Missing Elixir ebin paths or classpath entries")
+                        }
+                        if (hasErlangSdkIssues(erlangSdk)) {
+                            classpathIssues.add("Erlang SDK configuration issues")
+                        }
+                        if (!Type.hasErlangClasspathInElixirSdk(elixirSdk, erlangSdk)) {
+                            classpathIssues.add("Erlang SDK classpath entries missing - reopen SDK settings to fix")
+                        }
+                        if (classpathIssues.isNotEmpty()) {
+                            SdkStatus.ClasspathIssue(elixirSdk, erlangSdk, elixirVersion, classpathIssues)
+                        } else {
+                            SdkStatus.Configured(elixirSdk, erlangSdk, elixirVersion)
+                        }
+                    }
+                }
+            }
+        }
+
+        val issueKey = computeIssueKey(sdkStatus)
+
+        // No issue - expire any active notification and reset
+        if (issueKey == null) {
+            activeNotification?.expire()
+            activeNotification = null
+            lastNotifiedIssueKey = null
+            return
+        }
+        // Same issue already notified - keep the existing notification
+        if (issueKey == lastNotifiedIssueKey) return
+
+        // Issue changed - expire the old notification before showing the new one
+        activeNotification?.expire()
+        activeNotification = null
+        lastNotifiedIssueKey = issueKey
+
+        val (title, message, type) = buildNotificationContent(sdkStatus) ?: return
+
+        val notification = NotificationGroupManager.getInstance()
+            .getNotificationGroup("Elixir")
+            .createNotification(title, message, type)
+
+        // For module SDK errors or folder mark warnings, offer one-click fix via ReconfigureModuleSetupAction
+        if (sdkStatus is SdkStatus.ModuleSdkError || sdkStatus is SdkStatus.FolderMarkWarning) {
+            val reconfigureAction = ActionManager.getInstance().getAction("Elixir.ReconfigureModuleSetup")
+            if (reconfigureAction != null) {
+                notification.addAction(object : AnAction("Reconfigure Now") {
+                    override fun actionPerformed(e: AnActionEvent) {
+                        reconfigureAction.actionPerformed(e)
+                        notification.expire()
+                    }
+                })
+            }
+        }
+
+        notification.addAction(object : AnAction("Open Project Structure") {
+            override fun actionPerformed(e: AnActionEvent) {
+                SdkSettingsOpener.getInstance().open(e)
+                notification.expire()
+            }
+        })
+
+        notification.notify(project)
+        activeNotification = notification
+        LOG.info("SDK discrepancy in project '${project.name}': $message")
+
+        if (sdkStatus is SdkStatus.FolderMarkWarning) {
+            for (issue in sdkStatus.folderMarkIssues) {
+                LOG.info("  Folder mark issue: module '${issue.moduleName}' -- ${issue.folderRelativePath}/ should be ${issue.folderMark.displayName} but is ${issue.currentState}")
+            }
+        }
+        if (sdkStatus is SdkStatus.ModuleSdkError) {
+            for (issue in sdkStatus.moduleSdkIssues) {
+                LOG.info("  Module SDK issue: module '${issue.moduleName}' -- ${issue.issue}")
+            }
+        }
+    }
+
+    private fun computeIssueKey(status: SdkStatus): String? {
+        return when (status) {
+            is SdkStatus.Configured -> null
+            is SdkStatus.NotConfigured -> "not-configured"
+            is SdkStatus.InvalidSdk -> "partial:${status.issue}"
+            is SdkStatus.ClasspathIssue -> "warning:${status.issues.sorted().joinToString(",")}"
+            is SdkStatus.ModuleSdkError -> "module-error:${status.moduleSdkIssues.map { "${it.moduleName}:${it.isDangling}:${it.issue}" }.sorted().joinToString(",")}"
+            is SdkStatus.FolderMarkWarning -> "folder-marks:${status.folderMarkIssues.map { "${it.moduleName}:${it.folderRelativePath}:${it.folderMark}" }.sorted().joinToString(",")}"
+        }
+    }
+
+    private data class NotificationContent(val title: String, val message: String, val type: NotificationType)
+
+    private fun buildNotificationContent(status: SdkStatus): NotificationContent? {
+        return when (status) {
+            is SdkStatus.Configured -> null
+
+            is SdkStatus.NotConfigured -> NotificationContent(
+                "Elixir SDK Not Configured",
+                "No Elixir SDK is configured for this project. Code insight will not work.",
+                NotificationType.WARNING
+            )
+
+            is SdkStatus.InvalidSdk -> NotificationContent(
+                "Elixir SDK Issue",
+                "Elixir SDK: ${status.elixirVersion ?: "Unknown"} - ${status.issue}.",
+                NotificationType.WARNING
+            )
+
+            is SdkStatus.ClasspathIssue -> NotificationContent(
+                "Elixir SDK Warning",
+                "Elixir SDK ${status.elixirVersion}: ${status.issues.joinToString("; ")}.",
+                NotificationType.WARNING
+            )
+
+            is SdkStatus.ModuleSdkError -> {
+                val hasDangling = status.moduleSdkIssues.any { it.isDangling }
+                if (hasDangling) {
+                    val danglingIssues = status.moduleSdkIssues.filter { it.isDangling }
+                    val moduleNames = danglingIssues.map { it.moduleName }.distinct()
+                    val sdkNames = danglingIssues.map { it.issue.substringAfter("SDK '").substringBefore("'") }.distinct()
+                    NotificationContent(
+                        "Elixir SDK Error: Module SDK ${StringUtil.pluralize("reference", moduleNames.size)} broken",
+                        formatDanglingMessage(moduleNames, sdkNames),
+                        NotificationType.ERROR
+                    )
+                } else {
+                    val summary = status.moduleSdkIssues.joinToString("; ") { "'${it.moduleName}': ${it.issue}" }
+                    NotificationContent(
+                        "Elixir SDK: Module SDK Mismatch",
+                        "Module SDK mismatch detected. $summary",
+                        NotificationType.WARNING
+                    )
+                }
+            }
+
+            is SdkStatus.FolderMarkWarning -> {
+                val issueCount = status.folderMarkIssues.size
+                val moduleCount = status.folderMarkIssues.map { it.moduleName }.distinct().size
+                val summary = if (issueCount == 1) {
+                    val issue = status.folderMarkIssues.first()
+                    "${issue.folderRelativePath}/ is not marked as ${issue.folderMark.displayName} in module '${issue.moduleName}'"
+                } else {
+                    "$issueCount folder mark ${StringUtil.pluralize("issue", issueCount)} across $moduleCount ${StringUtil.pluralize("module", moduleCount)}"
+                }
+                NotificationContent(
+                    "Elixir: Project Structure Suboptimal",
+                    "$summary. Some code insight features may not work correctly.",
+                    NotificationType.WARNING
+                )
+            }
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // SDK detection helpers (shared between getWidgetState and notification scan)
+    // -------------------------------------------------------------------------
+
+    /**
+     * Finds the active Elixir SDK by scanning all Elixir modules.
+     *
+     * Uses [Type.mostSpecificSdk] (module overload) which checks Facet SDK → module SDK → project SDK,
+     * returning the first non-null result. This covers both Rich IDEs (JdkOrderEntry) and Small IDEs
+     * (Facet library entry) without additional branching.
+     *
+     * When both the project SDK and a module SDK are Elixir, this returns the **module** SDK - the one
+     * that actually drives code insight - rather than the project-level one. The mismatch between them
+     * is reported separately by [detectModuleSdkIssues].
+     */
+    internal fun findModuleLevelElixirSdk(): Sdk? {
+        for (module in ModuleManager.getInstance(project).modules) {
+            if (!module.isElixirModule()) continue
+            val moduleSdk = Type.mostSpecificSdk(module)
+            if (moduleSdk != null) return moduleSdk
+        }
+        return null
+    }
+
+    /**
+     * Detects project-wide module SDK issues (dangling references and mismatches).
+     * O(modules × orderEntries) - only called from the rootsChanged background job,
+     * never from [getWidgetState].
+     *
+     * **Threading**: must be called off the EDT (background thread).  Accesses
+     * [ModuleRootManager] which requires read access; the caller must either hold a read lock
+     * or call this inside a `readAction { }` block.
+     */
+    @RequiresBackgroundThread
+    internal fun detectModuleSdkIssues(): List<ModuleSdkIssue> {
+        ThreadingAssertions.assertBackgroundThread()
+        val issues = mutableListOf<ModuleSdkIssue>()
+        val projectSdk = ProjectRootManager.getInstance(project).projectSdk
+
+        for (module in ModuleManager.getInstance(project).modules) {
+            if (!module.isElixirModule()) continue
+
+            val rootManager = ModuleRootManager.getInstance(module)
+
+            // --- Rich IDE path: detect dangling/mismatch JdkOrderEntry ---
+            var hasJdkEntry = false
+            for (entry in rootManager.orderEntries) {
+                if (entry !is JdkOrderEntry) continue
+
+                val jdkName = entry.jdkName ?: continue
+                hasJdkEntry = true
+                // Only check Elixir SDK entries (when SDK is resolvable, check its type)
+                val resolvedSdk = entry.jdk
+                if (resolvedSdk != null && resolvedSdk.sdkType !is Type) continue
+
+                if (resolvedSdk == null) {
+                    // DANGLING: SDK name exists in .iml but not in JDK table
+                    issues.add(
+                        ModuleSdkIssue(module.name, "references non-existent SDK '$jdkName'", isDangling = true)
+                    )
+                } else if (projectSdk != null && projectSdk.sdkType is Type && resolvedSdk != projectSdk) {
+                    // MISMATCH: Module uses different Elixir SDK than project in a single-version project.
+                    // Only meaningful when the project SDK is itself Elixir; skip when it is Java/Python/etc.
+                    issues.add(
+                        ModuleSdkIssue(module.name, "uses '$jdkName' but project SDK is '${projectSdk.name}'", isDangling = false)
+                    )
+                }
+            }
+
+            // --- Small IDE path: detect dangling Facet SDK ---
+            // Only check if the Rich IDE path didn't find any JDK entries (Small IDE modules use
+            // a Facet library entry instead of a JdkOrderEntry to hold the Elixir SDK).
+            if (!hasJdkEntry) {
+                val facet = FacetManager.getInstance(module).getFacetByType(Facet.ID)
+                if (facet != null && Facet.sdk(module) == null && Facet.sdks().isNotEmpty()) {
+                    // The module has an Elixir Facet and Elixir SDKs exist in the table, but the
+                    // Facet library entry doesn't match any current SDK name - stale/dangling reference.
+                    issues.add(
+                        ModuleSdkIssue(
+                            module.name,
+                            "Elixir Facet SDK is not configured (stale reference). Reconfigure in Settings → Languages → Elixir.",
+                            isDangling = true
+                        )
+                    )
+                }
+            }
+        }
+        return issues
+    }
+
+    private fun isValidSdk(sdk: Sdk?): Boolean {
+        if (sdk == null) return false
+        val sdkType = sdk.sdkType as? Type ?: return false
+        val homePath = sdk.homePath ?: return false
+        return sdkType.isValidSdkHome(homePath)
+    }
+
+    private fun getErlangSdk(elixirSdk: Sdk): Sdk? {
+        val additionalData = elixirSdk.sdkAdditionalData as? SdkAdditionalData
+        return additionalData?.getErlangSdk()
+    }
+
+    private fun hasEbinPathIssues(elixirSdk: Sdk): Boolean {
+        val homePath = elixirSdk.homePath ?: return true
+
+        // Check if Elixir SDK has proper ebin paths in lib directory
+        if (!SdkEbinPaths.hasEbinPath(homePath)) {
+            return true
+        }
+
+        // Check if SDK has proper classpath roots configured
+        val classRoots = elixirSdk.rootProvider.getFiles(com.intellij.openapi.roots.OrderRootType.CLASSES)
+        return classRoots.isEmpty()
+    }
+
+    private fun hasErlangSdkIssues(erlangSdk: Sdk): Boolean {
+        val homePath = erlangSdk.homePath ?: return true
+
+        // Check if Erlang SDK has proper ebin paths
+        if (!SdkEbinPaths.hasEbinPath(homePath)) {
+            return true
+        }
+
+        // Validate that this is a proper Erlang SDK type
+        return !org.elixir_lang.sdk.erlang_dependent.Type.staticIsValidDependency(erlangSdk)
+    }
+
+    private fun createAddSdkAction(): AnAction {
+        return object : AnAction("Configure Elixir SDKs...", "", AllIcons.General.Add) {
+            override fun actionPerformed(e: AnActionEvent) {
+                SdkSettingsOpener.getInstance().open(e)
+            }
+
+            override fun getActionUpdateThread(): ActionUpdateThread = ActionUpdateThread.BGT
+
+            override fun update(e: AnActionEvent) {
+                val isConfigured = findModuleLevelElixirSdk() != null
+                val text = if (isConfigured) "Configure Elixir SDKs..." else "Add Elixir SDK..."
+                val targetName = SdkSettingsOpener.getInstance().targetName()
+                val description = if (isConfigured) {
+                    "Configure Elixir SDKs in $targetName"
+                } else {
+                    "Open $targetName to add an Elixir SDK"
+                }
+                e.presentation.text = text
+                e.presentation.description = description
+            }
+        }
+    }
+
+    private fun formatDanglingMessage(moduleNames: List<String>, sdkNames: List<String>): String {
+        val moduleCount = moduleNames.size
+        val moduleWord = StringUtil.pluralize("Module", moduleCount)
+        val moduleList = formatNameList(moduleNames)
+        val verb = if (moduleCount == 1) "references" else "reference"
+        val sdkWord = StringUtil.pluralize("SDK", sdkNames.size)
+        val sdkList = sdkNames.joinToString(", ") { "'$it'" }
+        val navigationHint = if (moduleCount == 1) {
+            "Project Structure → Modules → ${moduleNames.first()} → Dependencies → Module SDK. Set it to \"Project SDK\""
+        } else {
+            "Project Structure → Modules → <module> → Dependencies → Module SDK. Set each to \"Project SDK\""
+        }
+        return "$moduleWord $moduleList $verb non-existent $sdkWord $sdkList. Code insight will not work until fixed in $navigationHint."
+    }
+
+    private fun formatNameList(names: List<String>): String {
+        return if (names.size <= 3) {
+            names.joinToString(", ") { "'$it'" }
+        } else {
+            names.take(3).joinToString(", ") { "'$it'" } + " and ${names.size - 3} more"
+        }
+    }
+}

--- a/src/org/elixir_lang/status_bar_widget/ElixirEditorBasedSdkWidget.kt
+++ b/src/org/elixir_lang/status_bar_widget/ElixirEditorBasedSdkWidget.kt
@@ -5,15 +5,12 @@ import com.intellij.icons.AllIcons
 import com.intellij.notification.NotificationGroupManager
 import com.intellij.notification.NotificationType
 import com.intellij.openapi.actionSystem.*
-import com.intellij.openapi.application.readAction
 import com.intellij.openapi.application.edtWriteAction
-import com.intellij.platform.ide.progress.ModalTaskOwner
-import com.intellij.platform.ide.progress.runWithModalProgressBlocking
+import com.intellij.openapi.application.readAction
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.module.ModuleManager
 import com.intellij.openapi.module.ModuleUtilCore
 import com.intellij.openapi.project.Project
-import com.intellij.ui.EditorNotifications
 import com.intellij.openapi.projectRoots.ProjectJdkTable
 import com.intellij.openapi.projectRoots.Sdk
 import com.intellij.openapi.roots.JdkOrderEntry
@@ -28,19 +25,17 @@ import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.vfs.toNioPathOrNull
 import com.intellij.openapi.wm.StatusBarWidget
 import com.intellij.openapi.wm.impl.status.EditorBasedStatusBarPopup
+import com.intellij.platform.ide.progress.ModalTaskOwner
+import com.intellij.platform.ide.progress.runWithModalProgressBlocking
+import com.intellij.ui.EditorNotifications
 import com.intellij.util.concurrency.ThreadingAssertions
 import com.intellij.util.concurrency.annotations.RequiresBackgroundThread
 import com.intellij.util.messages.MessageBusConnection
-import java.nio.file.Path
-import java.util.concurrent.CancellationException
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.debounce
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
+import kotlinx.coroutines.flow.onStart
 import org.elixir_lang.Facet
 import org.elixir_lang.Icons
 import org.elixir_lang.isElixirModule
@@ -53,6 +48,9 @@ import org.elixir_lang.sdk.SdkRegistrar
 import org.elixir_lang.sdk.elixir.SdkSettingsOpener
 import org.elixir_lang.sdk.elixir.Type
 import org.elixir_lang.sdk.erlang_dependent.SdkAdditionalData
+import org.elixir_lang.sdk.wsl.wslCompat
+import java.nio.file.Path
+import java.util.concurrent.CancellationException
 import kotlin.time.Duration.Companion.milliseconds
 
 private val LOG = logger<ElixirEditorBasedSdkWidget>()
@@ -154,6 +152,11 @@ class ElixirEditorBasedSdkWidget(
         // multiframe widget instances would leave behind active collectors until project close.
         val notificationScanJob = scope.launch {
             notificationScanRequests
+                // Emit a synthetic Unit on start so the initial scan fires ~500 ms after the
+                // coroutine starts (same debounce path as a rootsChanged event), without waiting
+                // for the first external trigger.  onStart { emit(Unit) } is safe here because
+                // we are already inside the subscribed collector, so the event is not dropped.
+                .onStart { emit(Unit) }
                 .debounce(500.milliseconds)  // slightly longer than widget debounce since notifications are less urgent
                 // Use `collect` (not `collectLatest`) deliberately: if events arrive while a scan
                 // is running, they queue in the debounce operator and trigger one follow-up scan
@@ -169,14 +172,17 @@ class ElixirEditorBasedSdkWidget(
                         ioData.elixirVersionBySdk,
                         ioData.miseByContentRoot,
                     )
-                    val miseSuggestion = detectMiseSdkForUnconfiguredModules(
+                    // Build per-module mise assignments: module name → the MiseVersions that mise
+                    // resolves for that module's own content root.  Covers all modules with an
+                    // installed elixir entry, regardless of whether they already have an SDK.
+                    val miseAssignments = buildMiseAssignments(
                         modelData.moduleMiseCheckData,
                         ioData.miseByContentRoot,
                     )
                     notifyIfNeeded(
                         moduleSdkIssues = modelData.moduleSdkIssues + miseIssues,
                         folderMarkIssues = modelData.folderMarkIssues,
-                        miseSuggestion = miseSuggestion,
+                        miseAssignments = miseAssignments,
                         projectSdkSnapshot = modelData.projectSdkSnapshot,
                         classpathIssues = ioData.classpathIssues,
                     )
@@ -234,7 +240,7 @@ class ElixirEditorBasedSdkWidget(
     }
 
     override fun createInstance(project: Project): StatusBarWidget =
-        ElixirEditorBasedSdkWidget(project, scope)
+            ElixirEditorBasedSdkWidget(project, scope)
 
     override fun registerCustomListeners(connection: MessageBusConnection) {
         // JDK table changes (SDK added/removed/renamed) - affects both widget display and
@@ -330,7 +336,9 @@ class ElixirEditorBasedSdkWidget(
             return state
         }
 
-        val tooltipBase = if (showModuleName) "Elixir SDK: $elixirVersion (module '${module.name}')" else "Elixir SDK: $elixirVersion"
+        val tooltipBase =
+                if (showModuleName) "Elixir SDK: $elixirVersion (module '${module.name}')"
+                else "Elixir SDK: $elixirVersion"
         val state = WidgetState(
             toolTip = tooltipBase,
             text = "Elixir $elixirVersion",
@@ -357,7 +365,8 @@ class ElixirEditorBasedSdkWidget(
     private fun notifyIfNeeded(
         moduleSdkIssues: List<ModuleSdkIssue>,
         folderMarkIssues: List<FolderMarkIssue>,
-        miseSuggestion: MiseVersions? = null,
+        /** Per-module mise assignments: module name → MiseVersions for that module's own content root. */
+        miseAssignments: Map<String, MiseVersions> = emptyMap(),
         projectSdkSnapshot: ProjectSdkSnapshot,
         classpathIssues: List<String>,
     ) {
@@ -368,16 +377,22 @@ class ElixirEditorBasedSdkWidget(
         val sdkStatus: SdkStatus = when {
             moduleSdkIssues.isNotEmpty() ->
                 SdkStatus.ModuleSdkError(elixirSdk, projectSdkSnapshot.elixirVersion, moduleSdkIssues)
+
             folderMarkIssues.isNotEmpty() && elixirSdk != null ->
                 SdkStatus.FolderMarkWarning(elixirSdk, elixirVersion, folderMarkIssues)
-            elixirSdk == null && miseSuggestion != null ->
-                SdkStatus.NotConfiguredMiseAvailable(miseSuggestion)
+
+            elixirSdk == null && miseAssignments.isNotEmpty() ->
+                SdkStatus.NotConfiguredMiseAvailable(miseAssignments.values.first())
+
             elixirSdk == null ->
                 SdkStatus.NotConfigured
+
             erlangSdk == null ->
                 SdkStatus.InvalidSdk(elixirSdk, elixirVersion, "Missing internal Erlang SDK dependency")
+
             classpathIssues.isNotEmpty() ->
                 SdkStatus.ClasspathIssue(elixirSdk, erlangSdk, elixirVersion, classpathIssues)
+
             else ->
                 SdkStatus.Configured(elixirSdk, erlangSdk, elixirVersion)
         }
@@ -405,7 +420,39 @@ class ElixirEditorBasedSdkWidget(
             .getNotificationGroup("Elixir")
             .createNotification(title, message, type)
 
-        // For module SDK errors or folder mark warnings, offer one-click fix via ReconfigureModuleSetupAction
+        // "Configure from Mise" is added first so it appears as the primary inline action.
+        // When any module SDK issue has a corresponding mise assignment (covering both dangling
+        // references and version mismatches), offer it.  Each affected module is assigned the
+        // SDK that mise resolves for *its own* content root - umbrella apps with different
+        // mise.toml entries get different SDKs rather than a shared one.
+        if (sdkStatus is SdkStatus.ModuleSdkError) {
+            val affectedNames = sdkStatus.moduleSdkIssues.mapTo(HashSet()) { it.moduleName }
+            val relevantAssignments = miseAssignments.filterKeys { it in affectedNames }
+            if (relevantAssignments.isNotEmpty()) {
+                notification.addAction(object : AnAction("Configure from Mise") {
+                    override fun actionPerformed(e: AnActionEvent) {
+                        notification.expire()
+                        lastNotifiedIssueKey = null
+                        activeNotification = null
+                        configureSdkFromMise(project, relevantAssignments)
+                    }
+                })
+            }
+        }
+
+        // For mise-available case (no SDK configured at all), offer one-click SDK configuration.
+        // Each module is assigned the SDK for its own content root.
+        if (sdkStatus is SdkStatus.NotConfiguredMiseAvailable) {
+            notification.addAction(object : AnAction("Configure from Mise") {
+                override fun actionPerformed(e: AnActionEvent) {
+                    notification.expire()
+                    configureSdkFromMise(project, miseAssignments)
+                }
+            })
+        }
+
+        // For module SDK errors or folder mark warnings, offer the reconfigure action as a
+        // secondary option (after "Configure from Mise" when both are present).
         if (sdkStatus is SdkStatus.ModuleSdkError || sdkStatus is SdkStatus.FolderMarkWarning) {
             val reconfigureAction = ActionManager.getInstance().getAction("Elixir.ReconfigureModuleSetup")
             if (reconfigureAction != null) {
@@ -420,16 +467,6 @@ class ElixirEditorBasedSdkWidget(
                     }
                 })
             }
-        }
-
-        // For mise-available case, offer one-click SDK configuration from mise install paths.
-        if (sdkStatus is SdkStatus.NotConfiguredMiseAvailable) {
-            notification.addAction(object : AnAction("Configure from Mise") {
-                override fun actionPerformed(e: AnActionEvent) {
-                    notification.expire()
-                    configureSdkFromMise(project, sdkStatus.miseVersions)
-                }
-            })
         }
 
         notification.addAction(object : AnAction("Open Project Structure") {
@@ -461,10 +498,20 @@ class ElixirEditorBasedSdkWidget(
             is SdkStatus.NotConfigured -> "not-configured"
             is SdkStatus.NotConfiguredMiseAvailable ->
                 "not-configured-mise:${status.miseVersions.elixir?.let { Mise.stripElixirOtpSuffix(it.version) }}"
+
             is SdkStatus.InvalidSdk -> "partial:${status.issue}"
             is SdkStatus.ClasspathIssue -> "warning:${status.issues.sorted().joinToString(",")}"
-            is SdkStatus.ModuleSdkError -> "module-error:${status.moduleSdkIssues.map { "${it.moduleName}:${it.isDangling}:${it.issue}" }.sorted().joinToString(",")}"
-            is SdkStatus.FolderMarkWarning -> "folder-marks:${status.folderMarkIssues.map { "${it.moduleName}:${it.folderRelativePath}:${it.folderMark}" }.sorted().joinToString(",")}"
+            is SdkStatus.ModuleSdkError -> "module-error:${
+                status.moduleSdkIssues.map { "${it.moduleName}:${it.isDangling}:${it.issue}" }
+                    .sorted()
+                    .joinToString(",")
+            }"
+
+            is SdkStatus.FolderMarkWarning -> "folder-marks:${
+                status.folderMarkIssues.map { "${it.moduleName}:${it.folderRelativePath}:${it.folderMark}" }
+                    .sorted()
+                    .joinToString(",")
+            }"
         }
     }
 
@@ -508,7 +555,8 @@ class ElixirEditorBasedSdkWidget(
                 if (hasDangling) {
                     val danglingIssues = status.moduleSdkIssues.filter { it.isDangling }
                     val moduleNames = danglingIssues.map { it.moduleName }.distinct()
-                    val sdkNames = danglingIssues.map { it.issue.substringAfter("SDK '").substringBefore("'") }.distinct()
+                    val sdkNames =
+                            danglingIssues.map { it.issue.substringAfter("SDK '").substringBefore("'") }.distinct()
                     NotificationContent(
                         "Elixir SDK Error: Module SDK ${StringUtil.pluralize("reference", moduleNames.size)} broken",
                         formatDanglingMessage(moduleNames, sdkNames),
@@ -531,7 +579,9 @@ class ElixirEditorBasedSdkWidget(
                     val issue = status.folderMarkIssues.first()
                     "${issue.folderRelativePath}/ is not marked as ${issue.folderMark.displayName} in module '${issue.moduleName}'"
                 } else {
-                    "$issueCount folder mark ${StringUtil.pluralize("issue", issueCount)} across $moduleCount ${StringUtil.pluralize("module", moduleCount)}"
+                    val issuesPlural=StringUtil.pluralize("issue", issueCount)
+                    val modulesPlural=StringUtil.pluralize("module", moduleCount)
+                    "$issueCount folder mark $issuesPlural across $moduleCount $modulesPlural"
                 }
                 NotificationContent(
                     "Elixir: Project Structure Suboptimal",
@@ -606,7 +656,11 @@ class ElixirEditorBasedSdkWidget(
                     // MISMATCH: Module uses different Elixir SDK than project in a single-version project.
                     // Only meaningful when the project SDK is itself Elixir; skip when it is Java/Python/etc.
                     issues.add(
-                        ModuleSdkIssue(module.name, "uses '$jdkName' but project SDK is '${projectSdk.name}'", isDangling = false)
+                        ModuleSdkIssue(
+                            module.name,
+                            "uses '$jdkName' but project SDK is '${projectSdk.name}'",
+                            isDangling = false
+                        )
                     )
                 }
             }
@@ -761,65 +815,120 @@ class ElixirEditorBasedSdkWidget(
     }
 
     /**
-     * Feature A: for Elixir modules with no SDK configured, checks if mise has an installed
-     * Elixir version for that module's content root.
+     * Builds a map of module name → [MiseVersions] for every Elixir module whose content root
+     * has an installed mise Elixir version.
      *
-     * Returns the first [MiseVersions] with an installed Elixir entry, or null if no unconfigured
-     * module has mise data available.
+     * Intentionally covers **all** modules - both those without a configured SDK (dangling /
+     * unconfigured) and those that already have one (for mismatch detection and correction).
+     * The caller decides which subset to act on.
      *
-     * Must NOT be called under a read lock - runs `mise ls` as a subprocess.
+     * The value for each entry is the [MiseVersions] that mise resolves specifically for *that
+     * module's own content root*, so umbrella apps with per-app `mise.toml` entries each get
+     * their own versions rather than inheriting a single shared value.
+     *
+     * Must NOT be called under a read lock - [miseByContentRoot] was populated by calling
+     * [Mise.resolveVersions] (a subprocess) on a background thread.
      */
-    private fun detectMiseSdkForUnconfiguredModules(
+    private fun buildMiseAssignments(
         moduleDataList: List<ModuleMiseCheckData>,
         miseByContentRoot: Map<Path, MiseVersions?>,
-    ): MiseVersions? {
-        for (moduleData in moduleDataList) {
-            if (moduleData.elixirSdk != null) continue
-            val contentRoot = moduleData.contentRoot ?: continue
+    ): Map<String, MiseVersions> {
+        val result = LinkedHashMap<String, MiseVersions>()
+        for (data in moduleDataList) {
+            val contentRoot = data.contentRoot ?: continue
             val versions = miseByContentRoot[contentRoot] ?: continue
             if (versions.elixir?.installed == true) {
-                return versions
+                result[data.moduleName] = versions
             }
         }
-        return null
+        return result
     }
 
-    /**
-     * Registers Erlang and Elixir SDKs from mise install paths, pairs them, and assigns the
-     * Elixir SDK to the first unconfigured Elixir module.
-     *
-     * Called from the EDT (notification action click handler). Uses
-     * [runWithModalProgressBlocking] so the user sees a modal progress dialog while SDKs are
-     * being registered. Write-action mutations use [edtWriteAction].
-     */
-    private fun configureSdkFromMise(project: Project, miseVersions: MiseVersions) {
+    private fun configureSdkFromMise(project: Project, miseAssignments: Map<String, MiseVersions>) {
         runWithModalProgressBlocking(ModalTaskOwner.project(project), "Configuring Elixir SDK from mise") {
-            val erlangSdk = miseVersions.erlang?.let { erlang ->
-                SdkRegistrar.registerOrUpdateErlangSdk(erlang.installPath)
+            // Collect content roots so Linux install paths returned by WSL-side mise
+            // (e.g. /home/steve/.local/share/mise/installs/erlang/23.3.4.20) can be
+            // converted to the Windows UNC form that SdkRegistrar and WslCompatService expect
+            // (e.g. \\wsl.localhost\ItronUbuntu\home\steve\.local\share\mise\installs\erlang\23.3.4.20).
+            val contentRootByModule: Map<String, Path?> = readAction {
+                miseAssignments.keys.associateWith { name ->
+                    ModuleManager.getInstance(project).findModuleByName(name)
+                        ?.let { ModuleRootManager.getInstance(it).contentRoots.firstOrNull()?.toNioPathOrNull() }
+                }
             }
 
-            val elixirSdk = miseVersions.elixir?.let { elixir ->
-                SdkRegistrar.registerOrUpdateElixirSdk(
-                    homePath = elixir.installPath,
+            // Register unique (erlang, elixir) install-path combinations once each.
+            // Deduplication key = resolved elixir install path (post Linux→UNC conversion)
+            // so that multiple modules sharing the same mise config register the SDK only once.
+            val elixirSdkByInstallPath = mutableMapOf<String, Sdk>()
+
+            for ((moduleName, miseVersions) in miseAssignments) {
+                val elixirEntry = miseVersions.elixir ?: continue
+                val contentRoot = contentRootByModule[moduleName]
+                val resolvedElixirPath = resolveInstallPathForWsl(elixirEntry.installPath, contentRoot)
+                if (resolvedElixirPath in elixirSdkByInstallPath) continue
+
+                val erlangSdk = miseVersions.erlang?.let { erlang ->
+                    val resolvedErlangPath = resolveInstallPathForWsl(erlang.installPath, contentRoot)
+                    SdkRegistrar.registerOrUpdateErlangSdk(resolvedErlangPath)
+                }
+                val elixirSdk = SdkRegistrar.registerOrUpdateElixirSdk(
+                    homePath = resolvedElixirPath,
                     erlangSdk = erlangSdk,
                     project = project,
-                )
-            } ?: return@runWithModalProgressBlocking
+                ) ?: continue
 
-            // Assign to the first unconfigured Elixir module.
-            val module = readAction {
-                ModuleManager.getInstance(project).modules
-                    .firstOrNull { it.isElixirModule() && Type.mostSpecificSdk(it) == null }
-            } ?: return@runWithModalProgressBlocking
+                elixirSdkByInstallPath[resolvedElixirPath] = elixirSdk
+            }
 
+            if (elixirSdkByInstallPath.isEmpty()) return@runWithModalProgressBlocking
+
+            // Assign per-module SDKs in a single write action.
             edtWriteAction {
-                val modifiableModel = ModuleRootManager.getInstance(module).modifiableModel
-                modifiableModel.sdk = elixirSdk
-                modifiableModel.commit()
+                for ((moduleName, miseVersions) in miseAssignments) {
+                    val elixirEntry = miseVersions.elixir ?: continue
+                    val contentRoot = contentRootByModule[moduleName]
+                    val resolvedElixirPath = resolveInstallPathForWsl(elixirEntry.installPath, contentRoot)
+                    val elixirSdk = elixirSdkByInstallPath[resolvedElixirPath] ?: continue
+                    val module = ModuleManager.getInstance(project).findModuleByName(moduleName)
+                        ?.takeIf { !it.isDisposed } ?: continue
+
+                    val modifiableModel = ModuleRootManager.getInstance(module).modifiableModel
+                    var committed = false
+                    try {
+                        modifiableModel.sdk = elixirSdk
+                        modifiableModel.commit()
+                        committed = true
+                    } finally {
+                        if (!committed) modifiableModel.dispose()
+                    }
+                }
             }
 
             EditorNotifications.getInstance(project).updateAllNotifications()
         }
+    }
+
+    /**
+     * Converts a Linux absolute path (e.g. `/home/steve/.local/share/mise/installs/elixir/1.11.3`)
+     * to the Windows UNC form expected by [SdkRegistrar] and `wslCompat`
+     * (e.g. `\\wsl.localhost\ItronUbuntu\home\steve\.local\share\mise\installs\elixir\1.11.3`).
+     *
+     * The WSL distribution is inferred from [contentRoot], which must be a Windows UNC path for
+     * a WSL filesystem (e.g. `\\wsl.localhost\ItronUbuntu\home\steve\workspace\intelliconnect`).
+     *
+     * Returns [installPath] unchanged when:
+     * - it is not a Linux absolute path (does not start with `/`),
+     * - [contentRoot] is null,
+     * - [contentRoot] is not a WSL UNC path, or
+     * - the distribution cannot be resolved or the conversion fails.
+     */
+    private fun resolveInstallPathForWsl(installPath: String, contentRoot: Path?): String {
+        if (!installPath.startsWith("/")) return installPath
+        val contentRootStr = contentRoot?.toString() ?: return installPath
+        if (!wslCompat.isWslUncPath(contentRootStr)) return installPath
+        val distribution = wslCompat.getDistributionByWindowsUncPath(contentRootStr) ?: return installPath
+        return wslCompat.convertLinuxPathToWindowsUnc(distribution, installPath) ?: installPath
     }
 
     /**
@@ -851,7 +960,7 @@ class ElixirEditorBasedSdkWidget(
                 if (configuredVersion != null && configuredVersion != miseVersion) {
                     LOG.info(
                         "Mise version mismatch in module '${data.moduleName}': " +
-                        "SDK=$configuredVersion, mise=$miseVersion"
+                                "SDK=$configuredVersion, mise=$miseVersion"
                     )
                     issues.add(
                         ModuleSdkIssue(
@@ -872,7 +981,7 @@ class ElixirEditorBasedSdkWidget(
                 if (miseErlangMajor != data.erlangOtpRelease) {
                     LOG.info(
                         "Mise OTP mismatch in module '${data.moduleName}': " +
-                        "SDK OTP=${data.erlangOtpRelease}, mise=${miseErlang.version}"
+                                "SDK OTP=${data.erlangOtpRelease}, mise=${miseErlang.version}"
                     )
                     issues.add(
                         ModuleSdkIssue(

--- a/src/org/elixir_lang/status_bar_widget/ElixirEditorBasedSdkWidget.kt
+++ b/src/org/elixir_lang/status_bar_widget/ElixirEditorBasedSdkWidget.kt
@@ -46,6 +46,7 @@ import org.elixir_lang.mix.project.ProjectModuleSetupValidator.FolderMarkIssue
 import org.elixir_lang.sdk.SdkEbinPaths
 import org.elixir_lang.sdk.SdkRegistrar
 import org.elixir_lang.sdk.elixir.SdkSettingsOpener
+import org.elixir_lang.sdk.elixir.ElixirSdkLookup
 import org.elixir_lang.sdk.elixir.Type
 import org.elixir_lang.sdk.erlang_dependent.SdkAdditionalData
 import org.elixir_lang.sdk.wsl.wslCompat
@@ -291,7 +292,7 @@ class ElixirEditorBasedSdkWidget(
     // -------------------------------------------------------------------------
 
     private fun buildModuleWidgetState(module: com.intellij.openapi.module.Module): WidgetState {
-        val elixirSdk = Type.mostSpecificSdk(module)
+        val elixirSdk = ElixirSdkLookup.mostSpecificSdk(module)
 
         // Determine whether to show module name in tooltip (only in multi-module projects).
         // Uses the cached count (refreshed on rootsChanged) to keep getWidgetState() O(1).
@@ -610,7 +611,7 @@ class ElixirEditorBasedSdkWidget(
     internal fun findModuleLevelElixirSdk(): Sdk? {
         for (module in ModuleManager.getInstance(project).modules) {
             if (!module.isElixirModule()) continue
-            val moduleSdk = Type.mostSpecificSdk(module)
+            val moduleSdk = ElixirSdkLookup.mostSpecificSdk(module)
             if (moduleSdk != null) return moduleSdk
         }
         return null
@@ -798,7 +799,7 @@ class ElixirEditorBasedSdkWidget(
         return ModuleManager.getInstance(project).modules
             .filter { it.isElixirModule() }
             .map { module ->
-                val elixirSdk = Type.mostSpecificSdk(module)
+                val elixirSdk = ElixirSdkLookup.mostSpecificSdk(module)
                 val erlangSdk = elixirSdk?.let { getErlangSdk(it) }
                 val contentRoot = ModuleRootManager.getInstance(module)
                     .contentRoots

--- a/src/org/elixir_lang/status_bar_widget/ElixirSdkStatusWidget.kt
+++ b/src/org/elixir_lang/status_bar_widget/ElixirSdkStatusWidget.kt
@@ -5,7 +5,8 @@ import com.intellij.ide.DataManager
 import com.intellij.notification.NotificationGroupManager
 import com.intellij.notification.NotificationType
 import com.intellij.openapi.actionSystem.*
-import com.intellij.openapi.application.ReadAction
+import com.intellij.openapi.application.UI
+import com.intellij.openapi.application.readAction
 import com.intellij.openapi.components.service
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.module.ModuleManager
@@ -26,7 +27,6 @@ import com.intellij.ui.ClickListener
 import com.intellij.ui.awt.RelativePoint
 import com.intellij.util.messages.MessageBusConnection
 import com.intellij.util.ui.JBUI
-import com.intellij.openapi.application.UI
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.cancel
@@ -37,14 +37,11 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.elixir_lang.Icons
 import org.elixir_lang.isElixirModule
-import org.elixir_lang.sdk.SdkHomeKey
-import org.elixir_lang.sdk.SdkHomePaths
 import org.elixir_lang.mix.project.ProjectModuleSetupValidator
 import org.elixir_lang.mix.project.ProjectModuleSetupValidator.FolderMarkIssue
 import org.elixir_lang.sdk.SdkEbinPaths
 import org.elixir_lang.sdk.elixir.SdkSettingsOpener
 import org.elixir_lang.sdk.elixir.Type
-import org.elixir_lang.sdk.elixir.Type.Companion.SKIP_ERLANG_SETTINGS_HINT_KEY
 import org.elixir_lang.sdk.erlang_dependent.SdkAdditionalData
 import org.elixir_lang.util.ElixirCoroutineService
 import org.jetbrains.annotations.NotNull
@@ -73,9 +70,7 @@ class ElixirSdkStatusWidget(@param:NotNull private val project: Project) : Custo
     private val rootsChangedFlow = MutableSharedFlow<Unit>(
         extraBufferCapacity = 1,
         onBufferOverflow = BufferOverflow.DROP_OLDEST,
-    )
-
-    // Track last notified status to avoid spamming duplicate notifications
+    )    // Track last notified status to avoid spamming duplicate notifications
     @Volatile
     private var lastNotifiedIssueKey: String? = null
 
@@ -100,9 +95,6 @@ class ElixirSdkStatusWidget(@param:NotNull private val project: Project) : Custo
     // Cached widget presentation data - computed once per update
     @Volatile
     private var cachedPresentation: WidgetPresentation? = null
-
-    @Volatile
-    private var cachedSdkConfigured: Boolean = true
 
     private data class WidgetPresentation(
         val text: String,
@@ -148,6 +140,9 @@ class ElixirSdkStatusWidget(@param:NotNull private val project: Project) : Custo
     private data class ModuleSdkIssue(val moduleName: String, val issue: String, val isDangling: Boolean)
 
     init {
+        // Kick off the first presentation computation asynchronously.
+        // updateWidget() only schedules a coroutine and returns immediately, so it is safe
+        // to call from the EDT (the widget constructor runs on the EDT during widget creation).
         updateWidget()
     }
 
@@ -158,6 +153,7 @@ class ElixirSdkStatusWidget(@param:NotNull private val project: Project) : Custo
     override fun install(statusBar: StatusBar) {
         this.statusBar = statusBar
         setupListeners()
+        // Refresh immediately now that statusBar is wired up.  Safe to call from EDT - async.
         updateWidget()
     }
 
@@ -174,16 +170,6 @@ class ElixirSdkStatusWidget(@param:NotNull private val project: Project) : Custo
     private fun showPopup(e: MouseEvent) {
         val actionGroup = DefaultActionGroup().apply {
             add(createAddSdkAction())
-
-            // When no SDK is configured, show detected mise Elixir SDKs for quick setup
-            if (!cachedSdkConfigured) {
-                val detectedActions = createDetectedSdkActions()
-                if (detectedActions.isNotEmpty()) {
-                    add(Separator.create("Detected Elixir SDKs"))
-                    detectedActions.forEach { add(it) }
-                }
-            }
-
             val actionManager = ActionManager.getInstance()
             actionManager.getAction("Elixir.RefreshAllElixirSdks")?.let { add(it) }
             actionManager.getAction("Elixir.InstallMixDependencies")?.let { add(it) }
@@ -235,68 +221,19 @@ class ElixirSdkStatusWidget(@param:NotNull private val project: Project) : Custo
         }
     }
 
-    private fun createDetectedSdkActions(): List<AnAction> {
-        val miseHomes = mutableMapOf<SdkHomeKey, String>()
-        SdkHomePaths.mergeMise(miseHomes, "elixir")
-
-        val elixirSdkType = Type.instance
-        return miseHomes.entries
-            .filter { (_, path) -> elixirSdkType.isValidSdkHome(path) }
-            .map { (_, homePath) ->
-                val sdkName = Type.suggestSdkNameForHome(homePath, null)
-                object : AnAction(sdkName, "Add $sdkName and set as project SDK", Icons.LANGUAGE) {
-                    override fun actionPerformed(e: AnActionEvent) {
-                        addDetectedElixirSdk(homePath)
-                    }
-
-                    override fun getActionUpdateThread(): ActionUpdateThread = ActionUpdateThread.BGT
-                }
-            }
-    }
-
-    private fun addDetectedElixirSdk(homePath: String) {
-        val elixirSdkType = Type.instance
-        val canonicalHome = org.elixir_lang.sdk.wsl.wslCompat.canonicalizePath(homePath)
-        val versionString = Type.versionStringForHome(canonicalHome, null) ?: return
-        val sdkName = Type.suggestSdkNameForHome(canonicalHome, null)
-
-        val newSdk = com.intellij.openapi.projectRoots.impl.ProjectJdkImpl(
-            sdkName, elixirSdkType, canonicalHome, versionString
-        )
-
-        val app = com.intellij.openapi.application.ApplicationManager.getApplication()
-        app.invokeLater {
-            app.runWriteAction {
-                ProjectJdkTable.getInstance().addJdk(newSdk)
-            }
-            // setupSdkPaths triggers the Erlang SDK prompt if needed.
-            // Skip the "reopen settings" hint since we're not in the settings dialog.
-            newSdk.putUserData(SKIP_ERLANG_SETTINGS_HINT_KEY, true)
-            elixirSdkType.setupSdkPaths(newSdk)
-
-            // Set as project SDK
-            app.runWriteAction {
-                ProjectRootManager.getInstance(project).projectSdk = newSdk
-            }
-        }
-    }
-
     private fun updateWidget() {
         widgetScope.launch {
-            cachedPresentation = null
-            val sdkStatus = detectSdkStatus()
-            cachedSdkConfigured = sdkStatus !is SdkStatus.NotConfigured
+            val sdkStatus = readAction { detectSdkStatus() }
             val presentation = createPresentation(sdkStatus)
-            cachedPresentation = presentation
-
             withContext(Dispatchers.UI) {
+                cachedPresentation = presentation
                 component.text = presentation.text
                 component.icon = presentation.icon
                 component.toolTipText = presentation.tooltip
                 statusBar?.updateWidget(ID)
+                // Fire notification whenever a discrepancy is detected
+                notifyIfNeeded(sdkStatus)
             }
-
-            notifyIfNeeded(sdkStatus)
         }
     }
 
@@ -543,7 +480,8 @@ class ElixirSdkStatusWidget(@param:NotNull private val project: Project) : Custo
     private fun setupListeners() {
         messageBusConnection = project.messageBus.connect(this)
 
-        // Listen for project JDK table changes (SDK added/removed/modified)
+        // Listen for project JDK table changes (SDK added/removed/modified).
+        // These events are infrequent; call updateWidget() directly (it just launches a coroutine).
         messageBusConnection?.subscribe(ProjectJdkTable.JDK_TABLE_TOPIC, object : ProjectJdkTable.Listener {
             override fun jdkAdded(jdk: Sdk) {
                 if (jdk.sdkType is Type) {
@@ -564,7 +502,7 @@ class ElixirSdkStatusWidget(@param:NotNull private val project: Project) : Custo
             }
         })
 
-        // Listen for project root changes (project SDK changes)
+        // Listen for project root changes (project SDK changes).
         // Debounced: bulk operations (import wizard, DepsWatcher) fire rootsChanged() rapidly;
         // collapse them into a single update after a 2-second quiet window.
         messageBusConnection?.subscribe(
@@ -590,49 +528,47 @@ class ElixirSdkStatusWidget(@param:NotNull private val project: Project) : Custo
     }
 
     private fun detectSdkStatus(): SdkStatus {
-        return ReadAction.nonBlocking<SdkStatus> {
-            val elixirSdk = Type.mostSpecificSdk(project) ?: return@nonBlocking SdkStatus.NotConfigured
-            val versionString = elixirSdk.versionString ?: "Unknown"
+        val elixirSdk = Type.mostSpecificSdk(project) ?: return SdkStatus.NotConfigured
+        val versionString = elixirSdk.versionString ?: "Unknown"
 
-            // Add WSL distribution suffix if this is a WSL SDK
-            val elixirVersion = org.elixir_lang.sdk.Type.appendWslSuffix(versionString, elixirSdk.homePath)
+        // Add WSL distribution suffix if this is a WSL SDK
+        val elixirVersion = org.elixir_lang.sdk.Type.appendWslSuffix(versionString, elixirSdk.homePath)
 
-            if (!isValidSdk(elixirSdk)) {
-                return@nonBlocking SdkStatus.InvalidSdk(elixirSdk, elixirVersion, "Invalid Elixir SDK")
-            }
+        if (!isValidSdk(elixirSdk)) {
+            return SdkStatus.InvalidSdk(elixirSdk, elixirVersion, "Invalid Elixir SDK")
+        }
 
-            val erlangSdk = getErlangSdk(elixirSdk)
-                ?: return@nonBlocking SdkStatus.InvalidSdk(elixirSdk, elixirVersion, "Missing Erlang SDK")
+        val erlangSdk = getErlangSdk(elixirSdk)
+            ?: return SdkStatus.InvalidSdk(elixirSdk, elixirVersion, "Missing Erlang SDK")
 
-            // Check module-level SDK consistency (dangling references or mismatches)
-            val moduleSdkIssues = detectModuleSdkIssues()
-            if (moduleSdkIssues.isNotEmpty()) {
-                return@nonBlocking SdkStatus.ModuleSdkError(elixirSdk, elixirVersion, moduleSdkIssues)
-            }
+        // Check module-level SDK consistency (dangling references or mismatches)
+        val moduleSdkIssues = detectModuleSdkIssues()
+        if (moduleSdkIssues.isNotEmpty()) {
+            return SdkStatus.ModuleSdkError(elixirSdk, elixirVersion, moduleSdkIssues)
+        }
 
-            // Check classpath/ebin configuration (breaks code resolution globally)
-            val issues = mutableListOf<String>()
-            if (hasEbinPathIssues(elixirSdk)) {
-                issues.add("Missing Elixir ebin paths or classpath entries")
-            }
-            if (hasErlangSdkIssues(erlangSdk)) {
-                issues.add("Erlang SDK configuration issues")
-            }
-            if (!Type.hasErlangClasspathInElixirSdk(elixirSdk, erlangSdk)) {
-                issues.add("Erlang SDK classpath entries missing - reopen SDK settings to fix")
-            }
-            if (issues.isNotEmpty()) {
-                return@nonBlocking SdkStatus.ClasspathIssue(elixirSdk, erlangSdk, elixirVersion, issues)
-            }
+        // Check classpath/ebin configuration (breaks code resolution globally)
+        val issues = mutableListOf<String>()
+        if (hasEbinPathIssues(elixirSdk)) {
+            issues.add("Missing Elixir ebin paths or classpath entries")
+        }
+        if (hasErlangSdkIssues(erlangSdk)) {
+            issues.add("Erlang SDK configuration issues")
+        }
+        if (!Type.hasErlangClasspathInElixirSdk(elixirSdk, erlangSdk)) {
+            issues.add("Erlang SDK classpath entries missing - reopen SDK settings to fix")
+        }
+        if (issues.isNotEmpty()) {
+            return SdkStatus.ClasspathIssue(elixirSdk, erlangSdk, elixirVersion, issues)
+        }
 
-            // Check folder mark configuration (breaks specific per-directory features)
-            val folderMarkIssues = ProjectModuleSetupValidator.detectFolderMarkIssues(project)
-            if (folderMarkIssues.isNotEmpty()) {
-                return@nonBlocking SdkStatus.FolderMarkWarning(elixirSdk, elixirVersion, folderMarkIssues)
-            }
+        // Check folder mark configuration (breaks specific per-directory features)
+        val folderMarkIssues = ProjectModuleSetupValidator.detectFolderMarkIssues(project)
+        if (folderMarkIssues.isNotEmpty()) {
+            return SdkStatus.FolderMarkWarning(elixirSdk, elixirVersion, folderMarkIssues)
+        }
 
-            SdkStatus.Configured(elixirSdk, erlangSdk, elixirVersion)
-        }.executeSynchronously()
+        return SdkStatus.Configured(elixirSdk, erlangSdk, elixirVersion)
     }
 
     private fun detectModuleSdkIssues(): List<ModuleSdkIssue> {

--- a/src/org/elixir_lang/status_bar_widget/ElixirSdkStatusWidget.kt
+++ b/src/org/elixir_lang/status_bar_widget/ElixirSdkStatusWidget.kt
@@ -529,8 +529,28 @@ class ElixirSdkStatusWidget(@param:NotNull private val project: Project) : Custo
         })
     }
 
+    /**
+     * Finds the active Elixir SDK by scanning all Elixir modules.
+     *
+     * Uses [Type.mostSpecificSdk] (module overload) which checks Facet SDK → module SDK → project SDK,
+     * returning the first non-null result. This covers both Rich IDEs (JdkOrderEntry) and Small IDEs
+     * (Facet library entry) without additional branching.
+     *
+     * When both the project SDK and a module SDK are Elixir, this returns the **module** SDK - the one
+     * that actually drives code insight - rather than the project-level one. The mismatch between them
+     * is reported separately by [detectModuleSdkIssues].
+     */
+    private fun findModuleLevelElixirSdk(): Sdk? {
+        for (module in ModuleManager.getInstance(project).modules) {
+            if (!module.isElixirModule()) continue
+            val moduleSdk = Type.mostSpecificSdk(module)
+            if (moduleSdk != null) return moduleSdk
+        }
+        return null
+    }
+
     private fun detectSdkStatus(): SdkStatus {
-        val elixirSdk = Type.mostSpecificSdk(project) ?: return SdkStatus.NotConfigured
+        val elixirSdk = findModuleLevelElixirSdk() ?: return SdkStatus.NotConfigured
         val versionString = elixirSdk.versionString ?: "Unknown"
 
         // Add WSL distribution suffix if this is a WSL SDK

--- a/src/org/elixir_lang/status_bar_widget/ElixirSdkStatusWidget.kt
+++ b/src/org/elixir_lang/status_bar_widget/ElixirSdkStatusWidget.kt
@@ -20,7 +20,6 @@ import com.intellij.openapi.roots.ProjectRootManager
 import com.intellij.openapi.ui.popup.JBPopupFactory
 import com.intellij.openapi.util.Disposer
 import com.intellij.openapi.util.text.StringUtil
-import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.wm.CustomStatusBarWidget
 import com.intellij.openapi.wm.StatusBar
 import com.intellij.openapi.wm.impl.status.TextPanel
@@ -104,7 +103,7 @@ class ElixirSdkStatusWidget(@param:NotNull private val project: Project) : Custo
         val tooltip: String
     )
 
-    private sealed interface SdkStatus {
+    internal sealed interface SdkStatus {
         data class Configured(
             val elixirSdk: Sdk,
             val erlangSdk: Sdk,
@@ -139,7 +138,7 @@ class ElixirSdkStatusWidget(@param:NotNull private val project: Project) : Custo
         data object NotConfigured : SdkStatus
     }
 
-    private data class ModuleSdkIssue(val moduleName: String, val issue: String, val isDangling: Boolean)
+    internal data class ModuleSdkIssue(val moduleName: String, val issue: String, val isDangling: Boolean)
 
     init {
         // Kick off the first presentation computation asynchronously.
@@ -540,7 +539,7 @@ class ElixirSdkStatusWidget(@param:NotNull private val project: Project) : Custo
      * that actually drives code insight - rather than the project-level one. The mismatch between them
      * is reported separately by [detectModuleSdkIssues].
      */
-    private fun findModuleLevelElixirSdk(): Sdk? {
+    internal fun findModuleLevelElixirSdk(): Sdk? {
         for (module in ModuleManager.getInstance(project).modules) {
             if (!module.isElixirModule()) continue
             val moduleSdk = Type.mostSpecificSdk(module)
@@ -549,7 +548,7 @@ class ElixirSdkStatusWidget(@param:NotNull private val project: Project) : Custo
         return null
     }
 
-    private fun detectSdkStatus(): SdkStatus {
+    internal fun detectSdkStatus(): SdkStatus {
         val elixirSdk = findModuleLevelElixirSdk() ?: return SdkStatus.NotConfigured
         val versionString = elixirSdk.versionString ?: "Unknown"
 
@@ -593,12 +592,9 @@ class ElixirSdkStatusWidget(@param:NotNull private val project: Project) : Custo
         return SdkStatus.Configured(elixirSdk, erlangSdk, elixirVersion)
     }
 
-    private fun detectModuleSdkIssues(): List<ModuleSdkIssue> {
+    internal fun detectModuleSdkIssues(): List<ModuleSdkIssue> {
         val issues = mutableListOf<ModuleSdkIssue>()
         val projectSdk = ProjectRootManager.getInstance(project).projectSdk
-        val hasRootMixExs = project.basePath?.let { basePath ->
-            LocalFileSystem.getInstance().findFileByPath(basePath)?.findChild("mix.exs")
-        } != null
 
         for (module in ModuleManager.getInstance(project).modules) {
             if (!module.isElixirModule()) continue
@@ -625,8 +621,8 @@ class ElixirSdkStatusWidget(@param:NotNull private val project: Project) : Custo
                             isDangling = true
                         )
                     )
-                } else if (hasRootMixExs && projectSdk != null && projectSdk.sdkType is Type && resolvedSdk != projectSdk) {
-                    // MISMATCH: Module uses different SDK than project in a single-version project.
+                } else if (projectSdk != null && projectSdk.sdkType is Type && resolvedSdk != projectSdk) {
+                    // MISMATCH: Module uses different Elixir SDK than project in a single-version project.
                     // Only meaningful when the project SDK is itself Elixir; skip when it is Java/Python/etc.
                     issues.add(
                         ModuleSdkIssue(

--- a/src/org/elixir_lang/status_bar_widget/ElixirSdkStatusWidget.kt
+++ b/src/org/elixir_lang/status_bar_widget/ElixirSdkStatusWidget.kt
@@ -1,5 +1,6 @@
 package org.elixir_lang.status_bar_widget
 
+import com.intellij.facet.FacetManager
 import com.intellij.icons.AllIcons
 import com.intellij.ide.DataManager
 import com.intellij.notification.NotificationGroupManager
@@ -35,6 +36,7 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import org.elixir_lang.Facet
 import org.elixir_lang.Icons
 import org.elixir_lang.isElixirModule
 import org.elixir_lang.mix.project.ProjectModuleSetupValidator
@@ -583,10 +585,13 @@ class ElixirSdkStatusWidget(@param:NotNull private val project: Project) : Custo
 
             val rootManager = ModuleRootManager.getInstance(module)
 
+            // --- Rich IDE path: detect dangling/mismatch JdkOrderEntry ---
+            var hasJdkEntry = false
             for (entry in rootManager.orderEntries) {
                 if (entry !is JdkOrderEntry) continue
 
                 val jdkName = entry.jdkName ?: continue
+                hasJdkEntry = true
                 // Only check Elixir SDK entries (when SDK is resolvable, check its type)
                 val resolvedSdk = entry.jdk
                 if (resolvedSdk != null && resolvedSdk.sdkType !is Type) continue
@@ -600,13 +605,32 @@ class ElixirSdkStatusWidget(@param:NotNull private val project: Project) : Custo
                             isDangling = true
                         )
                     )
-                } else if (hasRootMixExs && projectSdk != null && resolvedSdk != projectSdk) {
-                    // MISMATCH: Module uses different SDK than project in a single-version project
+                } else if (hasRootMixExs && projectSdk != null && projectSdk.sdkType is Type && resolvedSdk != projectSdk) {
+                    // MISMATCH: Module uses different SDK than project in a single-version project.
+                    // Only meaningful when the project SDK is itself Elixir; skip when it is Java/Python/etc.
                     issues.add(
                         ModuleSdkIssue(
                             module.name,
                             "uses '$jdkName' but project SDK is '${projectSdk.name}'",
                             isDangling = false
+                        )
+                    )
+                }
+            }
+
+            // --- Small IDE path: detect dangling Facet SDK ---
+            // Only check if the Rich IDE path didn't find any JDK entries (Small IDE modules use
+            // a Facet library entry instead of a JdkOrderEntry to hold the Elixir SDK).
+            if (!hasJdkEntry) {
+                val facet = FacetManager.getInstance(module).getFacetByType(Facet.ID)
+                if (facet != null && Facet.sdk(module) == null && Facet.sdks().isNotEmpty()) {
+                    // The module has an Elixir Facet and Elixir SDKs exist in the table, but the
+                    // Facet library entry doesn't match any current SDK name - stale/dangling reference.
+                    issues.add(
+                        ModuleSdkIssue(
+                            module.name,
+                            "Elixir Facet SDK is not configured (stale reference). Reconfigure in Settings → Languages → Elixir.",
+                            isDangling = true
                         )
                     )
                 }

--- a/src/org/elixir_lang/status_bar_widget/ElixirSdkStatusWidget.kt
+++ b/src/org/elixir_lang/status_bar_widget/ElixirSdkStatusWidget.kt
@@ -41,6 +41,7 @@ import org.elixir_lang.isElixirModule
 import org.elixir_lang.mix.project.ProjectModuleSetupValidator
 import org.elixir_lang.mix.project.ProjectModuleSetupValidator.FolderMarkIssue
 import org.elixir_lang.sdk.SdkEbinPaths
+import org.elixir_lang.sdk.elixir.ElixirSdkLookup
 import org.elixir_lang.sdk.elixir.SdkSettingsOpener
 import org.elixir_lang.sdk.elixir.Type
 import org.elixir_lang.sdk.erlang_dependent.SdkAdditionalData
@@ -542,7 +543,7 @@ class ElixirSdkStatusWidget(@param:NotNull private val project: Project) : Custo
     internal fun findModuleLevelElixirSdk(): Sdk? {
         for (module in ModuleManager.getInstance(project).modules) {
             if (!module.isElixirModule()) continue
-            val moduleSdk = Type.mostSpecificSdk(module)
+            val moduleSdk = ElixirSdkLookup.mostSpecificSdk(module)
             if (moduleSdk != null) return moduleSdk
         }
         return null

--- a/src/org/elixir_lang/status_bar_widget/ElixirSdkStatusWidgetFactory.kt
+++ b/src/org/elixir_lang/status_bar_widget/ElixirSdkStatusWidgetFactory.kt
@@ -1,10 +1,12 @@
 package org.elixir_lang.status_bar_widget
 
 import com.intellij.openapi.diagnostic.logger
+import com.intellij.openapi.module.ModuleManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.wm.StatusBar
 import com.intellij.openapi.wm.StatusBarWidget
 import com.intellij.openapi.wm.StatusBarWidgetFactory
+import org.elixir_lang.isElixirModule
 import org.elixir_lang.settings.ElixirExperimentalSettings
 
 private val LOG = logger<ElixirSdkStatusWidgetFactory>()
@@ -15,9 +17,12 @@ class ElixirSdkStatusWidgetFactory : StatusBarWidgetFactory {
     override fun getDisplayName(): String = "Elixir SDK Status"
 
     override fun isAvailable(project: Project): Boolean {
-        // Widget is available when the experimental setting is enabled
-        val isAvailable = ElixirExperimentalSettings.instance.state.enableStatusBarWidget
-        LOG.debug("isAvailable called for project ${project.name}, returning $isAvailable")
+        val isSettingEnabled = ElixirExperimentalSettings.instance.state.enableStatusBarWidget
+        if (!isSettingEnabled) return false
+
+        val hasElixirModule = ModuleManager.getInstance(project).modules.any { it.isElixirModule() }
+        val isAvailable = hasElixirModule
+        LOG.debug("isAvailable called for project ${project.name}, setting=$isSettingEnabled, hasElixirModule=$hasElixirModule, returning $isAvailable")
         return isAvailable
     }
 

--- a/src/org/elixir_lang/status_bar_widget/ElixirSdkStatusWidgetFactory.kt
+++ b/src/org/elixir_lang/status_bar_widget/ElixirSdkStatusWidgetFactory.kt
@@ -6,13 +6,14 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.wm.StatusBar
 import com.intellij.openapi.wm.StatusBarWidget
 import com.intellij.openapi.wm.StatusBarWidgetFactory
+import kotlinx.coroutines.CoroutineScope
 import org.elixir_lang.isElixirModule
 import org.elixir_lang.settings.ElixirExperimentalSettings
 
 private val LOG = logger<ElixirSdkStatusWidgetFactory>()
 
 class ElixirSdkStatusWidgetFactory : StatusBarWidgetFactory {
-    override fun getId(): String = ElixirSdkStatusWidget.ID
+    override fun getId(): String = ElixirEditorBasedSdkWidget.ID
 
     override fun getDisplayName(): String = "Elixir SDK Status"
 
@@ -27,20 +28,17 @@ class ElixirSdkStatusWidgetFactory : StatusBarWidgetFactory {
     }
 
     override fun canBeEnabledOn(statusBar: StatusBar): Boolean {
-        // Widget can be enabled when the experimental setting is enabled
         return ElixirExperimentalSettings.instance.state.enableStatusBarWidget
     }
 
-    override fun createWidget(project: Project): StatusBarWidget {
+    override fun createWidget(project: Project, scope: CoroutineScope): StatusBarWidget {
         LOG.debug("Creating widget for project: ${project.name}")
-        return ElixirSdkStatusWidget(project)
+        return ElixirEditorBasedSdkWidget(project, scope)
     }
 
     // Mark this widget as configurable so users can enable/disable it
     override fun isConfigurable(): Boolean = true
 
     // if the experimental setting is enabled, make it so the widget immediately appears in the status bar
-    // this was previously set to false, which required the user to enable it in project settings, and then enable
-    // it again on the status bar.
-    override fun isEnabledByDefault(): Boolean =  true
+    override fun isEnabledByDefault(): Boolean = true
 }

--- a/src/org/elixir_lang/util/ProgressUtils.kt
+++ b/src/org/elixir_lang/util/ProgressUtils.kt
@@ -1,4 +1,4 @@
-package org.elixir_lang.sdk
+package org.elixir_lang.util
 
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.platform.ide.progress.ModalTaskOwner

--- a/tests/org/elixir_lang/action/ReconfigureModuleSetupActionTest.kt
+++ b/tests/org/elixir_lang/action/ReconfigureModuleSetupActionTest.kt
@@ -6,6 +6,12 @@ import com.intellij.openapi.actionSystem.ActionUiKind
 import com.intellij.openapi.actionSystem.CommonDataKeys
 import com.intellij.openapi.actionSystem.DataContext
 import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.application.WriteAction
+import com.intellij.openapi.projectRoots.ProjectJdkTable
+import com.intellij.openapi.projectRoots.SimpleJavaSdkType
+import com.intellij.openapi.projectRoots.Sdk
+import com.intellij.openapi.projectRoots.impl.ProjectJdkImpl
+import com.intellij.openapi.roots.ProjectRootManager
 import com.intellij.openapi.util.ThrowableComputable
 import com.intellij.facet.FacetManager
 import com.intellij.facet.FacetType
@@ -16,11 +22,15 @@ import org.elixir_lang.Facet
 import org.elixir_lang.PlatformTestCase
 import org.elixir_lang.facet.Type
 import org.elixir_lang.mix.project.ProjectModuleSetupValidator
+import org.elixir_lang.sdk.elixir.Type as ElixirSdkType
 
 class ReconfigureModuleSetupActionTest : PlatformTestCase() {
 
     /** URLs of content entries added during a test, cleaned up in [tearDown]. */
     private val addedContentRootUrls = mutableListOf<String>()
+
+    /** SDKs registered in the JDK table during a test, cleaned up in [tearDown]. */
+    private val addedSdks = mutableListOf<Sdk>()
 
     override fun setUp() {
         super.setUp()
@@ -42,6 +52,20 @@ class ReconfigureModuleSetupActionTest : PlatformTestCase() {
                     }
                 }
                 addedContentRootUrls.clear()
+            }
+            // Clear module SDK before removing SDKs from the table
+            ModuleRootModificationUtil.setModuleSdk(module, null)
+            // Clear project SDK
+            WriteAction.run<Throwable> {
+                ProjectRootManager.getInstance(project).projectSdk = null
+            }
+            // Remove registered SDKs
+            WriteAction.run<Throwable> {
+                val jdkTable = ProjectJdkTable.getInstance()
+                for (sdk in addedSdks) {
+                    if (jdkTable.allJdks.contains(sdk)) jdkTable.removeJdk(sdk)
+                }
+                addedSdks.clear()
             }
         } finally {
             super.tearDown()
@@ -333,5 +357,45 @@ class ReconfigureModuleSetupActionTest : PlatformTestCase() {
 
         assertNotNull("web/ should be marked as Source even when it does not exist", webFolder)
         assertFalse("web/ should be Sources (not Test Sources)", webFolder!!.isTestSource)
+    }
+
+    // -------------------------------------------------------------------------
+    // Scenario 4: Project SDK = Java, Reconfigure action invoked
+    // → folder marks applied; module SDK left untouched (Step 1 guard)
+    // -------------------------------------------------------------------------
+
+    /**
+     * When the project SDK is non-Elixir (e.g. Java), the Reconfigure action must NOT
+     * touch the module SDK.  Before Step 1, `fixModuleSdk()` would call `model.inheritSdk()`
+     * unconditionally, replacing the Elixir module SDK with the Java project SDK.
+     */
+    fun testReconfigureWithNonElixirProjectSdkDoesNotTouchModuleSdk() {
+        val javaHome = System.getProperty("java.home") ?: "/usr/lib/jvm/java"
+        val javaSdk = SimpleJavaSdkType().createJdk("Java Mock", javaHome)
+
+        val elixirSdk = ProjectJdkImpl("Elixir Mock", ElixirSdkType.instance)
+        WriteAction.run<Throwable> {
+            ProjectJdkTable.getInstance().addJdk(elixirSdk)
+        }
+        addedSdks.add(elixirSdk)
+
+        // Set project SDK to Java and module SDK to Elixir
+        WriteAction.run<Throwable> {
+            ProjectRootManager.getInstance(project).projectSdk = javaSdk
+        }
+        ModuleRootModificationUtil.setModuleSdk(module, elixirSdk)
+
+        // Add a Mix content entry so the action processes the module
+        addMixContentEntry("sdk_guard_app", subdirs = listOf("lib", "test"))
+
+        runAction()
+
+        // The module SDK should still be the Elixir SDK, not the Java project SDK
+        val moduleSdkAfter = ModuleRootManager.getInstance(module).sdk
+        assertEquals(
+            "Module SDK must not be replaced with Java project SDK when project SDK is non-Elixir",
+            elixirSdk,
+            moduleSdkAfter
+        )
     }
 }

--- a/tests/org/elixir_lang/cli/CliArgumentsDataTest.kt
+++ b/tests/org/elixir_lang/cli/CliArgumentsDataTest.kt
@@ -3,6 +3,7 @@ package org.elixir_lang.cli
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.projectRoots.Sdk
 import com.intellij.openapi.projectRoots.SdkModel
+import com.intellij.openapi.projectRoots.impl.ProjectJdkImpl
 import com.intellij.openapi.util.io.FileUtil
 import com.intellij.testFramework.registerOrReplaceServiceInstance
 import com.intellij.util.execution.ParametersListUtil
@@ -15,11 +16,10 @@ import org.elixir_lang.sdk.erlang_dependent.MissingErlangSdkReason
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
-import org.mockito.Mockito.mock
-import org.mockito.Mockito.`when`
 import java.nio.file.Files
 import java.nio.file.Path
 import kotlin.io.path.absolutePathString
+import org.elixir_lang.sdk.erlang.Type as ErlangSdkType
 
 /**
  * Generate new data for this with the [testData/org/elixir_lang/cli/gen_elixir_cli_base_args.sh](../../../testData/org/elixir_lang/cli/gen_elixir_cli_base_args.sh) script.
@@ -122,11 +122,9 @@ class CliArgumentsDataTest(private val case: Case) : PlatformTestCase() {
     }
 
     private fun mockSdk(version: String?, homePath: Path, erlangSdk: Sdk? = null): Sdk {
-        val sdk = mock(Sdk::class.java)
-        `when`(sdk.versionString).thenReturn(version)
-        `when`(sdk.homePath).thenReturn(homePath.toString())
-        `when`(sdk.name).thenReturn(version ?: homePath.fileName.toString())
-        if (erlangSdk != null ) {
+        val name = version ?: homePath.fileName.toString()
+        val sdk = ProjectJdkImpl(name, ErlangSdkType.instance, homePath.toString(), version ?: "")
+        if (erlangSdk != null) {
             erlangSdkByElixirSdk[sdk] = erlangSdk
         }
         return sdk

--- a/tests/org/elixir_lang/cli/CliArgumentsTest.kt
+++ b/tests/org/elixir_lang/cli/CliArgumentsTest.kt
@@ -4,6 +4,7 @@ import com.intellij.openapi.application.ApplicationManager
 import com.intellij.execution.CantRunException
 import com.intellij.openapi.projectRoots.Sdk
 import com.intellij.openapi.projectRoots.SdkModel
+import com.intellij.openapi.projectRoots.impl.ProjectJdkImpl
 import com.intellij.openapi.util.io.FileUtil
 import com.intellij.testFramework.registerOrReplaceServiceInstance
 import com.intellij.util.system.OS
@@ -15,11 +16,10 @@ import org.elixir_lang.sdk.erlang_dependent.MissingErlangSdkReason
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
-import org.mockito.Mockito.mock
-import org.mockito.Mockito.`when`
 import java.nio.file.Files
 import java.nio.file.Path
 import kotlin.io.path.absolutePathString
+import org.elixir_lang.sdk.erlang.Type as ErlangSdkType
 
 @RunWith(Parameterized::class)
 class CliArgumentsTest(private val targetOS: OS) : PlatformTestCase() {
@@ -200,11 +200,9 @@ class CliArgumentsTest(private val targetOS: OS) : PlatformTestCase() {
     }
 
     private fun mockSdk(version: String?, homePath: Path, erlangSdk: Sdk? = null): Sdk {
-        val sdk = mock(Sdk::class.java)
-        `when`(sdk.versionString).thenReturn(version)
-        `when`(sdk.homePath).thenReturn(homePath.toString())
-        `when`(sdk.name).thenReturn(version ?: homePath.fileName.toString())
-        if (erlangSdk != null ) {
+        val name = version ?: homePath.fileName.toString()
+        val sdk = ProjectJdkImpl(name, ErlangSdkType.instance, homePath.toString(), version ?: "")
+        if (erlangSdk != null) {
             erlangSdkByElixirSdk[sdk] = erlangSdk
         }
         return sdk

--- a/tests/org/elixir_lang/mise/MiseTest.kt
+++ b/tests/org/elixir_lang/mise/MiseTest.kt
@@ -1,0 +1,211 @@
+package org.elixir_lang.mise
+
+import org.elixir_lang.PlatformTestCase
+
+/**
+ * Tests for [Mise.parseOutput] (internal) and [Mise.stripElixirOtpSuffix].
+ *
+ * Both functions are pure with no IDE dependencies, so no sandbox setup is needed.
+ */
+class MiseTest : PlatformTestCase() {
+
+    // -------------------------------------------------------------------------
+    // parseOutput
+    // -------------------------------------------------------------------------
+
+    fun testParseOutput_bothTools_returnsElixirAndErlang() {
+        val json = """
+            {
+              "elixir": [{"version":"1.13.4-otp-24","requested_version":"1.13.4","install_path":"/home/user/.local/share/mise/installs/elixir/1.13.4-otp-24","source":{"type":"file","path":"/project/.tool-versions"},"installed":true,"active":true}],
+              "erlang": [{"version":"24.3.4.6","requested_version":"24.3","install_path":"/home/user/.local/share/mise/installs/erlang/24.3.4.6","source":{"type":"file","path":"/project/.tool-versions"},"installed":true,"active":true}]
+            }
+        """.trimIndent()
+
+        val result = Mise.parseOutput(json)
+
+        assertNotNull(result)
+        assertNotNull(result!!.elixir)
+        assertEquals("1.13.4-otp-24", result.elixir!!.version)
+        assertEquals("/home/user/.local/share/mise/installs/elixir/1.13.4-otp-24", result.elixir.installPath)
+        assertNotNull(result.erlang)
+        assertEquals("24.3.4.6", result.erlang!!.version)
+    }
+
+    fun testParseOutput_onlyElixir_erlangIsNull() {
+        val json = """
+            {
+              "elixir": [{"version":"1.15.7","requested_version":"1.15.7","install_path":"/installs/elixir/1.15.7","installed":true,"active":true}]
+            }
+        """.trimIndent()
+
+        val result = Mise.parseOutput(json)
+
+        assertNotNull(result)
+        assertNotNull(result!!.elixir)
+        assertNull(result.erlang)
+    }
+
+    fun testParseOutput_onlyErlang_elixirIsNull() {
+        val json = """
+            {
+              "erlang": [{"version":"26.2.5","requested_version":"26","install_path":"/installs/erlang/26.2.5","installed":true,"active":true}]
+            }
+        """.trimIndent()
+
+        val result = Mise.parseOutput(json)
+
+        assertNotNull(result)
+        assertNull(result!!.elixir)
+        assertNotNull(result.erlang)
+        assertEquals("26.2.5", result.erlang!!.version)
+    }
+
+    fun testParseOutput_emptyObject_returnsBothNull() {
+        val result = Mise.parseOutput("{}")
+
+        assertNotNull(result)
+        assertNull(result!!.elixir)
+        assertNull(result.erlang)
+    }
+
+    fun testParseOutput_firstActiveInstalledEntryWins() {
+        // First entry: not active. Second entry: active and installed.
+        val json = """
+            {
+              "elixir": [
+                {"version":"1.12.0","requested_version":"1.12.0","install_path":"/installs/elixir/1.12.0","installed":true,"active":false},
+                {"version":"1.13.4","requested_version":"~>1.13","install_path":"/installs/elixir/1.13.4","installed":true,"active":true}
+              ]
+            }
+        """.trimIndent()
+
+        val result = Mise.parseOutput(json)
+
+        assertNotNull(result)
+        assertEquals("1.13.4", result!!.elixir!!.version)
+    }
+
+    fun testParseOutput_notInstalledEntrySkipped() {
+        val json = """
+            {
+              "elixir": [{"version":"1.15.7","requested_version":"1.15.7","install_path":"/installs/elixir/1.15.7","installed":false,"active":true}]
+            }
+        """.trimIndent()
+
+        val result = Mise.parseOutput(json)
+
+        assertNotNull(result)
+        assertNull(result!!.elixir)
+    }
+
+    fun testParseOutput_notActiveEntrySkipped() {
+        val json = """
+            {
+              "elixir": [{"version":"1.15.7","requested_version":"1.15.7","install_path":"/installs/elixir/1.15.7","installed":true,"active":false}]
+            }
+        """.trimIndent()
+
+        val result = Mise.parseOutput(json)
+
+        assertNotNull(result)
+        assertNull(result!!.elixir)
+    }
+
+    fun testParseOutput_extraToolsIgnored() {
+        val json = """
+            {
+              "node": [{"version":"20.0.0","requested_version":"20","install_path":"/installs/node/20.0.0","installed":true,"active":true}],
+              "elixir": [{"version":"1.15.7","requested_version":"1.15.7","install_path":"/installs/elixir/1.15.7","installed":true,"active":true}]
+            }
+        """.trimIndent()
+
+        val result = Mise.parseOutput(json)
+
+        assertNotNull(result)
+        assertNotNull(result!!.elixir)
+        assertNull(result.erlang)
+    }
+
+    fun testParseOutput_missingVersion_entrySkipped() {
+        // version field is null - toMiseToolEntry() returns null, filtered out
+        val json = """
+            {
+              "elixir": [{"requested_version":"1.15.7","install_path":"/installs/elixir/1.15.7","installed":true,"active":true}]
+            }
+        """.trimIndent()
+
+        val result = Mise.parseOutput(json)
+
+        assertNotNull(result)
+        assertNull(result!!.elixir)
+    }
+
+    fun testParseOutput_missingInstallPath_entrySkipped() {
+        val json = """
+            {
+              "elixir": [{"version":"1.15.7","requested_version":"1.15.7","installed":true,"active":true}]
+            }
+        """.trimIndent()
+
+        val result = Mise.parseOutput(json)
+
+        assertNotNull(result)
+        assertNull(result!!.elixir)
+    }
+
+    fun testParseOutput_emptyString_returnsNull() {
+        assertNull(Mise.parseOutput(""))
+    }
+
+    fun testParseOutput_malformedJson_returnsNull() {
+        assertNull(Mise.parseOutput("not json at all {{{"))
+    }
+
+    fun testParseOutput_sourceFieldPresent_populatedCorrectly() {
+        val json = """
+            {
+              "elixir": [{"version":"1.15.7","requested_version":"1.15.7","install_path":"/installs/elixir/1.15.7","source":{"type":"file","path":"/project/.tool-versions"},"installed":true,"active":true}]
+            }
+        """.trimIndent()
+
+        val result = Mise.parseOutput(json)
+
+        assertNotNull(result)
+        assertEquals("file", result!!.elixir!!.sourceType)
+        assertEquals("/project/.tool-versions", result.elixir.sourcePath)
+    }
+
+    fun testParseOutput_sourceFieldAbsent_nullSourceFields() {
+        val json = """
+            {
+              "elixir": [{"version":"1.15.7","requested_version":"1.15.7","install_path":"/installs/elixir/1.15.7","installed":true,"active":true}]
+            }
+        """.trimIndent()
+
+        val result = Mise.parseOutput(json)
+
+        assertNotNull(result)
+        assertNull(result!!.elixir!!.sourceType)
+        assertNull(result.elixir.sourcePath)
+    }
+
+    // -------------------------------------------------------------------------
+    // stripElixirOtpSuffix
+    // -------------------------------------------------------------------------
+
+    fun testStripElixirOtpSuffix_withSuffix() {
+        assertEquals("1.13.4", Mise.stripElixirOtpSuffix("1.13.4-otp-24"))
+    }
+
+    fun testStripElixirOtpSuffix_noSuffix() {
+        assertEquals("1.15.7", Mise.stripElixirOtpSuffix("1.15.7"))
+    }
+
+    fun testStripElixirOtpSuffix_preReleaseWithSuffix() {
+        assertEquals("1.18.0-rc.1", Mise.stripElixirOtpSuffix("1.18.0-rc.1-otp-27"))
+    }
+
+    fun testStripElixirOtpSuffix_emptyString() {
+        assertEquals("", Mise.stripElixirOtpSuffix(""))
+    }
+}

--- a/tests/org/elixir_lang/mix/project/ProjectModuleSetupValidatorTest.kt
+++ b/tests/org/elixir_lang/mix/project/ProjectModuleSetupValidatorTest.kt
@@ -427,5 +427,93 @@ class ProjectModuleSetupValidatorTest : PlatformTestCase() {
         assertEquals(FolderMark.EXCLUDED, depsIssues.single().folderMark)
     }
 
+    /**
+     * When an umbrella project is imported as a single module (one content entry at the umbrella
+     * root), sub-apps under `apps/` that have no folder marks on the content entry must produce
+     * [ProjectModuleSetupValidator.FolderMarkIssue]s for each missing mark.
+     */
+    fun testUmbrellaSubAppsNotConfiguredReportsFolderMarkIssues() {
+        // Set up umbrella root with mix.exs and a single sub-app (app_a) with lib/ and test/.
+        myFixture.tempDirFixture.findOrCreateDir("umbrella_single/apps/app_a/lib")
+        myFixture.tempDirFixture.findOrCreateDir("umbrella_single/apps/app_a/test")
+        myFixture.tempDirFixture.createFile("umbrella_single/apps/app_a/mix.exs", "")
+
+        addMixContentEntry("umbrella_single") { _, _ ->
+            // No sub-app folder marks added - simulates an unconfigured single-module umbrella.
+        }
+
+        val issues = detectFolderMarkIssuesOnBackgroundThread()
+        val moduleIssues = issues.filter { it.moduleName == module.name }
+
+        val libIssues = moduleIssues.filter { it.folderRelativePath == "apps/app_a/lib" }
+        val testIssues = moduleIssues.filter { it.folderRelativePath == "apps/app_a/test" }
+
+        assertEquals(
+            "Expected exactly one issue for apps/app_a/lib (unmarked Sources)",
+            1,
+            libIssues.size,
+        )
+        assertEquals(FolderMark.SOURCES, libIssues.single().folderMark)
+        assertEquals("unmarked", libIssues.single().currentState)
+
+        assertEquals(
+            "Expected exactly one issue for apps/app_a/test (unmarked Test Sources)",
+            1,
+            testIssues.size,
+        )
+        assertEquals(FolderMark.TEST_SOURCES, testIssues.single().folderMark)
+        assertEquals("unmarked", testIssues.single().currentState)
+    }
+
+    /**
+     * When one sub-app (`app_a`) already has its own content entry (e.g., from the import wizard),
+     * the umbrella scan must skip it and only report issues for sub-apps (`app_b`) that do NOT
+     * have their own content entry.
+     */
+    fun testUmbrellaSubAppAlreadyCoveredByContentEntryIsSkipped() {
+        // Umbrella root with mix.exs.
+        // app_a: has its own content entry → umbrella scan must skip it.
+        // app_b: only a plain directory under apps/ → umbrella scan must report it.
+        myFixture.tempDirFixture.findOrCreateDir("umbrella_mixed/apps/app_a/lib")
+        myFixture.tempDirFixture.findOrCreateDir("umbrella_mixed/apps/app_a/test")
+        myFixture.tempDirFixture.createFile("umbrella_mixed/apps/app_a/mix.exs", "")
+
+        myFixture.tempDirFixture.findOrCreateDir("umbrella_mixed/apps/app_b/lib")
+        myFixture.tempDirFixture.findOrCreateDir("umbrella_mixed/apps/app_b/test")
+        myFixture.tempDirFixture.createFile("umbrella_mixed/apps/app_b/mix.exs", "")
+
+        // Umbrella root content entry (no sub-app marks).
+        addMixContentEntry("umbrella_mixed") { _, _ -> }
+
+        // app_a gets its own content entry, fully configured - the per-entry loop handles it.
+        val appARoot = myFixture.tempDirFixture.findOrCreateDir("umbrella_mixed/apps/app_a")
+        ModuleRootModificationUtil.updateModel(module) { model ->
+            val contentA = model.addContentEntry(appARoot)
+            contentA.addSourceFolder("${appARoot.url}/lib", false)
+            contentA.addSourceFolder("${appARoot.url}/test", true)
+        }
+        addedContentRootUrls.add(appARoot.url)
+
+        val issues = detectFolderMarkIssuesOnBackgroundThread()
+        val moduleIssues = issues.filter { it.moduleName == module.name }
+
+        // app_a is covered by its own content entry and fully configured → no umbrella issues.
+        val appAIssues = moduleIssues.filter { it.folderRelativePath.startsWith("apps/app_a/") }
+        assertTrue(
+            "app_a is covered by its own content entry and must produce no umbrella issues, got: $appAIssues",
+            appAIssues.isEmpty(),
+        )
+
+        // app_b has no content entry → umbrella scan must report lib/ and test/.
+        val appBLibIssues = moduleIssues.filter { it.folderRelativePath == "apps/app_b/lib" }
+        val appBTestIssues = moduleIssues.filter { it.folderRelativePath == "apps/app_b/test" }
+
+        assertEquals("Expected one issue for apps/app_b/lib", 1, appBLibIssues.size)
+        assertEquals(FolderMark.SOURCES, appBLibIssues.single().folderMark)
+
+        assertEquals("Expected one issue for apps/app_b/test", 1, appBTestIssues.size)
+        assertEquals(FolderMark.TEST_SOURCES, appBTestIssues.single().folderMark)
+    }
+
     override fun getTestDataPath(): String = "testData/org/elixir_lang/mix/project"
 }

--- a/tests/org/elixir_lang/sdk/elixir/TypeErlangAutoLinkTest.kt
+++ b/tests/org/elixir_lang/sdk/elixir/TypeErlangAutoLinkTest.kt
@@ -7,8 +7,8 @@ import com.intellij.openapi.projectRoots.impl.ProjectJdkImpl
 import org.elixir_lang.PlatformTestCase
 import org.elixir_lang.sdk.SdkHomeKey
 import org.elixir_lang.sdk.SdkHomePaths
-import org.elixir_lang.sdk.erlang.Type as ErlangSdkType
 import org.elixir_lang.sdk.erlang_dependent.ErlangSdkResolver
+import org.elixir_lang.sdk.erlang.Type as ErlangSdkType
 
 class TypeErlangAutoLinkTest : PlatformTestCase() {
 
@@ -89,14 +89,14 @@ class TypeErlangAutoLinkTest : PlatformTestCase() {
             }
         }
 
-        val result = Type.promptForMiseErlangSdk(elixirSdk)
+        val result = ElixirInternalErlangSdkSetup.promptForMiseErlangSdk(elixirSdk)
         assertNull("Should return null for non-mise Elixir SDK", result)
     }
 
     fun testPromptForMiseErlangSdk_returnsNullWhenNoHomePath() {
         val elixirSdk = ProjectJdkImpl("Test Elixir SDK", Type.instance)
 
-        val result = Type.promptForMiseErlangSdk(elixirSdk)
+        val result = ElixirInternalErlangSdkSetup.promptForMiseErlangSdk(elixirSdk)
         assertNull("Should return null when Elixir SDK has no homePath", result)
     }
 
@@ -122,7 +122,7 @@ class TypeErlangAutoLinkTest : PlatformTestCase() {
 
     fun testRegisterErlangSdk_returnsNullForInvalidPath() {
         // Use a path that exists but isn't a valid Erlang home
-        val result = Type.registerErlangSdk(System.getProperty("java.io.tmpdir"))
+        val result = ElixirInternalErlangSdkSetup.registerErlangSdk(System.getProperty("java.io.tmpdir"))
         assertNull("Should return null for invalid Erlang home path", result)
     }
 
@@ -135,7 +135,7 @@ class TypeErlangAutoLinkTest : PlatformTestCase() {
         val validHome = miseHomes.values.firstOrNull { erlangSdkType.isValidSdkHome(it) }
             ?: return // Skip if no valid mise Erlang on this machine
 
-        val sdk = Type.registerErlangSdk(validHome)
+        val sdk = ElixirInternalErlangSdkSetup.registerErlangSdk(validHome)
         assertNotNull("registerErlangSdk should return non-null for valid home", sdk)
         registeredSdks.add(sdk!!)
 

--- a/tests/org/elixir_lang/sdk/elixir/TypeErlangAutoLinkTest.kt
+++ b/tests/org/elixir_lang/sdk/elixir/TypeErlangAutoLinkTest.kt
@@ -8,6 +8,7 @@ import org.elixir_lang.PlatformTestCase
 import org.elixir_lang.sdk.SdkHomeKey
 import org.elixir_lang.sdk.SdkHomePaths
 import org.elixir_lang.sdk.erlang.Type as ErlangSdkType
+import org.elixir_lang.sdk.erlang_dependent.ErlangSdkResolver
 
 class TypeErlangAutoLinkTest : PlatformTestCase() {
 
@@ -40,7 +41,7 @@ class TypeErlangAutoLinkTest : PlatformTestCase() {
         }
         registeredSdks.add(erlangSdk)
 
-        val result = Type.findRegisteredErlangSdk()
+        val result = ErlangSdkResolver.findAnyRegistered()
         assertNotNull("Should find the registered Erlang SDK", result)
         assertEquals("Test Erlang SDK", result!!.name)
     }
@@ -53,7 +54,7 @@ class TypeErlangAutoLinkTest : PlatformTestCase() {
             existing.forEach { table.removeJdk(it) }
         }
 
-        val result = Type.findRegisteredErlangSdk()
+        val result = ErlangSdkResolver.findAnyRegistered()
         assertNull("Should return null when no Erlang SDK is registered", result)
     }
 
@@ -73,7 +74,7 @@ class TypeErlangAutoLinkTest : PlatformTestCase() {
         }
         registeredSdks.add(sdkWithHome)
 
-        val result = Type.findRegisteredErlangSdk()
+        val result = ErlangSdkResolver.findAnyRegistered()
         assertNotNull("Should find the Erlang SDK with homePath", result)
         assertEquals("Erlang With Home", result!!.name)
     }
@@ -115,7 +116,7 @@ class TypeErlangAutoLinkTest : PlatformTestCase() {
         }
         registeredSdks.add(elixirSdk)
 
-        val result = Type.findRegisteredErlangSdk()
+        val result = ErlangSdkResolver.findAnyRegistered()
         assertNull("Should not return non-Erlang SDK", result)
     }
 

--- a/tests/org/elixir_lang/sdk/wsl/ElixirWslSdkTest.java
+++ b/tests/org/elixir_lang/sdk/wsl/ElixirWslSdkTest.java
@@ -370,7 +370,7 @@ public class ElixirWslSdkTest extends PlatformTestCase {
         // Test WSL path - use forward slashes which work cross-platform
         String wslPath = "//wsl$/Ubuntu/usr/lib/erlang";
         kotlin.Pair<String, String> result = captureLoggedWarning(
-                "org.elixir_lang.sdk.erlang.Type",
+                "org.elixir_lang.sdk.erlang.ErlangVersionDetector",
                 () -> erlangSdkType.suggestSdkName(null, wslPath)
         );
         String suggestedName = result.getFirst();
@@ -386,7 +386,7 @@ public class ElixirWslSdkTest extends PlatformTestCase {
         // Test local path - should NOT include WSL suffix
         String localPath = "/usr/lib/erlang";
         kotlin.Pair<String, String> localResult = captureLoggedWarning(
-                "org.elixir_lang.sdk.erlang.Type",
+                "org.elixir_lang.sdk.erlang.ErlangVersionDetector",
                 () -> erlangSdkType.suggestSdkName(null, localPath)
         );
         String localName = localResult.getFirst();
@@ -408,7 +408,7 @@ public class ElixirWslSdkTest extends PlatformTestCase {
 
         // This line emits a warning - capture it
         kotlin.Pair<String, String> result = captureLoggedWarning(
-            "org.elixir_lang.sdk.erlang.Type",
+            "org.elixir_lang.sdk.erlang.ErlangVersionDetector",
             () -> erlangSdkType.suggestSdkName(null, wslPath)
         );
         String erlangName = result.getFirst();

--- a/tests/org/elixir_lang/status_bar_widget/ElixirSdkStatusWidgetTest.kt
+++ b/tests/org/elixir_lang/status_bar_widget/ElixirSdkStatusWidgetTest.kt
@@ -11,34 +11,45 @@ import com.intellij.openapi.projectRoots.Sdk
 import com.intellij.openapi.projectRoots.impl.ProjectJdkImpl
 import com.intellij.openapi.roots.ModuleRootModificationUtil
 import com.intellij.openapi.roots.ProjectRootManager
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import org.elixir_lang.Facet
 import org.elixir_lang.PlatformTestCase
 import org.elixir_lang.facet.Type
 import org.elixir_lang.sdk.elixir.Type as ElixirSdkType
 
 /**
- * Tests for [ElixirSdkStatusWidget] detection logic.
+ * Tests for [ElixirEditorBasedSdkWidget] detection logic (notification scan methods).
  *
- * Tests scenarios from the project-sdk-fixes plan (Step 8):
- * 1. Project SDK = Java, module SDK = Elixir → no NotConfigured, no mismatch
- * 2. Project SDK = null, module SDK = Elixir → no NotConfigured
- * 3. Project SDK = Elixir A, module SDK = Elixir B → mismatch reported
- * 5. No Elixir modules → widget factory isAvailable() = false
- * 6. Small IDE: stale Facet SDK reference, Elixir SDKs exist → dangling issue
- * 7. Small IDE: Facet SDK resolves correctly → no issue
- * 8. Small IDE: stale Facet SDK reference, no Elixir SDKs in table → no dangling (NotConfigured)
+ * These tests exercise the project-wide background notification helpers directly:
+ * [ElixirEditorBasedSdkWidget.detectModuleSdkIssues] and
+ * [ElixirEditorBasedSdkWidget.findModuleLevelElixirSdk].
+ *
+ * Tests scenarios from the project-sdk-fixes plan (adapted for the new widget class):
+ * 1a. Project SDK = Java, module SDK = Elixir → no NotConfigured, no mismatch
+ * 1b. Project SDK = Java, module SDK = Elixir → no mismatch issues
+ * 2.  Project SDK = null, module SDK = Elixir → no NotConfigured
+ * 3.  Project SDK = Elixir A, module SDK = Elixir B → mismatch reported
+ * 5.  No Elixir modules → widget factory isAvailable() = false
+ * 6.  Small IDE: stale Facet SDK reference, Elixir SDKs exist → dangling issue
+ * 7.  Small IDE: Facet SDK resolves correctly → no issue
+ * 8.  Small IDE: stale Facet SDK reference, no Elixir SDKs in table → no dangling (NotConfigured)
  */
 class ElixirSdkStatusWidgetTest : PlatformTestCase() {
 
     private val addedSdks = mutableListOf<Sdk>()
+    private lateinit var testScope: CoroutineScope
 
     override fun setUp() {
         super.setUp()
+        testScope = CoroutineScope(SupervisorJob())
         ensureElixirFacet()
     }
 
     override fun tearDown() {
         try {
+            testScope.cancel("test tearDown")
             ModuleRootModificationUtil.setModuleSdk(module, null)
             WriteAction.run<Throwable> {
                 ProjectRootManager.getInstance(project).projectSdk = null
@@ -80,8 +91,6 @@ class ElixirSdkStatusWidgetTest : PlatformTestCase() {
     }
 
     private fun removeElixirFacetLibraries() {
-        // Use the Facet setter with null - this calls removeElixirSDKs() internally,
-        // which removes all Elixir SDK library entries from the module.
         val facetManager = FacetManager.getInstance(module)
         val facet = facetManager.getFacetByType(Facet.ID) ?: return
         ApplicationManager.getApplication().runWriteAction {
@@ -121,7 +130,28 @@ class ElixirSdkStatusWidgetTest : PlatformTestCase() {
         }
     }
 
-    private fun createWidget(): ElixirSdkStatusWidget = ElixirSdkStatusWidget(project)
+    private fun createWidget(): ElixirEditorBasedSdkWidget = ElixirEditorBasedSdkWidget(project, testScope)
+
+    /**
+     * Calls [ElixirEditorBasedSdkWidget.detectModuleSdkIssues] from the EDT-bound test body.
+     *
+     * [detectModuleSdkIssues] asserts it runs off the EDT.  Test methods run on the EDT, so we
+     * dispatch to a pooled background thread via [com.intellij.openapi.application.Application.executeOnPooledThread] and
+     * use the synchronous (blocking, non-suspending) [com.intellij.openapi.application.Application.runReadAction]
+     * to acquire the read lock.  [java.util.concurrent.Future.get] blocks the EDT while waiting;
+     * this is safe because there are no pending write actions at the call site, so the background
+     * thread acquires the read lock immediately without needing the EDT.
+     *
+     * Prefer this over `runBlocking { readAction { } }` on the EDT: the suspend form of
+     * `readAction` internally needs the EDT to pump events for write-action coordination, which
+     * deadlocks when the EDT is already blocked by `runBlocking`.
+     */
+    private fun ElixirEditorBasedSdkWidget.detectModuleSdkIssuesInTest(): List<ModuleSdkIssue> =
+        ApplicationManager.getApplication().executeOnPooledThread<List<ModuleSdkIssue>> {
+            ApplicationManager.getApplication().runReadAction<List<ModuleSdkIssue>> {
+                detectModuleSdkIssues()
+            }
+        }.get()
 
     // -------------------------------------------------------------------------
     // Scenario 1: Project SDK = Java, module SDK = Elixir
@@ -149,7 +179,7 @@ class ElixirSdkStatusWidgetTest : PlatformTestCase() {
         setModuleSdk(elixirSdk)
 
         val widget = createWidget()
-        val issues = widget.detectModuleSdkIssues()
+        val issues = widget.detectModuleSdkIssuesInTest()
 
         assertTrue(
             "No module SDK issues should be reported when project SDK is non-Elixir; got: $issues",
@@ -175,8 +205,7 @@ class ElixirSdkStatusWidgetTest : PlatformTestCase() {
     }
 
     // -------------------------------------------------------------------------
-    // Scenario 3: Project SDK = Elixir A, module SDK = Elixir B
-    // → mismatch reported
+    // Scenario 3: Project SDK = Elixir A, module SDK = Elixir B → mismatch reported
     // -------------------------------------------------------------------------
 
     fun testMismatchReportedWhenModuleSdkDiffersFromElixirProjectSdk() {
@@ -187,7 +216,7 @@ class ElixirSdkStatusWidgetTest : PlatformTestCase() {
         setModuleSdk(elixirSdkB)
 
         val widget = createWidget()
-        val issues = widget.detectModuleSdkIssues()
+        val issues = widget.detectModuleSdkIssuesInTest()
 
         assertTrue(
             "Expected a mismatch issue (project=Elixir 1.17, module=Elixir 1.16); got: $issues",
@@ -214,7 +243,6 @@ class ElixirSdkStatusWidgetTest : PlatformTestCase() {
     // -------------------------------------------------------------------------
 
     fun testDanglingFacetSdkReportedWhenElixirSdkExistsButFacetReferenceIsStale() {
-        // Set up: Facet references "Elixir 1.17", then remove it from the JDK table
         val staleSdk = createAndRegisterElixirSdk("Elixir 1.17")
         setFacetSdk(staleSdk)
 
@@ -229,7 +257,7 @@ class ElixirSdkStatusWidgetTest : PlatformTestCase() {
         // Do NOT call setModuleSdk() - no JdkOrderEntry, simulating Small IDE path
 
         val widget = createWidget()
-        val issues = widget.detectModuleSdkIssues()
+        val issues = widget.detectModuleSdkIssuesInTest()
 
         assertTrue(
             "Expected a dangling issue for stale Facet SDK reference; got: $issues",
@@ -246,7 +274,7 @@ class ElixirSdkStatusWidgetTest : PlatformTestCase() {
         setFacetSdk(registeredSdk)
 
         val widget = createWidget()
-        val issues = widget.detectModuleSdkIssues()
+        val issues = widget.detectModuleSdkIssuesInTest()
 
         assertTrue(
             "Expected no issues when Facet SDK resolves correctly; got: $issues",
@@ -270,7 +298,7 @@ class ElixirSdkStatusWidgetTest : PlatformTestCase() {
         assertTrue("Precondition: no Elixir SDKs in table", Facet.sdks().isEmpty())
 
         val widget = createWidget()
-        val issues = widget.detectModuleSdkIssues()
+        val issues = widget.detectModuleSdkIssuesInTest()
 
         assertTrue(
             "Expected no dangling issue when no Elixir SDKs exist (this is NotConfigured); got: $issues",
@@ -282,24 +310,7 @@ class ElixirSdkStatusWidgetTest : PlatformTestCase() {
     // Smoke tests (regression)
     // -------------------------------------------------------------------------
 
-    fun testWidgetCreation() {
-        val widget = createWidget()
-        assertNotNull(widget)
-        assertEquals(ElixirSdkStatusWidget.ID, widget.ID())
-    }
-
-    fun testWidgetComponent() {
-        val widget = createWidget()
-        val component = widget.getComponent()
-        assertNotNull("Widget should have a component", component)
-    }
-
     fun testWidgetIdConstant() {
-        assertEquals("ElixirSdkStatus", ElixirSdkStatusWidget.ID)
-    }
-
-    fun testWidgetDispose() {
-        val widget = createWidget()
-        widget.dispose()
+        assertEquals("ElixirSdkStatus", ElixirEditorBasedSdkWidget.ID)
     }
 }

--- a/tests/org/elixir_lang/status_bar_widget/ElixirSdkStatusWidgetTest.kt
+++ b/tests/org/elixir_lang/status_bar_widget/ElixirSdkStatusWidgetTest.kt
@@ -1,31 +1,297 @@
 package org.elixir_lang.status_bar_widget
 
+import com.intellij.facet.FacetManager
+import com.intellij.facet.FacetType
+import com.intellij.facet.impl.FacetUtil
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.application.WriteAction
+import com.intellij.openapi.projectRoots.ProjectJdkTable
+import com.intellij.openapi.projectRoots.SimpleJavaSdkType
+import com.intellij.openapi.projectRoots.Sdk
+import com.intellij.openapi.projectRoots.impl.ProjectJdkImpl
+import com.intellij.openapi.roots.ModuleRootModificationUtil
+import com.intellij.openapi.roots.ProjectRootManager
+import org.elixir_lang.Facet
 import org.elixir_lang.PlatformTestCase
+import org.elixir_lang.facet.Type
+import org.elixir_lang.sdk.elixir.Type as ElixirSdkType
 
 /**
- * Tests for ElixirSdkStatusWidget functionality.
+ * Tests for [ElixirSdkStatusWidget] detection logic.
+ *
+ * Tests scenarios from the project-sdk-fixes plan (Step 8):
+ * 1. Project SDK = Java, module SDK = Elixir → no NotConfigured, no mismatch
+ * 2. Project SDK = null, module SDK = Elixir → no NotConfigured
+ * 3. Project SDK = Elixir A, module SDK = Elixir B → mismatch reported
+ * 5. No Elixir modules → widget factory isAvailable() = false
+ * 6. Small IDE: stale Facet SDK reference, Elixir SDKs exist → dangling issue
+ * 7. Small IDE: Facet SDK resolves correctly → no issue
+ * 8. Small IDE: stale Facet SDK reference, no Elixir SDKs in table → no dangling (NotConfigured)
  */
 class ElixirSdkStatusWidgetTest : PlatformTestCase() {
 
+    private val addedSdks = mutableListOf<Sdk>()
+
+    override fun setUp() {
+        super.setUp()
+        ensureElixirFacet()
+    }
+
+    override fun tearDown() {
+        try {
+            ModuleRootModificationUtil.setModuleSdk(module, null)
+            WriteAction.run<Throwable> {
+                ProjectRootManager.getInstance(project).projectSdk = null
+            }
+            WriteAction.run<Throwable> {
+                val jdkTable = ProjectJdkTable.getInstance()
+                for (sdk in addedSdks) {
+                    if (jdkTable.allJdks.contains(sdk)) {
+                        jdkTable.removeJdk(sdk)
+                    }
+                }
+                addedSdks.clear()
+            }
+            removeElixirFacetLibraries()
+        } finally {
+            super.tearDown()
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private fun ensureElixirFacet() {
+        val facetManager = FacetManager.getInstance(module)
+        if (facetManager.getFacetByType(Facet.ID) == null) {
+            FacetUtil.addFacet(module, FacetType.findInstance(Type::class.java))
+        }
+    }
+
+    private fun removeElixirFacet() {
+        val facetManager = FacetManager.getInstance(module)
+        val facet = facetManager.getFacetByType(Facet.ID) ?: return
+        ApplicationManager.getApplication().runWriteAction {
+            val model = facetManager.createModifiableModel()
+            model.removeFacet(facet)
+            model.commit()
+        }
+    }
+
+    private fun removeElixirFacetLibraries() {
+        // Use the Facet setter with null - this calls removeElixirSDKs() internally,
+        // which removes all Elixir SDK library entries from the module.
+        val facetManager = FacetManager.getInstance(module)
+        val facet = facetManager.getFacetByType(Facet.ID) ?: return
+        ApplicationManager.getApplication().runWriteAction {
+            facet.sdk = null
+        }
+    }
+
+    private fun createAndRegisterElixirSdk(name: String): Sdk {
+        val sdk = ProjectJdkImpl(name, ElixirSdkType.instance)
+        WriteAction.run<Throwable> {
+            ProjectJdkTable.getInstance().addJdk(sdk)
+        }
+        addedSdks.add(sdk)
+        return sdk
+    }
+
+    private fun createJavaSdk(): Sdk {
+        val javaHome = System.getProperty("java.home") ?: "/usr/lib/jvm/java"
+        return SimpleJavaSdkType().createJdk("Java Mock", javaHome)
+    }
+
+    private fun setModuleSdk(sdk: Sdk) {
+        ModuleRootModificationUtil.setModuleSdk(module, sdk)
+    }
+
+    private fun setProjectSdk(sdk: Sdk?) {
+        WriteAction.run<Throwable> {
+            ProjectRootManager.getInstance(project).projectSdk = sdk
+        }
+    }
+
+    private fun setFacetSdk(sdk: Sdk) {
+        val facetManager = FacetManager.getInstance(module)
+        val facet = facetManager.getFacetByType(Facet.ID) ?: error("No Elixir Facet on module")
+        ApplicationManager.getApplication().runWriteAction {
+            facet.sdk = sdk
+        }
+    }
+
+    private fun createWidget(): ElixirSdkStatusWidget = ElixirSdkStatusWidget(project)
+
+    // -------------------------------------------------------------------------
+    // Scenario 1: Project SDK = Java, module SDK = Elixir
+    // -------------------------------------------------------------------------
+
+    fun testModuleElixirSdkFoundWhenProjectSdkIsJava() {
+        val elixirSdk = createAndRegisterElixirSdk("Elixir Mock")
+        val javaSdk = createJavaSdk()
+
+        setProjectSdk(javaSdk)
+        setModuleSdk(elixirSdk)
+
+        val widget = createWidget()
+        val foundSdk = widget.findModuleLevelElixirSdk()
+
+        assertNotNull("Should find Elixir SDK from module even when project SDK is Java", foundSdk)
+        assertEquals("Should return the module's Elixir SDK", elixirSdk, foundSdk)
+    }
+
+    fun testNoMismatchWhenProjectSdkIsJavaAndModuleSdkIsElixir() {
+        val elixirSdk = createAndRegisterElixirSdk("Elixir Mock")
+        val javaSdk = createJavaSdk()
+
+        setProjectSdk(javaSdk)
+        setModuleSdk(elixirSdk)
+
+        val widget = createWidget()
+        val issues = widget.detectModuleSdkIssues()
+
+        assertTrue(
+            "No module SDK issues should be reported when project SDK is non-Elixir; got: $issues",
+            issues.isEmpty()
+        )
+    }
+
+    // -------------------------------------------------------------------------
+    // Scenario 2: Project SDK = null, module SDK = Elixir
+    // -------------------------------------------------------------------------
+
+    fun testModuleElixirSdkFoundWhenProjectSdkIsNull() {
+        val elixirSdk = createAndRegisterElixirSdk("Elixir Mock")
+
+        setProjectSdk(null)
+        setModuleSdk(elixirSdk)
+
+        val widget = createWidget()
+        val foundSdk = widget.findModuleLevelElixirSdk()
+
+        assertNotNull("Should find Elixir SDK from module when project SDK is null", foundSdk)
+        assertEquals(elixirSdk, foundSdk)
+    }
+
+    // -------------------------------------------------------------------------
+    // Scenario 3: Project SDK = Elixir A, module SDK = Elixir B
+    // → mismatch reported
+    // -------------------------------------------------------------------------
+
+    fun testMismatchReportedWhenModuleSdkDiffersFromElixirProjectSdk() {
+        val elixirSdkA = createAndRegisterElixirSdk("Elixir 1.17")
+        val elixirSdkB = createAndRegisterElixirSdk("Elixir 1.16")
+
+        setProjectSdk(elixirSdkA)
+        setModuleSdk(elixirSdkB)
+
+        val widget = createWidget()
+        val issues = widget.detectModuleSdkIssues()
+
+        assertTrue(
+            "Expected a mismatch issue (project=Elixir 1.17, module=Elixir 1.16); got: $issues",
+            issues.any { !it.isDangling && it.moduleName == module.name }
+        )
+    }
+
+    // -------------------------------------------------------------------------
+    // Scenario 5: No Elixir modules → widget factory isAvailable = false
+    // -------------------------------------------------------------------------
+
+    fun testWidgetFactoryNotAvailableWhenNoElixirModules() {
+        removeElixirFacet()
+
+        val factory = ElixirSdkStatusWidgetFactory()
+        assertFalse(
+            "Widget should not be available when the project has no Elixir modules",
+            factory.isAvailable(project)
+        )
+    }
+
+    // -------------------------------------------------------------------------
+    // Scenario 6: Small IDE - stale Facet SDK, SDKs exist → dangling issue
+    // -------------------------------------------------------------------------
+
+    fun testDanglingFacetSdkReportedWhenElixirSdkExistsButFacetReferenceIsStale() {
+        // Set up: Facet references "Elixir 1.17", then remove it from the JDK table
+        val staleSdk = createAndRegisterElixirSdk("Elixir 1.17")
+        setFacetSdk(staleSdk)
+
+        WriteAction.run<Throwable> {
+            ProjectJdkTable.getInstance().removeJdk(staleSdk)
+        }
+        addedSdks.remove(staleSdk)
+
+        // Register a different SDK so Facet.sdks().isNotEmpty() → stale (not NotConfigured)
+        createAndRegisterElixirSdk("Elixir 1.18")
+
+        // Do NOT call setModuleSdk() - no JdkOrderEntry, simulating Small IDE path
+
+        val widget = createWidget()
+        val issues = widget.detectModuleSdkIssues()
+
+        assertTrue(
+            "Expected a dangling issue for stale Facet SDK reference; got: $issues",
+            issues.any { it.isDangling && it.moduleName == module.name }
+        )
+    }
+
+    // -------------------------------------------------------------------------
+    // Scenario 7: Small IDE - Facet SDK resolves correctly → no issue
+    // -------------------------------------------------------------------------
+
+    fun testNoDanglingWhenFacetSdkResolvesCorrectly() {
+        val registeredSdk = createAndRegisterElixirSdk("Elixir 1.17")
+        setFacetSdk(registeredSdk)
+
+        val widget = createWidget()
+        val issues = widget.detectModuleSdkIssues()
+
+        assertTrue(
+            "Expected no issues when Facet SDK resolves correctly; got: $issues",
+            issues.isEmpty()
+        )
+    }
+
+    // -------------------------------------------------------------------------
+    // Scenario 8: Small IDE - stale Facet SDK, NO Elixir SDKs in table → no dangling
+    // -------------------------------------------------------------------------
+
+    fun testNoDanglingWhenNoElixirSdksExistInTable() {
+        val sdk = createAndRegisterElixirSdk("Elixir 1.17")
+        setFacetSdk(sdk)
+
+        WriteAction.run<Throwable> {
+            ProjectJdkTable.getInstance().removeJdk(sdk)
+        }
+        addedSdks.remove(sdk)
+
+        assertTrue("Precondition: no Elixir SDKs in table", Facet.sdks().isEmpty())
+
+        val widget = createWidget()
+        val issues = widget.detectModuleSdkIssues()
+
+        assertTrue(
+            "Expected no dangling issue when no Elixir SDKs exist (this is NotConfigured); got: $issues",
+            issues.isEmpty()
+        )
+    }
+
+    // -------------------------------------------------------------------------
+    // Smoke tests (regression)
+    // -------------------------------------------------------------------------
+
     fun testWidgetCreation() {
-        val widget = ElixirSdkStatusWidget(project)
+        val widget = createWidget()
         assertNotNull(widget)
         assertEquals(ElixirSdkStatusWidget.ID, widget.ID())
     }
 
     fun testWidgetComponent() {
-        val widget = ElixirSdkStatusWidget(project)
+        val widget = createWidget()
         val component = widget.getComponent()
         assertNotNull("Widget should have a component", component)
-    }
-
-    fun testWidgetComponentTextWithNoSdk() {
-        val widget = ElixirSdkStatusWidget(project)
-        val component = widget.getComponent()
-
-        // The component is a TextPanel.WithIconAndArrows
-        // When no SDK is configured, should show "No Elixir SDK"
-        assertNotNull(component)
     }
 
     fun testWidgetIdConstant() {
@@ -33,8 +299,7 @@ class ElixirSdkStatusWidgetTest : PlatformTestCase() {
     }
 
     fun testWidgetDispose() {
-        val widget = ElixirSdkStatusWidget(project)
-        // Should not throw
+        val widget = createWidget()
         widget.dispose()
     }
 }


### PR DESCRIPTION
### Summary

Splits the oversized `Type.kt` files (Elixir and Erlang `SdkType` companions) into focused single-responsibility objects and fixes three independent bugs in the New Project Wizard that left projects with a misconfigured Elixir SDK after creation. Stacked on #3842.

### Bug Fixes

**New Project Wizard produces an unconfigured Elixir SDK** — Creating a new Elixir project through the wizard appeared to succeed, but the project opened with no Erlang SDK linked, making it unable to resolve dependencies or compile. Three defects were responsible:

1. **No-op `newSdkCallback`**: `createSdkComboBox` was passed a no-op callback. After `setupSdkPaths` completed, the new SDK was never added to the `ProjectSdksModel` or selected in the combo box. Replaced with a callback that handles both the cancel case (removes incomplete SDK, clears selection) and the success case (adds SDK to model, stores Erlang SDK reference for `setupProject`).
2. **Modality mismatch with `edtWriteAction`**: `registerErlangSdk` now delegates to `SdkRegistrar.registerOrUpdateErlangSdk`, which uses `edtWriteAction`. Unlike `invokeAndWait`, `edtWriteAction` defaults to `ModalityState.nonModal()` — but IntelliJ runs `setupSdkPaths` inside a 'Configuring SDK...' modal whose event loop doesn't process non-modal tasks. Fixed by capturing `ModalityState.defaultModalityState()` on the ProgressManager background thread and passing it as a coroutine context element.

3. **Workspace-model sync wipes newly registered SDKs**: `JpsGlobalModelSynchronizerImpl` overwrites `ProjectJdkTable` ~5s after IDE start using a snapshot captured *before* the wizard ran. SDKs registered during setup are absent from that snapshot and get wiped before `setupProject` executes. Fixed by re-adding both SDKs inside a `runWriteAction` at the start of `setupProject`.

### Refactoring

Extracts the following focused objects from the monolithic `Type.kt` files:

| New file | Responsibility |
|---|---|
| `ElixirErlangClasspath` | Erlang classpath add/remove operations |
| `ElixirSdkPathConfigurator` | SDK path setup during `setupSdkPaths` |
| `ElixirVersionDetector` | Elixir version detection and caching |
| `ElixirBuildInfo` | BEAM file parsing for OTP release detection |
| `ElixirSdkLookup` | PSI/module/project SDK accessors |
| `ElixirInternalErlangSdkSetup` | Wizard-driven Erlang SDK linking/prompting |
| `ErlangVersionDetector` | Erlang version detection (file-based, no subprocess) |
| `ErlangSdkTableListener` | JDK table lifecycle listener |
| `ErlangSdkResolver` | `findAnyRegistered` moved here |
| `ProgressUtils` | `runWithEdtGuard` threading utility (moved from `SdkProcessUtils`) |

Additionally:

- `SdkRegistrar.prepareErlangSdk()` extracted as shared helper used by both the suspend (`registerOrUpdateErlangSdk`) and synchronous (`registerErlangSdk`) registration paths, eliminating duplicated `ProjectJdkImpl` construction and giving the EDT path home-path dedup it previously lacked.
- `ElixirInternalErlangSdkSetup.promptForMiseErlangSdk` replaced `showChooseDialog` with `showEditableChooseDialog` + `InputValidator` so that cancelling the Erlang SDK picker no longer accidentally selects a valid entry.

- Removed the 'Please save settings and reopen this dialog' info message and `SKIP_ERLANG_SETTINGS_HINT_KEY` — no longer needed with the corrected flow.

### Testing

- `TypeErlangAutoLinkTest` updated for extracted call sites.
- `mockSdk` test helper switched from a custom mock to `ProjectJdkImpl` for better coverage.
- Linter warnings fixed.

### Validation

Validated the wizard flow end-to-end:

- Create new Elixir project -> SDK combo box populates -> Erlang SDK selected via mise dialog -> `mix new` succeeds -> project opens with correctly linked Elixir + Erlang SDKs.
- Cancel Erlang SDK dialog -> combo box clears to 'No SDK' -> wizard blocks with validation error.
- Workspace-model sync fires after SDK registration -> `setupProject` re-adds SDKs -> `mix new` resolves Elixir correctly.

## Fixes

- Closes #3655 — "Forbidden to mutate SDK outside of the `SdkModificator`": the exact code path (`Type.configureInternalErlangSdk` → `createDefaultErlangSdk` → `setHomePath`) is replaced by `ElixirInternalErlangSdkSetup` which uses the proper `SdkModificator` pattern and `WriteActions` helpers throughout.
- Fixes #3666 — `java.io.IOException` at `Step.setupProject`: wizard SDK registration now correctly commits both Elixir and Erlang SDKs before `setupProject` runs, including a re-registration guard for the `JpsGlobalModelSynchronizer` wipe race.
- Fixes #3669 — "Create new Elixir project not working when adding SDK": the `newSdkCallback` now properly adds the new SDK to `ProjectSdksModel` and stores the Erlang SDK reference for `setupProject`, fixing the no-op that left projects with no linked SDK after wizard completion.
- Relates to #3715 — Can't add Erlang SDK: `ElixirSdkPathConfigurator` now correctly guards the `removeJdk` path and `SdkRegistrar.prepareErlangSdk` deduplicates by home path on the EDT registration path.

