### PR TITLE
fix(mix/inspections): reliability improvements for sync, runs, and debugger access

### DIFF
--- a/src/org/elixir_lang/credo/inspection_tool/Global.kt
+++ b/src/org/elixir_lang/credo/inspection_tool/Global.kt
@@ -8,7 +8,10 @@ import com.intellij.execution.util.ExecUtil
 import com.intellij.notification.NotificationGroupManager
 import com.intellij.notification.NotificationType
 import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.application.ModalityState
+import com.intellij.openapi.application.ReadAction
 import com.intellij.openapi.diagnostic.logger
+import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.openapi.module.Module
 import com.intellij.openapi.module.ModuleManager
 import com.intellij.openapi.progress.ProgressIndicator
@@ -23,11 +26,12 @@ import org.elixir_lang.credo.Action
 import org.elixir_lang.isElixirMixModule
 import org.elixir_lang.jps.shared.ParametersList
 import org.elixir_lang.mix.Project
-import org.elixir_lang.notification.setup_sdk.Notifier
-import org.elixir_lang.sdk.elixir.ElixirSdkLookup.mostSpecificSdk
+import org.elixir_lang.notification.setup_sdk.sdkOrNotify
+import org.elixir_lang.sdk.elixir.ElixirSdkLookup
 import java.nio.charset.StandardCharsets
 import java.nio.file.InvalidPathException
 import java.nio.file.Paths
+import java.util.concurrent.Callable
 
 // Phase 2 location parsing: try the most specific location shape first to avoid path/line ambiguity.
 // lib/level_web/ui/empty_state.ex:1:11: R: Modules should have a @moduledoc tag.
