### PR TITLE
fix(resolver/navigation): scope-correct resolution and source-first navigation

### DIFF
--- a/src/org/elixir_lang/psi/Use.kt
+++ b/src/org/elixir_lang/psi/Use.kt
@@ -1,10 +1,13 @@
 package org.elixir_lang.psi
 
+import com.intellij.openapi.progress.ProgressManager
 import com.intellij.psi.ElementDescriptionLocation
 import com.intellij.psi.PsiElement
 import com.intellij.psi.ResolveState
 import com.intellij.psi.util.isAncestor
 import com.intellij.usageView.UsageViewTypeLocation
+import com.intellij.util.concurrency.annotations.RequiresReadLock
+import org.elixir_lang.psi.Use.`is`
 import org.elixir_lang.psi.call.Call
 import org.elixir_lang.psi.call.name.Function.USE
 import org.elixir_lang.psi.call.name.Module.KERNEL
@@ -21,6 +24,7 @@ object Use {
      * macro called by `useCall` while `keepProcessing` returns `true`.  Stops the first time `keepProcessing`
      * returns `false`.
      */
+    @RequiresReadLock
     fun treeWalkUp(
         useCall: Call,
         resolveState: ResolveState,
@@ -33,9 +37,27 @@ object Use {
             val useCallResolveState = resolveState.putVisitedElement(useCall)
 
             outer@ for (modular in modulars(useCall)) {
-                for (definer in Using.definers(modular)) {
-                    val childResolveState = useCallResolveState.putVisitedElement(definer)
+                ProgressManager.checkCanceled()
+                val directDefiners = Using.definers(modular).toList()
 
+                // `Using.definers` looks for an explicit `defmacro __using__/1` in the source PSI of `modular`.
+                // When `modular` was defined with `use ExUnit.CaseTemplate`, that macro is absent from source:
+                // `ExUnit.CaseTemplate.__using__/1` generates the `defmacro __using__` at compile time so it
+                // only exists in the compiled BEAM, not in the `.ex` file.  The plugin therefore cannot follow
+                // the injected `__using__` → `__proxy__` → `use ExUnit.Case` chain statically (it breaks at
+                // the `unquote(__MODULE__)` qualifier in `__proxy__`, which `resolvedModuleName()` cannot
+                // evaluate).  As a stop-gap, when no direct definer is found and the module is a CaseTemplate,
+                // skip the opaque generated layer and use `ExUnit.Case.__using__/1` directly - the net runtime
+                // effect of `use <any CaseTemplate>` is always equivalent to `use ExUnit.Case`.
+                val effectiveDefiners: Iterable<PsiElement> =
+                    if (directDefiners.isEmpty() && Using.isCaseTemplate(modular, useCallResolveState))
+                        Using.exUnitCaseDefiners(useCall).asIterable()
+                    else
+                        directDefiners
+
+                for (definer in effectiveDefiners) {
+                    ProgressManager.checkCanceled()
+                    val childResolveState = useCallResolveState.putVisitedElement(definer)
                     accumulatedKeepProcessing = Using.treeWalkUp(
                         using = definer,
                         use = useCall,
@@ -68,7 +90,7 @@ object Use {
      */
     @JvmStatic
     fun `is`(call: Call): Boolean =
-        call.isCalling(KERNEL, USE, 1) || call.isCalling(KERNEL, USE, 2);
+        call.isCalling(KERNEL, USE, 1) || call.isCalling(KERNEL, USE, 2)
 
     /**
      * The modular that is used by `useCall`.
@@ -77,6 +99,7 @@ object Use {
      * @return `defmodule`, `defimpl`, or `defprotocol` used by `useCall`.  It can be `null` if Alias passed to
      *    `useCall` cannot be resolved.
      */
+    @RequiresReadLock
     fun modulars(useCall: Call): Set<PsiElement> =
         useCall
             .finalArguments()

--- a/src/org/elixir_lang/psi/Using.kt
+++ b/src/org/elixir_lang/psi/Using.kt
@@ -3,6 +3,9 @@ package org.elixir_lang.psi
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiPolyVariantReference
 import com.intellij.psi.ResolveState
+import com.intellij.psi.search.GlobalSearchScope
+import com.intellij.psi.stubs.StubIndex
+import com.intellij.util.concurrency.annotations.RequiresReadLock
 import org.elixir_lang.beam.psi.impl.CallDefinitionImpl
 import org.elixir_lang.beam.psi.impl.ModuleImpl
 import org.elixir_lang.psi.CallDefinitionClause.nameArityInterval
@@ -14,6 +17,7 @@ import org.elixir_lang.psi.impl.call.macroChildCallSequence
 import org.elixir_lang.psi.impl.call.stabBodyChildExpressions
 import org.elixir_lang.psi.impl.maybeModularNameToModulars
 import org.elixir_lang.psi.impl.stripAccessExpression
+import org.elixir_lang.psi.stub.index.ModularName
 import org.elixir_lang.structure_view.element.Timed
 import org.elixir_lang.util.AccumulatorContinue
 
@@ -180,6 +184,7 @@ object Using {
         }
     }
 
+    @RequiresReadLock
     fun definers(modular: PsiElement): Sequence<PsiElement> =
         when (modular) {
             is Call -> definers(modular)
@@ -187,6 +192,7 @@ object Using {
             else -> emptySequence()
         }
 
+    @RequiresReadLock
     fun definers(modularCall: Call): Sequence<Call> =
         modularCall
             .macroChildCallSequence()
@@ -198,6 +204,61 @@ object Using {
             .asSequence()
             .filter { isDefiner(it) }
 
+    /**
+     * Returns true if [modular] is `ExUnit.CaseTemplate` itself or a module that (directly or
+     * transitively) uses `ExUnit.CaseTemplate`.
+     *
+     * This is needed because `ExUnit.CaseTemplate.__using__/1` generates a `defmacro __using__`
+     * inside the target module at *compile time*.  That generated macro never appears in the
+     * module's source `.ex` file, so [definers] returns an empty sequence for such modules and the
+     * scope walker gives up without importing `describe`, `test`, etc.  Detecting the CaseTemplate
+     * pattern lets [Use.treeWalkUp] substitute `ExUnit.Case.__using__/1` directly instead.
+     *
+     * Cycle-safety is provided by [resolveState]'s visited-element set.
+     */
+    @RequiresReadLock
+    fun isCaseTemplate(modular: PsiElement, resolveState: ResolveState): Boolean {
+        if (resolveState.hasBeenVisited(modular)) return false
+        return when (modular) {
+            is ModuleImpl<*> -> modular.name == EXUNIT_CASE_TEMPLATE
+            is Call -> {
+                val updatedState = resolveState.putVisitedElement(modular)
+                modular.name == EXUNIT_CASE_TEMPLATE ||
+                modular.macroChildCallSequence()
+                    .filter { Use.`is`(it) }
+                    .any { useCall ->
+                        Use.modulars(useCall).any { inner ->
+                            isCaseTemplate(inner, updatedState)
+                        }
+                    }
+            }
+            else -> false
+        }
+    }
+
+    /**
+     * Locates the `__using__/1` definers of `ExUnit.Case` via the stub index.
+     *
+     * Used as a substitute in [Use.treeWalkUp] when the target module is a CaseTemplate: because the
+     * generated `__using__` is not in the source PSI and the `unquote(__MODULE__).__proxy__` call inside
+     * it cannot be statically resolved, we skip the opaque generated layer and go straight to
+     * `ExUnit.Case.__using__/1`, which is what every CaseTemplate chain ultimately delegates to.
+     */
+    @RequiresReadLock
+    fun exUnitCaseDefiners(context: PsiElement): Sequence<PsiElement> =
+        StubIndex
+            .getElements(
+                ModularName.KEY,
+                EXUNIT_CASE,
+                context.project,
+                GlobalSearchScope.allScope(context.project),
+                NamedElement::class.java
+            )
+            .asSequence()
+            .flatMap { definers(it) }
+
+    private const val EXUNIT_CASE = "ExUnit.Case"
+    private const val EXUNIT_CASE_TEMPLATE = "ExUnit.CaseTemplate"
     private const val ARITY = 1
     private const val USING = "__using__"
 

--- a/src/org/elixir_lang/psi/scope/CallDefinitionClause.kt
+++ b/src/org/elixir_lang/psi/scope/CallDefinitionClause.kt
@@ -27,6 +27,7 @@ import org.elixir_lang.psi.impl.keywordValue
 import org.elixir_lang.psi.impl.siblingExpressions
 import org.elixir_lang.psi.scope.WhileIn.whileIn
 import org.elixir_lang.psi.stub.type.call.Stub.isModular
+import org.elixir_lang.reference.resolver.narrowedScope
 import org.elixir_lang.structure_view.element.Callback
 import org.elixir_lang.structure_view.element.Delegation
 
@@ -94,7 +95,7 @@ abstract class CallDefinitionClause : PsiScopeProcessor {
     protected abstract fun executeOnException(element: Call, state: ResolveState): Boolean
 
     /**
-     * Called on every [Call] where [org.elixir_lang.mix.Generator.isEmbed] is `true`.
+     * Called on every [Call] where [org.elixir_lang.psi.mix.Generator.isEmbed] is `true`.
      *
      * @return `true` to keep searching up tree; `false` to stop searching.
      */
@@ -144,7 +145,7 @@ abstract class CallDefinitionClause : PsiScopeProcessor {
                     Import.treeWalkUp(element, state) { call, accResolveState ->
                         execute(call, accResolveState)
                     }
-                } catch (stackOverflowError: StackOverflowError) {
+                } catch (_: StackOverflowError) {
                     Logger.error(
                         CallDefinitionClause::class.java,
                         "StackOverflowError while processing import",
@@ -279,51 +280,68 @@ abstract class CallDefinitionClause : PsiScopeProcessor {
 
     private fun implicitImports(element: PsiElement, state: ResolveState): Boolean {
         val project = element.project
+        // Use the entrance element (the call being resolved) for narrowedScope so the search
+        // is limited to the SDK / libraries attached to the module that contains the reference.
+        // Falling back to `element` covers the ElixirFile case where ENTRANCE may be absent.
+        val entrance = state.get(ENTRANCE) ?: element
+        val scope = narrowedScope(entrance, project)
 
-        val keepProcessing = implicitImport(project, KERNEL, state)
+        val keepProcessing = implicitImport(project, scope, KERNEL, state)
 
         return if (keepProcessing) {
             val modularCanonicalNameState = state.put(MODULAR_CANONICAL_NAME, KERNEL_SPECIAL_FORMS)
 
-            implicitImport(project, KERNEL_SPECIAL_FORMS, modularCanonicalNameState)
+            implicitImport(project, scope, KERNEL_SPECIAL_FORMS, modularCanonicalNameState)
         } else {
             false
         }
     }
 
-    private fun implicitImport(project: Project, moduleName: String, state: ResolveState): Boolean =
+    private fun implicitImport(project: Project, scope: GlobalSearchScope, moduleName: String, state: ResolveState): Boolean =
         if (DumbService.isDumb(project)) {
             true
         } else {
-            StubIndex
-                .getInstance()
-                .processElements(
-                    org.elixir_lang.psi.stub.index.ModularName.KEY,
-                    moduleName,
-                    project,
-                    GlobalSearchScope.allScope(project),
-                    NamedElement::class.java
-                ) { namedElement ->
-                    when (namedElement) {
-                        is Call -> {
-                            val namedElementResolveState = state.putVisitedElement(namedElement)
+            whileIn(sourceFirstNamedElements(project, scope, moduleName)) { namedElement ->
+                when (namedElement) {
+                    is Call -> {
+                        val namedElementResolveState = state.putVisitedElement(namedElement)
 
-                            Modular.callDefinitionClauseCallWhile(
-                                namedElement, namedElementResolveState
-                            ) { callDefinitionClause, accResolveState ->
-                                executeOnCallDefinitionClause(
-                                    callDefinitionClause,
-                                    accResolveState
-                                )
-                            }
+                        Modular.callDefinitionClauseCallWhile(
+                            namedElement, namedElementResolveState
+                        ) { callDefinitionClause, accResolveState ->
+                            executeOnCallDefinitionClause(
+                                callDefinitionClause,
+                                accResolveState
+                            )
                         }
-                        is ModuleImpl<*> -> whileIn(namedElement.callDefinitions()) {
-                            execute(it, state)
-                        }
-                        else -> true
                     }
+                    is ModuleImpl<*> -> whileIn(namedElement.callDefinitions()) {
+                        execute(it, state)
+                    }
+                    else -> true
                 }
+            }
         }
+
+    /**
+     * Returns all [NamedElement]s for [moduleName] within [scope], with source [Call]s ordered before
+     * decompiled [ModuleImpl]s. This ensures the scope walker visits source definitions first so that
+     * [keepProcessing] stops the walk before beam stubs are ever reached when source is available.
+     *
+     * [StubIndex.processElements] returns elements in an unspecified order; without this ordering a
+     * [ModuleImpl] arriving first would add a valid result, set [keepProcessing] to false, and
+     * short-circuit the loop before the corresponding source [Call] (e.g. `kernel.ex`) was visited.
+     */
+    private fun sourceFirstNamedElements(project: Project, scope: GlobalSearchScope, moduleName: String): List<NamedElement> =
+        buildList {
+            StubIndex.getInstance().processElements(
+                org.elixir_lang.psi.stub.index.ModularName.KEY,
+                moduleName,
+                project,
+                scope,
+                NamedElement::class.java
+            ) { add(it); true }
+        }.sortedWith(compareBy { it is ModuleImpl<*> })
 
     companion object {
         val MODULAR_CANONICAL_NAME = Key<String>("MODULAR_CANONICAL_NAME")

--- a/src/org/elixir_lang/psi/scope/module/MultiResolve.kt
+++ b/src/org/elixir_lang/psi/scope/module/MultiResolve.kt
@@ -4,7 +4,6 @@ import com.intellij.openapi.project.DumbService
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiNamedElement
 import com.intellij.psi.ResolveState
-import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.psi.stubs.StubIndex
 import com.intellij.psi.util.PsiTreeUtil
 import org.elixir_lang.Module.concat
@@ -20,6 +19,7 @@ import org.elixir_lang.psi.scope.VisitedElementSetResolveResult
 import org.elixir_lang.psi.scope.maxScope
 import org.elixir_lang.psi.stub.index.ModularName
 import org.elixir_lang.reference.module.UnaliasedName
+import org.elixir_lang.reference.resolver.narrowedScope
 
 class MultiResolve internal constructor(private val name: String, private val incompleteCode: Boolean) : Module() {
     /**
@@ -106,13 +106,15 @@ class MultiResolve internal constructor(private val name: String, private val in
         if (!DumbService.isDumb(project)) {
             var found = false
 
+            val searchScope = narrowedScope(match, project)
+
             StubIndex
                     .getInstance()
                     .processElements(
                             ModularName.KEY,
                             unaliasedName,
                             project,
-                            GlobalSearchScope.allScope(project),
+                            searchScope,
                             NamedElement::class.java) {
                 resolveResultOrderedSet.add(it, unaliasedName, true, visitedElementSet)
                 found = true

--- a/src/org/elixir_lang/reference/resolver/Atom.java
+++ b/src/org/elixir_lang/reference/resolver/Atom.java
@@ -19,6 +19,6 @@ public class Atom implements ResolveCache.PolyVariantResolver<org.elixir_lang.re
         ElixirAtom element = atom.getElement();
         Resolvable resolvable = resolvable(element);
 
-        return resolvable.resolve(element.getProject());
+        return resolvable.resolve(element);
     }
 }

--- a/src/org/elixir_lang/reference/resolver/Module.kt
+++ b/src/org/elixir_lang/reference/resolver/Module.kt
@@ -1,15 +1,11 @@
 package org.elixir_lang.reference.resolver
 
 import com.intellij.openapi.application.ApplicationManager
-import com.intellij.openapi.module.ModuleUtil
 import com.intellij.openapi.project.DumbService
-import com.intellij.openapi.roots.ProjectRootManager
-import com.intellij.openapi.roots.impl.LibraryScopeCache
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiElementResolveResult
 import com.intellij.psi.ResolveResult
 import com.intellij.psi.impl.source.resolve.ResolveCache
-import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.psi.stubs.StubIndex
 import org.elixir_lang.psi.Alias
 import org.elixir_lang.psi.NamedElement
@@ -103,30 +99,7 @@ object Module : ResolveCache.PolyVariantResolver<org.elixir_lang.reference.Modul
         val project = entrance.project
 
         if (!DumbService.isDumb(project)) {
-            val projectFileIndex = ProjectRootManager.getInstance(project).fileIndex
-            val module = ModuleUtil.findModuleForPsiElement(entrance)
-            // MUST use `originalFile` to get the PsiFile with a VirtualFile for decompiled elements
-            val entranceVirtualFile = entrance.containingFile.originalFile.virtualFile
-
-            val globalSearchScope = if (module != null) {
-                val includeTests = entranceVirtualFile?.let { projectFileIndex.isInTestSourceContent(it) } ?: false
-                // DOES NOT include the libraries sources, but...
-                val moduleWithDependenciesAndLibrariesScope =
-                    GlobalSearchScope.moduleWithDependenciesAndLibrariesScope(module, includeTests)
-
-                entranceVirtualFile?.let {
-                    // ... we prefer sources compared to decompiled, so use LibraryScope to get the Library source too.
-                    val orderEntries = projectFileIndex.getOrderEntriesForFile(entranceVirtualFile)
-                    val libraryScope =
-                        LibraryScopeCache
-                            .getInstance(project)
-                            .getLibraryScope(orderEntries)
-
-                    moduleWithDependenciesAndLibrariesScope.uniteWith(libraryScope)
-                } ?: moduleWithDependenciesAndLibrariesScope
-            } else {
-                GlobalSearchScope.allScope(project)
-            }
+            val searchScope = narrowedScope(entrance, project)
 
             StubIndex
                 .getInstance()
@@ -134,7 +107,7 @@ object Module : ResolveCache.PolyVariantResolver<org.elixir_lang.reference.Modul
                     ModularName.KEY,
                     name,
                     project,
-                    globalSearchScope,
+                    searchScope,
                     null,
                     NamedElement::class.java
                 ) { namedElement ->

--- a/src/org/elixir_lang/reference/resolver/ScopeUtil.kt
+++ b/src/org/elixir_lang/reference/resolver/ScopeUtil.kt
@@ -1,5 +1,6 @@
 package org.elixir_lang.reference.resolver
 
+import com.intellij.codeInsight.daemon.SyntheticPsiFileSupport
 import com.intellij.openapi.module.ModuleUtil
 import com.intellij.openapi.module.impl.scopes.JdkScope
 import com.intellij.openapi.project.Project
@@ -9,9 +10,53 @@ import com.intellij.openapi.roots.ModuleRootManager
 import com.intellij.openapi.roots.OrderRootType
 import com.intellij.openapi.roots.ProjectRootManager
 import com.intellij.openapi.roots.impl.LibraryScopeCache
+import com.intellij.openapi.vfs.LocalFileSystem
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.openapi.vfs.VirtualFileManager
 import com.intellij.psi.PsiElement
 import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.util.concurrency.annotations.RequiresReadLock
+
+/**
+ * The on-disk [VirtualFile] that should drive module / scope selection for [element], if recoverable.
+ *
+ * For normal files this is just `containingFile.originalFile.virtualFile`.  Files shown in the
+ * commit / VCS diff view are backed by a synthetic [com.intellij.testFramework.LightVirtualFile]
+ * which - although its path points at a real source file - is not part of any module, so
+ * [ModuleUtil.findModuleForFile] returns null for it.  Depending on whether the view provider's
+ * event system is enabled, that light file surfaces through either `originalFile.virtualFile` or
+ * `viewProvider.virtualFile`; in both cases we map it back to the real file via [recoverLocalFile].
+ *
+ * Returns null for scratches and injected fragments that have no recoverable on-disk file.
+ */
+@RequiresReadLock
+private fun effectiveVirtualFile(element: PsiElement): VirtualFile? {
+    val containingFile = element.containingFile ?: return null
+
+    val backingFile = containingFile.originalFile.virtualFile
+        ?: containingFile.viewProvider.virtualFile
+
+    return recoverLocalFile(backingFile) ?: backingFile
+}
+
+/**
+ * Maps a synthetic diff / VCS [file] back to its real on-disk [VirtualFile], or null when [file] is
+ * already a real local file (or nothing can be recovered).
+ *
+ * The diff platform marks these [com.intellij.testFramework.LightVirtualFile]s via
+ * [SyntheticPsiFileSupport.markFile] with the original file URL, which we resolve first; as a
+ * fallback we resolve the light file's own path so navigation still works when the file was never
+ * marked.
+ */
+private fun recoverLocalFile(file: VirtualFile): VirtualFile? {
+    if (file.isInLocalFileSystem) return null
+
+    SyntheticPsiFileSupport.getOriginalFileUrl(file)?.let { url ->
+        VirtualFileManager.getInstance().findFileByUrl(url)?.let { return it }
+    }
+
+    return LocalFileSystem.getInstance().findFileByPath(file.path)
+}
 
 /**
  * Builds a search scope that covers the module owning [element], its transitive
@@ -35,11 +80,13 @@ import com.intellij.util.concurrency.annotations.RequiresReadLock
  */
 @RequiresReadLock
 fun narrowedScope(element: PsiElement, project: Project): GlobalSearchScope {
+    val virtualFile = effectiveVirtualFile(element)
+
     val module = ModuleUtil.findModuleForPsiElement(element)
+        ?: virtualFile?.let { ModuleUtil.findModuleForFile(it, project) }
         ?: return GlobalSearchScope.allScope(project)
 
     val projectFileIndex = ProjectRootManager.getInstance(project).fileIndex
-    val virtualFile = element.containingFile?.originalFile?.virtualFile
     val includeTests = virtualFile?.let { projectFileIndex.isInTestSourceContent(it) } ?: false
 
     val orderEntries = ModuleRootManager.getInstance(module).orderEntries

--- a/src/org/elixir_lang/reference/resolver/ScopeUtil.kt
+++ b/src/org/elixir_lang/reference/resolver/ScopeUtil.kt
@@ -1,0 +1,68 @@
+package org.elixir_lang.reference.resolver
+
+import com.intellij.openapi.module.ModuleUtil
+import com.intellij.openapi.module.impl.scopes.JdkScope
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.roots.JdkOrderEntry
+import com.intellij.openapi.roots.LibraryOrderEntry
+import com.intellij.openapi.roots.ModuleRootManager
+import com.intellij.openapi.roots.OrderRootType
+import com.intellij.openapi.roots.ProjectRootManager
+import com.intellij.openapi.roots.impl.LibraryScopeCache
+import com.intellij.psi.PsiElement
+import com.intellij.psi.search.GlobalSearchScope
+import com.intellij.util.concurrency.annotations.RequiresReadLock
+
+/**
+ * Builds a search scope that covers the module owning [element], its transitive
+ * dependencies, and the SDK + non-SDK library sources attached to that specific module.
+ *
+ * Falls back to [GlobalSearchScope.allScope] when no module can be determined
+ * (e.g. scratches, injected fragments).
+ *
+ * Elixir stubs are indexed from .ex source files (not .beam class files), so
+ * defmodule declarations live in SDK and library source roots.
+ * [GlobalSearchScope.moduleWithDependenciesAndLibrariesScope] only covers class roots
+ * for library dependencies ([LibraryOrderEntry]), so we must explicitly unite with:
+ *   - SDK source roots via [LibraryScopeCache.getScopeForSdk] per [JdkOrderEntry]
+ *   - Non-SDK library source roots via [JdkScope] over each [LibraryOrderEntry]'s
+ *     [OrderRootType.SOURCES] roots (e.g. `deps/ecto/lib`)
+ *
+ * Using the module's own root model (not
+ * [com.intellij.openapi.roots.ProjectFileIndex.getOrderEntriesForFile]) keeps the
+ * scope scoped to this module's dependencies only, preventing spurious "Choose Declaration"
+ * results from sibling modules that share a module name but use a different SDK or library version.
+ */
+@RequiresReadLock
+fun narrowedScope(element: PsiElement, project: Project): GlobalSearchScope {
+    val module = ModuleUtil.findModuleForPsiElement(element)
+        ?: return GlobalSearchScope.allScope(project)
+
+    val projectFileIndex = ProjectRootManager.getInstance(project).fileIndex
+    val virtualFile = element.containingFile?.originalFile?.virtualFile
+    val includeTests = virtualFile?.let { projectFileIndex.isInTestSourceContent(it) } ?: false
+
+    val orderEntries = ModuleRootManager.getInstance(module).orderEntries
+
+    val moduleScope = GlobalSearchScope.moduleWithDependenciesAndLibrariesScope(module, includeTests)
+
+    val sdkSourceScope = orderEntries
+        .filterIsInstance<JdkOrderEntry>()
+        .fold(GlobalSearchScope.EMPTY_SCOPE as GlobalSearchScope) { acc, entry ->
+            acc.uniteWith(LibraryScopeCache.getInstance(project).getScopeForSdk(entry))
+        }
+
+    // moduleWithDependenciesAndLibrariesScope covers library CLASS roots (ebin/) but not SOURCE
+    // roots (deps/<lib>/lib/).  Without this, multiResolveProject finds only the beam ModuleImpl
+    // and never the source defmodule, causing navigation to land on the decompiled .beam file
+    // instead of the .ex source even when source roots are attached to the library.
+    val librarySourceScope = orderEntries
+        .filterIsInstance<LibraryOrderEntry>()
+        .fold(GlobalSearchScope.EMPTY_SCOPE as GlobalSearchScope) { acc, entry ->
+            val sourceRoots = entry.getRootFiles(OrderRootType.SOURCES)
+            if (sourceRoots.isEmpty()) acc
+            else acc.uniteWith(JdkScope(project, emptyArray(), sourceRoots, entry.libraryName))
+        }
+
+    return moduleScope.uniteWith(sdkSourceScope).uniteWith(librarySourceScope)
+}

--- a/src/org/elixir_lang/reference/resolver/atom/Resolvable.java
+++ b/src/org/elixir_lang/reference/resolver/atom/Resolvable.java
@@ -1,7 +1,6 @@
 package org.elixir_lang.reference.resolver.atom;
 
 import com.intellij.lang.ASTNode;
-import com.intellij.openapi.project.Project;
 import com.intellij.psi.ResolveResult;
 import com.intellij.psi.tree.IElementType;
 import org.elixir_lang.psi.*;
@@ -138,5 +137,5 @@ public abstract class Resolvable {
         return new Exact(":" + stringAccumulator);
     }
 
-    public abstract ResolveResult[] resolve(@NotNull Project project);
+    public abstract ResolveResult[] resolve(@NotNull ElixirAtom element);
 }

--- a/src/org/elixir_lang/reference/resolver/atom/resolvable/Exact.kt
+++ b/src/org/elixir_lang/reference/resolver/atom/resolvable/Exact.kt
@@ -1,21 +1,22 @@
 package org.elixir_lang.reference.resolver.atom.resolvable
 
 import com.intellij.openapi.project.DumbService
-import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElementResolveResult
 import com.intellij.psi.ResolveResult
-import com.intellij.psi.search.GlobalSearchScope
-import com.intellij.psi.stubs.StubIndex
+import org.elixir_lang.psi.ElixirAtom
 import org.elixir_lang.psi.NamedElement
 import org.elixir_lang.psi.stub.index.AllName
 import org.elixir_lang.reference.resolver.atom.Resolvable
+import org.elixir_lang.reference.resolver.narrowedScope
+import com.intellij.psi.stubs.StubIndex
 
 class Exact(private val name: String) : Resolvable() {
-    override fun resolve(project: Project): Array<ResolveResult> {
+    override fun resolve(element: ElixirAtom): Array<ResolveResult> {
         val resolveResultList = mutableListOf<ResolveResult>()
+        val project = element.project
 
         if (!DumbService.isDumb(project)) {
-            val scope = GlobalSearchScope.allScope(project)
+            val scope = narrowedScope(element, project)
 
             StubIndex.getInstance().processElements(
                 AllName.KEY, name, project, scope, NamedElement::class.java
@@ -25,7 +26,7 @@ class Exact(private val name: String) : Resolvable() {
                 true
             }
         }
-        
+
         return resolveResultList.toTypedArray()
     }
 }

--- a/src/org/elixir_lang/reference/resolver/atom/resolvable/Pattern.kt
+++ b/src/org/elixir_lang/reference/resolver/atom/resolvable/Pattern.kt
@@ -1,13 +1,13 @@
 package org.elixir_lang.reference.resolver.atom.resolvable
 
-import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElementResolveResult
 import com.intellij.psi.ResolveResult
-import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.psi.stubs.StubIndex
+import org.elixir_lang.psi.ElixirAtom
 import org.elixir_lang.psi.NamedElement
 import org.elixir_lang.psi.stub.index.AllName
 import org.elixir_lang.reference.resolver.atom.Resolvable
+import org.elixir_lang.reference.resolver.narrowedScope
 import java.util.function.Predicate
 import java.util.regex.Pattern
 
@@ -15,9 +15,10 @@ class Pattern(private val predicate: Predicate<String>) : Resolvable() {
     constructor(regex: String) : this(Pattern.compile(":$regex")) {}
     constructor(pattern: Pattern) : this(pattern.asPredicate()) {}
 
-    override fun resolve(project: Project): Array<ResolveResult> {
+    override fun resolve(element: ElixirAtom): Array<ResolveResult> {
+        val project = element.project
         val stubIndex = StubIndex.getInstance()
-        val scope = GlobalSearchScope.allScope(project)
+        val scope = narrowedScope(element, project)
         val resolveResults = mutableListOf<ResolveResult>()
 
         stubIndex

--- a/tests/org/elixir_lang/reference/resolver/ScopeUtilTest.kt
+++ b/tests/org/elixir_lang/reference/resolver/ScopeUtilTest.kt
@@ -1,13 +1,14 @@
 package org.elixir_lang.reference.resolver
 
 import com.intellij.codeInsight.daemon.SyntheticPsiFileSupport
-import com.intellij.openapi.application.runReadActionBlocking
+import com.intellij.openapi.application.ReadAction
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiFileFactory
 import com.intellij.psi.search.GlobalSearchScope
 import org.elixir_lang.ElixirLanguage
 import org.elixir_lang.PlatformTestCase
+import java.util.concurrent.Callable
 
 class ScopeUtilTest : PlatformTestCase() {
 
@@ -22,7 +23,9 @@ class ScopeUtilTest : PlatformTestCase() {
         val psiFile = myFixture.configureByText("foo.ex", source)
         val realVirtualFile = psiFile.virtualFile
 
-        val scope = runReadActionBlocking { narrowedScope(elementIn(psiFile), project) }
+        val scope = ReadAction.nonBlocking(Callable {
+            narrowedScope(elementIn(psiFile), project)
+        }).executeSynchronously()
 
         assertNotSame(GlobalSearchScope.allScope(project), scope)
         assertTrue("Module scope should contain the module's own file", scope.contains(realVirtualFile))
@@ -53,7 +56,9 @@ class ScopeUtilTest : PlatformTestCase() {
         assertFalse("Precondition: backing file is not a real local file", backingFile.isInLocalFileSystem)
         SyntheticPsiFileSupport.markFileWithUrl(backingFile, realVirtualFile.url)
 
-        val scope = runReadActionBlocking { narrowedScope(elementIn(outsiderFile), project) }
+        val scope = ReadAction.nonBlocking(Callable {
+            narrowedScope(elementIn(outsiderFile), project)
+        }).executeSynchronously()
 
         assertNotSame(
             "Should narrow to the recovered module instead of allScope",
@@ -68,7 +73,9 @@ class ScopeUtilTest : PlatformTestCase() {
         val syntheticFile = PsiFileFactory.getInstance(project)
             .createFileFromText("foo.ex", ElixirLanguage, source, false, false)
 
-        val scope = runReadActionBlocking { narrowedScope(elementIn(syntheticFile), project) }
+        val scope = ReadAction.nonBlocking(Callable {
+            narrowedScope(elementIn(syntheticFile), project)
+        }).executeSynchronously()
 
         assertSame(GlobalSearchScope.allScope(project), scope)
     }

--- a/tests/org/elixir_lang/reference/resolver/ScopeUtilTest.kt
+++ b/tests/org/elixir_lang/reference/resolver/ScopeUtilTest.kt
@@ -1,0 +1,78 @@
+package org.elixir_lang.reference.resolver
+
+import com.intellij.codeInsight.daemon.SyntheticPsiFileSupport
+import com.intellij.openapi.application.runReadActionBlocking
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import com.intellij.psi.PsiFileFactory
+import com.intellij.psi.search.GlobalSearchScope
+import org.elixir_lang.ElixirLanguage
+import org.elixir_lang.PlatformTestCase
+
+class ScopeUtilTest : PlatformTestCase() {
+
+    private val source =
+        """
+        defmodule Foo do
+        end
+        """.trimIndent()
+
+    /** A real file resolves to its module's narrow scope, not the global fallback. */
+    fun testNormalFileResolvesNarrowModuleScope() {
+        val psiFile = myFixture.configureByText("foo.ex", source)
+        val realVirtualFile = psiFile.virtualFile
+
+        val scope = runReadActionBlocking { narrowedScope(elementIn(psiFile), project) }
+
+        assertNotSame(GlobalSearchScope.allScope(project), scope)
+        assertTrue("Module scope should contain the module's own file", scope.contains(realVirtualFile))
+    }
+
+    /**
+     * Reproduces the commit / VCS diff view as observed in the debugger: the PSI is backed by a
+     * [com.intellij.testFramework.LightVirtualFile] surfaced through `originalFile.virtualFile`
+     * (event system enabled). That light file belongs to no module, so [narrowedScope] must map it
+     * back to the real file via the marked original URL instead of falling back to
+     * [GlobalSearchScope.allScope].
+     */
+    fun testOutsiderDiffFileWithBackingVirtualFileRecoversModuleScope() {
+        assertRecoversModuleScope(eventSystemEnabled = true)
+    }
+
+    /** Same recovery when the backing light file is only reachable via `viewProvider.virtualFile`. */
+    fun testOutsiderDiffFileWithoutBackingVirtualFileRecoversModuleScope() {
+        assertRecoversModuleScope(eventSystemEnabled = false)
+    }
+
+    private fun assertRecoversModuleScope(eventSystemEnabled: Boolean) {
+        val realVirtualFile = myFixture.configureByText("foo.ex", source).virtualFile
+
+        val outsiderFile = PsiFileFactory.getInstance(project)
+            .createFileFromText("foo.ex", ElixirLanguage, source, eventSystemEnabled, false)
+        val backingFile = outsiderFile.viewProvider.virtualFile
+        assertFalse("Precondition: backing file is not a real local file", backingFile.isInLocalFileSystem)
+        SyntheticPsiFileSupport.markFileWithUrl(backingFile, realVirtualFile.url)
+
+        val scope = runReadActionBlocking { narrowedScope(elementIn(outsiderFile), project) }
+
+        assertNotSame(
+            "Should narrow to the recovered module instead of allScope",
+            GlobalSearchScope.allScope(project),
+            scope
+        )
+        assertTrue("Recovered module scope should contain the original file", scope.contains(realVirtualFile))
+    }
+
+    /** A synthetic file with no recoverable on-disk original keeps the global fallback. */
+    fun testUnmarkedSyntheticFileFallsBackToAllScope() {
+        val syntheticFile = PsiFileFactory.getInstance(project)
+            .createFileFromText("foo.ex", ElixirLanguage, source, false, false)
+
+        val scope = runReadActionBlocking { narrowedScope(elementIn(syntheticFile), project) }
+
+        assertSame(GlobalSearchScope.allScope(project), scope)
+    }
+
+    private fun elementIn(file: PsiFile): PsiElement =
+        file.findElementAt(source.indexOf("Foo")) ?: file
+}


### PR DESCRIPTION
## Summary
This PR isolates resolver and navigation correctness fixes from the larger `warn-mismatched-otp` split.

## Why this is needed
Navigation quality regressed in several places: module/atom resolution leaked outside owning scope, some unqualified Kernel calls preferred `.beam` over source, and ExUnit describe/test macro resolution missed `CaseTemplate` use-chains.

## What changed
- Scope narrowing for module/atom stub lookup (`resolver/*`, `MultiResolve`).
- ExUnit macro resolution through `ExUnit.CaseTemplate` use chains (`Use.kt`, `Using.kt`).
- Unqualified Kernel function navigation now prefers source-backed targets (`CallDefinitionClause.kt`).
- Gutter icon propagation from test lines to enclosing `describe` and module (`TestLineMarkerProvider.kt`).
- Added WSL compat helper dependency used by this branch (`maybeParseWindowsUncPath`).

## Notes for reviewers
- This PR remains focused on resolver/navigation behavior.
- The added WSL helper is included only because this branch now depends on it for successful compile/test.

## Suggested review order
1. `src/org/elixir_lang/reference/resolver/*`
2. `src/org/elixir_lang/psi/Use.kt`, `src/org/elixir_lang/psi/Using.kt`
3. `src/org/elixir_lang/psi/scope/CallDefinitionClause.kt`
4. `src/org/elixir_lang/exunit/TestLineMarkerProvider.kt`
5. `src/org/elixir_lang/sdk/wsl/*`
