### PR TITLE
refactor(elixir-sdk): read Elixir version from elixir.app instead of subprocess

### DIFF
--- a/src/org/elixir_lang/mise/Mise.kt
+++ b/src/org/elixir_lang/mise/Mise.kt
@@ -9,6 +9,7 @@ import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.util.concurrency.ThreadingAssertions
 import com.intellij.util.concurrency.annotations.RequiresBackgroundThread
+import org.elixir_lang.sdk.wsl.wslCompat
 import org.jetbrains.annotations.VisibleForTesting
 import java.nio.file.Path
 
@@ -67,7 +68,7 @@ object Mise {
     private const val TIMEOUT_MS = 10_000
 
     /**
-     * Invokes `mise ls --local --json` in `workDir` and parses the result.
+     * Invokes `mise ls --local --json` in [workDir] and parses the result.
      *
      * Returns `null` if mise is not on PATH, returns a non-zero exit code, times out, or
      * produces output that cannot be parsed. Callers should treat `null` as "mise unavailable".
@@ -83,7 +84,7 @@ object Mise {
         ThreadingAssertions.assertBackgroundThread()
         check(!ApplicationManager.getApplication().holdsReadLock()) {
             "Mise.resolveVersions() must not be called under a read lock - " +
-            "it spawns a subprocess that blocks for up to ${TIMEOUT_MS}ms"
+                    "it spawns a subprocess that blocks for up to ${TIMEOUT_MS}ms"
         }
         return try {
             val commandLine = GeneralCommandLine("mise", "ls", "--local", "--json")
@@ -96,7 +97,7 @@ object Mise {
                 return null
             }
 
-            parseOutput(output.stdout)
+            parseOutput(output.stdout, workDir)
         } catch (e: Exception) {
             LOG.debug("mise ls --local --json failed in $workDir: ${e.message}")
             null
@@ -111,7 +112,7 @@ object Mise {
      * `internal` for testing - use [Mise.resolveVersions] in production code.
      */
     @VisibleForTesting
-    internal fun parseOutput(json: String): MiseVersions? {
+    internal fun parseOutput(json: String, workDir: Path): MiseVersions? {
         return try {
             val gson = GsonBuilder()
                 .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
@@ -124,11 +125,11 @@ object Mise {
 
             val elixir = allTools["elixir"]
                 ?.firstOrNull { it.installed == true && it.active == true }
-                ?.toMiseToolEntry()
+                ?.toMiseToolEntry(workDir)
 
             val erlang = allTools["erlang"]
                 ?.firstOrNull { it.installed == true && it.active == true }
-                ?.toMiseToolEntry()
+                ?.toMiseToolEntry(workDir)
 
             MiseVersions(elixir, erlang)
         } catch (e: Exception) {
@@ -137,9 +138,11 @@ object Mise {
         }
     }
 
-    private fun RawMiseEntry.toMiseToolEntry(): MiseToolEntry? {
+    private fun RawMiseEntry.toMiseToolEntry(workDir: Path): MiseToolEntry? {
         val v = version ?: return null
-        val ip = install_path ?: return null
+        val ip = install_path?.let {
+            wslCompat.maybeConvertLinuxPathToWindowsUncFromContext(workDir.toString(), it)
+        } ?: return null
         return MiseToolEntry(
             version = v,
             requestedVersion = requested_version ?: v,

--- a/src/org/elixir_lang/mise/Mise.kt
+++ b/src/org/elixir_lang/mise/Mise.kt
@@ -150,18 +150,4 @@ object Mise {
             active = active ?: false,
         )
     }
-
-    /**
-     * Strips the `-otp-XX` suffix that mise appends to Elixir version strings
-     * (e.g. `"1.13.4-otp-24"` → `"1.13.4"`).
-     *
-     * **Note**: this is a temporary workaround. Once `ElixirVersionDetector` reads
-     * the `vsn` field from `elixir.app` directly, both sides of the version comparison
-     * will be bare version strings and this function can be removed.
-     */
-    @VisibleForTesting
-    internal fun stripElixirOtpSuffix(version: String): String {
-        val idx = version.indexOf("-otp-")
-        return if (idx >= 0) version.substring(0, idx) else version
-    }
 }

--- a/src/org/elixir_lang/mise/Mise.kt
+++ b/src/org/elixir_lang/mise/Mise.kt
@@ -57,7 +57,7 @@ private data class RawMiseSource(
 /**
  * Integrates with [mise](https://mise.jdx.dev/) to resolve tool versions for the current project.
  *
- * Shells out to `mise ls --local --json` using the module content root as the working directory,
+ * Shells out to `mise ls --current --json` using the module content root as the working directory,
  * which causes mise to apply its normal walk-up resolution rules (.tool-versions, mise.toml, etc.)
  * for that directory.
  *
@@ -68,7 +68,7 @@ object Mise {
     private const val TIMEOUT_MS = 10_000
 
     /**
-     * Invokes `mise ls --local --json` in [workDir] and parses the result.
+     * Invokes `mise ls --current --json` in [workDir] and parses the result.
      *
      * Returns `null` if mise is not on PATH, returns a non-zero exit code, times out, or
      * produces output that cannot be parsed. Callers should treat `null` as "mise unavailable".
@@ -86,20 +86,27 @@ object Mise {
             "Mise.resolveVersions() must not be called under a read lock - " +
                     "it spawns a subprocess that blocks for up to ${TIMEOUT_MS}ms"
         }
+        LOG.trace("resolveVersions: invoked for workDir=$workDir")
         return try {
-            val commandLine = GeneralCommandLine("mise", "ls", "--local", "--json")
+            val commandLine = GeneralCommandLine("mise", "ls", "--current", "--json")
                 .withWorkDirectory(workDir.toFile())
+            LOG.trace("resolveVersions: running '${commandLine.commandLineString}' in $workDir")
             val handler = CapturingProcessHandler(commandLine)
             val output = handler.runProcess(TIMEOUT_MS)
 
+            LOG.trace("resolveVersions: exit=${output.exitCode}, stdout.length=${output.stdout.length}, stderr.length=${output.stderr.length}")
             if (output.exitCode != 0) {
-                LOG.debug("mise ls --local --json exited with ${output.exitCode} in $workDir: ${output.stderr.take(200)}")
+                LOG.debug("mise ls --current --json exited with ${output.exitCode} in $workDir: ${output.stderr.take(200)}")
                 return null
             }
 
-            parseOutput(output.stdout, workDir)
+            LOG.trace("resolveVersions: stdout=${output.stdout.take(500)}")
+            val result = parseOutput(output.stdout, workDir)
+            LOG.trace("resolveVersions: parsed result=$result")
+            result
         } catch (e: Exception) {
-            LOG.debug("mise ls --local --json failed in $workDir: ${e.message}")
+            LOG.debug("mise ls --current --json failed in $workDir: ${e.message}")
+            LOG.trace("resolveVersions: exception class=${e::class.simpleName} message=${e.message}")
             null
         }
     }

--- a/src/org/elixir_lang/sdk/elixir/ElixirVersionDetector.kt
+++ b/src/org/elixir_lang/sdk/elixir/ElixirVersionDetector.kt
@@ -7,73 +7,76 @@ import com.intellij.openapi.util.Key
 import com.intellij.openapi.util.UserDataHolderEx
 import com.intellij.util.concurrency.ThreadingAssertions
 import com.intellij.util.concurrency.annotations.RequiresBackgroundThread
-import org.elixir_lang.cli.getExecutableFilepathWslSafe
-import org.elixir_lang.jps.shared.cli.CliTool
-import org.elixir_lang.sdk.ProcessOutput
 import org.elixir_lang.sdk.wsl.wslCompat
 import org.elixir_lang.util.runWithEdtGuard
-import org.jetbrains.annotations.Contract
 import java.io.File
 import java.util.concurrent.ConcurrentHashMap
+import java.util.regex.Pattern
 
 object ElixirVersionDetector {
     val ELIXIR_VERSION_KEY = Key.create<String>("ELIXIR_CANONICAL_VERSION")
     private val LOG = Logger.getInstance(ElixirVersionDetector::class.java)
     private val versionByHomePath: MutableMap<String, String> = ConcurrentHashMap()
 
+    /** Matches `{vsn, "X.Y.Z"}` (or any quoted value) anywhere in an Erlang `.app` file.
+     *  Allows optional whitespace around the key, comma, value, and closing brace. */
+    private val VSN_PATTERN: Pattern = Pattern.compile("""\{\s*vsn\s*,\s*"([^"]+)"\s*}""")
+
+    /**
+     * Reads the Elixir version from `<canonicalHome>/lib/elixir/ebin/elixir.app`.
+     *
+     * The `.app` file is the standard Erlang application resource file - a plain-text term of the
+     * form `{application, elixir, [{vsn, "X.Y.Z"}, ...]}.`. Parsing the `vsn` field via regex is
+     * safe because the value is always a simple string literal in OTP `.app` files.
+     *
+     * Entries are cached by `"$canonicalHome@$appFileMtime"` so stale entries are evicted
+     * automatically when the Elixir installation is replaced without restarting the IDE.
+     *
+     * Must NOT be called on the EDT - file I/O on WSL UNC paths (`\\wsl.localhost\...`)
+     * goes through the Plan 9 filesystem redirector and can block for 50–200 ms.
+     */
+    @RequiresBackgroundThread
+    private fun readElixirAppVersion(canonicalHome: String): String? {
+        ThreadingAssertions.assertBackgroundThread()
+        val appFile = File(canonicalHome, "lib/elixir/ebin/elixir.app")
+        if (!appFile.exists()) {
+            LOG.debug("elixir.app not found at ${appFile.path}")
+            return null
+        }
+        val lastModified = appFile.lastModified()
+        val cacheKey = "$canonicalHome@$lastModified"
+        versionByHomePath[cacheKey]?.let { return it }
+        return try {
+            val content = appFile.readText(Charsets.UTF_8)
+            val matcher = VSN_PATTERN.matcher(content)
+            if (matcher.find()) {
+                val version = matcher.group(1).trim()
+                if (version.isNotEmpty()) {
+                    versionByHomePath[cacheKey] = version
+                    version
+                } else {
+                    LOG.debug("Empty vsn field in ${appFile.path}")
+                    null
+                }
+            } else {
+                LOG.debug("Could not find vsn field in ${appFile.path}")
+                null
+            }
+        } catch (e: Exception) {
+            LOG.debug("Failed to read ${appFile.path}", e)
+            null
+        }
+    }
+
     internal fun elixirVersion(sdkHome: String, resolvedVersion: String?): String? {
         if (!resolvedVersion.isNullOrBlank()) {
             return resolvedVersion
         }
-
         val canonicalHome = wslCompat.canonicalizePath(sdkHome)
-        val exePath = CliTool.ELIXIR.getExecutableFilepathWslSafe(canonicalHome)
-        val exeFile = File(exePath)
-        val lastModified = exeFile.lastModified()
-        if (lastModified == 0L) {
-            LOG.debug("Elixir executable missing or unreadable: $exePath")
-            return elixirVersionFromHomePath(canonicalHome)
-        }
-
-        val cacheKey = "$canonicalHome@$lastModified"
-        val cached = versionByHomePath[cacheKey]
-        if (cached != null || versionByHomePath.containsKey(cacheKey)) {
-            return cached
-        }
-
         return runWithEdtGuard("Detecting Elixir SDK version...") {
-            elixirVersionBackground(canonicalHome, exePath, cacheKey)
+            readElixirAppVersion(canonicalHome)
         }
     }
-
-    private fun elixirVersionBackground(canonicalHome: String, exePath: String, cacheKey: String): String? {
-        return try {
-            val output =
-                ProcessOutput.getProcessOutput(
-                    ProcessOutput.STANDARD_TIMEOUT,
-                    canonicalHome,
-                    exePath,
-                    "--short-version"
-                )
-            val version =
-                if (output.exitCode == 0 && !output.isTimeout && !output.isCancelled) {
-                    output.stdoutLines.firstOrNull { it.isNotBlank() }?.trim()
-                } else {
-                    LOG.debug("Failed to read Elixir version from $exePath (exitCode=${output.exitCode})")
-                    elixirVersionFromHomePath(canonicalHome)
-                }
-            if (version != null) {
-                versionByHomePath[cacheKey] = version
-            }
-            version
-        } catch (e: Exception) {
-            LOG.debug("Failed to read Elixir version from $exePath", e)
-            elixirVersionFromHomePath(canonicalHome)
-        }
-    }
-
-    private fun elixirVersionFromHomePath(homePath: String) =
-        homePath.let { Release.fromString(File(it).name) }?.version()
 
     /**
      * Returns the bare canonical Elixir version string for [sdk] (e.g. `"1.15.7"`), or `null`
@@ -81,10 +84,10 @@ object ElixirVersionDetector {
      *
      * The result is cached on the [sdk] instance via [UserDataHolderEx] after the first call.
      * On a cold start (after IDE restart, before any SDK setup has run), the backing
-     * [ElixirVersionDetector.elixirVersion] may shell out to `elixir --short-version`.  That subprocess call
-     * **must not** happen while a read lock is held - doing so blocks write actions and
-     * triggers a platform SEVERE.  Always call this from a background thread or an IO
-     * coroutine dispatcher, never from inside `readAction { }`.
+     * [ElixirVersionDetector.elixirVersion] reads `elixir.app` from the SDK home directory.
+     * That file I/O **must not** happen while a read lock is held - doing so blocks write
+     * actions and may be very slow on WSL UNC paths.  Always call this from a background
+     * thread or an IO coroutine dispatcher, never from inside `readAction { }`.
      */
     @RequiresBackgroundThread
     fun canonicalVersion(sdk: Sdk): String? {
@@ -94,10 +97,9 @@ object ElixirVersionDetector {
 
         sdk.getUserData(ELIXIR_VERSION_KEY)?.let { return it }
 
-        // Cold path: may shell out to `elixir --short-version`.
-        // Calling elixirVersion() under a read lock blocks write actions - assert early.
+        // Cold path: reads elixir.app - must not be called under a read lock.
         check(!ApplicationManager.getApplication().holdsReadLock()) {
-            "canonicalVersion() may shell out to `elixir --short-version` and must not be called under a read lock"
+            "canonicalVersion() reads elixir.app and must not be called under a read lock"
         }
 
         val homePath = sdk.homePath ?: return null
@@ -111,30 +113,4 @@ object ElixirVersionDetector {
         sdk.putUserData(ELIXIR_VERSION_KEY, version)
         return version
     }
-
-    /**
-     * Returns the [Release] for [sdk], or `null` if the SDK is not an Elixir SDK or the
-     * release cannot be determined.
-     *
-     * This method is read-lock-safe and may be called from any thread, including the EDT
-     * and under a read action.  It uses only the pre-cached [ElixirVersionDetector.ELIXIR_VERSION_KEY] user data
-     * (populated by a prior [ElixirVersionDetector.canonicalVersion] call from an IO phase) and falls back to
-     * parsing the SDK home directory name.  It deliberately does **not** call
-     * [ElixirVersionDetector.canonicalVersion] - that would spawn `elixir --short-version` on a cold start and
-     * is forbidden under a read lock.
-     *
-     * Callers that need a guaranteed-accurate version at the cost of a subprocess on cold
-     * start should call [ElixirVersionDetector.canonicalVersion] from a background/IO thread instead.
-     */
-    @Contract("null -> null")
-    fun getRelease(sdk: Sdk?): Release? =
-        if (sdk != null && sdk.sdkType === Type.instance) {
-            // Prefer the pre-cached bare version (set by canonicalVersion() in IO phase).
-            // Fall back to directory name parsing - never spawn a subprocess here.
-            val cachedVersion = sdk.getUserData(ELIXIR_VERSION_KEY)
-            cachedVersion?.let { Release.fromString(it) }
-                ?: sdk.homePath?.let { Release.fromString(File(it).name) }
-        } else {
-            null
-        }
 }

--- a/src/org/elixir_lang/sdk/elixir/ElixirVersionDetector.kt
+++ b/src/org/elixir_lang/sdk/elixir/ElixirVersionDetector.kt
@@ -72,7 +72,12 @@ object ElixirVersionDetector {
         if (!resolvedVersion.isNullOrBlank()) {
             return resolvedVersion
         }
-        val canonicalHome = wslCompat.canonicalizePath(sdkHome)
+        val canonicalHome = try {
+            wslCompat.canonicalizePath(sdkHome)
+        } catch (e: Exception) {
+            LOG.debug("Failed to canonicalize Elixir SDK home '$sdkHome'; using raw path", e)
+            sdkHome
+        }
         return runWithEdtGuard("Detecting Elixir SDK version...") {
             readElixirAppVersion(canonicalHome)
         }

--- a/src/org/elixir_lang/sdk/elixir/Type.kt
+++ b/src/org/elixir_lang/sdk/elixir/Type.kt
@@ -26,9 +26,10 @@ import org.elixir_lang.jps.shared.sdk.SdkPaths
 import org.elixir_lang.sdk.*
 import org.elixir_lang.sdk.erlang_dependent.AdditionalDataConfigurable
 import org.elixir_lang.sdk.erlang_dependent.SdkAdditionalData
+import org.elixir_lang.sdk.wsl.wslCompat
 import org.elixir_lang.util.WriteActions
+import org.elixir_lang.util.runWithEdtGuard
 import org.jdom.Element
-import org.jetbrains.annotations.Contract
 import org.jetbrains.annotations.Unmodifiable
 import java.io.File
 import java.nio.file.Path
@@ -71,7 +72,8 @@ class Type : org.elixir_lang.sdk.erlang_dependent.Type(ElixirSdkTypeId.ELIXIR_SD
         return adjustedSdkHome
     }
 
-    override fun getDefaultDocumentationUrl(sdk: Sdk): String? = getDefaultDocumentationUrl(getRelease(sdk))
+    override fun getDefaultDocumentationUrl(sdk: Sdk): String? =
+        getDefaultDocumentationUrl(sdk.getUserData(ElixirVersionDetector.ELIXIR_VERSION_KEY))
 
     override fun getHomeChooserDescriptor(): FileChooserDescriptor =
         org.elixir_lang.sdk.Type.createHomeChooserDescriptor(presentableName, ::validateSdkHomePath)
@@ -170,7 +172,11 @@ ELIXIR_SDK_HOME
         currentSdkName: String?,
         sdkHome: String,
     ): String {
-        return suggestSdkNameForHome(sdkHome, null)
+        val canonicalHome = wslCompat.canonicalizePath(sdkHome)
+        val otpMajor = runWithEdtGuard("Detecting Elixir SDK...") {
+            ElixirBuildInfo.elixirOtpRelease(canonicalHome)
+        }
+        return suggestSdkNameForHome(sdkHome, null, otpMajor, null)
     }
 
     private fun validateSdkHomePath(virtualFile: VirtualFile) {
@@ -228,11 +234,18 @@ ELIXIR_SDK_HOME
         internal fun versionStringForHome(sdkHome: String, resolvedVersion: String?): String? {
             val version = ElixirVersionDetector.elixirVersion(sdkHome, resolvedVersion) ?: return null
             val source = SdkPaths.detectSource(sdkHome)
+            val canonicalHome = wslCompat.canonicalizePath(sdkHome)
+            val otpMajor = runWithEdtGuard("Detecting Elixir SDK...") {
+                ElixirBuildInfo.elixirOtpRelease(canonicalHome)
+            }
             return buildString {
                 if (source != null) {
                     append(source).append(" ")
                 }
                 append("Elixir ").append(version)
+                if (otpMajor != null) {
+                    append(" (OTP ").append(otpMajor).append(")")
+                }
             }
         }
 
@@ -261,7 +274,7 @@ ELIXIR_SDK_HOME
          *
          * Example: `"mise Elixir 1.13.4-otp-24 (Erlang 24.3.4.6)"`
          *
-         * Falls back to [suggestSdkNameForHome] when [otpMajor] is null (pre-Elixir-1.6 installs
+         * Falls back to [Type.suggestSdkNameForHome] when [otpMajor] is null (pre-Elixir-1.6 installs
          * where BEAM parsing is unavailable).
          */
         @JvmStatic
@@ -294,10 +307,6 @@ ELIXIR_SDK_HOME
         @JvmStatic
         @RequiresBackgroundThread
         fun canonicalVersion(sdk: Sdk): String? = ElixirVersionDetector.canonicalVersion(sdk)
-
-        @JvmStatic
-        @Contract("null -> null")
-        fun getRelease(sdk: Sdk?): Release? = ElixirVersionDetector.getRelease(sdk)
 
         @JvmStatic
         internal fun setupSdkTableListener() {
@@ -413,7 +422,7 @@ ELIXIR_SDK_HOME
             }
         }
 
-        private fun getDefaultDocumentationUrl(version: Release?): String? =
+        private fun getDefaultDocumentationUrl(version: String?): String? =
             if (version == null) null else "https://elixir-lang.org/docs/stable/elixir/"
 
         @JvmStatic

--- a/src/org/elixir_lang/sdk/wsl/WslCompatService.kt
+++ b/src/org/elixir_lang/sdk/wsl/WslCompatService.kt
@@ -6,6 +6,7 @@ import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.util.io.FileUtil
 import com.intellij.util.system.OS
+import org.jetbrains.annotations.VisibleForTesting
 import java.nio.file.Paths
 import kotlin.io.path.absolutePathString
 
@@ -76,28 +77,52 @@ interface WslCompatService {
      * @param path the path to canonicalize
      * @return the canonicalized path,
      */
-    fun canonicalizePath(path: String, currentOs: OS = OS.CURRENT): String {
-        val maybeConvertedPath = when {
-            currentOs != OS.Windows -> path
-
-            currentOs.isAtLeast(11, 0) ->
-                path.replacePrefix(LEGACY_WSL_PREFIX, MODERN_WSL_PREFIX)
-
-            else -> path.replacePrefix(MODERN_WSL_PREFIX, LEGACY_WSL_PREFIX)
+    fun canonicalizePath(path: String): String {
+        val maybeConvertedPath = path.canonicalizeWslPrefix()
+        return try {
+            toRealPath(maybeConvertedPath)
+        } catch (_: Exception) {
+            maybeConvertedPath
         }
-        // Resolve symlinks
-        return Paths.get(maybeConvertedPath).toRealPath().absolutePathString()
     }
+
+    @VisibleForTesting
+    fun toRealPath(myPath: String) = Paths.get(myPath).toRealPath().absolutePathString()
 
     /**
      * Nullable version of [canonicalizePath]
      */
-    fun canonicalizePathNullable(path: String?, currentOs: OS = OS.CURRENT): String? {
+    fun canonicalizePathNullable(path: String?): String? {
         if (path == null) {
             return path
         }
-        return canonicalizePath(path, currentOs)
+        return canonicalizePath(path)
     }
+
+    /**
+     * Decides how a WSL UNC prefix should be normalized for [currentOs], returning the
+     * `(fromPrefix, toPrefix)` pair to apply, or `null` when no conversion should happen
+     * (i.e. not on Windows).
+     *
+     * This is the single ambient-OS decision point, kept separate from the pure string
+     * rewrite in [canonicalizeWslPrefix] so the rewrite is testable without an OS dependency
+     * and this policy can be overridden deterministically in tests.
+     *
+     * - Windows 11+ normalizes the legacy `\\wsl$\` prefix to the modern `\\wsl.localhost\`.
+     * - Older Windows normalizes the modern prefix to the legacy one.
+     */
+    fun wslPrefixConversion(currentOs: OS = OS.CURRENT): Pair<String, String>? = when {
+        currentOs != OS.Windows -> null
+        currentOs.isAtLeast(11, 0) -> LEGACY_WSL_PREFIX to MODERN_WSL_PREFIX
+        else -> MODERN_WSL_PREFIX to LEGACY_WSL_PREFIX
+    }
+
+    /**
+     * Applies the [wslPrefixConversion] decision for the current OS to this path, leaving it
+     * unchanged when no conversion applies.
+     */
+    fun String.canonicalizeWslPrefix(): String =
+            wslPrefixConversion()?.let { (from, to) -> replacePrefix(from, to) } ?: this
 
     fun String.replacePrefix(prefix: String, replacement: String) = if (startsWith(prefix, true))
         replacement + substring(prefix.length)
@@ -111,7 +136,9 @@ interface WslCompatService {
         if (first.isNullOrBlank() || second.isNullOrBlank()) {
             false
         } else {
-            FileUtil.pathsEqual(canonicalizePath(first), canonicalizePath(second))
+                val canonicalizedFirst = canonicalizePath(first)
+                val canonicalizedSecond = canonicalizePath(second)
+                FileUtil.pathsEqual(canonicalizedFirst, canonicalizedSecond)
         }
 
     /**

--- a/src/org/elixir_lang/sdk/wsl/WslCompatService.kt
+++ b/src/org/elixir_lang/sdk/wsl/WslCompatService.kt
@@ -221,6 +221,32 @@ interface WslCompatService {
     fun convertLinuxPathToWindowsUnc(distribution: WSLDistribution, linuxPath: String?): String?
 
     /**
+     * Converts a Linux absolute path (for example `/home/user/.local/share/mise/...`) to a canonical Windows UNC path
+     * by inferring the WSL distribution from a known WSL UNC context path.
+     *
+     * Returns `null` when:
+     * - [contextWindowsUncPath] is empty or not a WSL UNC path,
+     * - [linuxPath] is not a Linux absolute path,
+     * - the WSL distribution cannot be inferred, or
+     * - conversion fails.
+     */
+    fun convertLinuxPathToWindowsUncFromContext(contextWindowsUncPath: String, linuxPath: String): String? {
+        if (!linuxPath.startsWith("/")) return null
+        if (!isWslUncPath(contextWindowsUncPath)) return null
+        val distribution = getDistributionByWindowsUncPath(contextWindowsUncPath) ?: return null
+        return convertLinuxPathToWindowsUnc(distribution, linuxPath)
+    }
+
+    /**
+     * Best-effort variant of [convertLinuxPathToWindowsUncFromContext].
+     *
+     * Returns [linuxPath] unchanged when conversion cannot be performed.
+     */
+    fun maybeConvertLinuxPathToWindowsUncFromContext(contextWindowsUncPath: String, linuxPath: String): String {
+        return convertLinuxPathToWindowsUncFromContext(contextWindowsUncPath, linuxPath) ?: linuxPath
+    }
+
+    /**
      * Detects if the command line runs on WSL, caches the result, and returns the distribution.
      */
     private fun determineDistribution(commandLine: GeneralCommandLine): WSLDistribution? {

--- a/src/org/elixir_lang/sdk/wsl/WslCompatServiceImpl.kt
+++ b/src/org/elixir_lang/sdk/wsl/WslCompatServiceImpl.kt
@@ -91,12 +91,7 @@ internal class WslCompatServiceImpl : WslCompatService {
             // Delegate to native IntelliJ API
             val wslPath = WslPath(distribution.msId, linuxPath)
             val converted = wslPath.toWindowsUncPath()
-            try {
-                canonicalizePath(converted)
-            } catch (e: Exception) {
-                log.debug("Failed to canonicalize converted WSL path '$converted'; using raw converted path", e)
-                converted
-            }
+            canonicalizePath(converted)
         } catch (e: Exception) {
             log.debug("Error converting Linux path to Windows UNC: $linuxPath", e)
             null

--- a/src/org/elixir_lang/sdk/wsl/WslCompatServiceImpl.kt
+++ b/src/org/elixir_lang/sdk/wsl/WslCompatServiceImpl.kt
@@ -90,7 +90,13 @@ internal class WslCompatServiceImpl : WslCompatService {
         return try {
             // Delegate to native IntelliJ API
             val wslPath = WslPath(distribution.msId, linuxPath)
-            wslPath.toWindowsUncPath()
+            val converted = wslPath.toWindowsUncPath()
+            try {
+                canonicalizePath(converted)
+            } catch (e: Exception) {
+                log.debug("Failed to canonicalize converted WSL path '$converted'; using raw converted path", e)
+                converted
+            }
         } catch (e: Exception) {
             log.debug("Error converting Linux path to Windows UNC: $linuxPath", e)
             null

--- a/src/org/elixir_lang/status_bar_widget/ElixirEditorBasedSdkWidget.kt
+++ b/src/org/elixir_lang/status_bar_widget/ElixirEditorBasedSdkWidget.kt
@@ -47,6 +47,7 @@ import org.elixir_lang.mix.project.ProjectModuleSetupValidator
 import org.elixir_lang.mix.project.ProjectModuleSetupValidator.FolderMarkIssue
 import org.elixir_lang.sdk.SdkEbinPaths
 import org.elixir_lang.sdk.SdkRegistrar
+import org.elixir_lang.sdk.elixir.ElixirVersionDetector
 import org.elixir_lang.sdk.elixir.SdkSettingsOpener
 import org.elixir_lang.sdk.elixir.ElixirSdkLookup
 import org.elixir_lang.sdk.elixir.Type
@@ -102,8 +103,16 @@ internal sealed interface SdkStatus {
     /**
      * No Elixir SDK is configured, but mise has an installed Elixir version for the module's
      * content root. Surfaces a notification with a one-click "Configure from mise" action.
+     *
+     * [miseVersions] carries the full mise resolution result (used for configuration).
+     * [elixirCanonicalVersion] is the bare version string read from the mise install's
+     * `elixir.app` (e.g. `"1.15.7"`), pre-computed in the IO phase so Phase 3 display
+     * can use it without further file I/O or string parsing.
      */
-    data class NotConfiguredMiseAvailable(val miseVersions: MiseVersions) : SdkStatus
+    data class NotConfiguredMiseAvailable(
+        val miseVersions: MiseVersions,
+        val elixirCanonicalVersion: String?,
+    ) : SdkStatus
 }
 
 internal data class ModuleSdkIssue(val moduleName: String, val issue: String, val isDangling: Boolean)
@@ -176,6 +185,7 @@ class ElixirEditorBasedSdkWidget(
                         ioData.elixirVersionBySdk,
                         ioData.miseByContentRoot,
                         ioData.erlangOtpMajorByHomePath,
+                        ioData.elixirVersionByInstallPath,
                     )
                     // Build per-module mise assignments: module name → the MiseVersions that mise
                     // resolves for that module's own content root.  Covers all modules with an
@@ -190,6 +200,7 @@ class ElixirEditorBasedSdkWidget(
                         miseAssignments = miseAssignments,
                         projectSdkSnapshot = modelData.projectSdkSnapshot,
                         classpathIssues = ioData.classpathIssues,
+                        elixirVersionByInstallPath = ioData.elixirVersionByInstallPath,
                     )
                 }
         }
@@ -374,6 +385,7 @@ class ElixirEditorBasedSdkWidget(
         miseAssignments: Map<String, MiseVersions> = emptyMap(),
         projectSdkSnapshot: ProjectSdkSnapshot,
         classpathIssues: List<String>,
+        elixirVersionByInstallPath: Map<String, String?> = emptyMap(),
     ) {
         val elixirSdk = projectSdkSnapshot.elixirSdk
         val erlangSdk = projectSdkSnapshot.erlangSdk
@@ -386,8 +398,11 @@ class ElixirEditorBasedSdkWidget(
             folderMarkIssues.isNotEmpty() && elixirSdk != null ->
                 SdkStatus.FolderMarkWarning(elixirSdk, elixirVersion, folderMarkIssues)
 
-            elixirSdk == null && miseAssignments.isNotEmpty() ->
-                SdkStatus.NotConfiguredMiseAvailable(miseAssignments.values.first())
+            elixirSdk == null && miseAssignments.isNotEmpty() -> {
+                val firstMise = miseAssignments.values.first()
+                val canonicalVersion = firstMise.elixir?.installPath?.let { elixirVersionByInstallPath[it] }
+                SdkStatus.NotConfiguredMiseAvailable(firstMise, canonicalVersion)
+            }
 
             elixirSdk == null ->
                 SdkStatus.NotConfigured
@@ -502,7 +517,7 @@ class ElixirEditorBasedSdkWidget(
             is SdkStatus.Configured -> null
             is SdkStatus.NotConfigured -> "not-configured"
             is SdkStatus.NotConfiguredMiseAvailable ->
-                "not-configured-mise:${status.miseVersions.elixir?.let { Mise.stripElixirOtpSuffix(it.version) }}"
+                "not-configured-mise:${status.elixirCanonicalVersion ?: status.miseVersions.elixir?.version}"
 
             is SdkStatus.InvalidSdk -> "partial:${status.issue}"
             is SdkStatus.ClasspathIssue -> "warning:${status.issues.sorted().joinToString(",")}"
@@ -533,9 +548,9 @@ class ElixirEditorBasedSdkWidget(
             )
 
             is SdkStatus.NotConfiguredMiseAvailable -> {
-                val displayVersion = status.miseVersions.elixir?.let {
-                    Mise.stripElixirOtpSuffix(it.version)
-                } ?: "unknown"
+                val displayVersion = status.elixirCanonicalVersion
+                    ?: status.miseVersions.elixir?.version
+                    ?: "unknown"
                 NotificationContent(
                     "Elixir SDK Not Configured",
                     "No Elixir SDK configured, but Elixir $displayVersion is available via mise.",
@@ -733,6 +748,10 @@ class ElixirEditorBasedSdkWidget(
         /** OTP major (e.g. `"26"`) keyed by canonical Erlang SDK home path. Populated from
          *  `releases/<N>/OTP_VERSION` - no subprocess. */
         val erlangOtpMajorByHomePath: Map<String, String?>,
+        /** Canonical Elixir version (e.g. `"1.15.7"`) keyed by install path, read from
+         *  `lib/elixir/ebin/elixir.app` inside each tool-manager install directory.
+         *  Works for mise, asdf, or any other manager that populates [org.elixir_lang.mise.MiseToolEntry.installPath]. */
+        val elixirVersionByInstallPath: Map<String, String?>,
         val classpathIssues: List<String>,
     )
 
@@ -784,12 +803,24 @@ class ElixirEditorBasedSdkWidget(
                 ErlangVersionDetector.detectRelease(homePath)?.otpMajor
             }
 
+        // Read the canonical Elixir version from each unique mise install's elixir.app.
+        // This avoids string-mangling the mise-reported version (e.g. "1.15.7-otp-26") and
+        // uses the same authoritative source as the SDK version detection.
+        val elixirVersionByInstallPath: Map<String, String?> = miseByContentRoot.values
+            .filterNotNull()
+            .mapNotNull { it.elixir?.installPath }
+            .distinct()
+            .associateWith { installPath ->
+                ElixirVersionDetector.elixirVersion(installPath, null)
+            }
+
         val classpathIssues = detectClasspathIssues(modelData.projectSdkSnapshot)
 
         return NotificationScanIoData(
             miseByContentRoot = miseByContentRoot,
             elixirVersionBySdk = elixirVersionBySdk,
             erlangOtpMajorByHomePath = erlangOtpMajorByHomePath,
+            elixirVersionByInstallPath = elixirVersionByInstallPath,
             classpathIssues = classpathIssues,
         )
     }
@@ -966,6 +997,7 @@ class ElixirEditorBasedSdkWidget(
         elixirVersionBySdk: Map<Sdk, String?>,
         miseByContentRoot: Map<Path, MiseVersions?>,
         erlangOtpMajorByHomePath: Map<String, String?>,
+        elixirVersionByInstallPath: Map<String, String?>,
     ): List<ModuleSdkIssue> {
         val issues = mutableListOf<ModuleSdkIssue>()
 
@@ -977,8 +1009,11 @@ class ElixirEditorBasedSdkWidget(
             val miseElixir = miseVersions.elixir
             if (miseElixir != null) {
                 val configuredVersion = data.elixirSdk?.let { elixirVersionBySdk[it] }
-                val miseVersion = Mise.stripElixirOtpSuffix(miseElixir.version)
-                if (configuredVersion != null && configuredVersion != miseVersion) {
+                // Use the canonical version read from elixir.app in the mise install directory.
+                // This is the same source as the SDK version, so both sides are bare strings
+                // (e.g. "1.15.7") with no OTP suffix manipulation.
+                val miseVersion = elixirVersionByInstallPath[miseElixir.installPath]
+                if (configuredVersion != null && miseVersion != null && configuredVersion != miseVersion) {
                     LOG.info(
                         "Mise version mismatch in module '${data.moduleName}': " +
                                 "SDK=$configuredVersion, mise=$miseVersion"

--- a/tests/org/elixir_lang/mise/MiseTest.kt
+++ b/tests/org/elixir_lang/mise/MiseTest.kt
@@ -3,9 +3,9 @@ package org.elixir_lang.mise
 import org.elixir_lang.PlatformTestCase
 
 /**
- * Tests for [Mise.parseOutput] (internal) and [Mise.stripElixirOtpSuffix].
+ * Tests for [Mise.parseOutput] (internal).
  *
- * Both functions are pure with no IDE dependencies, so no sandbox setup is needed.
+ * Pure with no IDE dependencies, so no sandbox setup is needed.
  */
 class MiseTest : PlatformTestCase() {
 
@@ -187,25 +187,5 @@ class MiseTest : PlatformTestCase() {
         assertNotNull(result)
         assertNull(result!!.elixir!!.sourceType)
         assertNull(result.elixir.sourcePath)
-    }
-
-    // -------------------------------------------------------------------------
-    // stripElixirOtpSuffix
-    // -------------------------------------------------------------------------
-
-    fun testStripElixirOtpSuffix_withSuffix() {
-        assertEquals("1.13.4", Mise.stripElixirOtpSuffix("1.13.4-otp-24"))
-    }
-
-    fun testStripElixirOtpSuffix_noSuffix() {
-        assertEquals("1.15.7", Mise.stripElixirOtpSuffix("1.15.7"))
-    }
-
-    fun testStripElixirOtpSuffix_preReleaseWithSuffix() {
-        assertEquals("1.18.0-rc.1", Mise.stripElixirOtpSuffix("1.18.0-rc.1-otp-27"))
-    }
-
-    fun testStripElixirOtpSuffix_emptyString() {
-        assertEquals("", Mise.stripElixirOtpSuffix(""))
     }
 }

--- a/tests/org/elixir_lang/mise/MiseTest.kt
+++ b/tests/org/elixir_lang/mise/MiseTest.kt
@@ -1,6 +1,7 @@
 package org.elixir_lang.mise
 
 import org.elixir_lang.PlatformTestCase
+import java.nio.file.Path
 
 /**
  * Tests for [Mise.parseOutput] (internal).
@@ -8,6 +9,7 @@ import org.elixir_lang.PlatformTestCase
  * Pure with no IDE dependencies, so no sandbox setup is needed.
  */
 class MiseTest : PlatformTestCase() {
+    private val workDir: Path = Path.of(".")
 
     // -------------------------------------------------------------------------
     // parseOutput
@@ -21,7 +23,7 @@ class MiseTest : PlatformTestCase() {
             }
         """.trimIndent()
 
-        val result = Mise.parseOutput(json)
+        val result = Mise.parseOutput(json, workDir)
 
         assertNotNull(result)
         assertNotNull(result!!.elixir)
@@ -38,7 +40,7 @@ class MiseTest : PlatformTestCase() {
             }
         """.trimIndent()
 
-        val result = Mise.parseOutput(json)
+        val result = Mise.parseOutput(json, workDir)
 
         assertNotNull(result)
         assertNotNull(result!!.elixir)
@@ -52,7 +54,7 @@ class MiseTest : PlatformTestCase() {
             }
         """.trimIndent()
 
-        val result = Mise.parseOutput(json)
+        val result = Mise.parseOutput(json, workDir)
 
         assertNotNull(result)
         assertNull(result!!.elixir)
@@ -61,7 +63,7 @@ class MiseTest : PlatformTestCase() {
     }
 
     fun testParseOutput_emptyObject_returnsBothNull() {
-        val result = Mise.parseOutput("{}")
+        val result = Mise.parseOutput("{}", workDir)
 
         assertNotNull(result)
         assertNull(result!!.elixir)
@@ -79,7 +81,7 @@ class MiseTest : PlatformTestCase() {
             }
         """.trimIndent()
 
-        val result = Mise.parseOutput(json)
+        val result = Mise.parseOutput(json, workDir)
 
         assertNotNull(result)
         assertEquals("1.13.4", result!!.elixir!!.version)
@@ -92,7 +94,7 @@ class MiseTest : PlatformTestCase() {
             }
         """.trimIndent()
 
-        val result = Mise.parseOutput(json)
+        val result = Mise.parseOutput(json, workDir)
 
         assertNotNull(result)
         assertNull(result!!.elixir)
@@ -105,7 +107,7 @@ class MiseTest : PlatformTestCase() {
             }
         """.trimIndent()
 
-        val result = Mise.parseOutput(json)
+        val result = Mise.parseOutput(json, workDir)
 
         assertNotNull(result)
         assertNull(result!!.elixir)
@@ -119,7 +121,7 @@ class MiseTest : PlatformTestCase() {
             }
         """.trimIndent()
 
-        val result = Mise.parseOutput(json)
+        val result = Mise.parseOutput(json, workDir)
 
         assertNotNull(result)
         assertNotNull(result!!.elixir)
@@ -134,7 +136,7 @@ class MiseTest : PlatformTestCase() {
             }
         """.trimIndent()
 
-        val result = Mise.parseOutput(json)
+        val result = Mise.parseOutput(json, workDir)
 
         assertNotNull(result)
         assertNull(result!!.elixir)
@@ -147,18 +149,18 @@ class MiseTest : PlatformTestCase() {
             }
         """.trimIndent()
 
-        val result = Mise.parseOutput(json)
+        val result = Mise.parseOutput(json, workDir)
 
         assertNotNull(result)
         assertNull(result!!.elixir)
     }
 
     fun testParseOutput_emptyString_returnsNull() {
-        assertNull(Mise.parseOutput(""))
+        assertNull(Mise.parseOutput("", workDir))
     }
 
     fun testParseOutput_malformedJson_returnsNull() {
-        assertNull(Mise.parseOutput("not json at all {{{"))
+        assertNull(Mise.parseOutput("not json at all {{{", workDir))
     }
 
     fun testParseOutput_sourceFieldPresent_populatedCorrectly() {
@@ -168,7 +170,7 @@ class MiseTest : PlatformTestCase() {
             }
         """.trimIndent()
 
-        val result = Mise.parseOutput(json)
+        val result = Mise.parseOutput(json, workDir)
 
         assertNotNull(result)
         assertEquals("file", result!!.elixir!!.sourceType)
@@ -182,7 +184,7 @@ class MiseTest : PlatformTestCase() {
             }
         """.trimIndent()
 
-        val result = Mise.parseOutput(json)
+        val result = Mise.parseOutput(json, workDir)
 
         assertNotNull(result)
         assertNull(result!!.elixir!!.sourceType)

--- a/tests/org/elixir_lang/sdk/elixir/ElixirVersionDetectorTest.kt
+++ b/tests/org/elixir_lang/sdk/elixir/ElixirVersionDetectorTest.kt
@@ -1,0 +1,175 @@
+package org.elixir_lang.sdk.elixir
+
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.vfs.newvfs.impl.VfsRootAccess
+import com.intellij.testFramework.registerOrReplaceServiceInstance
+import org.elixir_lang.PlatformTestCase
+import org.elixir_lang.sdk.wsl.MockWslCompatService
+import org.elixir_lang.sdk.wsl.WslCompatService
+import java.io.File
+import java.nio.file.Files
+
+/**
+ * Tests for [ElixirVersionDetector] - specifically the `elixir.app` file parsing that
+ * replaced the old `elixir --short-version` subprocess and directory-name fallback.
+ *
+ * Each test creates a temporary directory tree so no real Elixir installation is required.
+ */
+class ElixirVersionDetectorTest : PlatformTestCase() {
+
+    override fun setUp() {
+        super.setUp()
+        // MockWslCompatService returns paths unchanged (identity transform)
+        ApplicationManager.getApplication().registerOrReplaceServiceInstance(
+            WslCompatService::class.java,
+            MockWslCompatService(),
+            testRootDisposable,
+        )
+    }
+
+    // ---------------------------------------------------------------
+    // Happy-path parsing
+    // ---------------------------------------------------------------
+
+    fun testElixirVersion_simpleVersion() {
+        val sdkHome = createSdkHomeWithApp("1.15.7")
+        VfsRootAccess.allowRootAccess(testRootDisposable, sdkHome)
+
+        val version = ElixirVersionDetector.elixirVersion(sdkHome, null)
+        assertEquals("1.15.7", version)
+    }
+
+    fun testElixirVersion_preReleaseVersion() {
+        val sdkHome = createSdkHomeWithApp("1.20.0-rc.0")
+        VfsRootAccess.allowRootAccess(testRootDisposable, sdkHome)
+
+        val version = ElixirVersionDetector.elixirVersion(sdkHome, null)
+        assertEquals("1.20.0-rc.0", version)
+    }
+
+    fun testElixirVersion_devVersion() {
+        val sdkHome = createSdkHomeWithApp("1.21.0-dev")
+        VfsRootAccess.allowRootAccess(testRootDisposable, sdkHome)
+
+        val version = ElixirVersionDetector.elixirVersion(sdkHome, null)
+        assertEquals("1.21.0-dev", version)
+    }
+
+    fun testElixirVersion_whitespaceTolerance() {
+        // Extra whitespace around the vsn value and braces
+        val sdkHome = createSdkHomeWithCustomApp(
+            """
+            {application, elixir, [
+              { vsn ,  "1.16.2"  },
+              {modules, []}
+            ]}.
+            """.trimIndent(),
+        )
+        VfsRootAccess.allowRootAccess(testRootDisposable, sdkHome)
+
+        val version = ElixirVersionDetector.elixirVersion(sdkHome, null)
+        assertEquals("1.16.2", version)
+    }
+
+    // ---------------------------------------------------------------
+    // resolvedVersion shortcut
+    // ---------------------------------------------------------------
+
+    fun testElixirVersion_resolvedVersionShortCircuits() {
+        // When a resolvedVersion is provided it is returned immediately without reading any file
+        val sdkHome = "/this/path/does/not/exist"
+        val version = ElixirVersionDetector.elixirVersion(sdkHome, "1.13.4")
+        assertEquals("1.13.4", version)
+    }
+
+    // ---------------------------------------------------------------
+    // Graceful failure paths
+    // ---------------------------------------------------------------
+
+    fun testElixirVersion_missingAppFile_returnsNull() {
+        // SDK home exists but has no elixir.app
+        val sdkHome = Files.createTempDirectory("elixir-sdk-test-").toString()
+        VfsRootAccess.allowRootAccess(testRootDisposable, sdkHome)
+
+        val version = ElixirVersionDetector.elixirVersion(sdkHome, null)
+        assertNull("Should return null when elixir.app is absent", version)
+    }
+
+    fun testElixirVersion_missingVsnField_returnsNull() {
+        val sdkHome = createSdkHomeWithCustomApp(
+            """
+            {application, elixir, [
+              {description, "elixir"},
+              {modules, []}
+            ]}.
+            """.trimIndent(),
+        )
+        VfsRootAccess.allowRootAccess(testRootDisposable, sdkHome)
+
+        val version = ElixirVersionDetector.elixirVersion(sdkHome, null)
+        assertNull("Should return null when vsn key is absent", version)
+    }
+
+    fun testElixirVersion_emptyAppFile_returnsNull() {
+        val sdkHome = createSdkHomeWithCustomApp("")
+        VfsRootAccess.allowRootAccess(testRootDisposable, sdkHome)
+
+        val version = ElixirVersionDetector.elixirVersion(sdkHome, null)
+        assertNull("Should return null for an empty .app file", version)
+    }
+
+    fun testElixirVersion_nonExistentSdkHome_returnsNull() {
+        val version = ElixirVersionDetector.elixirVersion("/path/that/does/not/exist/at/all", null)
+        assertNull("Should return null for a completely missing SDK home", version)
+    }
+
+    // ---------------------------------------------------------------
+    // Caching
+    // ---------------------------------------------------------------
+
+    fun testElixirVersion_cachedAcrossCalls() {
+        val sdkHome = createSdkHomeWithApp("1.15.7")
+        VfsRootAccess.allowRootAccess(testRootDisposable, sdkHome)
+
+        val first = ElixirVersionDetector.elixirVersion(sdkHome, null)
+        val second = ElixirVersionDetector.elixirVersion(sdkHome, null)
+        assertEquals(first, second)
+        assertEquals("1.15.7", first)
+    }
+
+    // ---------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------
+
+    /**
+     * Creates a temp SDK home with the given [version] in a standard `elixir.app` file.
+     *
+     * Layout: `<root>/lib/elixir/ebin/elixir.app`
+     */
+    private fun createSdkHomeWithApp(version: String): String =
+        createSdkHomeWithCustomApp(
+            """
+            {application, elixir, [
+              {description, "elixir"},
+              {vsn, "$version"},
+              {modules, []},
+              {registered, []},
+              {applications, [kernel, stdlib]}
+            ]}.
+            """.trimIndent(),
+        )
+
+    /**
+     * Creates a temp SDK home with the given raw [appContent] as the `elixir.app` file content.
+     *
+     * Layout: `<root>/lib/elixir/ebin/elixir.app`
+     */
+    private fun createSdkHomeWithCustomApp(appContent: String): String {
+        val root = Files.createTempDirectory("elixir-sdk-test-").toFile()
+        root.deleteOnExit()
+        val ebinDir = File(root, "lib/elixir/ebin")
+        ebinDir.mkdirs()
+        File(ebinDir, "elixir.app").writeText(appContent)
+        return root.path
+    }
+}

--- a/tests/org/elixir_lang/sdk/elixir/TypeNamingTest.kt
+++ b/tests/org/elixir_lang/sdk/elixir/TypeNamingTest.kt
@@ -6,6 +6,8 @@ import com.intellij.testFramework.registerOrReplaceServiceInstance
 import org.elixir_lang.PlatformTestCase
 import org.elixir_lang.sdk.wsl.MockWslCompatService
 import org.elixir_lang.sdk.wsl.WslCompatService
+import org.mockito.ArgumentMatchers.anyString
+import org.mockito.Mockito.*
 import java.io.File
 import java.nio.file.Files
 
@@ -117,6 +119,24 @@ class TypeNamingTest : PlatformTestCase() {
         assertEquals("Should contain exactly one 'Elixir'; was: $name", 1, name.split("Elixir").size - 1)
     }
 
+    fun testSuggestSdkName_doesNotThrowWhenCanonicalizeFails() {
+        val throwingService = spy(MockWslCompatService())
+        doThrow(IllegalStateException("boom"))
+            .`when`(throwingService)
+            .toRealPath(anyString())
+
+        ApplicationManager.getApplication().registerOrReplaceServiceInstance(
+            WslCompatService::class.java,
+            throwingService,
+            testRootDisposable,
+        )
+
+        val name = elixirType.suggestSdkName(null, "/not/a/real/elixir/install")
+
+        assertTrue("Name should still be produced even if canonicalization fails; was: $name", name.contains("Elixir"))
+        verify(throwingService, atLeastOnce()).toRealPath(anyString())
+    }
+
     // ---------------------------------------------------------------
     // getVersionString
     // ---------------------------------------------------------------
@@ -140,6 +160,46 @@ class TypeNamingTest : PlatformTestCase() {
         // Even the fallback path must contain "Elixir" for display correctness
         val version = elixirType.getVersionString("/Users/josh/.local/share/mise/installs/elixir/1.15.7")
         assertTrue("Version string should contain 'Elixir'; was: $version", version.contains("Elixir"))
+    }
+
+    fun testGetVersionString_doesNotThrowWhenCanonicalizeFails() {
+        val throwingService = spy(MockWslCompatService())
+        doThrow(IllegalStateException("boom"))
+            .`when`(throwingService)
+            .toRealPath(anyString())
+
+        ApplicationManager.getApplication().registerOrReplaceServiceInstance(
+            WslCompatService::class.java,
+            throwingService,
+            testRootDisposable,
+        )
+
+        val version = elixirType.getVersionString("/not/a/real/path/elixir")
+
+        assertTrue("Version string should still be produced when canonicalization fails; was: $version", version.contains("Elixir"))
+        verify(throwingService, atLeastOnce()).toRealPath(anyString())
+    }
+
+    fun testGetVersionString_withRealAppFile_doesNotThrowWhenCanonicalizeFails() {
+        val sdkHome = createElixirSdkHome("1.15.7")
+        VfsRootAccess.allowRootAccess(testRootDisposable, sdkHome)
+
+        val throwingService = spy(MockWslCompatService())
+        doThrow(IllegalStateException("boom"))
+            .`when`(throwingService)
+            .toRealPath(anyString())
+
+        ApplicationManager.getApplication().registerOrReplaceServiceInstance(
+            WslCompatService::class.java,
+            throwingService,
+            testRootDisposable,
+        )
+
+        val version = elixirType.getVersionString(sdkHome)
+
+        assertTrue("Version string should still be produced when canonicalization fails; was: $version", version.contains("Elixir"))
+        assertTrue("Version string should still contain parsed version when canonicalization fails; was: $version", version.contains("1.15.7"))
+        verify(throwingService, atLeastOnce()).toRealPath(anyString())
     }
 
     // ---------------------------------------------------------------

--- a/tests/org/elixir_lang/sdk/elixir/TypeNamingTest.kt
+++ b/tests/org/elixir_lang/sdk/elixir/TypeNamingTest.kt
@@ -1,13 +1,20 @@
 package org.elixir_lang.sdk.elixir
 
 import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.vfs.newvfs.impl.VfsRootAccess
 import com.intellij.testFramework.registerOrReplaceServiceInstance
 import org.elixir_lang.PlatformTestCase
 import org.elixir_lang.sdk.wsl.MockWslCompatService
 import org.elixir_lang.sdk.wsl.WslCompatService
+import java.io.File
+import java.nio.file.Files
 
 /**
  * Tests for Elixir SDK Type naming methods.
+ *
+ * Version detection now uses `elixir.app` file parsing (no subprocess, no directory-name parsing).
+ * Tests verify source detection via [Type.suggestSdkNameForHome] with an explicit `resolvedVersion`,
+ * and end-to-end version reading via a temp directory containing a real `elixir.app` file.
  */
 class TypeNamingTest : PlatformTestCase() {
 
@@ -15,8 +22,6 @@ class TypeNamingTest : PlatformTestCase() {
 
     override fun setUp() {
         super.setUp()
-
-        // Replace the real WslCompatService with MockWslCompatService for testing
         ApplicationManager.getApplication().registerOrReplaceServiceInstance(
             WslCompatService::class.java,
             MockWslCompatService(),
@@ -25,57 +30,145 @@ class TypeNamingTest : PlatformTestCase() {
         elixirType = Type.instance
     }
 
-    fun testSuggestSdkName_miseElixir() {
-        val name = elixirType.suggestSdkName(null, "/Users/josh/.local/share/mise/installs/elixir/1.15.7")
+    // ---------------------------------------------------------------
+    // suggestSdkNameForHome (static, resolvedVersion bypasses file I/O)
+    // These tests verify source detection without needing a real .app file.
+    // ---------------------------------------------------------------
+
+    fun testSuggestSdkNameForHome_miseElixir() {
+        val name = Type.suggestSdkNameForHome(
+            "/Users/josh/.local/share/mise/installs/elixir/1.15.7",
+            "1.15.7",
+        )
         assertEquals("mise Elixir 1.15.7", name)
     }
 
-    fun testSuggestSdkName_miseElixirWithOtp() {
-        val name = elixirType.suggestSdkName(null, "/Users/josh/.local/share/mise/installs/elixir/1.15.7-otp-26")
-        assertEquals("mise Elixir 1.15.7-otp-26", name)
+    fun testSuggestSdkNameForHome_miseElixirWithOtpSuffix() {
+        // resolvedVersion from .app is the bare version; OTP suffix is stripped on the mise side
+        val name = Type.suggestSdkNameForHome(
+            "/Users/josh/.local/share/mise/installs/elixir/1.15.7-otp-26",
+            "1.15.7",
+        )
+        assertEquals("mise Elixir 1.15.7", name)
     }
 
-    fun testSuggestSdkName_asdfElixir() {
-        val name = elixirType.suggestSdkName(null, "/Users/josh/.asdf/installs/elixir/1.14.0")
+    fun testSuggestSdkNameForHome_asdfElixir() {
+        val name = Type.suggestSdkNameForHome(
+            "/Users/josh/.asdf/installs/elixir/1.14.0",
+            "1.14.0",
+        )
         assertEquals("asdf Elixir 1.14.0", name)
     }
 
-    fun testSuggestSdkName_homebrewElixir() {
-        val name = elixirType.suggestSdkName(null, "/opt/homebrew/Cellar/elixir/1.15.0/libexec")
-        // Homebrew paths have nested structure, version comes from directory name
-        assertTrue("Name should contain Homebrew", name.contains("Homebrew") || name.contains("Elixir"))
-    }
-
-    fun testSuggestSdkName_unknownSource() {
-        val name = elixirType.suggestSdkName(null, "/custom/path/1.15.0")
+    fun testSuggestSdkNameForHome_unknownSource() {
+        val name = Type.suggestSdkNameForHome("/custom/path/elixir", "1.15.0")
         assertEquals("Elixir 1.15.0", name)
     }
 
-    fun testSuggestSdkName_noDuplicateElixir() {
-        // This was a bug where "Elixir" appeared twice
-        val name = elixirType.suggestSdkName(null, "/Users/josh/.local/share/mise/installs/elixir/1.15.7")
-        val elixirCount = name.split("Elixir").size - 1
-        assertEquals("Should contain exactly one 'Elixir'", 1, elixirCount)
+    fun testSuggestSdkNameForHome_variantQualified() {
+        val name = Type.suggestSdkNameForHome(
+            "/Users/josh/.local/share/mise/installs/elixir/1.15.7-otp-26",
+            "1.15.7",
+            "26",
+            "26.2.5",
+        )
+        assertEquals("mise Elixir 1.15.7-otp-26 (Erlang 26.2.5)", name)
     }
 
-    fun testGetVersionString_miseElixir() {
-        val version = elixirType.getVersionString("/Users/josh/.local/share/mise/installs/elixir/1.15.7")
-        assertEquals("mise Elixir 1.15.7", version)
+    fun testSuggestSdkNameForHome_noOtpMajorFallsBackToTwoArg() {
+        val name = Type.suggestSdkNameForHome(
+            "/Users/josh/.local/share/mise/installs/elixir/1.15.7",
+            "1.15.7",
+            null,
+            null,
+        )
+        assertEquals("mise Elixir 1.15.7", name)
     }
 
-    fun testGetVersionString_asdfElixir() {
-        val version = elixirType.getVersionString("/Users/josh/.asdf/installs/elixir/1.14.0")
-        assertEquals("asdf Elixir 1.14.0", version)
+    // ---------------------------------------------------------------
+    // suggestSdkName (instance, reads .app file or falls back to "at <path>")
+    // ---------------------------------------------------------------
+
+    fun testSuggestSdkName_withRealAppFile() {
+        val sdkHome = createElixirSdkHome("1.15.7")
+        VfsRootAccess.allowRootAccess(testRootDisposable, sdkHome)
+
+        val name = elixirType.suggestSdkName(null, sdkHome)
+        assertTrue("Name should contain version; was: $name", name.contains("1.15.7"))
+        assertTrue("Name should contain 'Elixir'; was: $name", name.contains("Elixir"))
     }
 
-    fun testGetVersionString_unknownSource() {
-        val version = elixirType.getVersionString("/custom/path/1.15.0")
-        assertEquals("Elixir 1.15.0", version)
+    fun testSuggestSdkName_fallbackWhenNoAppFile() {
+        val fakePath = "/not/a/real/elixir/install"
+        val name = elixirType.suggestSdkName(null, fakePath)
+        assertTrue("Name should show path when version unreadable; was: $name", name.contains("at"))
+        assertEquals(
+            "Should contain exactly one 'Elixir'; was: $name",
+            1,
+            name.split("Elixir").size - 1,
+        )
+    }
+
+    fun testSuggestSdkName_noDuplicateElixir_withAppFile() {
+        val sdkHome = createElixirSdkHome("1.17.4")
+        VfsRootAccess.allowRootAccess(testRootDisposable, sdkHome)
+
+        val name = elixirType.suggestSdkName(null, sdkHome)
+        assertEquals("Should contain exactly one 'Elixir'; was: $name", 1, name.split("Elixir").size - 1)
+    }
+
+    // ---------------------------------------------------------------
+    // getVersionString
+    // ---------------------------------------------------------------
+
+    fun testGetVersionString_withRealAppFile() {
+        val sdkHome = createElixirSdkHome("1.15.7")
+        VfsRootAccess.allowRootAccess(testRootDisposable, sdkHome)
+
+        val version = elixirType.getVersionString(sdkHome)
+        assertNotNull(version)
+        assertTrue("Version string should contain 1.15.7; was: $version", version.contains("1.15.7"))
+        assertTrue("Version string should contain 'Elixir'; was: $version", version.contains("Elixir"))
+    }
+
+    fun testGetVersionString_unknownWhenNoAppFile() {
+        val version = elixirType.getVersionString("/not/a/real/path/elixir")
+        assertTrue("Fallback should still contain 'Elixir'; was: $version", version.contains("Elixir"))
     }
 
     fun testGetVersionString_includesElixir() {
-        // Version string should include "Elixir" for clarity in detected SDKs list
+        // Even the fallback path must contain "Elixir" for display correctness
         val version = elixirType.getVersionString("/Users/josh/.local/share/mise/installs/elixir/1.15.7")
-        assertTrue("Version string should contain 'Elixir'", version.contains("Elixir"))
+        assertTrue("Version string should contain 'Elixir'; was: $version", version.contains("Elixir"))
+    }
+
+    // ---------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------
+
+    /**
+     * Creates a temporary Elixir SDK home directory containing a minimal `elixir.app`.
+     *
+     * Structure: `<tmpDir>/lib/elixir/ebin/elixir.app`
+     *
+     * @return the path to the SDK home root (the directory containing `lib/`).
+     */
+    private fun createElixirSdkHome(version: String): String {
+        val tmpRoot = Files.createTempDirectory("elixir-sdk-test-").toFile()
+        tmpRoot.deleteOnExit()
+        val ebinDir = File(tmpRoot, "lib/elixir/ebin")
+        ebinDir.mkdirs()
+        File(ebinDir, "elixir.app").writeText(
+            """
+            {application, elixir, [
+              {description, "elixir"},
+              {vsn, "$version"},
+              {modules, []},
+              {registered, []},
+              {applications, [kernel, stdlib]}
+            ]}.
+            """.trimIndent(),
+        )
+        return tmpRoot.path
     }
 }

--- a/tests/org/elixir_lang/sdk/wsl/MockWslCompatService.kt
+++ b/tests/org/elixir_lang/sdk/wsl/MockWslCompatService.kt
@@ -17,7 +17,7 @@ import org.mockito.Mockito
 class MockWslCompatService(
     private val distributionOverride: ((String?) -> WSLDistribution?)? = null,
     private val conversionOverride: ((WSLDistribution, String?) -> String?)? = null,
-    private val canonicalWslPrefixOverride: String? = null,
+    private val prefixConversionOverride: Pair<String, String>? = LEGACY_WSL_PREFIX to MODERN_WSL_PREFIX,
 ) : WslCompatService {
     override val log = Logger.getInstance(MockWslCompatService::class.java)
 
@@ -143,25 +143,11 @@ class MockWslCompatService(
         return null
     }
 
-    // Only performs prefix normalization (\\wsl$\ ↔ \\wsl.localhost\) without calling toRealPath(),
-    // since test paths don't exist on the filesystem.
-    override fun canonicalizePath(path: String, currentOs: OS): String {
-        val forcedPrefix = canonicalWslPrefixOverride
-        if (forcedPrefix != null) {
-            return when {
-                forcedPrefix == MODERN_WSL_PREFIX -> path.replacePrefix(LEGACY_WSL_PREFIX, MODERN_WSL_PREFIX)
-                forcedPrefix == LEGACY_WSL_PREFIX -> path.replacePrefix(MODERN_WSL_PREFIX, LEGACY_WSL_PREFIX)
-                else -> path
-            }
-        }
-
-        return when {
-            currentOs != OS.Windows -> path
-
-            currentOs.isAtLeast(11, 0) ->
-                path.replacePrefix(LEGACY_WSL_PREFIX, MODERN_WSL_PREFIX)
-
-            else -> path.replacePrefix(MODERN_WSL_PREFIX, LEGACY_WSL_PREFIX)
-        }
-    }
+    /**
+     * Returns [prefixConversionOverride] (default: legacy→modern) instead of consulting the host OS,
+     * so tests are deterministic across the CI matrix (Windows 11, older Windows, and Linux runners).
+     * Only the OS-version policy is stubbed; the real prefix rewrite in [canonicalizeWslPrefix] still runs.
+     * Pass `prefixConversionOverride = null` to simulate the "no conversion" (non-Windows) case.
+     */
+    override fun wslPrefixConversion(currentOs: OS): Pair<String, String>? = prefixConversionOverride
 }

--- a/tests/org/elixir_lang/sdk/wsl/MockWslCompatService.kt
+++ b/tests/org/elixir_lang/sdk/wsl/MockWslCompatService.kt
@@ -3,6 +3,8 @@ package org.elixir_lang.sdk.wsl
 import com.intellij.execution.wsl.WSLDistribution
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.util.system.OS
+import org.jetbrains.annotations.TestOnly
+import org.mockito.Mockito
 
 /**
  * Mock implementation of WslCompatService for testing purposes.
@@ -11,7 +13,12 @@ import com.intellij.util.system.OS
  * without requiring WSL installation. In production, the real WslCompatServiceImpl
  * is used, while in tests this mock can be injected.
  */
-class MockWslCompatService : WslCompatService {
+@TestOnly
+class MockWslCompatService(
+    private val distributionOverride: ((String?) -> WSLDistribution?)? = null,
+    private val conversionOverride: ((WSLDistribution, String?) -> String?)? = null,
+    private val canonicalWslPrefixOverride: String? = null,
+) : WslCompatService {
     override val log = Logger.getInstance(MockWslCompatService::class.java)
 
     override fun isWslUncPath(path: String?): Boolean {
@@ -30,6 +37,8 @@ class MockWslCompatService : WslCompatService {
     }
 
     override fun getDistributionByWindowsUncPath(path: String?): WSLDistribution? {
+        distributionOverride?.let { return it(path) }
+
         if (!isWslUncPath(path)) {
             return null
         }
@@ -42,8 +51,8 @@ class MockWslCompatService : WslCompatService {
             else -> "WSL"
         }
 
-        return org.mockito.Mockito.mock(WSLDistribution::class.java).also {
-            org.mockito.Mockito.`when`(it.msId).thenReturn(distroName)
+        return Mockito.mock(WSLDistribution::class.java).also {
+            Mockito.`when`(it.msId).thenReturn(distroName)
         }
     }
 
@@ -99,12 +108,20 @@ class MockWslCompatService : WslCompatService {
     }
 
     override fun convertLinuxPathToWindowsUnc(distribution: WSLDistribution, linuxPath: String?): String? {
+        conversionOverride?.let { return it(distribution, linuxPath) }
+
         if (linuxPath.isNullOrEmpty()) {
             return null
         }
 
-        // Mock implementation returns a Windows UNC path
-        return "\\\\wsl.localhost\\${distribution.msId}$linuxPath"
+        // Mock implementation returns a well-formed Windows UNC path
+        val linuxAsWindows = linuxPath.replace('/', '\\')
+        val converted = "\\\\wsl.localhost\\${distribution.msId}$linuxAsWindows"
+        return try {
+            canonicalizePath(converted)
+        } catch (_: Exception) {
+            converted
+        }
     }
 
     override fun convertSingleWslPath(windowsPath: String, distribution: WSLDistribution): String? {
@@ -126,12 +143,25 @@ class MockWslCompatService : WslCompatService {
         return null
     }
 
-    override fun canonicalizePath(path: String, currentOs: OS): String = when {
-        currentOs != OS.Windows -> path
+    // Only performs prefix normalization (\\wsl$\ ↔ \\wsl.localhost\) without calling toRealPath(),
+    // since test paths don't exist on the filesystem.
+    override fun canonicalizePath(path: String, currentOs: OS): String {
+        val forcedPrefix = canonicalWslPrefixOverride
+        if (forcedPrefix != null) {
+            return when {
+                forcedPrefix == MODERN_WSL_PREFIX -> path.replacePrefix(LEGACY_WSL_PREFIX, MODERN_WSL_PREFIX)
+                forcedPrefix == LEGACY_WSL_PREFIX -> path.replacePrefix(MODERN_WSL_PREFIX, LEGACY_WSL_PREFIX)
+                else -> path
+            }
+        }
 
-        currentOs.isAtLeast(11, 0) ->
-            path.replacePrefix(LEGACY_WSL_PREFIX, MODERN_WSL_PREFIX)
+        return when {
+            currentOs != OS.Windows -> path
 
-        else -> path.replacePrefix(MODERN_WSL_PREFIX, LEGACY_WSL_PREFIX)
+            currentOs.isAtLeast(11, 0) ->
+                path.replacePrefix(LEGACY_WSL_PREFIX, MODERN_WSL_PREFIX)
+
+            else -> path.replacePrefix(MODERN_WSL_PREFIX, LEGACY_WSL_PREFIX)
+        }
     }
 }

--- a/tests/org/elixir_lang/sdk/wsl/WslCompatServiceExtensionsTest.kt
+++ b/tests/org/elixir_lang/sdk/wsl/WslCompatServiceExtensionsTest.kt
@@ -1,17 +1,20 @@
 package org.elixir_lang.sdk.wsl
 
 import com.intellij.execution.wsl.WSLDistribution
+import com.intellij.util.system.OS
 import org.elixir_lang.PlatformTestCase
+import org.mockito.ArgumentMatchers.anyString
 import org.mockito.Mockito
+import org.mockito.Mockito.*
 
 class WslCompatServiceExtensionsTest : PlatformTestCase() {
-    private val service = MockWslCompatService(canonicalWslPrefixOverride = MODERN_WSL_PREFIX)
+    private val wslCompatMock = MockWslCompatService()
 
     fun testConvertLinuxPathToWindowsUncFromContext_convertsForWslContext() {
         val contextPath = "\\\\wsl.localhost\\Ubuntu-24.04\\home\\testuser\\project"
         val linuxPath = "/home/testuser/.local/share/mise/installs/elixir/1.15.7"
 
-        val converted = service.convertLinuxPathToWindowsUncFromContext(contextPath, linuxPath)
+        val converted = wslCompatMock.convertLinuxPathToWindowsUncFromContext(contextPath, linuxPath)
 
         assertEquals(
             "\\\\wsl.localhost\\Ubuntu-24.04\\home\\testuser\\.local\\share\\mise\\installs\\elixir\\1.15.7",
@@ -20,7 +23,7 @@ class WslCompatServiceExtensionsTest : PlatformTestCase() {
     }
 
     fun testConvertLinuxPathToWindowsUncFromContext_returnsNullForNonWslContext() {
-        val converted = service.convertLinuxPathToWindowsUncFromContext(
+        val converted = wslCompatMock.convertLinuxPathToWindowsUncFromContext(
             "C:\\Users\\steve\\IdeaProjects\\intellij-elixir",
             "/home/testuser/.local/share/mise/installs/elixir/1.15.7",
         )
@@ -29,7 +32,7 @@ class WslCompatServiceExtensionsTest : PlatformTestCase() {
     }
 
     fun testConvertLinuxPathToWindowsUncFromContext_returnsNullForNonLinuxPath() {
-        val converted = service.convertLinuxPathToWindowsUncFromContext(
+        val converted = wslCompatMock.convertLinuxPathToWindowsUncFromContext(
             "\\\\wsl.localhost\\Ubuntu-24.04\\home\\testuser\\project",
             "C:\\Program Files\\Elixir",
         )
@@ -50,7 +53,7 @@ class WslCompatServiceExtensionsTest : PlatformTestCase() {
 
     fun testConvertLinuxPathToWindowsUncFromContext_returnsNullWhenConversionFails() {
         val distro = Mockito.mock(WSLDistribution::class.java)
-        Mockito.`when`(distro.msId).thenReturn("Ubuntu-24.04")
+        `when`(distro.msId).thenReturn("Ubuntu-24.04")
 
         val serviceWithFailingConversion = MockWslCompatService(
             distributionOverride = { distro },
@@ -69,7 +72,7 @@ class WslCompatServiceExtensionsTest : PlatformTestCase() {
         val contextPath = "\\\\wsl.localhost\\Ubuntu-24.04\\home\\testuser\\project"
         val linuxPath = "/home/testuser/.local/share/mise/installs/elixir/1.15.7"
         val expected = "\\\\wsl.localhost\\Ubuntu-24.04\\home\\testuser\\.local\\share\\mise\\installs\\elixir\\1.15.7"
-        val converted = service.maybeConvertLinuxPathToWindowsUncFromContext(contextPath, linuxPath)
+        val converted = wslCompatMock.maybeConvertLinuxPathToWindowsUncFromContext(contextPath, linuxPath)
 
         assertEquals(expected, converted)
     }
@@ -77,11 +80,170 @@ class WslCompatServiceExtensionsTest : PlatformTestCase() {
     fun testMaybeConvertLinuxPathToWindowsUncFromContext_returnsOriginalOnNonWslContext() {
         val linuxPath = "/home/testuser/.local/share/mise/installs/elixir/1.15.7"
 
-        val converted = service.maybeConvertLinuxPathToWindowsUncFromContext(
+        val converted = wslCompatMock.maybeConvertLinuxPathToWindowsUncFromContext(
             "C:\\Users\\steve\\IdeaProjects\\intellij-elixir",
             linuxPath,
         )
 
         assertEquals(linuxPath, converted)
+    }
+
+    fun testPathsEqualWslAware_returnsTrueWhenEqualButRealpathThrowsWindows() {
+        val myPath = "C:\\sdk-a"
+        val throwingService = spy(wslCompatMock)
+        doThrow(IllegalStateException("boom"))
+            .`when`(throwingService)
+            .toRealPath(anyString())
+
+        val equal = throwingService.pathsEqualWslAware(myPath, myPath)
+
+        assertTrue(equal)
+        verify(throwingService, times(2)).toRealPath(anyString())
+    }
+
+    fun testPathsEqualWslAware_returnsTrueWhenEqualButRealpathThrowsLinux() {
+        val myPath = "/home/testuser/.local/share//mise//installs//elixir//1.15.7"
+        val throwingService = spy(wslCompatMock)
+        doThrow(IllegalStateException("boom"))
+            .`when`(throwingService)
+            .toRealPath(anyString())
+
+        val equal = throwingService.pathsEqualWslAware(myPath, myPath)
+
+        assertTrue(equal)
+        verify(throwingService, times(2)).toRealPath(anyString())
+    }
+
+    fun testPathsEqualWslAware_returnsTrueWhenEqualButRealpathThrowsWsl() {
+        val myPath = "\\\\wsl.localhost\\Ubuntu-24.04\\home\\testuser\\.local\\share\\mise\\installs\\elixir\\1.15.7"
+        val throwingService = spy(wslCompatMock)
+        doThrow(IllegalStateException("boom"))
+            .`when`(throwingService)
+            .toRealPath(anyString())
+
+        val equal = throwingService.pathsEqualWslAware(myPath, myPath)
+
+        assertTrue(equal)
+        verify(throwingService, times(2)).toRealPath(anyString())
+    }
+
+    fun testPathsEqualWslAware_returnsTrueWhenEqualButRealpathThrowsDifferentPrefixWsl() {
+        val myPath = "\\\\wsl.localhost\\Ubuntu-24.04\\home\\testuser\\.local\\share\\mise\\installs\\elixir\\1.15.7"
+        val myPath2 = "\\\\wsl$\\Ubuntu-24.04\\home\\testuser\\.local\\share\\mise\\installs\\elixir\\1.15.7"
+        val throwingService = spy(wslCompatMock)
+        doThrow(IllegalStateException("boom"))
+            .`when`(throwingService)
+            .toRealPath(anyString())
+
+        val equal = throwingService.pathsEqualWslAware(myPath, myPath2)
+
+        assertTrue(equal)
+        // path is canonicalized before comparison, so same path calls twice
+        verify(throwingService, times(2)).toRealPath(anyString())
+    }
+
+    fun testPathsEqualWslAware_returnsFalseWhenNotEqualButRealpathThrowsWindows() {
+        val myPath = "C:\\sdk-a"
+        val myPath2 = "C:\\sdk-b"
+        val throwingService = spy(wslCompatMock)
+        doThrow(IllegalStateException("boom"))
+            .`when`(throwingService)
+            .toRealPath(anyString())
+
+        val equal = throwingService.pathsEqualWslAware(myPath, myPath2)
+
+        assertFalse(equal)
+        verify(throwingService).toRealPath(myPath)
+        verify(throwingService).toRealPath(myPath2)
+    }
+
+    fun testPathsEqualWslAware_returnsFalseWhenNotEqualButRealpathThrowsLinux() {
+        val myPath = "/home/testuser/.local/share//mise//installs//elixir//1.15.7"
+        val myPath2 = "/home/testuser/.local/share//mise//installs//elixir//1.19.7"
+        val throwingService = spy(wslCompatMock)
+        doThrow(IllegalStateException("boom"))
+            .`when`(throwingService)
+            .toRealPath(anyString())
+
+        val equal = throwingService.pathsEqualWslAware(myPath, myPath2)
+
+        assertFalse(equal)
+        verify(throwingService).toRealPath(myPath)
+        verify(throwingService).toRealPath(myPath2)
+    }
+
+    fun testPathsEqualWslAware_returnsFalseWhenNotEqualButRealpathThrowsWsl() {
+        val myPath = "\\\\wsl.localhost\\Ubuntu-24.04\\home\\testuser\\.local\\share\\mise\\installs\\elixir\\1.15.7"
+        val myPath2 = "\\\\wsl.localhost\\Ubuntu-24.04\\home\\testuser\\.local\\share\\mise\\installs\\elixir\\1.19.7"
+        val throwingService = spy(wslCompatMock)
+        doThrow(IllegalStateException("boom"))
+            .`when`(throwingService)
+            .toRealPath(anyString())
+
+        val equal = throwingService.pathsEqualWslAware(myPath, myPath2)
+
+        assertFalse(equal)
+        verify(throwingService).toRealPath(myPath)
+        verify(throwingService).toRealPath(myPath2)
+    }
+
+    fun testPathsEqualWslAware_returnsFalseWhenNotEqualButRealpathThrowsDifferentPrefixWsl() {
+        val myPath = "\\\\wsl.localhost\\Ubuntu-24.04\\home\\testuser\\.local\\share\\mise\\installs\\elixir\\1.15.7"
+        val myPath2 = "\\\\wsl$\\Ubuntu-24.04\\home\\testuser\\.local\\share\\mise\\installs\\elixir\\1.19.7"
+        val myPath2Canonicalized = "\\\\wsl.localhost\\Ubuntu-24.04\\home\\testuser\\.local\\share\\mise\\installs\\elixir\\1.19.7"
+        val throwingService = spy(wslCompatMock)
+        doThrow(IllegalStateException("boom"))
+            .`when`(throwingService)
+            .toRealPath(anyString())
+
+        val equal = throwingService.pathsEqualWslAware(myPath, myPath2)
+
+        assertFalse(equal)
+        // path is canonicalized before comparison, so same path calls twice
+        verify(throwingService).toRealPath(myPath)
+        verify(throwingService).toRealPath(myPath2Canonicalized)
+    }
+
+    // -------------------------------------------------------------------------
+    // WSL prefix canonicalization: OS-policy seam ([wslPrefixConversion]) and the
+    // pure rewrite it drives ([canonicalizeWslPrefix]).
+    // -------------------------------------------------------------------------
+
+    fun testWslPrefixConversion_returnsNullForNonWindows() {
+        // Exercises the REAL production decision: off Windows there is no prefix conversion.
+        // Deterministic on every runner because Linux/macOS are never OS.Windows.
+        val real = WslCompatServiceImpl()
+        assertNull(real.wslPrefixConversion(OS.Linux))
+        assertNull(real.wslPrefixConversion(OS.macOS))
+    }
+
+    fun testCanonicalizeWslPrefix_rewritesLegacyToModern() {
+        val legacy = "\\\\wsl$\\Ubuntu-24.04\\home\\testuser\\project"
+        val modern = "\\\\wsl.localhost\\Ubuntu-24.04\\home\\testuser\\project"
+        // Default mock policy is legacy -> modern; the real string rewrite still runs.
+        with(MockWslCompatService()) {
+            assertEquals(modern, legacy.canonicalizeWslPrefix())
+            // Already-modern paths are left unchanged.
+            assertEquals(modern, modern.canonicalizeWslPrefix())
+        }
+    }
+
+    fun testCanonicalizeWslPrefix_rewritesModernToLegacy() {
+        val legacy = "\\\\wsl$\\Ubuntu-24.04\\home\\testuser\\project"
+        val modern = "\\\\wsl.localhost\\Ubuntu-24.04\\home\\testuser\\project"
+        with(MockWslCompatService(prefixConversionOverride = MODERN_WSL_PREFIX to LEGACY_WSL_PREFIX)) {
+            assertEquals(legacy, modern.canonicalizeWslPrefix())
+            assertEquals(legacy, legacy.canonicalizeWslPrefix())
+        }
+    }
+
+    fun testCanonicalizeWslPrefix_leavesPathUnchangedWhenNoConversion() {
+        val legacy = "\\\\wsl$\\Ubuntu-24.04\\home\\testuser\\project"
+        val modern = "\\\\wsl.localhost\\Ubuntu-24.04\\home\\testuser\\project"
+        // null policy simulates the non-Windows "no conversion" branch.
+        with(MockWslCompatService(prefixConversionOverride = null)) {
+            assertEquals(legacy, legacy.canonicalizeWslPrefix())
+            assertEquals(modern, modern.canonicalizeWslPrefix())
+        }
     }
 }

--- a/tests/org/elixir_lang/sdk/wsl/WslCompatServiceExtensionsTest.kt
+++ b/tests/org/elixir_lang/sdk/wsl/WslCompatServiceExtensionsTest.kt
@@ -1,0 +1,87 @@
+package org.elixir_lang.sdk.wsl
+
+import com.intellij.execution.wsl.WSLDistribution
+import org.elixir_lang.PlatformTestCase
+import org.mockito.Mockito
+
+class WslCompatServiceExtensionsTest : PlatformTestCase() {
+    private val service = MockWslCompatService(canonicalWslPrefixOverride = MODERN_WSL_PREFIX)
+
+    fun testConvertLinuxPathToWindowsUncFromContext_convertsForWslContext() {
+        val contextPath = "\\\\wsl.localhost\\Ubuntu-24.04\\home\\testuser\\project"
+        val linuxPath = "/home/testuser/.local/share/mise/installs/elixir/1.15.7"
+
+        val converted = service.convertLinuxPathToWindowsUncFromContext(contextPath, linuxPath)
+
+        assertEquals(
+            "\\\\wsl.localhost\\Ubuntu-24.04\\home\\testuser\\.local\\share\\mise\\installs\\elixir\\1.15.7",
+            converted,
+        )
+    }
+
+    fun testConvertLinuxPathToWindowsUncFromContext_returnsNullForNonWslContext() {
+        val converted = service.convertLinuxPathToWindowsUncFromContext(
+            "C:\\Users\\steve\\IdeaProjects\\intellij-elixir",
+            "/home/testuser/.local/share/mise/installs/elixir/1.15.7",
+        )
+
+        assertNull(converted)
+    }
+
+    fun testConvertLinuxPathToWindowsUncFromContext_returnsNullForNonLinuxPath() {
+        val converted = service.convertLinuxPathToWindowsUncFromContext(
+            "\\\\wsl.localhost\\Ubuntu-24.04\\home\\testuser\\project",
+            "C:\\Program Files\\Elixir",
+        )
+
+        assertNull(converted)
+    }
+
+    fun testConvertLinuxPathToWindowsUncFromContext_returnsNullWhenDistributionNotResolvable() {
+        val serviceWithUnknownDistribution = MockWslCompatService(distributionOverride = { null })
+
+        val converted = serviceWithUnknownDistribution.convertLinuxPathToWindowsUncFromContext(
+            "\\\\wsl.localhost\\Unknown\\home\\testuser\\project",
+            "/home/testuser/.local/share/mise/installs/elixir/1.15.7",
+        )
+
+        assertNull(converted)
+    }
+
+    fun testConvertLinuxPathToWindowsUncFromContext_returnsNullWhenConversionFails() {
+        val distro = Mockito.mock(WSLDistribution::class.java)
+        Mockito.`when`(distro.msId).thenReturn("Ubuntu-24.04")
+
+        val serviceWithFailingConversion = MockWslCompatService(
+            distributionOverride = { distro },
+            conversionOverride = { _, _ -> null },
+        )
+
+        val converted = serviceWithFailingConversion.convertLinuxPathToWindowsUncFromContext(
+            "\\\\wsl.localhost\\Ubuntu-24.04\\home\\testuser\\project",
+            "/home/testuser/.local/share/mise/installs/elixir/1.15.7",
+        )
+
+        assertNull(converted)
+    }
+
+    fun testMaybeConvertLinuxPathToWindowsUncFromContext_convertsForWslContext() {
+        val contextPath = "\\\\wsl.localhost\\Ubuntu-24.04\\home\\testuser\\project"
+        val linuxPath = "/home/testuser/.local/share/mise/installs/elixir/1.15.7"
+        val expected = "\\\\wsl.localhost\\Ubuntu-24.04\\home\\testuser\\.local\\share\\mise\\installs\\elixir\\1.15.7"
+        val converted = service.maybeConvertLinuxPathToWindowsUncFromContext(contextPath, linuxPath)
+
+        assertEquals(expected, converted)
+    }
+
+    fun testMaybeConvertLinuxPathToWindowsUncFromContext_returnsOriginalOnNonWslContext() {
+        val linuxPath = "/home/testuser/.local/share/mise/installs/elixir/1.15.7"
+
+        val converted = service.maybeConvertLinuxPathToWindowsUncFromContext(
+            "C:\\Users\\steve\\IdeaProjects\\intellij-elixir",
+            linuxPath,
+        )
+
+        assertEquals(linuxPath, converted)
+    }
+}


### PR DESCRIPTION
## Summary
This PR switches Elixir version detection to a file-based source: <sdkHome>/lib/elixir/ebin/elixir.app. Instead of shelling out to elixir --short-version and parsing directory names, it reads {vsn, ...} directly from elixir.app, caches it, and reuses it in SDK naming and status/mismatch checks.
Additionally, it switches mise resolution from mise ls --local to mise ls --current, which picks up inherited tool versions from parent directories (.tool-versions, mise.toml walk-up resolution), and adds context-aware WSL path conversion helpers so that Linux install paths reported by mise are correctly mapped to Windows UNC paths.
## Why this helps maintainers
- Removes subprocess dependence from version detection paths.
- Uses the build artifact that is authoritative for Elixir version metadata.
- Makes mismatch checks deterministic across tool managers (both sides compare bare version strings from elixir.app).
- Enables inherited mise configs by using --current instead of --local.
- Keeps this PR focused as a single-step change on top of #3839.
## What changed in this PR (delta vs #3839)
- **ElixirVersionDetector**: adds eadElixirAppVersion, removes subprocess/path-name fallbacks, updates cache strategy, and removes now-unused getRelease.
- **Type**: uses cached ELIXIR_VERSION_KEY directly for naming and docs-path decisions while keeping OTP-aware display text.
- **ElixirEditorBasedSdkWidget + Mise**: precomputes install-path Elixir versions from elixir.app in the IO phase and removes stripElixirOtpSuffix.
- **Mise**: switches from mise ls --local to mise ls --current; passes workDir to parseOutput for context-aware WSL path conversion of tool install paths.
- **WslCompatService**: makes canonicalizePath best-effort (catches exceptions, falls back to prefix-converted path); adds convertLinuxPathToWindowsUncFromContext and maybeConvertLinuxPathToWindowsUncFromContext helpers; extracts wslPrefixConversion() as the testable OS-policy decision point.
- **Tests**: adds ElixirVersionDetectorTest, WslCompatServiceExtensionsTest; updates TypeNamingTest and MiseTest; removes obsolete stripElixirOtpSuffix expectations.
## Review guide
- Preferred review diff (this PR only): [#3839...#3845](https://github.com/KronicDeth/intellij-elixir/compare/sh41:split/post-3808-B-dep-watcher...sh41:split/elixir-version-from-elixir-app)
- Most critical file: src/org/elixir_lang/sdk/elixir/ElixirVersionDetector.kt
- Highest regression risk: SDK naming/status text paths that previously depended on subprocess output.
## Stack and dependencies
See the [PR Stack Navigation comment](https://github.com/KronicDeth/intellij-elixir/pull/3845#issuecomment-4545927853) for the full dependency graph.
Historical context: #3841, #3842, #3843, #3844 are merged; #3840 integration branch was removed.