@@ -92,7 +96,7 @@ internal fun parseFlycheckFinding(line: String): FlycheckFinding? {
 
 private val LOG = logger<Global>()
 
-class Global : GlobalInspectionTool() {
+internal class Global : GlobalInspectionTool() {
     private data class CredoRunOutcome(
         val findingCount: Int,
         val failureSummary: String? = null,
@@ -111,6 +115,17 @@ class Global : GlobalInspectionTool() {
         globalContext: GlobalInspectionContext,
         problemDescriptionsProcessor: ProblemDescriptionsProcessor,
     ) {
+        // Save all modified documents before launching mix credo so the external process
+        // sees the current file contents.  Same reasoning as dialyzer/inspection/Global.kt:
+        // runInspection runs on a background thread (isReadActionNeeded = false);
+        // saveAllDocuments() requires EDT; invokeAndWait is the correct bridge for
+        // non-suspend blocking code.  ModalityState.nonModal() ensures the save is not
+        // deferred by an open dialog.
+        ApplicationManager.getApplication().invokeAndWait(
+            { FileDocumentManager.getInstance().saveAllDocuments() },
+            ModalityState.nonModal()
+        )
+
         val project = scope.project
         val scopedModules = ApplicationManager.getApplication().runReadAction<List<Module>> {
             ModuleManager.getInstance(project).modules.filter { scope.containsModule(it) && it.isElixirMixModule() }
@@ -214,17 +229,11 @@ class Global : GlobalInspectionTool() {
         module: Module,
         workingDirectory: String,
     ): CredoRunOutcome {
-        val elixirSdk = mostSpecificSdk(module)
+        val elixirSdk = ReadAction.nonBlocking(Callable {
+            ElixirSdkLookup.resolveWithErlang(module).sdkOrNotify(module)
+        }).executeSynchronously()
+            ?: return CredoRunOutcome(findingCount = 0) // notification already fired by sdkOrNotify
         val project = module.project
-
-        if (elixirSdk == null) {
-            Notifier.error(
-                module,
-                "Missing module Elixir SDK",
-                "There is no configured Elixir SDK for the module ${module.name} or its project ${project.name}, so credo cannot be run"
-            )
-            return CredoRunOutcome(findingCount = 0, failureSummary = "Missing Elixir SDK for module ${module.name}")
-        }
 
         val service = org.elixir_lang.credo.Service.getInstance(project)
         val environment = service.environmentVariableData.envs

--- a/src/org/elixir_lang/debugger/Process.kt
+++ b/src/org/elixir_lang/debugger/Process.kt
@@ -25,9 +25,11 @@ import com.intellij.execution.ExecutionException
 import com.intellij.execution.process.ProcessHandler
 import com.intellij.execution.runners.ExecutionEnvironment
 import com.intellij.execution.ui.ExecutionConsole
-import com.intellij.icons.AllIcons
 import com.intellij.execution.wsl.WSLDistribution
+import com.intellij.icons.AllIcons
+import com.intellij.openapi.application.ReadAction
 import com.intellij.openapi.components.service
+import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.editor.Document
 import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.openapi.fileTypes.FileType
@@ -49,6 +51,11 @@ import com.intellij.xdebugger.evaluation.EvaluationMode
 import com.intellij.xdebugger.evaluation.XDebuggerEditorsProvider
 import com.intellij.xdebugger.evaluation.XDebuggerEvaluator
 import com.intellij.xdebugger.frame.XSuspendContext
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
 import org.elixir_lang.ElixirFileType
 import org.elixir_lang.beam.chunk.lines.file_names.Index
 import org.elixir_lang.beam.term.inspect
@@ -56,7 +63,6 @@ import org.elixir_lang.debugger.configuration.Debuggable
 import org.elixir_lang.debugger.configuration.doNotInterpretPatterns
 import org.elixir_lang.debugger.line_breakpoint.Handler
 import org.elixir_lang.debugger.line_breakpoint.Properties
-import org.elixir_lang.debugger.node.Exception as NodeException
 import org.elixir_lang.debugger.node.ProcessSnapshot
 import org.elixir_lang.debugger.node.event.Listener
 import org.elixir_lang.debugger.node.ok_error_reason.ErrorReason
@@ -68,20 +74,21 @@ import org.elixir_lang.run.ensureWorkingDirectory
 import org.elixir_lang.util.ElixirCoroutineService
 import org.elixir_lang.util.supervisedChildScope
 import org.elixir_lang.utils.ElixirModulesUtil.elixirModuleNameToErlang
-import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.cancel
-import kotlinx.coroutines.launch
 import java.util.*
+import java.util.concurrent.Callable
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.system.measureNanoTime
+import org.elixir_lang.debugger.node.Exception as NodeException
 
 class Process(session: XDebugSession, private val executionEnvironment: ExecutionEnvironment) :
     XDebugProcess(session), Listener {
+    companion object {
+        private val LOG = logger<Process>()
+    }
+
     private val projectCoroutineService = session.project.service<ElixirCoroutineService>()
 
     private val scope: CoroutineScope =
@@ -409,8 +416,12 @@ class Process(session: XDebugSession, private val executionEnvironment: Executio
             session.reportMessage("Interpreting modules... ", MessageType.INFO)
 
             val interpretationSeconds = measureNanoTime {
+                val sdkPaths = ReadAction.nonBlocking(Callable {
+                    debuggableConfiguration.let { it as Configuration }.sdkPaths()
+                }).executeSynchronously()
+
                 node.interpret(
-                    debuggableConfiguration.let { it as Configuration }.sdkPaths(),
+                    sdkPaths,
                     debuggableConfiguration.doNotInterpretPatterns()
                 )
             }.let { TimeUnit.NANOSECONDS.toSeconds(it) }
@@ -448,7 +459,14 @@ class Process(session: XDebugSession, private val executionEnvironment: Executio
             val initializer = initializers.poll()
 
             if (initializer != null) {
-                initializer()
+                try {
+                    initializer()
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    LOG.error("Debugger initializer failed", e)
+                    throw e
+                }
             }
         }
     }

--- a/src/org/elixir_lang/dialyzer/inspection/Global.kt
+++ b/src/org/elixir_lang/dialyzer/inspection/Global.kt
@@ -3,16 +3,20 @@ package org.elixir_lang.dialyzer.inspection
 import com.intellij.analysis.AnalysisScope
 import com.intellij.codeInspection.*
 import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.application.ModalityState
+import com.intellij.openapi.application.ReadAction
 import com.intellij.openapi.module.Module
 import com.intellij.openapi.module.ModuleUtil
+import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiElementVisitor
 import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiRecursiveElementWalkingVisitor
+import com.intellij.xml.util.XmlStringUtil
 import org.elixir_lang.dialyzer.service.DialyzerService
 import org.elixir_lang.dialyzer.service.DialyzerWarn
 import org.elixir_lang.psi.impl.document
-import java.io.File
+import java.util.concurrent.Callable
 
 /**
  * Implements an inspection showing dialyzer warnings.
@@ -21,36 +25,62 @@ import java.io.File
  * (mix dialyzer) which must NOT execute under a read lock (2026.1: waitFor() under read lock
  * logs an error). PSI and model access is wrapped in explicit runReadAction blocks instead.
  */
-class Global : GlobalInspectionTool() {
+internal class Global : GlobalInspectionTool() {
 
-    override fun runInspection(scope: AnalysisScope, manager: InspectionManager, globalContext: GlobalInspectionContext, problemDescriptionsProcessor: ProblemDescriptionsProcessor) {
+    override fun runInspection(
+        scope: AnalysisScope,
+        manager: InspectionManager,
+        globalContext: GlobalInspectionContext,
+        problemDescriptionsProcessor: ProblemDescriptionsProcessor
+    ) {
+        // Save all modified documents before launching mix dialyzer so the external process
+        // sees the current file contents.  runInspection runs on a background thread
+        // (isReadActionNeeded = false); FileDocumentManager.saveAllDocuments() requires EDT
+        // because it calls runWriteAction internally.
+        //
+        // invokeAndWait is the correct bridge from blocking background code to EDT - this is
+        // a non-suspend override so coroutine APIs (edtWriteAction, withContext(Dispatchers.EDT))
+        // are not available here.  ModalityState.nonModal() ensures the save is not deferred
+        // by an open dialog - we must flush to disk before handing off to the external process.
+        ApplicationManager.getApplication().invokeAndWait(
+            { FileDocumentManager.getInstance().saveAllDocuments() },
+            ModalityState.nonModal()
+        )
+
         val moduleSet = moduleSet(scope)
         val dialyzerWarnsByModule = dialyzerWarnsByModule(moduleSet)
 
         scope.accept(object : PsiElementVisitor() {
             override fun visitFile(file: PsiFile) {
-                val problems = ApplicationManager.getApplication().runReadAction<List<ProblemDescriptor>> {
+                val problems = ReadAction.nonBlocking(Callable {
                     checkFile(file, manager, dialyzerWarnsByModule)
-                }
+                }).executeSynchronously()
                 for (problem in problems) {
                     problemDescriptionsProcessor.addProblemElement(globalContext.refManager.getReference(file), problem)
                 }
             }
         })
-        super.runInspection(scope, manager, globalContext, problemDescriptionsProcessor)
     }
 
     override fun isReadActionNeeded(): Boolean = false
+
+    /**
+     * This inspection never consults the reference graph - it delegates entirely to the
+     * external `mix dialyzer` process.  Returning false prevents the platform from building
+     * the graph before each run (a significant upfront cost) and eliminates the redundant
+     * default [runInspection] ref-graph iteration that would otherwise occur via `super`.
+     */
+    override fun isGraphNeeded(): Boolean = false
 
     private fun moduleSet(scope: AnalysisScope): Set<Module> {
         val moduleSet = mutableSetOf<Module>()
 
         scope.accept(object : PsiElementVisitor() {
             override fun visitFile(file: PsiFile) {
-                ApplicationManager.getApplication().runReadAction {
-                    ModuleUtil.findModuleForFile(file)?.let { module ->
-                        moduleSet.add(module)
-                    }
+                ReadAction.nonBlocking(Callable {
+                    ModuleUtil.findModuleForFile(file)
+                }).executeSynchronously()?.let { module ->
+                    moduleSet.add(module)
                 }
             }
         })
@@ -59,35 +89,49 @@ class Global : GlobalInspectionTool() {
     }
 
     private fun dialyzerWarnsByModule(moduleSet: Set<Module>): Map<Module, MutableList<DialyzerWarn>> =
-            moduleSet.associate { module ->
-                module to module.project.getService(DialyzerService::class.java).dialyzerWarnings(module).toMutableList()
+            moduleSet.associateWith { module ->
+                module.project.getService(DialyzerService::class.java)
+                    .dialyzerWarnings(module)
+                    .toMutableList()
             }
 
-    fun checkFile(file: PsiFile,
-                  manager: InspectionManager,
-                  dialyzerWarnsByModule: Map<Module, MutableList<DialyzerWarn>>): List<ProblemDescriptor> {
+    fun checkFile(
+        file: PsiFile,
+        manager: InspectionManager,
+        dialyzerWarnsByModule: Map<Module, MutableList<DialyzerWarn>>
+    ): List<ProblemDescriptor> {
         val problemsHolder = ProblemsHolder(manager, file, false)
 
         ModuleUtil.findModuleForFile(file)?.let { module ->
             dialyzerWarnsByModule[module]?.let { dialyzerWarns ->
-                val filePath = (file.containingDirectory.toString() + File.separator + file.name)
+                val filePath = file.virtualFile?.path ?: return problemsHolder.results
 
                 file.accept(
-                        object : PsiRecursiveElementWalkingVisitor() {
-                            override fun visitElement(element: PsiElement) {
-                                val lineNumber = element.document()?.getLineNumber(element.textOffset)
-                                if (lineNumber != null) {
-                                    val found = dialyzerWarns.filter { it.line == lineNumber + 1 }
-                                            .filter { filePath.endsWith(it.fileName) }
-                                            .map {
-                                                problemsHolder.registerProblem(element, it.message, ProblemHighlightType.ERROR)
-                                                it
-                                            }
-                                    dialyzerWarns.removeAll(found)
+                    object : PsiRecursiveElementWalkingVisitor() {
+                        override fun visitElement(element: PsiElement) {
+                            val doc = element.document() ?: return super.visitElement(element)
+                            val lineNumber = doc.getLineNumber(element.textOffset)
+                            val found = dialyzerWarns.filter { it.line == lineNumber + 1 }
+                                .filter { filePath.endsWith(it.fileName) }
+                                .map { warn ->
+                                    val lineOffset = element.textOffset - doc.getLineStartOffset(lineNumber)
+                                    val locationPrefix = "${warn.line}:${lineOffset + 1}: "
+
+                                    problemsHolder.registerProblem(
+                                        element,
+                                        XmlStringUtil.wrapInHtml(
+                                            XmlStringUtil.wrapInHtmlTag(
+                                                XmlStringUtil.escapeString(locationPrefix + warn.message), "pre"
+                                            )
+                                        ),
+                                        ProblemHighlightType.ERROR
+                                    )
+                                    warn
                                 }
-                                super.visitElement(element)
-                            }
+                            dialyzerWarns.removeAll(found)
+                            super.visitElement(element)
                         }
+                    }
                 )
             }
         }

--- a/src/org/elixir_lang/dialyzer/service/DialyzerOutputParsing.kt
+++ b/src/org/elixir_lang/dialyzer/service/DialyzerOutputParsing.kt
@@ -29,7 +29,7 @@ private fun parseStdErr(stderr: String): List<DialyzerWarn> {
     }
     return entries.map { e: List<String> ->
         val (file, line) = getFileAndLine(e[0])
-        val message = e.drop(1).joinToString(System.lineSeparator())
+        val message = e.drop(1).joinToString("\n")
         DialyzerWarn(file, line, message)
     }
 }

--- a/src/org/elixir_lang/dialyzer/service/DialyzerServiceImpl.kt
+++ b/src/org/elixir_lang/dialyzer/service/DialyzerServiceImpl.kt
@@ -5,6 +5,7 @@ import com.intellij.execution.process.ProcessEvent
 import com.intellij.execution.process.ProcessHandlerFactory
 import com.intellij.execution.process.ProcessListener
 import com.intellij.execution.process.ProcessOutputType
+import com.intellij.openapi.application.ReadAction
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.Storage
 import com.intellij.openapi.diagnostic.Logger
@@ -12,12 +13,12 @@ import com.intellij.openapi.module.Module
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.projectRoots.Sdk
 import com.intellij.openapi.util.Key
-import org.elixir_lang.Elixir.elixirSdkHasErlangSdk
 import org.elixir_lang.Mix
 import org.elixir_lang.isElixirMixModule
-import org.elixir_lang.notification.setup_sdk.Notifier
+import org.elixir_lang.notification.setup_sdk.sdkOrNotify
 import org.elixir_lang.run.ensureWorkingDirectory
-import org.elixir_lang.sdk.elixir.ElixirSdkLookup.mostSpecificSdk
+import org.elixir_lang.sdk.elixir.ElixirSdkLookup
+import java.util.concurrent.Callable
 
 data class DialyzerWarn(
     val fileName: String,
@@ -30,7 +31,7 @@ class DialyzerException(message: String?, inner: Throwable?) : Exception(message
 
 @Service
 @com.intellij.openapi.components.State(name = "Dialyzer", storages = [Storage(value = "elixir_dialyzer.xml")])
-class DialyzerServiceImpl : DialyzerService {
+internal class DialyzerServiceImpl : DialyzerService {
     override var mixArguments = "dialyzer"
     override var elixirArguments = ""
     override var erlArguments = ""
@@ -38,38 +39,13 @@ class DialyzerServiceImpl : DialyzerService {
     private val log = Logger.getInstance(DialyzerServiceImpl::class.java)
 
     override fun dialyzerWarnings(module: Module): List<DialyzerWarn> {
-        if (!module.isElixirMixModule()) {
-            return emptyList()
-        }
+        val (workingDirectory, sdk, project) = ReadAction.nonBlocking(Callable {
+            if (!module.isElixirMixModule()) return@Callable null
+            val sdk = ElixirSdkLookup.resolveWithErlang(module).sdkOrNotify(module) ?: return@Callable null
+            Triple(ensureWorkingDirectory(module), sdk, module.project)
+        }).executeSynchronously() ?: return emptyList()
 
-        val workingDirectory = ensureWorkingDirectory(module)
-
-        val sdk = mostSpecificSdk(module)
-
-        return if (sdk != null) {
-            if (elixirSdkHasErlangSdk(sdk)) {
-                dialyzerWarnings(workingDirectory, sdk, module.project)
-            } else {
-                val project = module.project
-                Notifier.error(
-                    module,
-                    "Missing Internal Erlang SDK for module Elixir SDK",
-                    "The configured Elixir SDK for the module ${module.name} or its project ${project.name} does not " +
-                            "have an Internal Erlang SDK configured"
-                )
-
-                emptyList()
-            }
-        } else {
-            val project = module.project
-            Notifier.error(
-                module,
-                "Missing module Elixir SDK",
-                "There is no configured Elixir SDK for the module ${module.name} or its project ${project.name}"
-            )
-
-            emptyList()
-        }
+        return dialyzerWarnings(workingDirectory, sdk, project)
     }
 
     private fun dialyzerWarnings(workingDirectory: String, elixirSdk: Sdk, project: Project): List<DialyzerWarn> = try {
@@ -93,6 +69,13 @@ class DialyzerServiceImpl : DialyzerService {
                 project = project,
             )
         commandLine.addParameters(mixArgumentList)
+        // Note: add "--force-check" to the Mix arguments in the Dialyzer settings panel
+        // if you need dialyxir to re-analyse all callers after a type-contract-only change
+        // (@spec / @type / @opaque).  It is not added by default because it forces a full
+        // project re-analysis on every run, which can be significantly slower than the
+        // normal incremental mode.  The pre-run document save (in Global.runInspection)
+        // handles the common stale-results case by ensuring files are flushed to disk
+        // before the external process starts.
 
         val processHandler = ProcessHandlerFactory.getInstance().createColoredProcessHandler(commandLine)
         val stderrBuilder = StringBuilder()

--- a/src/org/elixir_lang/mix/Dep.kt
+++ b/src/org/elixir_lang/mix/Dep.kt
@@ -1,7 +1,6 @@
 package org.elixir_lang.mix
 
 import com.intellij.openapi.vfs.LocalFileSystem
-import com.intellij.openapi.vfs.VfsUtil
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.PsiElement
 import org.elixir_lang.errorreport.Logger
@@ -18,15 +17,37 @@ data class Dep(val application: String, val path: String, val type: Type = Type.
      * Resolves the virtual file for this dependency relative to [moduleRoot].
      *
      * [path] is typically "deps/<name>" (relative) or an absolute path from a `path:` option.
-     * Relative paths are resolved against [moduleRoot]; absolute paths fall back to
-     * [VfsUtil.findFile] which handles paths like "/home/user/external_lib".
+     * Relative paths (including ones with `../` traversal like `"../../../exc1"`) are first
+     * resolved via [VirtualFile.findFileByRelativePath]; if that fails (e.g. because parent
+     * directories above the content root are not yet in the VFS), the path is resolved against
+     * [moduleRoot]'s filesystem path using [java.nio.file.Path] before attempting a
+     * [LocalFileSystem.refreshAndFindFileByPath] lookup.
      *
      * @param moduleRoot The content root of the module that declared this dependency.
      * @return The VirtualFile for the dep directory, or null if not found.
      */
-    fun virtualFile(moduleRoot: VirtualFile): VirtualFile? =
-        moduleRoot.findFileByRelativePath(path)
-            ?: LocalFileSystem.getInstance().refreshAndFindFileByPath(path)
+    fun virtualFile(moduleRoot: VirtualFile): VirtualFile? {
+        // First try VFS traversal - VirtualFile.findFileByRelativePath handles ../ by walking up
+        // via getParent(), so this works whenever the ancestor directories are in the VFS.
+        moduleRoot.findFileByRelativePath(path)?.let { return it }
+
+        // Compute an absolute path for the fallback refresh.
+        // For absolute paths (Unix "/" or Windows "C:\") use as-is.
+        // For relative paths, resolve against the module root's *filesystem* path so that
+        // directories above the content root (not tracked by the VFS) can still be found.
+        // Passing a bare relative path like "../../../exc1" to refreshAndFindFileByPath
+        // is meaningless because the method has no working-directory context.
+        val absolutePath: String = if (java.io.File(path).isAbsolute) {
+            path
+        } else {
+            try {
+                java.nio.file.Path.of(moduleRoot.path).resolve(path).normalize().toString()
+            } catch (_: Throwable) {
+                return null
+            }
+        }
+        return LocalFileSystem.getInstance().refreshAndFindFileByPath(absolutePath)
+    }
 
     enum class Type {
         LIBRARY,

--- a/src/org/elixir_lang/run/Configuration.kt
+++ b/src/org/elixir_lang/run/Configuration.kt
@@ -13,9 +13,11 @@ import com.intellij.openapi.projectRoots.Sdk
 import com.intellij.openapi.roots.ModuleRootManager
 import com.intellij.openapi.roots.OrderRootType
 import com.intellij.openapi.vfs.VfsUtil
+import com.intellij.util.concurrency.annotations.RequiresReadLock
 import org.elixir_lang.debugger.settings.stepping.ModuleFilter
 import org.elixir_lang.mix.ensureMostSpecificSdk
 import org.elixir_lang.run.configuration.Module
+import org.elixir_lang.sdk.wsl.wslCompat
 import org.jdom.Element
 import java.io.File
 
@@ -224,6 +226,7 @@ abstract class Configuration(name: String, project: Project, configurationFactor
     override fun getValidModules(): Collection<com.intellij.openapi.module.Module> =
             project.let { ModuleManager.getInstance(it) }.modules.asList()
 
+    @RequiresReadLock
     fun sdkPaths(): List<String> = ensureModule().sdkPaths()
 
     protected val _envs = mutableMapOf<String, String>()
@@ -244,13 +247,11 @@ private fun ensureModule(workingDirectory: String, project: Project): com.intell
 private fun workingDirectory(module: com.intellij.openapi.module.Module): String? =
         ModuleRootManager.getInstance(module).contentRoots.firstOrNull()?.path
 
+@RequiresReadLock
 private fun com.intellij.openapi.module.Module.sdkPaths(): List<String> = ensureMostSpecificSdk(this).paths()
 
-private fun Sdk.paths(): List<String> {
-    val rawPaths = rootProvider.getFiles(OrderRootType.CLASSES).map { it.canonicalPath!! }
-    return if (org.elixir_lang.sdk.wsl.wslCompat.isWslUncPath(homePath)) {
-        rawPaths.map { org.elixir_lang.sdk.wsl.wslCompat.parseWindowsUncPath(it) ?: it }
-    } else {
-        rawPaths
-    }
-}
+@RequiresReadLock
+private fun Sdk.paths(): List<String> =
+        rootProvider.getFiles(OrderRootType.CLASSES)
+            .mapNotNull { it.canonicalPath }
+            .map { wslCompat.maybeParseWindowsUncPath(it) }


### PR DESCRIPTION
## Summary
This PR isolates reliability fixes for mix sync, inspections, and debugger SDK path access.
Fixes #3538.
## Why this is needed
These changes prevent stale/incorrect dependency state and avoid running expensive operations on unsaved buffers or outside required read-action boundaries.
## What changed
- Mix sync classification fix for umbrella sub-app path deps and module dependency handling (Dep.kt).
- Dialyzer/Credo inspection flow tightened to save documents before execution and reduce inconsistent run behavior (Global.kt, DialyzerServiceImpl.kt).
- Debugger SDK path gathering wrapped in readAction to satisfy threading/read-access requirements (Process.kt).
- Run configuration creation threading safety (Configuration.kt).