### PR TITLE
fix(sdk): stable Elixir SDK variant identity keyed on Erlang home path

### DIFF
--- a/src/org/elixir_lang/formatter/MixFormatFormattingService.kt
+++ b/src/org/elixir_lang/formatter/MixFormatFormattingService.kt
@@ -8,7 +8,7 @@ import com.intellij.execution.process.ProcessEvent
 import com.intellij.formatting.service.AsyncDocumentFormattingService
 import com.intellij.formatting.service.AsyncFormattingRequest
 import com.intellij.formatting.service.FormattingService.Feature
-import com.intellij.openapi.application.runReadAction
+import com.intellij.openapi.application.ReadAction
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.roots.ProjectRootManager
 import com.intellij.openapi.util.text.StringUtil
@@ -21,6 +21,7 @@ import org.elixir_lang.psi.ElixirFile
 import org.elixir_lang.sdk.elixir.ElixirSdkLookup.mostSpecificSdk
 import java.io.FileNotFoundException
 import java.nio.charset.StandardCharsets
+import java.util.concurrent.Callable
 
 class MixFormatFormattingService : AsyncDocumentFormattingService() {
 
@@ -40,7 +41,7 @@ class MixFormatFormattingService : AsyncDocumentFormattingService() {
         val project = formattingContext.project
 
         val workingDirectory = workingDirectory(psiFile) ?: return null
-        val sdk = mostSpecificSdk(psiFile)?.takeIf(::elixirSdkHasErlangSdk) ?: return null
+        val sdk = ReadAction.nonBlocking(Callable { mostSpecificSdk(psiFile)?.takeIf(::elixirSdkHasErlangSdk) }).executeSynchronously() ?: return null
 
         // Build the command line in createFormattingTask() (must be fast and EDT-safe;
         // in sync/headless mode may still run on caller thread). Defer OSProcessHandler
@@ -118,7 +119,7 @@ class MixFormatFormattingService : AsyncDocumentFormattingService() {
 }
 
 private fun workingDirectory(psiFile: PsiFile): String? =
-    runReadAction<String?> {
+    ReadAction.nonBlocking(Callable<String?> {
         psiFile
             .virtualFile
             ?.let { virtualFile ->
@@ -131,7 +132,7 @@ private fun workingDirectory(psiFile: PsiFile): String? =
                 contentRoot.findChild(MixProject.MIX_EXS) != null
             }
             ?.path
-    }
+    }).executeSynchronously()
 
 /**
  * Wraps a plain-text error message in HTML suitable for an IntelliJ notification balloon.

--- a/src/org/elixir_lang/notification/mix_deps/InstallAction.kt
+++ b/src/org/elixir_lang/notification/mix_deps/InstallAction.kt
@@ -9,15 +9,15 @@ import org.elixir_lang.notification.setup_sdk.Notifier
 
 class InstallAction() : NotificationAction("Install deps") {
     override fun actionPerformed(e: AnActionEvent, notification: Notification) {
+        val action = ActionManager.getInstance().getAction("Elixir.InstallMixDependencies")
+        if (action != null) {
+            ActionUtil.performAction(action, e)
+        }
         val project = e.project
         if (project != null) {
             Notifier.clearMixDepsOutdated(project)
         } else {
             notification.expire()
-        }
-        val action = ActionManager.getInstance().getAction("Elixir.InstallMixDependencies")
-        if (action != null) {
-            ActionUtil.performAction(action, e)
         }
     }
 }

--- a/src/org/elixir_lang/sdk/SdkRegistrar.kt
+++ b/src/org/elixir_lang/sdk/SdkRegistrar.kt
@@ -1,49 +1,52 @@
 package org.elixir_lang.sdk
 
 import com.intellij.openapi.application.edtWriteAction
+import com.intellij.openapi.application.readAction
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.projectRoots.ProjectJdkTable
 import com.intellij.openapi.projectRoots.Sdk
-import com.intellij.openapi.projectRoots.SdkType
+import com.intellij.openapi.projectRoots.SdkTypeId
 import com.intellij.openapi.projectRoots.impl.ProjectJdkImpl
+import com.intellij.util.concurrency.ThreadingAssertions
+import com.intellij.util.concurrency.annotations.RequiresBackgroundThread
+import com.intellij.util.concurrency.annotations.RequiresWriteLock
+import org.elixir_lang.sdk.elixir.ElixirBuildInfo
+import org.elixir_lang.sdk.erlang.ErlangVersionDetector
+import org.elixir_lang.sdk.erlang_dependent.SdkAdditionalData
 import org.elixir_lang.sdk.erlang_dependent.resolveErlangSdkOrNullAndNotify
 import org.elixir_lang.sdk.wsl.wslCompat
 import org.elixir_lang.sdk.elixir.Type as ElixirSdkType
 import org.elixir_lang.sdk.erlang.Type as ErlangSdkType
 import org.elixir_lang.sdk.erlang_dependent.Type as ErlangDependentType
 
-/** Holds the pre-computed parts for registering or updating an Erlang SDK. */
-internal data class ErlangSdkPreparation(
-    val existing: Sdk?,
-    val template: ProjectJdkImpl,
-)
-
 object SdkRegistrar {
     /**
-     * Canonicalises [homePath], resolves the version string and SDK name, and looks up any
-     * already-registered SDK at that home. Returns null if the path or version cannot be resolved.
+     * Canonicalises [homePath], resolves the version string and SDK name, and builds an SDK
+     * template for registration. Returns null if the path or version cannot be resolved.
      * Shared by both the suspend ([registerOrUpdateErlangSdk]) and synchronous
      * ([org.elixir_lang.sdk.elixir.ElixirInternalErlangSdkSetup.registerErlangSdk]) registration paths.
      */
-    internal fun prepareErlangSdk(homePath: String, resolvedVersion: String? = null): ErlangSdkPreparation? {
+    internal fun prepareErlangSdk(homePath: String, resolvedVersion: String? = null): ProjectJdkImpl? {
         val canonicalHomePath = canonicalHomePath(homePath) ?: return null
         val sdkType = ErlangSdkType.instance
         val versionString = ErlangSdkType.versionStringForHome(canonicalHomePath, resolvedVersion) ?: return null
         val sdkName = ErlangSdkType.suggestSdkNameForHome(canonicalHomePath, resolvedVersion)
-        val existing = findSdkByHomePath(sdkType, canonicalHomePath)
-        return ErlangSdkPreparation(existing, ProjectJdkImpl(sdkName, sdkType, canonicalHomePath, versionString))
+        return ProjectJdkImpl(sdkName, sdkType, canonicalHomePath, versionString)
     }
 
     suspend fun registerOrUpdateErlangSdk(
         homePath: String,
         resolvedVersion: String? = null,
     ): Sdk? {
-        val prep = prepareErlangSdk(homePath, resolvedVersion) ?: return null
-        val registeredSdk = registerOrUpdate(prep.existing, prep.template)
+        val template = prepareErlangSdk(homePath, resolvedVersion) ?: return null
+        val registeredSdk = edtWriteAction {
+            registerOrUpdatePreparedErlangSdk(template, ProjectJdkTable.getInstance())
+        }
         ErlangSdkType.instance.setupSdkPaths(registeredSdk)
         return registeredSdk
     }
 
+    @RequiresBackgroundThread
     suspend fun registerOrUpdateElixirSdk(
         homePath: String,
         erlangSdk: Sdk?,
@@ -52,41 +55,168 @@ object SdkRegistrar {
     ): Sdk? {
         val canonicalHomePath = canonicalHomePath(homePath) ?: return null
         val sdkType = ElixirSdkType.instance
+
+        // Derive compiled-against OTP major from Elixir.System.beam - no subprocess
+        val otpMajor = ElixirBuildInfo.elixirOtpRelease(canonicalHomePath)
+
+        // Fast path: confirmed exact match - erlangSdkHomePath is persisted and Erlang home matches.
+        // Capture whether erlangSdkName is stale in the same read action as the lookup so we can
+        // sync it under a write action without an extra round-trip.
+        // Both allJdks access and sdkAdditionalData reads require a read lock.
+        val confirmedResult: Pair<Sdk, Boolean>? = readAction {
+            val sdk = findElixirSdkByVariant(canonicalHomePath, erlangSdk)?.takeIf {
+                (it.sdkAdditionalData as? SdkAdditionalData)?.getErlangSdkHomePath() != null
+            } ?: return@readAction null
+            val nameStale = (sdk.sdkAdditionalData as? SdkAdditionalData)?.getErlangSdkName() != erlangSdk?.name
+            sdk to nameStale
+        }
+        if (confirmedResult != null) {
+            val (confirmedExisting, nameIsStale) = confirmedResult
+            // Sync stale erlangSdkName under a write action when the Erlang SDK was renamed after
+            // pairing. Home path still matches, so no re-registration is needed.
+            if (nameIsStale && erlangSdk != null) {
+                edtWriteAction {
+                    val modificator = confirmedExisting.sdkModificator
+                    val existingData = (modificator.sdkAdditionalData as? SdkAdditionalData)
+                        ?: (confirmedExisting.sdkAdditionalData as? SdkAdditionalData)
+                    existingData?.setErlangSdk(erlangSdk)
+                    existingData?.let { modificator.sdkAdditionalData = it }
+                    modificator.commitChanges()
+                }
+            }
+            return confirmedExisting
+        }
+
+        // Slow path: no confirmed match. Re-check under a read lock for a legacy SDK (present but
+        // missing persisted erlangSdkHomePath) so we can update it in place rather than duplicating.
+        val existing = readAction { findElixirSdkByVariant(canonicalHomePath, erlangSdk) }
+
+        // Compute version/name only when a write will be needed (new SDK or legacy update).
+        val erlangFullVersion = erlangSdk?.homePath?.let {
+            ErlangVersionDetector.detectRelease(it)?.otpVersion
+        }
         val versionString = ElixirSdkType.versionStringForHome(canonicalHomePath, resolvedVersion) ?: return null
-        val existing = findSdkByHomePath(sdkType, canonicalHomePath)
-        val sdkName = ElixirSdkType.suggestSdkNameForHome(canonicalHomePath, resolvedVersion)
+        val sdkName =
+                ElixirSdkType.suggestSdkNameForHome(canonicalHomePath, resolvedVersion, otpMajor, erlangFullVersion)
 
-        val updatedSdk = ProjectJdkImpl(sdkName, sdkType, canonicalHomePath, versionString)
-        val registeredSdk = registerOrUpdate(existing, updatedSdk)
+        // Perform SDK registration + Erlang attachment atomically so the SDK is never visible
+        // in a half-configured state (added to table but Erlang dependency not yet attached).
+        val registeredSdk = edtWriteAction {
+            val table = ProjectJdkTable.getInstance()
+            val updatedSdk = ProjectJdkImpl(sdkName, sdkType, canonicalHomePath, versionString)
+            // Legacy SDK matched (erlangSdkHomePath not yet persisted) is updated in-place via
+            // registerOrUpdate rather than creating a duplicate.
+            val sdk = registerOrUpdate(existing, updatedSdk, table)
 
-        ErlangDependentType.attachErlangDependency(registeredSdk, erlangSdk)
+            // Attach Erlang dependency - done inside the same write action for atomicity
+            sdk.putUserData(ElixirBuildInfo.ELIXIR_OTP_MAJOR_KEY, otpMajor)
+            val modificator = sdk.sdkModificator
+            val existingData = (modificator.sdkAdditionalData as? SdkAdditionalData)
+                ?: (sdk.sdkAdditionalData as? SdkAdditionalData)
+            if (existingData != null) {
+                // Preserve an existing Erlang pairing when no specific Erlang SDK was requested.
+                // setErlangSdk(null) would silently clear a valid pairing on a legacy SDK that
+                // matched via the null-requestedHome (branch 1) path in sameErlangHome.
+                if (erlangSdk != null || existingData.getErlangSdkName() == null) {
+                    existingData.setErlangSdk(erlangSdk)
+                }
+                modificator.sdkAdditionalData = existingData
+            } else {
+                modificator.sdkAdditionalData = SdkAdditionalData(erlangSdk, sdk)
+            }
+            modificator.commitChanges()
+            sdk.putUserData(ErlangDependentType.ERLANG_SDK_KEY, erlangSdk)
+            sdk
+        }
 
         registeredSdk.resolveErlangSdkOrNullAndNotify(sdkModel = null, project = project)
-
         sdkType.setupSdkPaths(registeredSdk)
         return registeredSdk
     }
 
     private fun canonicalHomePath(homePath: String?): String? =
-        wslCompat.canonicalizePathNullable(homePath)
+            wslCompat.canonicalizePathNullable(homePath)
 
-    private fun findSdkByHomePath(sdkType: SdkType, homePath: String): Sdk? {
-        val projectJdkTable = ProjectJdkTable.getInstance()
-        return projectJdkTable.allJdks.firstOrNull { sdk ->
+    private fun findSdkByHomePath(sdkType: SdkTypeId, homePath: String, table: ProjectJdkTable): Sdk? {
+        ThreadingAssertions.assertReadAccess()
+        return table.allJdks.firstOrNull { sdk ->
             sdk.sdkType == sdkType && wslCompat.pathsEqualWslAware(sdk.homePath, homePath)
         }
     }
 
-    private suspend fun registerOrUpdate(existing: Sdk?, updatedSdk: Sdk): Sdk {
-        return edtWriteAction {
-            val table = ProjectJdkTable.getInstance()
-            if (existing == null) {
-                table.addJdk(updatedSdk)
-                updatedSdk
-            } else {
-                table.updateJdk(existing, updatedSdk)
-                existing
-            }
+    @RequiresWriteLock
+    internal fun registerOrUpdatePreparedErlangSdk(
+        template: ProjectJdkImpl,
+        table: ProjectJdkTable,
+    ): Sdk {
+        ThreadingAssertions.assertWriteAccess()
+        val homePath = template.homePath
+            ?: return registerOrUpdate(null, template, table)
+        val existing = findSdkByHomePath(template.sdkType, homePath, table)
+        return registerOrUpdate(existing, template, table)
+    }
+
+    @RequiresWriteLock
+    private fun registerOrUpdate(
+        existing: Sdk?,
+        updatedSdk: Sdk,
+        table: ProjectJdkTable,
+    ): Sdk {
+        ThreadingAssertions.assertWriteAccess()
+
+        return if (existing == null) {
+            table.addJdk(updatedSdk)
+            updatedSdk
+        } else {
+            table.updateJdk(existing, updatedSdk)
+            existing
+        }
+    }
+
+    /**
+     * Finds an existing Elixir SDK that matches the given home path AND Erlang home path
+     * (via [sameErlangHome]).
+     *
+     * Variant identity is `(elixirHomePath, erlangSdkHomePath)`. A given Elixir home path
+     * physically determines its compiled-against OTP major (only one OTP build can exist at a
+     * path), so no separate OTP-major check is required. Two projects can share the same Elixir
+     * install path but be paired with different Erlang SDK patch versions (e.g. 24.1.2.3 vs
+     * 24.5.6.7); [sameErlangHome] distinguishes those as separate variants.
+     *
+     * [sameErlangHome] treats legacy SDKs (no persisted `erlangSdkHomePath`, but a name is stored)
+     * as name-consistent matches: the stored Erlang SDK name must equal the requested SDK's name.
+     * The caller distinguishes confirmed vs. legacy matches by checking whether `erlangSdkHomePath`
+     * is non-null on the returned SDK.
+     *
+     * Returns the first match, or null if none exists.
+     */
+    private fun findElixirSdkByVariant(homePath: String, erlangSdk: Sdk?): Sdk? {
+        ThreadingAssertions.assertReadAccess()
+        val table = ProjectJdkTable.getInstance()
+        return table.allJdks.firstOrNull { sdk ->
+            sdk.sdkType is ElixirSdkType
+                    && wslCompat.pathsEqualWslAware(sdk.homePath, homePath)
+                    && sameErlangHome(sdk, erlangSdk)
+        }
+    }
+
+    private fun sameErlangHome(sdk: Sdk, erlangSdk: Sdk?): Boolean {
+        val additionalData = sdk.sdkAdditionalData as? SdkAdditionalData
+        val persistedHome = additionalData?.getErlangSdkHomePath()
+        val requestedHome = erlangSdk?.homePath
+        return when {
+            persistedHome == null && requestedHome == null -> true
+            // Legacy SDK: home path not yet persisted but a name is stored. Require the stored
+            // name to match the requested SDK's name - this prevents an Elixir SDK already paired
+            // with Erlang 24 from absorbing a registration request for Erlang 25, which would
+            // recreate the variant-collapse bug Problem 5 fixed for modern (home-path-persisted)
+            // SDKs. Branch 1 already handles the erlangSdk == null case (requestedHome == null),
+            // so when this branch is evaluated, erlangSdk is always non-null.
+            persistedHome == null && additionalData?.getErlangSdkName() != null ->
+                additionalData.getErlangSdkName() == erlangSdk?.name
+
+            persistedHome == null || requestedHome == null -> false
+            else -> wslCompat.pathsEqualWslAware(persistedHome, requestedHome)
         }
     }
 }

--- a/src/org/elixir_lang/sdk/elixir/ElixirBuildInfo.kt
+++ b/src/org/elixir_lang/sdk/elixir/ElixirBuildInfo.kt
@@ -1,0 +1,87 @@
+package org.elixir_lang.sdk.elixir
+
+import com.ericsson.otp.erlang.OtpErlangBinary
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.util.Key
+import com.intellij.util.concurrency.ThreadingAssertions
+import org.elixir_lang.beam.Beam
+import java.io.File
+import org.elixir_lang.beam.chunk.code.operation.Code as OpCode
+import org.elixir_lang.beam.term.Atom as BeamAtom
+import org.elixir_lang.beam.term.List as BeamList
+import org.elixir_lang.beam.term.Literal as BeamLiteral
+
+/**
+ * Reads build metadata directly from compiled BEAM artifacts in an Elixir SDK home.
+ *
+ * Currently used to extract which OTP release a given Elixir SDK was compiled against,
+ * by parsing the otp_release key from the build_info/0 literal map in Elixir.System.beam.
+ */
+object ElixirBuildInfo {
+    private val LOG = Logger.getInstance(ElixirBuildInfo::class.java)
+
+    /**
+     * UserData key for caching the compiled-against OTP major on a [com.intellij.openapi.projectRoots.Sdk]
+     * instance. E.g. `"26"`. Set during SDK registration; never re-computed from EDT.
+     */
+    val ELIXIR_OTP_MAJOR_KEY: Key<String> = Key.create("ELIXIR_OTP_MAJOR")
+
+    /**
+     * Extracts the compiled-against OTP release from `Elixir.System.beam`'s `build_info/0`
+     * function literal map (the `otp_release` key).
+     *
+     * Returns the OTP major version string (e.g. `"26"`) or `null` if the BEAM file is
+     * absent, cannot be parsed, or does not contain the expected map structure.
+     *
+     * Must be called with a canonical (WSL-resolved) home path.
+     *
+     * Must NOT be called on the EDT - reads a ~40KB BEAM file via [File.readBytes].
+     * On WSL UNC paths (`\\wsl.localhost\...`) this goes through the Plan 9 filesystem
+     * redirector and can take 50–200 ms. Use [org.elixir_lang.sdk.runWithEdtGuard] when
+     * calling from code paths that may be invoked on the EDT (e.g. `suggestSdkName`).
+     */
+    fun elixirOtpRelease(canonicalHome: String): String? {
+        ThreadingAssertions.assertBackgroundThread()
+        return try {
+            val beamFile = File(canonicalHome, "lib/elixir/ebin/Elixir.System.beam")
+            if (!beamFile.exists()) return null
+            val beam = Beam.from(beamFile.readBytes(), beamFile.path) ?: return null
+            val atoms = beam.atoms() ?: return null
+            val code = beam.code() ?: return null
+            val literals = beam.literals() ?: return null
+
+            val buildInfoIndex = (1..atoms.size()).firstOrNull { atoms.getOrNull(it)?.string == "build_info" } ?: return null
+            val otpReleaseIndex = (1..atoms.size()).firstOrNull { atoms.getOrNull(it)?.string == "otp_release" } ?: return null
+
+            var inBuildInfo = false
+            for (i in 0 until code.size()) {
+                val op = code[i]
+                when (op.code) {
+                    OpCode.FUNC_INFO -> {
+                        val func = op.termList.getOrNull(1) as? BeamAtom
+                        val arity = op.termList.getOrNull(2) as? BeamLiteral
+                        inBuildInfo = func?.index == buildInfoIndex && arity?.index == 0
+                    }
+                    OpCode.PUT_MAP_ASSOC, OpCode.PUT_MAP_EXACT -> {
+                        if (!inBuildInfo) continue
+                        val elements = (op.termList.getOrNull(4) as? BeamList)?.elements ?: continue
+                        var j = 0
+                        while (j < elements.size - 1) {
+                            if ((elements[j] as? BeamAtom)?.index == otpReleaseIndex) {
+                                val litIndex = (elements[j + 1] as? BeamLiteral)?.index ?: break
+                                return (literals[litIndex] as? OtpErlangBinary)
+                                    ?.let { String(it.binaryValue(), Charsets.UTF_8).trim() }
+                            }
+                            j += 2
+                        }
+                    }
+                    else -> {}
+                }
+            }
+            null
+        } catch (e: Exception) {
+            LOG.debug("Could not read otp_release from Elixir.System.beam in $canonicalHome", e)
+            null
+        }
+    }
+}

--- a/src/org/elixir_lang/sdk/elixir/ElixirInternalErlangSdkSetup.kt
+++ b/src/org/elixir_lang/sdk/elixir/ElixirInternalErlangSdkSetup.kt
@@ -161,15 +161,14 @@ object ElixirInternalErlangSdkSetup {
      * Reuses an already-registered SDK at the same home path rather than creating a duplicate.
      */
     internal fun registerErlangSdk(homePath: String): Sdk? {
-        val prep = SdkRegistrar.prepareErlangSdk(homePath) ?: return null
-        val sdk = if (prep.existing != null) {
-            prep.existing
-        } else {
-            WriteActions.runWriteAction { ProjectJdkTable.getInstance().addJdk(prep.template) }
-            prep.template
+        val template = SdkRegistrar.prepareErlangSdk(homePath) ?: return null
+        var sdk: Sdk? = null
+        WriteActions.runWriteAction {
+            sdk = SdkRegistrar.registerOrUpdatePreparedErlangSdk(template, ProjectJdkTable.getInstance())
         }
-        ErlangSdkType.instance.setupSdkPaths(sdk)
-        LOG.info("${if (prep.existing != null) "Reused" else "Registered"} Erlang SDK '${sdk.name}' from ${sdk.homePath}")
-        return sdk
+        val resolvedSdk = sdk ?: return null
+        ErlangSdkType.instance.setupSdkPaths(resolvedSdk)
+        LOG.info("${if (resolvedSdk === template) "Registered" else "Reused"} Erlang SDK '${resolvedSdk.name}' from ${resolvedSdk.homePath}")
+        return resolvedSdk
     }
 }

--- a/src/org/elixir_lang/sdk/elixir/ElixirSdkLookup.kt
+++ b/src/org/elixir_lang/sdk/elixir/ElixirSdkLookup.kt
@@ -1,7 +1,6 @@
 package org.elixir_lang.sdk.elixir
 
 import com.intellij.facet.FacetManager
-import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.module.Module
 import com.intellij.openapi.module.ModuleUtilCore
 import com.intellij.openapi.project.Project
@@ -9,11 +8,25 @@ import com.intellij.openapi.projectRoots.Sdk
 import com.intellij.openapi.roots.ModuleRootManager
 import com.intellij.openapi.roots.ProjectRootManager
 import com.intellij.psi.PsiElement
+import com.intellij.util.concurrency.ThreadingAssertions
+import com.intellij.util.concurrency.annotations.RequiresReadLock
 import org.elixir_lang.Facet
 
+/**
+ * Resolves the most specific Elixir SDK for a given [Module], [Project], or [PsiElement].
+ *
+ * All overloads require a read lock ([RequiresReadLock]). Callers that are not already inside
+ * a platform-provided read action (e.g. formatting service callbacks) must acquire one
+ * explicitly via [com.intellij.openapi.application.ReadAction.nonBlocking].
+ *
+ * Resolution order for [Module]: Facet SDK → module SDK → project SDK.
+ */
 object ElixirSdkLookup {
     private val LOG = com.intellij.openapi.diagnostic.logger<ElixirSdkLookup>()
+
+    @RequiresReadLock
     fun mostSpecificSdk(module: Module): Sdk? {
+        ThreadingAssertions.assertReadAccess()
         val facetSdk = FacetManager.getInstance(module).getFacetByType(Facet.ID)?.sdk
         if (facetSdk != null) {
             LOG.trace("ElixirSdkLookup.mostSpecificSdk(module='${module.name}'): resolved from Facet → '${facetSdk.name}'")
@@ -30,18 +43,23 @@ object ElixirSdkLookup {
         LOG.trace("ElixirSdkLookup.mostSpecificSdk(module='${module.name}'): fell through to project SDK → '${projSdk?.name}'")
         return projSdk
     }
+
+    @RequiresReadLock
     fun mostSpecificSdk(psiElement: PsiElement): Sdk? {
+        ThreadingAssertions.assertReadAccess()
         val project = psiElement.project
         if (project.isDisposed) return null
 
-        val module = ApplicationManager.getApplication().runReadAction<Module?> {
-            ModuleUtilCore.findModuleForPsiElement(psiElement)
-        }
+        val module = ModuleUtilCore.findModuleForPsiElement(psiElement)
 
         return if (module != null) mostSpecificSdk(module) else mostSpecificSdk(project)
     }
 
-    fun mostSpecificSdk(project: Project): Sdk? = projectSdk(project)
+    @RequiresReadLock
+    fun mostSpecificSdk(project: Project): Sdk? {
+        ThreadingAssertions.assertReadAccess()
+        return projectSdk(project)
+    }
 
     private fun moduleSdk(module: Module): Sdk? {
         val raw = ModuleRootManager.getInstance(module).sdk

--- a/src/org/elixir_lang/sdk/elixir/ElixirSdkLookup.kt
+++ b/src/org/elixir_lang/sdk/elixir/ElixirSdkLookup.kt
@@ -12,11 +12,24 @@ import com.intellij.psi.PsiElement
 import org.elixir_lang.Facet
 
 object ElixirSdkLookup {
-    fun mostSpecificSdk(module: Module): Sdk? =
-        FacetManager.getInstance(module).getFacetByType(Facet.ID)?.sdk
-            ?: moduleSdk(module)
-            ?: mostSpecificSdk(module.project)
+    private val LOG = com.intellij.openapi.diagnostic.logger<ElixirSdkLookup>()
+    fun mostSpecificSdk(module: Module): Sdk? {
+        val facetSdk = FacetManager.getInstance(module).getFacetByType(Facet.ID)?.sdk
+        if (facetSdk != null) {
+            LOG.trace("ElixirSdkLookup.mostSpecificSdk(module='${module.name}'): resolved from Facet → '${facetSdk.name}'")
+            return facetSdk
+        }
 
+        val modSdk = moduleSdk(module)
+        if (modSdk != null) {
+            LOG.trace("ElixirSdkLookup.mostSpecificSdk(module='${module.name}'): resolved from ModuleRootManager → '${modSdk.name}'")
+            return modSdk
+        }
+
+        val projSdk = mostSpecificSdk(module.project)
+        LOG.trace("ElixirSdkLookup.mostSpecificSdk(module='${module.name}'): fell through to project SDK → '${projSdk?.name}'")
+        return projSdk
+    }
     fun mostSpecificSdk(psiElement: PsiElement): Sdk? {
         val project = psiElement.project
         if (project.isDisposed) return null
@@ -30,7 +43,14 @@ object ElixirSdkLookup {
 
     fun mostSpecificSdk(project: Project): Sdk? = projectSdk(project)
 
-    private fun moduleSdk(module: Module): Sdk? = sdk(ModuleRootManager.getInstance(module).sdk)
+    private fun moduleSdk(module: Module): Sdk? {
+        val raw = ModuleRootManager.getInstance(module).sdk
+        val filtered = sdk(raw)
+        if (raw != null && filtered == null) {
+            LOG.trace("ElixirSdkLookup.moduleSdk(module='${module.name}'): raw SDK '${raw.name}' (type=${raw.sdkType.name}) rejected by type filter")
+        }
+        return filtered
+    }
 
     private fun projectSdk(project: Project): Sdk? = sdk(ProjectRootManager.getInstance(project).projectSdk)
 

--- a/src/org/elixir_lang/sdk/elixir/ElixirSdkUtil.kt
+++ b/src/org/elixir_lang/sdk/elixir/ElixirSdkUtil.kt
@@ -5,32 +5,38 @@ import com.intellij.openapi.module.ModuleUtilCore
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.projectRoots.Sdk
 import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.util.concurrency.ThreadingAssertions
+import com.intellij.util.concurrency.annotations.RequiresReadLock
 
 /**
  * Finds the Elixir SDK for a specific content root by resolving the owning module.
  *
- * Uses [Type.mostSpecificSdk] (module overload) which checks Facet SDK → module SDK → project SDK,
+ * Uses [ElixirSdkLookup.mostSpecificSdk] (module overload) which checks Facet SDK → module SDK → project SDK,
  * covering both Rich IDEs (JdkOrderEntry) and Small IDEs (Facet library entry).
  *
  * Falls back to the first module's SDK when no module owns [root] (e.g., external content roots).
  */
+@RequiresReadLock
 fun findElixirSdkForRoot(project: Project, root: VirtualFile): Sdk? {
+    ThreadingAssertions.assertReadAccess()
     val module = ModuleUtilCore.findModuleForFile(root, project)
         ?: ModuleManager.getInstance(project).modules.firstOrNull()
         ?: return null
-    return Type.mostSpecificSdk(module)
+    return ElixirSdkLookup.mostSpecificSdk(module)
 }
 
 /**
  * Collects all distinct active Elixir SDKs across all modules in the project.
  *
- * Uses [Type.mostSpecificSdk] per module, covering Facet SDKs in Small IDEs.
+ * Uses [ElixirSdkLookup.mostSpecificSdk] per module, covering Facet SDKs in Small IDEs.
  * Useful for SDK refresh actions and "does any Elixir SDK exist?" guards.
  */
+@RequiresReadLock
 fun findAllActiveElixirSdks(project: Project): Set<Sdk> {
+    ThreadingAssertions.assertReadAccess()
     val sdks = mutableSetOf<Sdk>()
     for (module in ModuleManager.getInstance(project).modules) {
-        val sdk = Type.mostSpecificSdk(module)
+        val sdk = ElixirSdkLookup.mostSpecificSdk(module)
         if (sdk != null) sdks.add(sdk)
     }
     return sdks

--- a/src/org/elixir_lang/sdk/elixir/Type.kt
+++ b/src/org/elixir_lang/sdk/elixir/Type.kt
@@ -256,6 +256,43 @@ ELIXIR_SDK_HOME
             return org.elixir_lang.sdk.Type.appendWslSuffix(base, sdkHome)
         }
 
+        /**
+         * Produces a variant-qualified SDK name that includes the compiled-against OTP major and the
+         * full Erlang release version, so two Elixir SDKs with the same base version but different
+         * Erlang pairings get distinct names in the SDK table.
+         *
+         * Example: `"mise Elixir 1.13.4-otp-24 (Erlang 24.3.4.6)"`
+         *
+         * Falls back to [suggestSdkNameForHome] when [otpMajor] is null (pre-Elixir-1.6 installs
+         * where BEAM parsing is unavailable).
+         */
+        @JvmStatic
+        internal fun suggestSdkNameForHome(
+            sdkHome: String,
+            resolvedVersion: String?,
+            otpMajor: String?,
+            erlangFullVersion: String?,
+        ): String {
+            if (otpMajor == null) return suggestSdkNameForHome(sdkHome, resolvedVersion)
+            val source = SdkPaths.detectSource(sdkHome)
+            val elixirVersion = ElixirVersionDetector.elixirVersion(sdkHome, resolvedVersion)
+            val base = buildString {
+                if (source != null) {
+                    append(source).append(" ")
+                }
+                append("Elixir ")
+                if (elixirVersion != null) {
+                    append(elixirVersion).append("-otp-").append(otpMajor)
+                } else {
+                    append("at ").append(sdkHome)
+                }
+                if (erlangFullVersion != null) {
+                    append(" (Erlang ").append(erlangFullVersion).append(")")
+                }
+            }
+            return org.elixir_lang.sdk.Type.appendWslSuffix(base, sdkHome)
+        }
+
         @JvmStatic
         @RequiresBackgroundThread
         fun canonicalVersion(sdk: Sdk): String? = ElixirVersionDetector.canonicalVersion(sdk)

--- a/src/org/elixir_lang/sdk/elixir/Type.kt
+++ b/src/org/elixir_lang/sdk/elixir/Type.kt
@@ -4,7 +4,6 @@ import com.intellij.notification.NotificationAction
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.fileChooser.FileChooserDescriptor
-import com.intellij.openapi.module.Module
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.project.guessProjectDir
 import com.intellij.openapi.projectRoots.*
@@ -17,7 +16,6 @@ import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.VfsUtilCore
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.vfs.toNioPathOrNull
-import com.intellij.psi.PsiElement
 import com.intellij.util.concurrency.annotations.RequiresBackgroundThread
 import org.apache.commons.io.FilenameUtils
 import org.elixir_lang.Icons
@@ -453,13 +451,5 @@ ELIXIR_SDK_HOME
                 ?: return false
             return classRoots.any { root -> VfsUtilCore.isAncestor(erlangHomePathVf, root, true) }
         }
-
-        @JvmStatic
-        fun mostSpecificSdk(module: Module): Sdk? = ElixirSdkLookup.mostSpecificSdk(module)
-
-        fun mostSpecificSdk(psiElement: PsiElement): Sdk? = ElixirSdkLookup.mostSpecificSdk(psiElement)
-
-        @JvmStatic
-        fun mostSpecificSdk(project: Project): Sdk? = ElixirSdkLookup.mostSpecificSdk(project)
     }
 }

--- a/src/org/elixir_lang/sdk/erlang/ErlangVersionDetector.kt
+++ b/src/org/elixir_lang/sdk/erlang/ErlangVersionDetector.kt
@@ -1,130 +1,94 @@
 package org.elixir_lang.sdk.erlang
 
-import com.intellij.execution.ExecutionException
-import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.diagnostic.Logger
-import com.intellij.platform.ide.progress.ModalTaskOwner
-import com.intellij.platform.ide.progress.runWithModalProgressBlocking
-import org.elixir_lang.cli.getExecutableFilepathWslSafe
-import org.elixir_lang.jps.shared.cli.CliTool
-import org.elixir_lang.sdk.ProcessOutput
+import com.intellij.util.concurrency.ThreadingAssertions
 import org.elixir_lang.sdk.wsl.wslCompat
 import java.io.File
-import java.util.Collections
-import java.util.WeakHashMap
+import java.util.concurrent.ConcurrentHashMap
 
+/**
+ * Detects the installed Erlang/OTP SDK version by reading the filesystem - no subprocess required.
+ *
+ * The canonical source of truth for an installed OTP release is:
+ *   `<sdkHome>/releases/<N>/OTP_VERSION`
+ * where `<N>` is the OTP major release directory (e.g. `26`).
+ *
+ * [detectRelease] must NOT be called on the EDT. WSL paths (\\wsl.localhost\...) involve
+ * the Plan 9 filesystem redirector and directory/file access can take 50–200 ms.
+ * Call only from background threads or [kotlinx.coroutines.Dispatchers.IO] contexts.
+ * The result is stored on the SDK object at registration time; subsequent accesses read
+ * the persisted value and do not call this function.
+ */
 object ErlangVersionDetector {
-    private const val OTP_RELEASE_PREFIX_LINE = "org.elixir_lang.sdk.erlang.Type OTP_RELEASE:"
-    private const val ERTS_VERSION_PREFIX_LINE = "org.elixir_lang.sdk.erlang.Type ERTS_VERSION:"
-    private const val PRINT_VERSION_INFO_EXPRESSION =
-        "io:format(\"~n~s~n~s~n~s~n~s~n\",[" +
-                "\"$OTP_RELEASE_PREFIX_LINE\"," +
-                "erlang:system_info(otp_release)," +
-                "\"$ERTS_VERSION_PREFIX_LINE\"," +
-                "erlang:system_info(version)" +
-                "]),erlang:halt()."
-
     private val LOGGER = Logger.getInstance(ErlangVersionDetector::class.java)
-    // Weak keys so entries for old "$canonicalHome@$mtime" cache keys are collected after
-    // the erl binary is updated. Synchronized because this object is shared across threads.
-    private val releaseBySdkHome: MutableMap<String, Release> =
-        Collections.synchronizedMap(WeakHashMap())
 
-    fun detectSdkVersion(sdkHome: String): Release? {
-        val canonicalHomePath = wslCompat.canonicalizePath(sdkHome)
-        val cachedRelease = getVersionCacheKey(canonicalHomePath)?.let { releaseBySdkHome[it] }
-        if (cachedRelease != null) {
-            return cachedRelease
+    // Keyed by "$canonicalHomePath@$otpVersionFileMtime" so entries for replaced OTP installs
+    // are superseded automatically.
+    private val cache: ConcurrentHashMap<String, Release> = ConcurrentHashMap()
+
+    /**
+     * Reads the installed Erlang/OTP version from `<sdkHome>/releases/<N>/OTP_VERSION`.
+     *
+     * Returns a [Release] with the OTP major and full patch version, or `null` if the
+     * `releases/` directory or `OTP_VERSION` file is absent or unreadable.
+     *
+     * When Erlang is patched in place via `otp_patch_apply`, the version string is
+     * suffixed with `**` (e.g. `"26.2.5.1**"`). This suffix is stripped before
+     * constructing the [Release].
+     *
+     * Must NOT be called on the EDT - see class KDoc.
+     */
+    fun detectRelease(sdkHome: String): Release? {
+        ThreadingAssertions.assertBackgroundThread()
+
+        val canonicalHome = wslCompat.canonicalizePath(sdkHome)
+        val releasesDir = File(canonicalHome, "releases")
+
+        val otpMajorDir = if (!releasesDir.exists()) {
+            LOGGER.warn("Can't detect Erlang version: ${releasesDir.path} is missing")
+            return null
+        } else {
+            releasesDir.listFiles { f -> f.isDirectory && f.name.all { it.isDigit() } }
+                ?.maxByOrNull { it.name.toIntOrNull() ?: 0 }
+                ?: run {
+                    LOGGER.debug("No numeric releases/ subdirectory found in $canonicalHome")
+                    return null
+                }
         }
 
-        val erl = erlExecutable(canonicalHomePath)
-        LOGGER.debug("=== ERLANG SDK: Erl executable path: ${erl.absolutePath}")
-        if (!erl.canExecute()) {
-            val message =
-                buildString {
-                    append("Can't detect Erlang version: ${erl.path}")
-                    if (erl.exists()) append(" is not executable.") else append(" is missing.")
-                }
-            LOGGER.warn(message)
+        val otpVersionFile = File(otpMajorDir, "OTP_VERSION")
+        val mtime = otpVersionFile.lastModified()
+        if (mtime == 0L) {
+            LOGGER.debug("OTP_VERSION file not found or unreadable: ${otpVersionFile.path}")
             return null
         }
 
-        // runBlockingMaybeCancellable can be reached transitively in WSL/Eel process startup,
-        // and that path is forbidden on EDT. Guard EDT callers with modal progress.
-        val app = ApplicationManager.getApplication()
-        if (app.isDispatchThread) {
-            return runWithModalProgressBlocking(
-                ModalTaskOwner.guess(),
-                "Detecting Erlang SDK version..."
-            ) {
-                detectSdkVersionBackground(sdkHome, erl)
-            }
-        }
+        val cacheKey = "$canonicalHome@$mtime"
+        // Fast path: return cached result if present.
+        // Two threads with the same key can both miss and both compute - this is intentional.
+        // The computation is a single file-read, the result is deterministic, and ConcurrentHashMap
+        // guarantees the winning put is visible to all subsequent reads. Wrapping in computeIfAbsent
+        // would prevent the double-compute but requires the entire fallible read to live inside the
+        // lambda, where early returns are not possible (non-inline). The benign race is the simpler
+        // and correct tradeoff here.
+        cache[cacheKey]?.let { return it }
 
-        return detectSdkVersionBackground(sdkHome, erl)
-    }
-
-    private fun detectSdkVersionBackground(sdkHome: String, erl: File): Release? {
-        LOGGER.debug("=== ERLANG SDK: Executing erl to detect version")
-        return try {
-            val erlPath = erl.absolutePath
-            LOGGER.debug("=== ERLANG SDK: Calling getProcessOutput with workDir: $sdkHome, exe: $erlPath")
-            val output =
-                ProcessOutput.getProcessOutput(
-                    10 * 1000,
-                    sdkHome,
-                    erlPath,
-                    "-noshell",
-                    "-eval",
-                    PRINT_VERSION_INFO_EXPRESSION,
-                )
-
-            if (output.exitCode == 0 && !output.isCancelled && !output.isTimeout) {
-                parseSdkVersion(output.stdoutLines)?.also { detectedRelease ->
-                    LOGGER.debug("=== ERLANG SDK: Detected release: ${detectedRelease.otpRelease}")
-                    getVersionCacheKey(sdkHome)?.let { key ->
-                        releaseBySdkHome[key] = detectedRelease
-                    }
-                }
-            } else {
-                LOGGER.warn(
-                    "=== ERLANG SDK: Failed to detect Erlang version. Workdir: '$sdkHome' " +
-                        "ErlPath: '$erlPath' Exit Code: ${output.exitCode}\nStdOut: ${output.stdout}\n" +
-                        "StdErr: ${output.stderr}"
-                )
-                null
-            }
-        } catch (e: ExecutionException) {
-            LOGGER.warn("=== ERLANG SDK: Exception during version detection", e)
-            null
-        }
-    }
-
-    private fun parseSdkVersion(printVersionInfoOutput: List<String>): Release? {
-        var otpRelease: String? = null
-        var ertsVersion: String? = null
-
-        val iterator = printVersionInfoOutput.listIterator()
-        while (iterator.hasNext()) {
-            when (iterator.next()) {
-                OTP_RELEASE_PREFIX_LINE -> if (iterator.hasNext()) otpRelease = iterator.next()
-                ERTS_VERSION_PREFIX_LINE -> if (iterator.hasNext()) ertsVersion = iterator.next()
-            }
-        }
-
-        return if (otpRelease != null && ertsVersion != null) Release(otpRelease, ertsVersion) else null
-    }
-
-    private fun getVersionCacheKey(sdkHome: String?): String? {
-        val homePath = sdkHome ?: return null
-        val canonicalHomePath = wslCompat.canonicalizePath(homePath)
-        val erlPath = CliTool.ERL.getExecutableFilepathWslSafe(canonicalHomePath)
-        val lastModified = File(erlPath).lastModified()
-        if (lastModified == 0L) {
+        val otpVersion = try {
+            otpVersionFile.readText().trim().trimEnd('*')
+        } catch (e: Exception) {
+            LOGGER.warn("Could not read OTP_VERSION from ${otpVersionFile.path}", e)
             return null
         }
-        return "$canonicalHomePath@$lastModified"
-    }
 
-    private fun erlExecutable(sdkHome: String): File = File(CliTool.ERL.getExecutableFilepathWslSafe(sdkHome))
+        if (otpVersion.isBlank()) {
+            LOGGER.warn("OTP_VERSION file is empty: ${otpVersionFile.path}")
+            return null
+        }
+
+        val otpMajor = otpMajorDir.name
+        val release = Release(otpMajor, otpVersion)
+        cache[cacheKey] = release
+        LOGGER.debug("Detected Erlang release: $release (from ${otpVersionFile.path})")
+        return release
+    }
 }

--- a/src/org/elixir_lang/sdk/erlang/Release.kt
+++ b/src/org/elixir_lang/sdk/erlang/Release.kt
@@ -1,27 +1,12 @@
 package org.elixir_lang.sdk.erlang
 
-import java.util.regex.Pattern
-
-class Release internal constructor(val otpRelease: String, private val ertsVersion: String) {
-    override fun toString(): String {
-        return "Erlang/OTP $otpRelease [erts-$ertsVersion]"
-    }
-
-    companion object {
-        private val VERSION_PATTERN: Pattern = Pattern.compile("Erlang/OTP (\\S+) \\[erts-(\\S+)\\]")
-
-        fun fromString(versionString: String?): Release? {
-            var release: Release? = null
-
-            if (versionString != null) {
-                val matcher = VERSION_PATTERN.matcher(versionString)
-
-                if (matcher.matches()) {
-                    release = Release(matcher.group(1), matcher.group(2))
-                }
-            }
-
-            return release
-        }
-    }
+/**
+ * Represents an installed Erlang/OTP SDK version, derived from the `OTP_VERSION` file and
+ * the `releases/` directory structure - no subprocess required.
+ *
+ * @param otpMajor  The major OTP release number, e.g. `"26"`.
+ * @param otpVersion The full patch version string, e.g. `"26.2.5.6"`.
+ */
+data class Release(val otpMajor: String, val otpVersion: String) {
+    override fun toString(): String = "Erlang/OTP $otpVersion"
 }

--- a/src/org/elixir_lang/sdk/erlang/Type.kt
+++ b/src/org/elixir_lang/sdk/erlang/Type.kt
@@ -2,11 +2,8 @@ package org.elixir_lang.sdk.erlang
 
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.fileChooser.FileChooserDescriptor
-import com.intellij.platform.ide.progress.ModalTaskOwner
-import com.intellij.platform.ide.progress.runWithModalProgressBlocking
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
 import com.intellij.openapi.project.Project
+import org.elixir_lang.util.runWithEdtGuard
 import com.intellij.openapi.project.guessProjectDir
 import com.intellij.openapi.projectRoots.Sdk
 import com.intellij.openapi.projectRoots.SdkModel
@@ -67,7 +64,7 @@ class Type : SdkType(ErlangSdkTypeId.ERLANG_SDK_TYPE_ID) {
                 if (version != null) {
                     // Use directory name for version if it's more specific (e.g., "28.3" vs "28")
                     val dirVersion = File(sdkHome).name
-                    val displayVersion = if (dirVersion.startsWith(version.otpRelease)) dirVersion else version.otpRelease
+                    val displayVersion = if (dirVersion.startsWith(version.otpMajor)) dirVersion else version.otpVersion
                     append(displayVersion)
                 } else {
                     append("at ").append(sdkHome)
@@ -82,7 +79,10 @@ class Type : SdkType(ErlangSdkTypeId.ERLANG_SDK_TYPE_ID) {
             val normalizedVersion = resolvedVersion?.takeIf { it.isNotBlank() }
             val baseName =
                 if (normalizedVersion == null) {
-                    getDefaultSdkName(sdkHome, ErlangVersionDetector.detectSdkVersion(sdkHome))
+                    getDefaultSdkName(
+                        sdkHome,
+                        runWithEdtGuard("Detecting Erlang SDK…") { ErlangVersionDetector.detectRelease(sdkHome) },
+                    )
                 } else {
                     val source = SdkPaths.detectSource(sdkHome)
                     val dirVersion = File(sdkHome).name
@@ -105,7 +105,9 @@ class Type : SdkType(ErlangSdkTypeId.ERLANG_SDK_TYPE_ID) {
             resolvedVersion: String?,
         ): String? {
             val normalizedVersion = resolvedVersion?.takeIf { it.isNotBlank() }
-            val version = normalizedVersion ?: ErlangVersionDetector.detectSdkVersion(sdkHome)?.otpRelease ?: return null
+            val version = normalizedVersion
+                ?: runWithEdtGuard("Detecting Erlang SDK…") { ErlangVersionDetector.detectRelease(sdkHome) }?.otpVersion
+                ?: return null
             val displayVersion =
                 if (normalizedVersion == null) {
                     val dirVersion = File(sdkHome).name
@@ -151,21 +153,14 @@ class Type : SdkType(ErlangSdkTypeId.ERLANG_SDK_TYPE_ID) {
         }
     }
 
-    override fun setupSdkPaths(sdk: Sdk) {
-        val app = ApplicationManager.getApplication()
-
-        // Following Java SDK pattern: if on EDT, run VirtualFile access in background thread
-        // This avoids EEL environment check issues with WSL paths
-        if (app.isDispatchThread && !app.isWriteAccessAllowed) {
-            runWithModalProgressBlocking(ModalTaskOwner.guess(), "Setting Up Erlang SDK Paths...") {
-                withContext(Dispatchers.IO) {
-                    setupSdkPathsImpl(sdk)
-                }
-            }
-        } else {
-            setupSdkPathsImpl(sdk)
-        }
-    }
+    // If called from inside a write action the modal progress dialog would deadlock, so skip
+    // it in that case and call setupSdkPathsImpl directly (see ElixirSdkPathConfigurator for
+    // the same pattern).
+    override fun setupSdkPaths(sdk: Sdk) =
+            runWithEdtGuard(
+                "Setting Up Erlang SDK Paths...",
+                skipModalIf = { ApplicationManager.getApplication().isWriteAccessAllowed },
+            ) { setupSdkPathsImpl(sdk) }
 
     private fun setupSdkPathsImpl(sdk: Sdk) {
         val sdkModificator = sdk.sdkModificator
@@ -215,10 +210,19 @@ class Type : SdkType(ErlangSdkTypeId.ERLANG_SDK_TYPE_ID) {
         return suggestSdkNameForHome(sdkHome, null)
     }
 
+    /**
+     * Returns a display string for the Erlang/OTP version at [sdkHome], or `null` if the
+     * version cannot be detected.
+     *
+     * The platform calls this override from the EDT (e.g. in the SDK settings dialog).
+     * [runWithEdtGuard] ensures [ErlangVersionDetector.detectRelease] (which asserts a background
+     * thread) is never called directly on the EDT.
+     */
     override fun getVersionString(sdkHome: String): String? {
-        val detectedVersion = ErlangVersionDetector.detectSdkVersion(sdkHome)?.otpRelease ?: return null
+        val release = runWithEdtGuard("Detecting Erlang SDK…") { ErlangVersionDetector.detectRelease(sdkHome) }
+            ?: return null
         val dirVersion = File(sdkHome).name
-        val displayVersion = if (dirVersion.startsWith(detectedVersion)) dirVersion else detectedVersion
+        val displayVersion = if (dirVersion.startsWith(release.otpMajor)) dirVersion else release.otpVersion
         return erlangDisplayString(SdkPaths.detectSource(sdkHome), displayVersion)
     }
 

--- a/src/org/elixir_lang/sdk/erlang_dependent/ErlangSdkResolver.kt
+++ b/src/org/elixir_lang/sdk/erlang_dependent/ErlangSdkResolver.kt
@@ -6,6 +6,7 @@ import com.intellij.openapi.diagnostic.debug
 import com.intellij.openapi.projectRoots.ProjectJdkTable
 import com.intellij.openapi.projectRoots.Sdk
 import com.intellij.openapi.projectRoots.SdkModel
+import org.elixir_lang.sdk.wsl.wslCompat
 
 
 /**
@@ -41,18 +42,21 @@ interface ErlangSdkResolver {
 }
 
 /**
- * Default implementation extracted from SdkAdditionalData
+ * Default implementation.
+ *
+ * Resolution priority:
+ * 1. `erlangSdkHomePath` (stable; survives SDK renames) - WSL-aware path match in ProjectJdkTable
+ * 2. `erlangSdkName` (legacy fallback for configs written before home-path was added) - name match;
+ *    self-heals by writing the resolved path back to `erlangSdkHomePath` so future lookups use path
+ * 3. Both absent → NOT_CONFIGURED
  */
 class DefaultErlangSdkResolver : ErlangSdkResolver {
     override fun resolveErlangSdkResult(elixirSdk: Sdk, sdkModel: SdkModel?): ErlangSdkResult {
         val elixirName = elixirSdk.name
         val additionalData = elixirSdk.elixirAdditionalData
-        val configuredName = additionalData?.getErlangSdkName()?.takeIf { it.isNotBlank() }
-            ?: return ErlangSdkResult.Missing(
-                elixirSdk,
-                MissingErlangSdkReason.NOT_CONFIGURED,
-            )
+            ?: return ErlangSdkResult.Missing(elixirSdk, MissingErlangSdkReason.NOT_CONFIGURED)
 
+        // Check cache first
         additionalData.getCachedErlangSdk()?.let { cached ->
             if (isValidAndExists(cached, sdkModel)) {
                 if (cached.homePath.isNullOrBlank()) {
@@ -68,17 +72,47 @@ class DefaultErlangSdkResolver : ErlangSdkResolver {
             additionalData.setCachedErlangSdk(null)
         }
 
-        logger.debug { "[$elixirName] Looking up Erlang SDK by name: $configuredName" }
+        // 1. Path-first lookup (stable; survives renames)
+        val configuredHomePath = additionalData.getErlangSdkHomePath()?.takeIf { it.isNotBlank() }
+        if (configuredHomePath != null) {
+            logger.debug { "[$elixirName] Looking up Erlang SDK by home path: $configuredHomePath" }
+            val found = findErlangSdkByHomePath(configuredHomePath, sdkModel)
+            if (found != null) {
+                logger.debug { "[$elixirName] Found Erlang SDK by home path: ${found.name}" }
+                additionalData.setCachedErlangSdk(found)
+                // Self-heal: keep name in sync with current SDK name after a rename.
+                // Not wrapped in a write action - see name-fallback path below for rationale.
+                if (additionalData.getErlangSdkName() != found.name) {
+                    additionalData.setErlangSdk(found)
+                }
+                if (found.homePath.isNullOrBlank()) {
+                    return ErlangSdkResult.Missing(elixirSdk, MissingErlangSdkReason.MISSING_HOME_PATH, found.name)
+                }
+                return ErlangSdkResult.Success(found)
+            }
+            logger.debug { "[$elixirName] No Erlang SDK found at home path: $configuredHomePath" }
+        }
+
+        // 2. Name-based fallback (legacy configs without erlangSdkHomePath)
+        val configuredName = additionalData.getErlangSdkName()?.takeIf { it.isNotBlank() }
+            ?: return ErlangSdkResult.Missing(elixirSdk, MissingErlangSdkReason.NOT_CONFIGURED)
+
+        logger.debug { "[$elixirName] Falling back to name lookup: $configuredName" }
         val found = findErlangSdkByName(configuredName, sdkModel)
         if (found != null) {
-            logger.debug { "[$elixirName] Found Erlang SDK '$configuredName'" }
+            logger.debug { "[$elixirName] Found Erlang SDK by name: $configuredName - self-healing home path and name" }
             additionalData.setCachedErlangSdk(found)
+            // Self-heal: atomically write both home path and name so that future lookups use
+            // path-first resolution and the name stays in sync with the current SDK name.
+            // Not wrapped in a write action intentionally - this resolver can be called while
+            // already holding a read lock (e.g. from EditorNotificationProvider.collectNotificationData
+            // which is @RequiresReadLock), and acquiring a write action from under a read lock
+            // deadlocks. String field assignment is an atomic JVM reference write; a stale value
+            // is only visible until the next project save, at which point commitChanges() in
+            // SdkRegistrar / attachErlangDependency writes the authoritative value.
+            additionalData.setErlangSdk(found)
             if (found.homePath.isNullOrBlank()) {
-                return ErlangSdkResult.Missing(
-                    elixirSdk,
-                    MissingErlangSdkReason.MISSING_HOME_PATH,
-                    found.name,
-                )
+                return ErlangSdkResult.Missing(elixirSdk, MissingErlangSdkReason.MISSING_HOME_PATH, found.name)
             }
             return ErlangSdkResult.Success(found)
         }
@@ -93,11 +127,7 @@ class DefaultErlangSdkResolver : ErlangSdkResolver {
             else -> MissingErlangSdkReason.NOT_FOUND
         }
 
-        return ErlangSdkResult.Missing(
-            elixirSdk,
-            reason,
-            configuredName,
-        )
+        return ErlangSdkResult.Missing(elixirSdk, reason, configuredName)
     }
 
     private fun isValidAndExists(sdk: Sdk, sdkModel: SdkModel?): Boolean {
@@ -106,6 +136,16 @@ class DefaultErlangSdkResolver : ErlangSdkResolver {
         val jdkTable = ProjectJdkTable.getInstance()
         return (sdkModel?.sdks?.any { it.name == name } == true)
             || (jdkTable.findJdk(name) != null)
+    }
+
+    private fun findErlangSdkByHomePath(homePath: String, sdkModel: SdkModel?): Sdk? {
+        val fromModel = sdkModel?.sdks?.find { sdk ->
+            Type.staticIsValidDependency(sdk) && wslCompat.pathsEqualWslAware(sdk.homePath, homePath)
+        }
+        if (fromModel != null) return fromModel
+        return ProjectJdkTable.getInstance().allJdks.firstOrNull { sdk ->
+            Type.staticIsValidDependency(sdk) && wslCompat.pathsEqualWslAware(sdk.homePath, homePath)
+        }
     }
 
     private fun findErlangSdkByName(name: String, sdkModel: SdkModel?): Sdk? {

--- a/src/org/elixir_lang/sdk/erlang_dependent/SdkAdditionalData.kt
+++ b/src/org/elixir_lang/sdk/erlang_dependent/SdkAdditionalData.kt
@@ -15,8 +15,16 @@ import org.jdom.Element
  *
  * ## Persistence Model
  *
- * Only the Erlang SDK **name** is persisted to disk (in the `erlang-sdk-name` XML attribute).
- * The actual SDK reference is resolved lazily when [getErlangSdk] is called.
+ * Both the Erlang SDK **home path** (`erlang-sdk-home-path`) and **name** (`erlang-sdk-name`)
+ * are persisted to disk. Home path is the primary stable identity - it survives SDK renames.
+ * Name is retained as a display hint and legacy fallback for configs written before the
+ * home-path field was added.
+ *
+ * ## Resolution Order
+ *
+ * 1. `erlangSdkHomePath` (stable, survives rename) - looked up by home path in ProjectJdkTable
+ * 2. `erlangSdkName` (legacy fallback) - looked up by name; self-heals by writing resolved path back
+ * 3. Both absent → NOT_CONFIGURED
  *
  * ## Cache Behavior
  *
@@ -40,7 +48,14 @@ class SdkAdditionalData :
     Cloneable {
     private val elixirSdk: Sdk
 
-    // Persistence layer - the ONLY thing saved to disk
+    // Primary stable identity - survives SDK renames.
+    // @Volatile ensures background-thread writes (self-heal in ErlangSdkResolver) are immediately
+    // visible to the EDT reading these fields in writeExternal, without requiring a write lock.
+    @Volatile
+    private var erlangSdkHomePath: String? = null
+
+    // Display hint + legacy fallback for configs written before erlangSdkHomePath was added
+    @Volatile
     private var erlangSdkName: String? = null
 
     // Runtime cache - lazily populated, cleared when invalid
@@ -49,6 +64,7 @@ class SdkAdditionalData :
     private var cachedErlangSdk: Sdk? = null
 
     companion object {
+        private const val ERLANG_SDK_HOME_PATH = "erlang-sdk-home-path"
         private const val ERLANG_SDK_NAME = "erlang-sdk-name"
         private val LOG = Logger.getInstance(SdkAdditionalData::class.java)
     }
@@ -61,6 +77,7 @@ class SdkAdditionalData :
     // Secondary constructor for creating new SDKs with a known Erlang SDK
     constructor(erlangSdk: Sdk?, elixirSdk: Sdk) : this(elixirSdk) {
         this.erlangSdkName = erlangSdk?.name
+        this.erlangSdkHomePath = erlangSdk?.homePath
         this.cachedErlangSdk = erlangSdk
     }
 
@@ -100,20 +117,25 @@ class SdkAdditionalData :
 
     @Throws(InvalidDataException::class)
     fun readExternal(element: Element) {
+        erlangSdkHomePath = element.getAttributeValue(ERLANG_SDK_HOME_PATH)
         erlangSdkName = element.getAttributeValue(ERLANG_SDK_NAME)
         cachedErlangSdk = null  // Force re-lookup on next access
     }
 
     @Throws(WriteExternalException::class)
     fun writeExternal(element: Element) {
-        erlangSdkName?.let {
-            element.setAttribute(ERLANG_SDK_NAME, it)
-        }
+        // Snapshot both @Volatile fields into locals before writing so that a concurrent
+        // self-heal write in ErlangSdkResolver cannot produce a torn (home, name) pair.
+        val homePath = erlangSdkHomePath
+        val name = erlangSdkName
+        homePath?.let { element.setAttribute(ERLANG_SDK_HOME_PATH, it) }
+        name?.let { element.setAttribute(ERLANG_SDK_NAME, it) }
     }
 
     @Throws(CloneNotSupportedException::class)
     public override fun clone(): Any {
         val cloned = SdkAdditionalData(elixirSdk)
+        cloned.erlangSdkHomePath = this.erlangSdkHomePath
         cloned.erlangSdkName = this.erlangSdkName
         // Don't clone cachedErlangSdk - let it be lazily resolved
         return cloned
@@ -125,8 +147,11 @@ class SdkAdditionalData :
      */
     fun getErlangSdkName(): String? = erlangSdkName
 
+    fun getErlangSdkHomePath(): String? = erlangSdkHomePath
+
     fun setErlangSdk(sdk: Sdk?) {
         erlangSdkName = sdk?.name
+        erlangSdkHomePath = sdk?.homePath
         cachedErlangSdk = sdk
     }
 

--- a/src/org/elixir_lang/status_bar_widget/ElixirEditorBasedSdkWidget.kt
+++ b/src/org/elixir_lang/status_bar_widget/ElixirEditorBasedSdkWidget.kt
@@ -602,7 +602,7 @@ class ElixirEditorBasedSdkWidget(
     /**
      * Finds the active Elixir SDK by scanning all Elixir modules.
      *
-     * Uses [Type.mostSpecificSdk] (module overload) which checks Facet SDK → module SDK → project SDK,
+     * Uses [ElixirSdkLookup.mostSpecificSdk] (module overload) which checks Facet SDK → module SDK → project SDK,
      * returning the first non-null result. This covers both Rich IDEs (JdkOrderEntry) and Small IDEs
      * (Facet library entry) without additional branching.
      *

--- a/src/org/elixir_lang/status_bar_widget/ElixirEditorBasedSdkWidget.kt
+++ b/src/org/elixir_lang/status_bar_widget/ElixirEditorBasedSdkWidget.kt
@@ -48,6 +48,7 @@ import org.elixir_lang.sdk.SdkRegistrar
 import org.elixir_lang.sdk.elixir.SdkSettingsOpener
 import org.elixir_lang.sdk.elixir.ElixirSdkLookup
 import org.elixir_lang.sdk.elixir.Type
+import org.elixir_lang.sdk.erlang.ErlangVersionDetector
 import org.elixir_lang.sdk.erlang_dependent.SdkAdditionalData
 import org.elixir_lang.sdk.wsl.wslCompat
 import java.nio.file.Path
@@ -293,6 +294,7 @@ class ElixirEditorBasedSdkWidget(
     // -------------------------------------------------------------------------
 
     private fun buildModuleWidgetState(module: com.intellij.openapi.module.Module): WidgetState {
+        LOG.trace("buildModuleWidgetState: ${module.name}")
         val elixirSdk = ElixirSdkLookup.mostSpecificSdk(module)
 
         // Determine whether to show module name in tooltip (only in multi-module projects).
@@ -314,12 +316,9 @@ class ElixirEditorBasedSdkWidget(
             return state
         }
 
-        val versionString = elixirSdk.versionString ?: "Unknown"
-        val elixirVersion = org.elixir_lang.sdk.Type.appendWslSuffix(versionString, elixirSdk.homePath)
-
         if (!isValidSdk(elixirSdk)) {
             val state = WidgetState(
-                toolTip = if (showModuleName) "Elixir SDK: $elixirVersion - Invalid SDK (module '${module.name}')" else "Elixir SDK: $elixirVersion - Invalid SDK",
+                toolTip = if (showModuleName) "Elixir SDK: ${elixirSdk.name} - Invalid SDK (module '${module.name}')" else "Elixir SDK: ${elixirSdk.name} - Invalid SDK",
                 text = "Elixir: SDK Error",
                 isActionEnabled = true
             )
@@ -330,7 +329,7 @@ class ElixirEditorBasedSdkWidget(
         val erlangSdk = getErlangSdk(elixirSdk)
         if (erlangSdk == null) {
             val state = WidgetState(
-                toolTip = if (showModuleName) "Elixir SDK: $elixirVersion - Missing Erlang SDK (module '${module.name}')" else "Elixir SDK: $elixirVersion - Missing Erlang SDK",
+                toolTip = if (showModuleName) "Elixir SDK: ${elixirSdk.name} - Missing Erlang SDK (module '${module.name}')" else "Elixir SDK: ${elixirSdk.name} - Missing Erlang SDK",
                 text = "Elixir: SDK Error",
                 isActionEnabled = true
             )
@@ -338,12 +337,14 @@ class ElixirEditorBasedSdkWidget(
             return state
         }
 
-        val tooltipBase =
-                if (showModuleName) "Elixir SDK: $elixirVersion (module '${module.name}')"
-                else "Elixir SDK: $elixirVersion"
+        val tooltipBase = buildString {
+            append("Elixir: <b>${elixirSdk.name}</b>")
+            append("<br>Erlang: <b>${erlangSdk.name}</b>")
+            if (showModuleName) append("<br>Module: <b>${module.name}</b>")
+        }
         val state = WidgetState(
             toolTip = tooltipBase,
-            text = "Elixir $elixirVersion",
+            text = elixirSdk.name,
             isActionEnabled = true
         )
         state.icon = Icons.LANGUAGE
@@ -771,7 +772,7 @@ class ElixirEditorBasedSdkWidget(
             .mapNotNull { it.erlangSdkHomePath }
             .distinct()
             .associateWith { homePath ->
-                org.elixir_lang.sdk.erlang.ErlangVersionDetector.detectRelease(homePath)?.otpMajor
+                ErlangVersionDetector.detectRelease(homePath)?.otpMajor
             }
 
         val classpathIssues = detectClasspathIssues(modelData.projectSdkSnapshot)

--- a/src/org/elixir_lang/status_bar_widget/ElixirEditorBasedSdkWidget.kt
+++ b/src/org/elixir_lang/status_bar_widget/ElixirEditorBasedSdkWidget.kt
@@ -172,6 +172,7 @@ class ElixirEditorBasedSdkWidget(
                         modelData.moduleMiseCheckData,
                         ioData.elixirVersionBySdk,
                         ioData.miseByContentRoot,
+                        ioData.erlangOtpMajorByHomePath,
                     )
                     // Build per-module mise assignments: module name → the MiseVersions that mise
                     // resolves for that module's own content root.  Covers all modules with an
@@ -688,7 +689,7 @@ class ElixirEditorBasedSdkWidget(
     }
 
     // -------------------------------------------------------------------------
-    // Mise version mismatch detection (Features B & C)
+    // Mise version mismatch detection
     // -------------------------------------------------------------------------
 
     /**
@@ -699,8 +700,8 @@ class ElixirEditorBasedSdkWidget(
         val moduleName: String,
         /** Elixir SDK configured for the module (if any). */
         val elixirSdk: Sdk?,
-        /** OTP major release reported by the Internal Erlang SDK (e.g. `"25"`). */
-        val erlangOtpRelease: String?,
+        /** Home path of the Internal Erlang SDK (if any). Resolved to OTP major in IO phase. */
+        val erlangSdkHomePath: String?,
         /** First content root of the module, used as the working directory for `mise ls`. */
         val contentRoot: Path?,
     )
@@ -721,6 +722,9 @@ class ElixirEditorBasedSdkWidget(
     private data class NotificationScanIoData(
         val miseByContentRoot: Map<Path, MiseVersions?>,
         val elixirVersionBySdk: Map<Sdk, String?>,
+        /** OTP major (e.g. `"26"`) keyed by canonical Erlang SDK home path. Populated from
+         *  `releases/<N>/OTP_VERSION` - no subprocess. */
+        val erlangOtpMajorByHomePath: Map<String, String?>,
         val classpathIssues: List<String>,
     )
 
@@ -763,11 +767,19 @@ class ElixirEditorBasedSdkWidget(
             .distinct()
             .associateWith { sdk -> Type.canonicalVersion(sdk) }
 
+        val erlangOtpMajorByHomePath = modelData.moduleMiseCheckData
+            .mapNotNull { it.erlangSdkHomePath }
+            .distinct()
+            .associateWith { homePath ->
+                org.elixir_lang.sdk.erlang.ErlangVersionDetector.detectRelease(homePath)?.otpMajor
+            }
+
         val classpathIssues = detectClasspathIssues(modelData.projectSdkSnapshot)
 
         return NotificationScanIoData(
             miseByContentRoot = miseByContentRoot,
             elixirVersionBySdk = elixirVersionBySdk,
+            erlangOtpMajorByHomePath = erlangOtpMajorByHomePath,
             classpathIssues = classpathIssues,
         )
     }
@@ -808,8 +820,7 @@ class ElixirEditorBasedSdkWidget(
                 ModuleMiseCheckData(
                     moduleName = module.name,
                     elixirSdk = elixirSdk,
-                    erlangOtpRelease = erlangSdk?.versionString
-                        ?.let { org.elixir_lang.sdk.erlang.Release.fromString(it)?.otpRelease },
+                    erlangSdkHomePath = erlangSdk?.homePath,
                     contentRoot = contentRoot,
                 )
             }
@@ -933,11 +944,9 @@ class ElixirEditorBasedSdkWidget(
     }
 
     /**
-     * Feature B: warns when the configured Elixir SDK version differs from the version mise
-     * resolves for the module directory.
-     *
-     * Feature C: warns when the Internal Erlang SDK OTP major release differs from the OTP major
-     * in the mise-resolved erlang version string.
+     * Warns when the configured Elixir SDK version differs from the version mise resolves for
+     * the module directory, or when the Internal Erlang SDK OTP major release differs from the
+     * OTP major in the mise-resolved erlang version.
      *
      * Runs `mise ls --local --json` (a subprocess) for each module. Must NOT be called inside a
      * read lock - use [collectModuleMiseCheckData] first to extract what you need, then call this.
@@ -946,6 +955,7 @@ class ElixirEditorBasedSdkWidget(
         moduleDataList: List<ModuleMiseCheckData>,
         elixirVersionBySdk: Map<Sdk, String?>,
         miseByContentRoot: Map<Path, MiseVersions?>,
+        erlangOtpMajorByHomePath: Map<String, String?>,
     ): List<ModuleSdkIssue> {
         val issues = mutableListOf<ModuleSdkIssue>()
 
@@ -953,7 +963,7 @@ class ElixirEditorBasedSdkWidget(
             val contentRoot = data.contentRoot ?: continue
             val miseVersions = miseByContentRoot[contentRoot] ?: continue
 
-            // Feature B: Elixir version mismatch
+            // Elixir version mismatch: configured SDK vs mise-resolved version
             val miseElixir = miseVersions.elixir
             if (miseElixir != null) {
                 val configuredVersion = data.elixirSdk?.let { elixirVersionBySdk[it] }
@@ -975,19 +985,20 @@ class ElixirEditorBasedSdkWidget(
                 }
             }
 
-            // Feature C: OTP version mismatch between Internal Erlang SDK and mise erlang
+            // OTP version mismatch: Internal Erlang SDK vs mise-resolved erlang
             val miseErlang = miseVersions.erlang
-            if (miseErlang != null && data.erlangOtpRelease != null) {
+            val erlangOtpMajor = data.erlangSdkHomePath?.let { erlangOtpMajorByHomePath[it] }
+            if (miseErlang != null && erlangOtpMajor != null) {
                 val miseErlangMajor = miseErlang.version.substringBefore(".")
-                if (miseErlangMajor != data.erlangOtpRelease) {
+                if (miseErlangMajor != erlangOtpMajor) {
                     LOG.info(
                         "Mise OTP mismatch in module '${data.moduleName}': " +
-                                "SDK OTP=${data.erlangOtpRelease}, mise=${miseErlang.version}"
+                                "SDK OTP=$erlangOtpMajor, mise=${miseErlang.version}"
                     )
                     issues.add(
                         ModuleSdkIssue(
                             moduleName = data.moduleName,
-                            issue = "Internal Erlang SDK OTP ${data.erlangOtpRelease} does not " +
+                            issue = "Internal Erlang SDK OTP $erlangOtpMajor does not " +
                                     "match mise (${miseErlang.version}). " +
                                     "Run 'Refresh Active Elixir SDKs' or reconfigure.",
                             isDangling = false,

--- a/src/org/elixir_lang/status_bar_widget/ElixirSdkStatusWidget.kt
+++ b/src/org/elixir_lang/status_bar_widget/ElixirSdkStatusWidget.kt
@@ -532,7 +532,7 @@ class ElixirSdkStatusWidget(@param:NotNull private val project: Project) : Custo
     /**
      * Finds the active Elixir SDK by scanning all Elixir modules.
      *
-     * Uses [Type.mostSpecificSdk] (module overload) which checks Facet SDK → module SDK → project SDK,
+     * Uses [ElixirSdkLookup.mostSpecificSdk] (module overload) which checks Facet SDK → module SDK → project SDK,
      * returning the first non-null result. This covers both Rich IDEs (JdkOrderEntry) and Small IDEs
      * (Facet library entry) without additional branching.
      *

--- a/src/org/elixir_lang/util/ProgressUtils.kt
+++ b/src/org/elixir_lang/util/ProgressUtils.kt
@@ -5,12 +5,22 @@ import com.intellij.platform.ide.progress.ModalTaskOwner
 import com.intellij.platform.ide.progress.runWithModalProgressBlocking
 
 /**
- * Runs [block] directly if off-EDT, or wraps it in [runWithModalProgressBlocking] if on EDT.
+ * Runs [block] directly if off-EDT (or if [skipModalIf] returns `true`), otherwise wraps it in
+ * [runWithModalProgressBlocking] so the EDT is not blocked.
+ *
+ * Use [skipModalIf] when the modal progress dialog must not be shown - for example, when a write
+ * action is already held on the EDT (`ApplicationManager.getApplication().isWriteAccessAllowed`),
+ * because starting modal progress from inside a write action would deadlock.
+ *
  * Use this to guard any blocking subprocess or I/O call that may be triggered from the EDT.
  */
-fun <T> runWithEdtGuard(title: String, block: () -> T): T {
+fun <T> runWithEdtGuard(
+    title: String,
+    skipModalIf: () -> Boolean = { false },
+    block: () -> T,
+): T {
     val app = ApplicationManager.getApplication()
-    return if (app.isDispatchThread) {
+    return if (app.isDispatchThread && !skipModalIf()) {
         runWithModalProgressBlocking(ModalTaskOwner.guess(), title) { block() }
     } else {
         block()

--- a/tests/org/elixir_lang/sdk/erlang/ErlangVersionDetectorTest.kt
+++ b/tests/org/elixir_lang/sdk/erlang/ErlangVersionDetectorTest.kt
@@ -1,0 +1,166 @@
+package org.elixir_lang.sdk.erlang
+
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.util.io.FileUtil
+import com.intellij.testFramework.registerOrReplaceServiceInstance
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import org.elixir_lang.PlatformTestCase
+import org.elixir_lang.sdk.wsl.MockWslCompatService
+import org.elixir_lang.sdk.wsl.WslCompatService
+import java.io.File
+
+/**
+ * Tests for ErlangVersionDetector - file-based OTP version detection from
+ * `<sdkHome>/releases/<N>/OTP_VERSION`.
+ */
+class ErlangVersionDetectorTest : PlatformTestCase() {
+
+    private lateinit var tempSdkHome: File
+
+    override fun setUp() {
+        super.setUp()
+
+        ApplicationManager.getApplication().registerOrReplaceServiceInstance(
+            WslCompatService::class.java,
+            MockWslCompatService(),
+            testRootDisposable,
+        )
+
+        tempSdkHome = FileUtil.createTempDirectory("erlang_sdk_home", null, true)
+    }
+
+    fun testDetectRelease_standardInstall() {
+        // Simulate: releases/26/OTP_VERSION contains "26.2.5.6"
+        val releasesDir = File(tempSdkHome, "releases/26")
+        releasesDir.mkdirs()
+        File(releasesDir, "OTP_VERSION").writeText("26.2.5.6\n")
+
+        val release = runBlocking(Dispatchers.IO) {
+            ErlangVersionDetector.detectRelease(tempSdkHome.absolutePath)
+        }
+
+        assertNotNull("Should detect release from OTP_VERSION", release)
+        assertEquals("26", release!!.otpMajor)
+        assertEquals("26.2.5.6", release.otpVersion)
+    }
+
+    fun testDetectRelease_multipleReleaseDirs_picksHighest() {
+        // Simulate multiple release directories (e.g. OTP upgrade in place)
+        File(tempSdkHome, "releases/25").mkdirs()
+        File(tempSdkHome, "releases/25/OTP_VERSION").writeText("25.3.2.12\n")
+        File(tempSdkHome, "releases/26").mkdirs()
+        File(tempSdkHome, "releases/26/OTP_VERSION").writeText("26.2.5.6\n")
+
+        val release = runBlocking(Dispatchers.IO) {
+            ErlangVersionDetector.detectRelease(tempSdkHome.absolutePath)
+        }
+
+        assertNotNull(release)
+        assertEquals("26", release!!.otpMajor)
+        assertEquals("26.2.5.6", release.otpVersion)
+    }
+
+    fun testDetectRelease_missingReleasesDir() {
+        // No releases/ directory at all
+        val release = runBlocking(Dispatchers.IO) {
+            ErlangVersionDetector.detectRelease(tempSdkHome.absolutePath)
+        }
+        assertNull("Should return null when releases/ is missing", release)
+    }
+
+    fun testDetectRelease_emptyReleasesDir() {
+        File(tempSdkHome, "releases").mkdirs()
+        // No numeric subdirectories
+
+        val release = runBlocking(Dispatchers.IO) {
+            ErlangVersionDetector.detectRelease(tempSdkHome.absolutePath)
+        }
+        assertNull("Should return null when releases/ has no numeric subdirectories", release)
+    }
+
+    fun testDetectRelease_missingOtpVersionFile() {
+        // Directory exists but no OTP_VERSION file
+        File(tempSdkHome, "releases/26").mkdirs()
+
+        val release = runBlocking(Dispatchers.IO) {
+            ErlangVersionDetector.detectRelease(tempSdkHome.absolutePath)
+        }
+        assertNull("Should return null when OTP_VERSION file is missing", release)
+    }
+
+    fun testDetectRelease_emptyOtpVersionFile() {
+        File(tempSdkHome, "releases/26").mkdirs()
+        File(tempSdkHome, "releases/26/OTP_VERSION").writeText("   \n")
+
+        val release = runBlocking(Dispatchers.IO) {
+            ErlangVersionDetector.detectRelease(tempSdkHome.absolutePath)
+        }
+        assertNull("Should return null when OTP_VERSION is blank", release)
+    }
+
+    fun testDetectRelease_ignoresNonNumericDirs() {
+        // Non-numeric directories should be ignored
+        File(tempSdkHome, "releases/RELEASES").mkdirs()
+        File(tempSdkHome, "releases/start_erl").mkdirs()
+        File(tempSdkHome, "releases/26").mkdirs()
+        File(tempSdkHome, "releases/26/OTP_VERSION").writeText("26.0\n")
+
+        val release = runBlocking(Dispatchers.IO) {
+            ErlangVersionDetector.detectRelease(tempSdkHome.absolutePath)
+        }
+
+        assertNotNull(release)
+        assertEquals("26", release!!.otpMajor)
+        assertEquals("26.0", release.otpVersion)
+    }
+
+    fun testDetectRelease_trimsWhitespace() {
+        File(tempSdkHome, "releases/28").mkdirs()
+        File(tempSdkHome, "releases/28/OTP_VERSION").writeText("  28.0.3  \n")
+
+        val release = runBlocking(Dispatchers.IO) {
+            ErlangVersionDetector.detectRelease(tempSdkHome.absolutePath)
+        }
+
+        assertNotNull(release)
+        assertEquals("28.0.3", release!!.otpVersion)
+    }
+
+    fun testDetectRelease_cachesResult() {
+        File(tempSdkHome, "releases/26").mkdirs()
+        File(tempSdkHome, "releases/26/OTP_VERSION").writeText("26.2.5.6\n")
+
+        val release1 = runBlocking(Dispatchers.IO) {
+            ErlangVersionDetector.detectRelease(tempSdkHome.absolutePath)
+        }
+        val release2 = runBlocking(Dispatchers.IO) {
+            ErlangVersionDetector.detectRelease(tempSdkHome.absolutePath)
+        }
+
+        assertNotNull(release1)
+        // Same object reference means it came from the cache, not a fresh file read.
+        assertSame(release1, release2)
+    }
+
+    fun testDetectRelease_patchedInPlace_stripsAsterisks() {
+        // otp_patch_apply appends "**" to OTP_VERSION when patching in place
+        File(tempSdkHome, "releases/26").mkdirs()
+        File(tempSdkHome, "releases/26/OTP_VERSION").writeText("26.2.5.1**\n")
+
+        val release = runBlocking(Dispatchers.IO) {
+            ErlangVersionDetector.detectRelease(tempSdkHome.absolutePath)
+        }
+
+        assertNotNull("Should detect release from patched OTP_VERSION", release)
+        assertEquals("26", release!!.otpMajor)
+        assertEquals("26.2.5.1", release.otpVersion)
+    }
+
+    fun testDetectRelease_nonExistentPath() {
+        val release = runBlocking(Dispatchers.IO) {
+            ErlangVersionDetector.detectRelease("/nonexistent/path/erlang")
+        }
+        assertNull("Should return null for non-existent path", release)
+    }
+}

--- a/tests/org/elixir_lang/sdk/erlang/TypeNamingTest.kt
+++ b/tests/org/elixir_lang/sdk/erlang/TypeNamingTest.kt
@@ -54,8 +54,6 @@ class TypeNamingTest : PlatformTestCase() {
     }
 
     fun testGetDefaultSdkName_unknownSource() {
-        val logger = com.intellij.openapi.diagnostic.Logger.getInstance("org.elixir_lang.sdk.erlang.Type")
-        logger.setLevel(com.intellij.openapi.diagnostic.LogLevel.ERROR)
         val name = Type.getDefaultSdkName(
             "/custom/path/erlang/26.0",
             null
@@ -64,19 +62,15 @@ class TypeNamingTest : PlatformTestCase() {
     }
 
     fun testGetDefaultSdkName_withVersion() {
-        val release = Release("26.0.1", "14.0.2")
-        val result: Pair<String?, String?> = captureLoggedWarning<String?>(
-            "org.elixir_lang.sdk.erlang.Type"
-        ) {
-            Type.getDefaultSdkName(
-                "/Users/josh/.local/share/mise/installs/erlang/26.0.1",
-                release
-            )
-        }
-        val name = result.first
+        val release = Release("26", "26.0.1")
+        val name = Type.getDefaultSdkName(
+            "/Users/josh/.local/share/mise/installs/erlang/26.0.1",
+            release
+        )
         assertNotNull(name)
-        // Should use directory name if more specific
-        assertTrue("Name should contain mise", name?.contains("mise") ?: false)
-        assertTrue("Name should contain Erlang for Elixir", name?.contains("Erlang for Elixir") ?: false)
+        // Should use directory name since it starts with the OTP major
+        assertTrue("Name should contain mise", name.contains("mise"))
+        assertTrue("Name should contain Erlang for Elixir", name.contains("Erlang for Elixir"))
+        assertTrue("Name should contain 26.0.1", name.contains("26.0.1"))
     }
 }

--- a/tests/org/elixir_lang/sdk/erlang_dependent/ErlangSdkResolverTest.kt
+++ b/tests/org/elixir_lang/sdk/erlang_dependent/ErlangSdkResolverTest.kt
@@ -1,19 +1,34 @@
 package org.elixir_lang.sdk.erlang_dependent
 
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.application.WriteAction
 import com.intellij.openapi.projectRoots.Sdk
 import com.intellij.openapi.projectRoots.SdkModel
 import com.intellij.openapi.projectRoots.SdkType
+import com.intellij.openapi.projectRoots.impl.ProjectJdkImpl
+import com.intellij.testFramework.registerOrReplaceServiceInstance
 import org.elixir_lang.PlatformTestCase
+import org.elixir_lang.sdk.wsl.MockWslCompatService
+import org.elixir_lang.sdk.wsl.WslCompatService
 import org.jdom.Element
 import org.junit.Assume
-import org.mockito.Mockito.mock
-import org.mockito.Mockito.`when`
+import org.elixir_lang.sdk.elixir.Type as ElixirSdkType
+import org.elixir_lang.sdk.erlang.Type as ErlangSdkType
 
 class ErlangSdkResolverTest : PlatformTestCase() {
     private val resolver = DefaultErlangSdkResolver()
 
+    override fun setUp() {
+        super.setUp()
+        ApplicationManager.getApplication().registerOrReplaceServiceInstance(
+            WslCompatService::class.java,
+            MockWslCompatService(),
+            testRootDisposable,
+        )
+    }
+
     fun testNotConfigured() {
-        val elixirSdk = mockElixirSdk { sdk -> SdkAdditionalData(sdk) }
+        val elixirSdk = createElixirSdk { sdk -> SdkAdditionalData(sdk) }
 
         val result = resolver.resolveErlangSdkResult(elixirSdk, sdkModel())
 
@@ -24,8 +39,8 @@ class ErlangSdkResolverTest : PlatformTestCase() {
 
     fun testNotFound() {
         val configuredName = "Erlang SDK"
-        val elixirSdk = mockElixirSdk { sdk ->
-            SdkAdditionalData(sdk).apply { readExternal(erlangSdkNameElement(configuredName)) }
+        val elixirSdk = createElixirSdk { sdk ->
+            SdkAdditionalData(sdk).apply { readExternal(erlangSdkElement(configuredName)) }
         }
 
         val result = resolver.resolveErlangSdkResult(elixirSdk, sdkModel())
@@ -38,13 +53,14 @@ class ErlangSdkResolverTest : PlatformTestCase() {
 
     fun testInvalidType() {
         val configuredName = "Not Erlang"
-        val invalidSdk = mockSdk(
+        // Use ElixirSdkType - it's not a valid Erlang dependency
+        val invalidSdk = createSdk(
             name = configuredName,
-            sdkType = mock(SdkType::class.java),
+            sdkType = ElixirSdkType.instance,
             homePath = "/tmp/invalid"
         )
-        val elixirSdk = mockElixirSdk { sdk ->
-            SdkAdditionalData(sdk).apply { readExternal(erlangSdkNameElement(configuredName)) }
+        val elixirSdk = createElixirSdk { sdk ->
+            SdkAdditionalData(sdk).apply { readExternal(erlangSdkElement(configuredName)) }
         }
 
         val result = resolver.resolveErlangSdkResult(elixirSdk, sdkModel(invalidSdk))
@@ -57,17 +73,16 @@ class ErlangSdkResolverTest : PlatformTestCase() {
 
     fun testMissingHomePath() {
         val configuredName = "Erlang SDK"
-        val sdkType = org.elixir_lang.sdk.elixir.Type.erlangSdkType()
-        val erlangSdk = mockSdk(
+        val erlangSdk = createSdk(
             name = configuredName,
-            sdkType = sdkType,
+            sdkType = ErlangSdkType.instance,
             homePath = null
         )
 
         Assume.assumeTrue(Type.staticIsValidDependency(erlangSdk))
 
-        val elixirSdk = mockElixirSdk { sdk ->
-            SdkAdditionalData(sdk).apply { readExternal(erlangSdkNameElement(configuredName)) }
+        val elixirSdk = createElixirSdk { sdk ->
+            SdkAdditionalData(sdk).apply { readExternal(erlangSdkElement(configuredName)) }
         }
 
         val result = resolver.resolveErlangSdkResult(elixirSdk, sdkModel(erlangSdk))
@@ -78,33 +93,100 @@ class ErlangSdkResolverTest : PlatformTestCase() {
         assertEquals(configuredName, missing.erlangSdkName)
     }
 
-    private fun mockElixirSdk(
+    fun testResolveByHomePath_success() {
+        val erlangHomePath = "/fake/erlang/26.0"
+        val erlangSdk = createSdk(name = "Erlang 26", sdkType = ErlangSdkType.instance, homePath = erlangHomePath)
+
+        val elixirSdk = createElixirSdk { sdk ->
+            SdkAdditionalData(sdk).apply {
+                readExternal(erlangSdkElement(name = "Erlang 26", homePath = erlangHomePath))
+            }
+        }
+
+        val result = resolver.resolveErlangSdkResult(elixirSdk, sdkModel(erlangSdk))
+
+        assertTrue("Should resolve successfully by home path", result is ErlangSdkResult.Success)
+        assertEquals(erlangSdk, (result as ErlangSdkResult.Success).sdk)
+    }
+
+    fun testResolveByHomePath_survivesRename() {
+        val erlangHomePath = "/fake/erlang/26.0"
+        // SDK was renamed from "Erlang 26" to "My Erlang"
+        val erlangSdk = createSdk(name = "My Erlang", sdkType = ErlangSdkType.instance, homePath = erlangHomePath)
+
+        val elixirSdk = createElixirSdk { sdk ->
+            SdkAdditionalData(sdk).apply {
+                // Persisted with old name but matching home path
+                readExternal(erlangSdkElement(name = "Erlang 26", homePath = erlangHomePath))
+            }
+        }
+
+        val result = resolver.resolveErlangSdkResult(elixirSdk, sdkModel(erlangSdk))
+
+        assertTrue("Should resolve by path even after rename", result is ErlangSdkResult.Success)
+        assertEquals(erlangSdk, (result as ErlangSdkResult.Success).sdk)
+    }
+
+    fun testResolveByName_legacyFallback() {
+        val configuredName = "Erlang 26"
+        val erlangSdk = createSdk(name = configuredName, sdkType = ErlangSdkType.instance, homePath = "/fake/erlang/26.0")
+
+        // Legacy config: name only, no home path
+        val elixirSdk = createElixirSdk { sdk ->
+            SdkAdditionalData(sdk).apply { readExternal(erlangSdkElement(configuredName)) }
+        }
+
+        val result = resolver.resolveErlangSdkResult(elixirSdk, sdkModel(erlangSdk))
+
+        assertTrue("Should resolve by name as legacy fallback", result is ErlangSdkResult.Success)
+        assertEquals(erlangSdk, (result as ErlangSdkResult.Success).sdk)
+    }
+
+    /**
+     * Creates a [ProjectJdkImpl] configured as an Elixir SDK with the given additional data.
+     */
+    private fun createElixirSdk(
         additionalDataProvider: (Sdk) -> SdkAdditionalData?
     ): Sdk {
-        val sdk = mock(Sdk::class.java)
-        `when`(sdk.name).thenReturn("Elixir SDK")
-        `when`(sdk.sdkAdditionalData).thenReturn(additionalDataProvider(sdk))
+        val sdk = ProjectJdkImpl("Elixir SDK", ElixirSdkType.instance, "/fake/elixir/1.15", "")
+        val data = additionalDataProvider(sdk)
+        if (data != null) {
+            WriteAction.run<Throwable> {
+                sdk.sdkModificator.apply {
+                    setSdkAdditionalData(data)
+                    commitChanges()
+                }
+            }
+        }
         return sdk
     }
 
-    private fun mockSdk(
+    /**
+     * Creates a [ProjectJdkImpl] with the given properties.
+     */
+    private fun createSdk(
         name: String,
         sdkType: SdkType,
         homePath: String?
     ): Sdk {
-        val sdk = mock(Sdk::class.java)
-        `when`(sdk.name).thenReturn(name)
-        `when`(sdk.sdkType).thenReturn(sdkType)
-        `when`(sdk.homePath).thenReturn(homePath)
-        return sdk
+        return ProjectJdkImpl(name, sdkType, homePath ?: "", "")
     }
 
-    private fun erlangSdkNameElement(name: String): Element =
-        Element("sdk").apply { setAttribute("erlang-sdk-name", name) }
+    private fun erlangSdkElement(name: String, homePath: String? = null): Element =
+        Element("sdk").apply {
+            setAttribute("erlang-sdk-name", name)
+            if (homePath != null) setAttribute("erlang-sdk-home-path", homePath)
+        }
 
-    private fun sdkModel(vararg sdks: Sdk): SdkModel {
-        val sdkModel = mock(SdkModel::class.java)
-        `when`(sdkModel.sdks).thenReturn(sdks)
-        return sdkModel
+    /**
+     * Simple [SdkModel] implementation backed by a fixed array of SDKs.
+     */
+    private fun sdkModel(vararg sdks: Sdk): SdkModel = object : SdkModel {
+        override fun getSdks(): Array<out Sdk> = arrayOf(*sdks)
+        override fun findSdk(sdkName: String?): Sdk? = sdks.find { it.name == sdkName }
+        override fun addSdk(sdk: Sdk) {}
+        override fun addListener(listener: SdkModel.Listener) {}
+        override fun removeListener(listener: SdkModel.Listener) {}
+        override fun getMulticaster(): SdkModel.Listener = object : SdkModel.Listener {}
     }
 }

--- a/tests/org/elixir_lang/sdk/erlang_dependent/SdkAdditionalDataTest.kt
+++ b/tests/org/elixir_lang/sdk/erlang_dependent/SdkAdditionalDataTest.kt
@@ -1,11 +1,10 @@
 package org.elixir_lang.sdk.erlang_dependent
 
 import com.intellij.openapi.projectRoots.Sdk
-import com.intellij.openapi.projectRoots.SdkTypeId
+import com.intellij.openapi.projectRoots.impl.ProjectJdkImpl
 import org.elixir_lang.PlatformTestCase
+import org.elixir_lang.sdk.erlang.Type as ErlangSdkType
 import org.jdom.Element
-import org.mockito.Mockito.mock
-import org.mockito.Mockito.`when`
 
 /**
  * Unit tests for SdkAdditionalData Phase 1 refactoring.
@@ -17,147 +16,162 @@ import org.mockito.Mockito.`when`
 class SdkAdditionalDataTest: PlatformTestCase() {
 
     /**
-     * Verify that creating SdkAdditionalData with an Erlang SDK sets both name and cache.
+     * Verify that creating SdkAdditionalData with an Erlang SDK sets both name and home path.
      */
-    fun testNewSdkCreation_SetsNameAndCache() {
-        val elixirSdk = createMockSdk("Elixir 1.15.0")
-        val erlangSdk = createMockSdk("Erlang 26.0")
+    fun testNewSdkCreation_SetsNameAndHomePath() {
+        val elixirSdk = createMockSdk("Elixir 1.15.0", "/fake/elixir/1.15")
+        val erlangSdk = createMockSdk("Erlang 26.0", "/fake/erlang/26.0")
 
         val additionalData = SdkAdditionalData(erlangSdk, elixirSdk)
 
-        // Both name and cache should be set
         assertEquals("Erlang 26.0", additionalData.getErlangSdkName())
-        // Note: Cannot directly test cachedErlangSdk as it's private
-        // But getErlangSdk() should return it from cache without lookup
+        assertEquals("/fake/erlang/26.0", additionalData.getErlangSdkHomePath())
     }
 
     /**
-     * Verify that setErlangSdk() updates both the name and cache atomically.
+     * Verify that setErlangSdk() updates both the name, home path, and cache atomically.
      */
-    fun testSetErlangSdk_UpdatesNameAndCache() {
-        val elixirSdk = createMockSdk("Elixir 1.15.0")
-        val erlangSdk1 = createMockSdk("Erlang 25.0")
-        val erlangSdk2 = createMockSdk("Erlang 26.0")
+    fun testSetErlangSdk_UpdatesNameHomePathAndCache() {
+        val elixirSdk = createMockSdk("Elixir 1.15.0", "/fake/elixir/1.15")
+        val erlangSdk1 = createMockSdk("Erlang 25.0", "/fake/erlang/25.0")
+        val erlangSdk2 = createMockSdk("Erlang 26.0", "/fake/erlang/26.0")
 
         val additionalData = SdkAdditionalData(erlangSdk1, elixirSdk)
         assertEquals("Erlang 25.0", additionalData.getErlangSdkName())
+        assertEquals("/fake/erlang/25.0", additionalData.getErlangSdkHomePath())
 
         // Update to a different Erlang SDK
         additionalData.setErlangSdk(erlangSdk2)
 
-        // Name should be updated
         assertEquals("Erlang 26.0", additionalData.getErlangSdkName())
+        assertEquals("/fake/erlang/26.0", additionalData.getErlangSdkHomePath())
     }
 
     /**
-     * Verify that setting null clears both name and cache.
+     * Verify that setting null clears name, home path, and cache.
      */
-    fun testSetErlangSdk_WithNull_ClearsNameAndCache() {
-        val elixirSdk = createMockSdk("Elixir 1.15.0")
-        val erlangSdk = createMockSdk("Erlang 26.0")
+    fun testSetErlangSdk_WithNull_ClearsAll() {
+        val elixirSdk = createMockSdk("Elixir 1.15.0", "/fake/elixir/1.15")
+        val erlangSdk = createMockSdk("Erlang 26.0", "/fake/erlang/26.0")
 
         val additionalData = SdkAdditionalData(erlangSdk, elixirSdk)
         assertEquals("Erlang 26.0", additionalData.getErlangSdkName())
+        assertEquals("/fake/erlang/26.0", additionalData.getErlangSdkHomePath())
 
         // Clear the Erlang SDK
         additionalData.setErlangSdk(null)
 
-        // Name should be null
         assertNull(additionalData.getErlangSdkName())
+        assertNull(additionalData.getErlangSdkHomePath())
     }
 
     /**
-     * Verify that readExternal() loads only the name and clears the cache.
+     * Verify that readExternal() loads both name and home path, and clears the cache.
      */
-    fun testReadExternal_LoadsNameAndClearsCache() {
-        val elixirSdk = createMockSdk("Elixir 1.15.0")
+    fun testReadExternal_LoadsNameAndHomePathAndClearsCache() {
+        val elixirSdk = createMockSdk("Elixir 1.15.0", "/fake/elixir/1.15")
         val additionalData = SdkAdditionalData(elixirSdk)
 
         val element = Element("additional")
         element.setAttribute("erlang-sdk-name", "Erlang 26.0")
+        element.setAttribute("erlang-sdk-home-path", "/fake/erlang/26.0")
 
         additionalData.readExternal(element)
 
-        // Name should be loaded
         assertEquals("Erlang 26.0", additionalData.getErlangSdkName())
-        // Cache would be null (tested implicitly by getErlangSdk needing to do lookup)
+        assertEquals("/fake/erlang/26.0", additionalData.getErlangSdkHomePath())
     }
 
     /**
-     * Verify that writeExternal() persists only the name.
+     * Verify readExternal with legacy data (name only, no home path).
      */
-    fun testWriteExternal_PersistsNameOnly() {
-        val elixirSdk = createMockSdk("Elixir 1.15.0")
-        val erlangSdk = createMockSdk("Erlang 26.0")
+    fun testReadExternal_LegacyNameOnly() {
+        val elixirSdk = createMockSdk("Elixir 1.15.0", "/fake/elixir/1.15")
+        val additionalData = SdkAdditionalData(elixirSdk)
+
+        val element = Element("additional")
+        element.setAttribute("erlang-sdk-name", "Erlang 26.0")
+        // No erlang-sdk-home-path attribute - simulates legacy config
+
+        additionalData.readExternal(element)
+
+        assertEquals("Erlang 26.0", additionalData.getErlangSdkName())
+        assertNull(additionalData.getErlangSdkHomePath())
+    }
+
+    /**
+     * Verify that writeExternal() persists both name and home path.
+     */
+    fun testWriteExternal_PersistsNameAndHomePath() {
+        val elixirSdk = createMockSdk("Elixir 1.15.0", "/fake/elixir/1.15")
+        val erlangSdk = createMockSdk("Erlang 26.0", "/fake/erlang/26.0")
 
         val additionalData = SdkAdditionalData(erlangSdk, elixirSdk)
 
         val element = Element("additional")
         additionalData.writeExternal(element)
 
-        // Name should be persisted
         assertEquals("Erlang 26.0", element.getAttributeValue("erlang-sdk-name"))
+        assertEquals("/fake/erlang/26.0", element.getAttributeValue("erlang-sdk-home-path"))
     }
 
     /**
-     * Verify that writeExternal() doesn't write anything if name is null.
+     * Verify that writeExternal() doesn't write anything if both name and home path are null.
      */
-    fun testWriteExternal_WithNullName_WritesNothing() {
-        val elixirSdk = createMockSdk("Elixir 1.15.0")
+    fun testWriteExternal_WithNullNameAndPath_WritesNothing() {
+        val elixirSdk = createMockSdk("Elixir 1.15.0", "/fake/elixir/1.15")
         val additionalData = SdkAdditionalData(elixirSdk)
 
         val element = Element("additional")
         additionalData.writeExternal(element)
 
-        // No attribute should be written
         assertNull(element.getAttributeValue("erlang-sdk-name"))
+        assertNull(element.getAttributeValue("erlang-sdk-home-path"))
     }
 
     /**
-     * Verify that clone() creates a new instance with the same name but no shared cache.
+     * Verify that clone() creates a new instance with the same name and home path but no shared cache.
      */
     fun testClone_CreatesIndependentCopy() {
-        val elixirSdk = createMockSdk("Elixir 1.15.0")
-        val erlangSdk = createMockSdk("Erlang 26.0")
+        val elixirSdk = createMockSdk("Elixir 1.15.0", "/fake/elixir/1.15")
+        val erlangSdk = createMockSdk("Erlang 26.0", "/fake/erlang/26.0")
 
         val original = SdkAdditionalData(erlangSdk, elixirSdk)
         val cloned = original.clone() as SdkAdditionalData
 
-        // Name should be copied
+        // Name and home path should be copied
         assertEquals(original.getErlangSdkName(), cloned.getErlangSdkName())
+        assertEquals(original.getErlangSdkHomePath(), cloned.getErlangSdkHomePath())
 
         // Modifying the clone should not affect the original
         cloned.setErlangSdk(null)
         assertNull(cloned.getErlangSdkName())
+        assertNull(cloned.getErlangSdkHomePath())
         assertEquals("Erlang 26.0", original.getErlangSdkName())
+        assertEquals("/fake/erlang/26.0", original.getErlangSdkHomePath())
     }
 
     /**
      * Verify that getErlangSdkName() returns the stored name without triggering SDK lookup.
      */
     fun testGetErlangSdkName_ReturnsNameWithoutLookup() {
-        val elixirSdk = createMockSdk("Elixir 1.15.0")
+        val elixirSdk = createMockSdk("Elixir 1.15.0", "/fake/elixir/1.15")
         val additionalData = SdkAdditionalData(elixirSdk)
 
         // Set name directly via readExternal
         val element = Element("additional")
         element.setAttribute("erlang-sdk-name", "Erlang 26.0")
+        element.setAttribute("erlang-sdk-home-path", "/fake/erlang/26.0")
         additionalData.readExternal(element)
 
         // getErlangSdkName should return the name immediately
         // (no lookup happens, no ProjectJdkTable access)
         assertEquals("Erlang 26.0", additionalData.getErlangSdkName())
+        assertEquals("/fake/erlang/26.0", additionalData.getErlangSdkHomePath())
     }
 
-    // Helper method to create mock SDK
-    private fun createMockSdk(name: String): Sdk {
-        val sdk = mock(Sdk::class.java)
-        `when`(sdk.name).thenReturn(name)
-
-        // Mock the sdkType to be a valid Erlang type for validation
-        val sdkType = mock(SdkTypeId::class.java)
-        `when`(sdk.sdkType).thenReturn(sdkType)
-
-        return sdk
+    // Helper method to create a lightweight SDK instance
+    private fun createMockSdk(name: String, homePath: String? = null): Sdk {
+        return ProjectJdkImpl(name, ErlangSdkType.instance, homePath ?: "", "")
     }
 }


### PR DESCRIPTION
## Summary
Elixir SDK registration now uses `(elixirHomePath, erlangSdkHomePath)` as the variant identity key. Two projects sharing the same Elixir install but paired with different Erlang SDK patch versions (e.g. 24.1.2.3 vs 24.5.6.7) get distinct SDK entries rather than collapsing into one.
## Changes
### SdkRegistrar.registerOrUpdateElixirSdk
- **Fast path**: confirmed existing SDK (erlangSdkHomePath persisted and matches) is returned immediately, syncing a stale erlangSdkName under a write action if the Erlang SDK was renamed after pairing.
- **Slow path**: legacy SDK (no persisted erlangSdkHomePath) is updated in place. New SDKs include OTP major in the display name via `ElixirBuildInfo.elixirOtpRelease` (BEAM parsing, no subprocess).
- **Atomic attachment**: Erlang dependency is written inside the same write action as SDK table mutation, so the SDK is never visible half-configured.
### Threading safety
- `@RequiresBackgroundThread` on `registerOrUpdateElixirSdk` (reads ~40KB BEAM file via `ElixirBuildInfo`)
- `@RequiresWriteLock` + `ThreadingAssertions.assertWriteAccess()` on `registerOrUpdate` and `registerOrUpdatePreparedErlangSdk`
- `ThreadingAssertions.assertReadAccess()` on `findElixirSdkByVariant` and `findSdkByHomePath` (`allJdks` requires read lock)
### ElixirInternalErlangSdkSetup
- `registerErlangSdk()` delegates to `SdkRegistrar.registerOrUpdatePreparedErlangSdk()` for deduplication and consistent error handling.
### Other
- Trace logging in `ElixirSdkLookup` for SDK resolution debugging
- Widget status readouts use the actual SDK name instead of a generic label
- Fix `mix deps` notification action invocation
## Stacking
Stacked on #3843 (`split/refactor-sdk-types`). Merge #3843 first.