### PR TITLE
fix(external-libraries): clearer SDK package names and source roots

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -223,7 +223,7 @@ The Elixir parser and PSI element classes in `gen/` are generated from `src/org/
 The GrammarKit generator writes files with CRLF line endings, but the repository uses LF. After regenerating, convert line endings from Git Bash:
 
 ```bash
-cd /c/Users/steve/IdeaProjects/intellij-elixir/intellij-elixir
+cd ~/IdeaProjects/intellij-elixir/intellij-elixir
 find gen -type f | xargs dos2unix.exe
 ```
 

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -44,6 +44,10 @@
         <sdkType implementation="org.elixir_lang.sdk.elixir.Type"/>
         <sdkType implementation="org.elixir_lang.sdk.erlang.Type"/>
 
+        <!-- External Libraries: rename SDK "ebin"/"lib" roots to their OTP app name and show .ex source -->
+        <projectViewNodeDecorator implementation="org.elixir_lang.sdk.ElixirSdkLibraryNodeDecorator"/>
+        <treeStructureProvider implementation="org.elixir_lang.sdk.ElixirSdkLibraryTreeStructureProvider"/>
+
 
         <editorNotificationProvider implementation="org.elixir_lang.notification.setup_sdk.Provider"/>
         <notificationGroup displayType="BALLOON" id="Elixir"/>

--- a/src/org/elixir_lang/DepsWatcher.kt
+++ b/src/org/elixir_lang/DepsWatcher.kt
@@ -9,7 +9,9 @@ import com.intellij.openapi.progress.ProgressIndicator
 import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.progress.Task
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.roots.LibraryOrderEntry
 import com.intellij.openapi.roots.ModuleRootManager
+import com.intellij.openapi.roots.ModuleRootModificationUtil
 import com.intellij.openapi.roots.OrderRootType
 import com.intellij.openapi.roots.ProjectRootManager
 import com.intellij.openapi.roots.libraries.Library
@@ -20,6 +22,7 @@ import com.intellij.openapi.vfs.newvfs.events.VFileCreateEvent
 import com.intellij.openapi.vfs.newvfs.events.VFileDeleteEvent
 import com.intellij.openapi.vfs.newvfs.events.VFileEvent
 import org.elixir_lang.mix.Watcher
+import org.elixir_lang.mix.library.CONSOLIDATED_LIBRARY_SUFFIX
 import org.elixir_lang.mix.library.Kind
 import org.elixir_lang.util.DebouncedBulkFileListener
 import org.elixir_lang.util.ElixirProjectDisposable
@@ -32,20 +35,22 @@ import java.net.URI
  * * `deps/APPLICATION/{c_src,lib,priv,src}` - sources
  * * `_build/ENVIRONMENT/{consolidated,lib/APPLICATION/ebin` - classes
  */
-class DepsWatcher(val project: Project) : DebouncedBulkFileListener(project.service<ElixirProjectDisposable>(), MERGE_DELAY_MS) {
+class DepsWatcher(val project: Project) :
+    DebouncedBulkFileListener(project.service<ElixirProjectDisposable>(), MERGE_DELAY_MS) {
     private val pendingLock = Any()
     private val pendingDeleteAllDepsUrls = mutableSetOf<String>()
     private val pendingDeleteLibraryNames = mutableSetOf<String>()
     private val pendingSyncDepsRoots = mutableSetOf<VirtualFile>()
     private val pendingSyncDepRoots = mutableSetOf<VirtualFile>()
+    private val pendingSyncConsolidatedRoots = mutableSetOf<VirtualFile>()
     private var pendingSyncAll = false
 
     override fun enqueue(event: VFileEvent): Boolean =
-        when (event) {
-            is VFileDeleteEvent -> fileDeleted(event)
-            is VFileCreateEvent -> fileCreated(event)
-            else -> false
-        }
+            when (event) {
+                is VFileDeleteEvent -> fileDeleted(event)
+                is VFileCreateEvent -> fileCreated(event)
+                else -> false
+            }
 
     /**
      * If a file is deleted, it is need to determine whether it affect no deps, 1 dep, or all deps.
@@ -60,8 +65,14 @@ class DepsWatcher(val project: Project) : DebouncedBulkFileListener(project.serv
 
         return when {
             file.name == "deps" && isModuleContentRoot(file.parent, project) -> queueDeleteAllLibraries(file.url)
-            file.parent?.let { parent -> parent.name == "deps" && isModuleContentRoot(parent.parent, project) } == true ->
+            file.parent?.let { parent ->
+                parent.name == "deps" && isModuleContentRoot(
+                    parent.parent,
+                    project
+                )
+            } == true ->
                 queueDeleteLibrary(file.name)
+
             else -> syncLibraries(event)
         }
     }
@@ -79,7 +90,12 @@ class DepsWatcher(val project: Project) : DebouncedBulkFileListener(project.serv
 
         return if (file.name == "deps" && isModuleContentRoot(event.parent, project)) {
             queueSyncDepsRoot(file)
-        } else if (event.parent.let { parent -> parent.name == "deps" && isModuleContentRoot(parent.parent, project) }) {
+        } else if (event.parent.let { parent ->
+                parent.name == "deps" && isModuleContentRoot(
+                    parent.parent,
+                    project
+                )
+            }) {
             queueSyncDepRoot(file)
         } else {
             syncLibraries(event)
@@ -107,6 +123,7 @@ class DepsWatcher(val project: Project) : DebouncedBulkFileListener(project.serv
         when (val request = syncRequestFor(virtualFile)) {
             SyncRequest.All -> scheduleSyncAll()
             is SyncRequest.Dep -> scheduleSyncDep(request.depRoot)
+            is SyncRequest.Consolidated -> scheduleConsolidatedSync(setOf(request.buildDir))
             null -> Unit
         }
     }
@@ -127,7 +144,11 @@ class DepsWatcher(val project: Project) : DebouncedBulkFileListener(project.serv
 
         val greatGrandParent = grandParent.parent ?: return null
 
-        if (fileName in arrayOf("consolidated", "lib") && grandParent.name == "_build" && isModuleContentRoot(greatGrandParent, project)) {
+        if (fileName in arrayOf("consolidated", "lib") && grandParent.name == "_build" && isModuleContentRoot(
+                greatGrandParent,
+                project
+            )
+        ) {
             return SyncRequest.All
         }
 
@@ -137,15 +158,30 @@ class DepsWatcher(val project: Project) : DebouncedBulkFileListener(project.serv
 
         val greatGreatGrandParent = greatGrandParent.parent ?: return null
 
-        if (parent.name == "lib" && greatGrandParent.name == "_build" && isModuleContentRoot(greatGreatGrandParent, project)) {
+        if (parent.name == "lib" && greatGrandParent.name == "_build" && isModuleContentRoot(
+                greatGreatGrandParent,
+                project
+            )
+        ) {
             val dep = greatGreatGrandParent.findChild("deps")?.findChild(fileName)
             return dep?.let { SyncRequest.Dep(it) }
         }
 
-        if (fileName == "ebin" && grandParent.name == "lib" && greatGreatGrandParent.name == "_build" &&
-            isModuleContentRoot(greatGreatGrandParent.parent, project)) {
+        if (fileName == "ebin" &&
+            grandParent.name == "lib" &&
+            greatGreatGrandParent.name == "_build" &&
+            isModuleContentRoot(greatGreatGrandParent.parent, project)
+        ) {
             val dep = greatGreatGrandParent.parent?.findChild("deps")?.findChild(parent.name)
             return dep?.let { SyncRequest.Dep(it) }
+        }
+
+        // A .beam file created inside _build/{env}/consolidated/ triggers a consolidated library sync.
+        if (parent.name == "consolidated" &&
+            greatGrandParent.name == "_build" &&
+            isModuleContentRoot(greatGreatGrandParent, project)
+        ) {
+            return SyncRequest.Consolidated(greatGrandParent)
         }
 
         return null
@@ -183,10 +219,21 @@ class DepsWatcher(val project: Project) : DebouncedBulkFileListener(project.serv
         return true
     }
 
+    private fun queueSyncConsolidated(buildDir: VirtualFile): Boolean {
+        synchronized(pendingLock) {
+            if (!pendingSyncAll) {
+                pendingSyncConsolidatedRoots.add(buildDir)
+            }
+        }
+
+        return true
+    }
+
     private fun queueSyncFor(file: VirtualFile): Boolean {
         return when (val request = syncRequestFor(file)) {
             SyncRequest.All -> queueSyncAll()
             is SyncRequest.Dep -> queueSyncDepRoot(request.depRoot)
+            is SyncRequest.Consolidated -> queueSyncConsolidated(request.buildDir)
             null -> false
         }
     }
@@ -196,6 +243,7 @@ class DepsWatcher(val project: Project) : DebouncedBulkFileListener(project.serv
             pendingSyncAll = true
             pendingSyncDepsRoots.clear()
             pendingSyncDepRoots.clear()
+            pendingSyncConsolidatedRoots.clear()
         }
 
         return true
@@ -208,6 +256,7 @@ class DepsWatcher(val project: Project) : DebouncedBulkFileListener(project.serv
         val syncAll: Boolean
         val syncDepsRoots: Set<VirtualFile>
         val syncDepRoots: Set<VirtualFile>
+        val syncConsolidatedRoots: Set<VirtualFile>
 
         synchronized(pendingLock) {
             deleteAllDepsUrls = pendingDeleteAllDepsUrls.toSet()
@@ -215,12 +264,14 @@ class DepsWatcher(val project: Project) : DebouncedBulkFileListener(project.serv
             syncAll = pendingSyncAll
             syncDepsRoots = pendingSyncDepsRoots.toSet()
             syncDepRoots = pendingSyncDepRoots.toSet()
+            syncConsolidatedRoots = pendingSyncConsolidatedRoots.toSet()
 
             pendingDeleteAllDepsUrls.clear()
             pendingDeleteLibraryNames.clear()
             pendingSyncAll = false
             pendingSyncDepsRoots.clear()
             pendingSyncDepRoots.clear()
+            pendingSyncConsolidatedRoots.clear()
         }
 
         deleteAllDepsUrls.forEach { deleteAllLibraries(it) }
@@ -230,6 +281,9 @@ class DepsWatcher(val project: Project) : DebouncedBulkFileListener(project.serv
             scheduleSyncAll()
         } else {
             scheduleSyncRequests(syncDepsRoots, syncDepRoots)
+            if (syncConsolidatedRoots.isNotEmpty()) {
+                scheduleConsolidatedSync(syncConsolidatedRoots)
+            }
         }
     }
 
@@ -237,6 +291,19 @@ class DepsWatcher(val project: Project) : DebouncedBulkFileListener(project.serv
         ProgressManager.getInstance().run(object : Task.Backgroundable(project, "Syncing Elixir libraries", true) {
             override fun run(indicator: ProgressIndicator) {
                 syncLibraries(indicator)
+            }
+        })
+    }
+
+    private fun scheduleConsolidatedSync(buildRoots: Set<VirtualFile>) {
+        val validRoots = buildRoots.filter { it.isValid }
+        if (validRoots.isEmpty()) return
+
+        ProgressManager.getInstance().run(object : Task.Backgroundable(project, "Syncing consolidated protocols", true) {
+            override fun run(indicator: ProgressIndicator) {
+                validRoots.forEach { buildRoot ->
+                    if (!indicator.isCanceled) syncConsolidatedLibrary(buildRoot, indicator)
+                }
             }
         })
     }
@@ -283,18 +350,86 @@ class DepsWatcher(val project: Project) : DebouncedBulkFileListener(project.serv
     fun syncLibraries(progressIndicator: ProgressIndicator) {
         val depsRoots = ReadAction.nonBlocking(java.util.concurrent.Callable {
             ProjectRootManager
-                    .getInstance(project)
-                    .contentRootsFromAllModules
-                    .mapNotNull { it.findChild("deps") }
+                .getInstance(project)
+                .contentRootsFromAllModules
+                .mapNotNull { it.findChild("deps") }
         }).executeSynchronously()
 
         depsRoots.forEach { syncLibraries(it, progressIndicator) }
     }
 
-    private fun syncLibrary(dep: VirtualFile, progressIndicator: ProgressIndicator) = syncLibraries(arrayOf(dep), progressIndicator)
+    private fun syncLibrary(dep: VirtualFile, progressIndicator: ProgressIndicator) =
+            syncLibraries(arrayOf(dep), progressIndicator)
 
     private fun syncLibraries(deps: VirtualFile, progressIndicator: ProgressIndicator) =
-        syncLibraries(deps.children, progressIndicator)
+            syncLibraries(deps.children, progressIndicator)
+
+    /**
+     * Creates or updates a single shared library named for the module with [CONSOLIDATED_LIBRARY_SUFFIX] that holds all
+     * `_build/{env}/consolidated/` directories as class roots.
+     *
+     * Protocol consolidation is a project-wide operation: the consolidated beam files for every
+     * protocol used anywhere in the project land here, regardless of which dep defines the protocol.
+     * It is therefore wrong to add them to individual dep libraries - they belong in one shared entry.
+     */
+    internal fun syncConsolidatedLibrary(build: VirtualFile, progressIndicator: ProgressIndicator) {
+        val envDirs = build.children.filter { it.isDirectory }
+
+        val consolidatedRoots = envDirs
+            .flatMap { env -> env.children.filter { it.isDirectory && it.name == "consolidated" } }
+
+        val libraryTable = LibraryTablesRegistrar.getInstance().getLibraryTable(project)
+        val consolidatedLibraryName = "${build.parent?.name ?: "unknown"} $CONSOLIDATED_LIBRARY_SUFFIX"
+
+        if (consolidatedRoots.isEmpty()) {
+            libraryTable.getLibraryByName(consolidatedLibraryName)?.let {
+                runWriteAction {
+                    progressIndicator.text2 = "Removing empty consolidated library $consolidatedLibraryName"
+                    libraryTable.removeLibrary(it)
+                }
+            }
+            return
+        }
+
+        val library: Library = libraryTable.getLibraryByName(consolidatedLibraryName)
+            ?: run {
+                var created: Library? = null
+                runWriteAction {
+                    val model = libraryTable.modifiableModel
+                    created = model.createLibrary(consolidatedLibraryName, Kind)
+                    model.commit()
+                }
+                created!!
+            }
+
+        runWriteAction {
+            val model = library.modifiableModel
+            model.clearRoots(OrderRootType.CLASSES)
+            for (consolidated in consolidatedRoots) {
+                progressIndicator.text2 = "Adding ${consolidated.path} as Classes root for $consolidatedLibraryName"
+                model.addRoot(consolidated, OrderRootType.CLASSES)
+            }
+            model.commit()
+        }
+
+        // A library only appears in External Libraries when at least one module depends on it.
+        // `_build` itself is not a content root, but its parent (the project dir) is.
+        val ownerModule = ReadAction.nonBlocking(java.util.concurrent.Callable {
+            build.parent?.let { ModuleUtil.findModuleForFile(it, project) }
+        }).executeSynchronously() ?: return
+
+        val alreadyAdded = ReadAction.nonBlocking(java.util.concurrent.Callable {
+            ModuleRootManager.getInstance(ownerModule).orderEntries
+                .any { it is LibraryOrderEntry && it.libraryName == consolidatedLibraryName }
+        }).executeSynchronously()
+
+        if (!alreadyAdded) {
+            runWriteAction {
+                progressIndicator.text2 = "Adding $consolidatedLibraryName as dependency of ${ownerModule.name}"
+                ModuleRootModificationUtil.addDependency(ownerModule, library)
+            }
+        }
+    }
 
     private fun syncLibraries(deps: Array<VirtualFile>, progressIndicator: ProgressIndicator) {
         if (deps.isNotEmpty()) {
@@ -315,13 +450,27 @@ class DepsWatcher(val project: Project) : DebouncedBulkFileListener(project.serv
 
                 Watcher(project).syncLibraries(module, progressIndicator)
             }
+
+            // Sync consolidated protocol libraries outside the write action - the method
+            // acquires its own minimal write locks internally.
+            val buildRoots = ReadAction.nonBlocking(java.util.concurrent.Callable {
+                ModuleManager.getInstance(project).modules
+                    .filter { it.isElixirMixModule() }
+                    .flatMap { ModuleRootManager.getInstance(it).contentRoots.toList() }
+                    .mapNotNull { it.findChild("_build") }
+                    .distinctBy { it.path }
+            }).executeSynchronously()
+
+            buildRoots.forEach { buildRoot ->
+                if (!progressIndicator.isCanceled) syncConsolidatedLibrary(buildRoot, progressIndicator)
+            }
         }
     }
 
     fun syncLibraries(
-            deps: Array<VirtualFile>,
-            libraryTable: LibraryTable,
-            progressIndicator: ProgressIndicator
+        deps: Array<VirtualFile>,
+        libraryTable: LibraryTable,
+        progressIndicator: ProgressIndicator
     ) {
         val libraryTableModifiableModel = libraryTable.modifiableModel
 
@@ -337,15 +486,15 @@ class DepsWatcher(val project: Project) : DebouncedBulkFileListener(project.serv
     }
 
     private fun syncLibrary(
-            dep: VirtualFile,
-            libraryTable: LibraryTable,
-            libraryTableModifiableModel: LibraryTable.ModifiableModel,
-            progressIndicator: ProgressIndicator
+        dep: VirtualFile,
+        libraryTable: LibraryTable,
+        libraryTableModifiableModel: LibraryTable.ModifiableModel,
+        progressIndicator: ProgressIndicator
     ) {
         val depName = dep.name
 
         val library = libraryTable.getLibraryByName(depName)
-                ?: libraryTableModifiableModel.createLibrary(dep.name, Kind)
+            ?: libraryTableModifiableModel.createLibrary(dep.name, Kind)
 
         syncLibrary(library, dep, depName, progressIndicator)
     }
@@ -358,62 +507,79 @@ class DepsWatcher(val project: Project) : DebouncedBulkFileListener(project.serv
 
         val buildRoots = ReadAction.nonBlocking(java.util.concurrent.Callable {
             ProjectRootManager
-                    .getInstance(project)
-                    .contentRootsFromAllModules
-                    .mapNotNull { it.findChild("_build") }
+                .getInstance(project)
+                .contentRootsFromAllModules
+                .mapNotNull { it.findChild("_build") }
         }).executeSynchronously()
 
+        // Track canonical paths to deduplicate symlinked ebin directories.
+        // Pure Erlang deps have _build/{env}/lib/{dep}/ebin → deps/{dep}/ebin (a symlink), so both
+        // the dev and test entries resolve to the same physical directory.
+        val addedClassRootPaths = mutableSetOf<String>()
+
         buildRoots
-                .forEach { build ->
-                    build
+            .forEach { build ->
+                build
+                    .children
+                    .filter { it.isDirectory }
+                    .forEach { environment ->
+                        environment
                             .children
                             .filter { it.isDirectory }
-                            .forEach { environment ->
-                                environment
-                                        .children
-                                        .filter { it.isDirectory }
-                                        .forEach { environmentChild ->
-                                            val environmentChildName = environmentChild.name
+                            .forEach { environmentChild ->
+                                val environmentChildName = environmentChild.name
 
-                                            if (environmentChildName == "consolidated") {
-                                                libraryModifiableModel.addRoot(environmentChild, OrderRootType.CLASSES)
-                                            } else if (environmentChildName == "lib") {
-                                                environmentChild.findChild(depName)?.let { depEnvironmentLibrary ->
-                                                    depEnvironmentLibrary.findChild("ebin")?.let { ebin ->
-                                                        if (ebin.isDirectory) {
-                                                            /* Mark build output as excluded when marking it as CLASSES, so that
-                                                               dependency will show up in External Libraries AND be pushed out into
-                                                               non-project results */
-                                                            ReadAction.nonBlocking(java.util.concurrent.Callable {
-                                                                ModuleUtil.findModuleForFile(depEnvironmentLibrary, project)
-                                                            }).executeSynchronously()
-                                                                    ?.let { module ->
-                                                                        ModuleRootManager.getInstance(module).modifiableModel.apply {
-                                                                            progressIndicator.text2 = "Excluding _build/lib/$depName/ebin from project so it is treated as an External Library"
+                                if (environmentChildName == "lib") {
+                                    environmentChild.findChild(depName)?.let { depEnvironmentLibrary ->
+                                        depEnvironmentLibrary.findChild("ebin")?.let { ebin ->
+                                            if (ebin.isDirectory) {
+                                                /* Mark build output as excluded when marking it as CLASSES, so that
+                                                   dependency will show up in External Libraries AND be pushed out into
+                                                   non-project results */
+                                                ReadAction.nonBlocking(java.util.concurrent.Callable {
+                                                    ModuleUtil.findModuleForFile(depEnvironmentLibrary, project)
+                                                }).executeSynchronously()
+                                                    ?.let { module ->
+                                                        ModuleRootManager.getInstance(module).modifiableModel.apply {
+                                                            progressIndicator.text2 =
+                                                                    "Excluding _build/lib/$depName/ebin from project so it is treated as an External Library"
 
-                                                                            for (contentEntry in contentEntries) {
-                                                                                if (progressIndicator.isCanceled) {
-                                                                                    break
-                                                                                }
+                                                            for (contentEntry in contentEntries) {
+                                                                if (progressIndicator.isCanceled) {
+                                                                    break
+                                                                }
 
-                                                                                contentEntry.addExcludeFolder(depEnvironmentLibrary)
-                                                                            }
-
-                                                                            commit()
-                                                                        }
-                                                                    }
-
-                                                            if (!progressIndicator.isCanceled) {
-                                                                progressIndicator.text2 = "Adding _build/lib/$depName/ebin as a Classes root for $"
-                                                                libraryModifiableModel.addRoot(ebin, OrderRootType.CLASSES)
+                                                                contentEntry.addExcludeFolder(depEnvironmentLibrary)
                                                             }
+
+                                                            commit()
                                                         }
+                                                    }
+
+                                                if (!progressIndicator.isCanceled) {
+                                                    // Resolve symlinks via VFS (cached, no disk I/O) before
+                                                    // registering: Erlang deps have
+                                                    // _build/{env}/lib/{dep}/ebin → deps/{dep}/ebin, so without
+                                                    // canonicalization the same physical directory is added once
+                                                    // per build environment, producing duplicate External Library entries.
+                                                    val canonicalEbin = ebin.canonicalFile ?: ebin
+
+                                                    if (addedClassRootPaths.add(canonicalEbin.path)) {
+                                                        progressIndicator.text2 =
+                                                                "Adding _build/lib/$depName/ebin as a Classes root for $depName"
+                                                        libraryModifiableModel.addRoot(
+                                                            canonicalEbin,
+                                                            OrderRootType.CLASSES
+                                                        )
                                                     }
                                                 }
                                             }
                                         }
+                                    }
+                                }
                             }
-                }
+                    }
+            }
 
         for (child in dep.children) {
             if (progressIndicator.isCanceled) {
@@ -454,9 +620,18 @@ class DepsWatcher(val project: Project) : DebouncedBulkFileListener(project.serv
             }
         }
 
-        if (depsLibraries.isNotEmpty()) {
+        // depsUrl is e.g. "file:///path/to/project/deps" -> project root name is the parent dir name.
+        val projectRootName = URI(depsUrl).path.trimEnd('/').let { java.io.File(it).parentFile?.name }
+        val consolidatedLibrary = projectRootName?.let {
+            libraryTable.getLibraryByName("$it $CONSOLIDATED_LIBRARY_SUFFIX")
+        }
+
+        if (depsLibraries.isNotEmpty() || consolidatedLibrary != null) {
             runWriteAction {
                 depsLibraries.forEach { libraryTable.removeLibrary(it) }
+
+                // Also remove the consolidated library that belongs to the same project root.
+                consolidatedLibrary?.let { libraryTable.removeLibrary(it) }
             }
         }
     }
@@ -476,6 +651,7 @@ class DepsWatcher(val project: Project) : DebouncedBulkFileListener(project.serv
 private sealed class SyncRequest {
     object All : SyncRequest()
     data class Dep(val depRoot: VirtualFile) : SyncRequest()
+    data class Consolidated(val buildDir: VirtualFile) : SyncRequest()
 }
 
 private const val MERGE_DELAY_MS = 250

--- a/src/org/elixir_lang/mix/library/Kind.kt
+++ b/src/org/elixir_lang/mix/library/Kind.kt
@@ -6,3 +6,6 @@ import com.intellij.openapi.roots.libraries.PersistentLibraryKind
 object Kind : PersistentLibraryKind<DummyLibraryProperties>("mix") {
     override fun createDefaultProperties(): DummyLibraryProperties = DummyLibraryProperties.INSTANCE
 }
+
+/** Suffix appended to the project-wide consolidated-protocols library name, e.g. `mymodule (consolidated)`. */
+internal const val CONSOLIDATED_LIBRARY_SUFFIX = "(consolidated)"

--- a/src/org/elixir_lang/mix/library/Type.kt
+++ b/src/org/elixir_lang/mix/library/Type.kt
@@ -1,6 +1,7 @@
 package org.elixir_lang.mix.library
 
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.roots.OrderRootType
 import com.intellij.openapi.roots.libraries.DummyLibraryProperties
 import com.intellij.openapi.roots.libraries.LibraryType
 import com.intellij.openapi.roots.libraries.NewLibraryConfiguration
@@ -11,7 +12,7 @@ import org.elixir_lang.mix.Icons
 import javax.swing.Icon
 import javax.swing.JComponent
 
-class Type : LibraryType<DummyLibraryProperties>(Kind) {
+internal class Type : LibraryType<DummyLibraryProperties>(Kind) {
     override fun getCreateActionName(): String? = null
     override fun createNewLibrary(parentComponent: JComponent, contextDirectory: VirtualFile?, project: Project): NewLibraryConfiguration? = null
     override fun createPropertiesEditor(editorComponent: LibraryEditorComponent<DummyLibraryProperties>): LibraryPropertiesEditor? = null
@@ -24,6 +25,14 @@ class Type : LibraryType<DummyLibraryProperties>(Kind) {
         }
 
     override fun getIcon(properties: DummyLibraryProperties?): Icon = Icons.LIBRARY
+
+    /**
+     * Show both class roots (ebin/*.beam) AND source roots (lib/ **/*.ex) in the
+     * External Libraries tree.  The platform default is [OrderRootType.CLASSES] only,
+     * which hides the .ex sources even when they are attached to the library.
+     */
+    override fun getExternalRootTypes(): Array<OrderRootType> =
+        arrayOf(OrderRootType.CLASSES, OrderRootType.SOURCES)
 }
 
 private val CLASS_ROOT_NAMES = arrayOf("consolidated", "ebin")

--- a/src/org/elixir_lang/mix/project/_import/step/ElixirSdkForModuleStep.kt
+++ b/src/org/elixir_lang/mix/project/_import/step/ElixirSdkForModuleStep.kt
@@ -79,7 +79,7 @@ class ElixirSdkForModuleStep(private val wizardContext: WizardContext) : ModuleW
     private val projectForSdkModel: Project = if (project.isDefault) {
         // Construct a project file path from the import directory.
         // The .idea/misc.xml path is used because getEelDescriptor() calls Path.of(filePath).getEelDescriptor(),
-        // which only needs the path prefix to determine the environment (e.g., //wsl$/ItronUbuntu/... for WSL).
+        // which only needs the path prefix to determine the environment (e.g., //wsl$/Ubuntu/... for WSL).
         val projectPath = wizardContext.projectFileDirectory.let { "$it/.idea/misc.xml" }
         NonDefaultProjectWrapper(project, projectPath)
     } else {

--- a/src/org/elixir_lang/sdk/ElixirSdkLibraryNodeDecorator.kt
+++ b/src/org/elixir_lang/sdk/ElixirSdkLibraryNodeDecorator.kt
@@ -1,0 +1,33 @@
+package org.elixir_lang.sdk
+
+import com.intellij.ide.projectView.PresentationData
+import com.intellij.ide.projectView.ProjectViewNode
+import com.intellij.ide.projectView.ProjectViewNodeDecorator
+import com.intellij.ide.projectView.impl.nodes.PsiDirectoryNode
+
+/**
+ * Renames SDK library root nodes in External Libraries from the generic directory name ("ebin" or "lib")
+ * to the parent application name (e.g., "iex", "elixir", "logger").
+ *
+ * Without this, every Elixir/Erlang SDK entry in External Libraries is labeled "ebin library root",
+ * making it impossible to tell which OTP application each node belongs to.
+ *
+ * Works in tandem with [ElixirSdkLibraryTreeStructureProvider] which replaces "ebin" class root nodes
+ * with "lib" source root nodes for Elixir applications (where .ex source files are available).
+ */
+internal class ElixirSdkLibraryNodeDecorator : ProjectViewNodeDecorator {
+    override fun decorate(node: ProjectViewNode<*>, data: PresentationData) {
+        if (node !is PsiDirectoryNode) return
+        val vFile = node.value?.virtualFile ?: return
+
+        // Cheap name pre-filter before touching the cache
+        if (vFile.name != "ebin" && vFile.name != "lib") return
+
+        // O(1) set lookup - avoids scanning all SDKs on every render
+        if (vFile !in ElixirSdkRootsCache.classAndSourceRoots()) return
+
+        // Rename to the OTP application directory name, e.g. lib/iex/ebin → "iex"
+        data.presentableText = vFile.parent?.name ?: return
+    }
+}
+

--- a/src/org/elixir_lang/sdk/ElixirSdkLibraryTreeStructureProvider.kt
+++ b/src/org/elixir_lang/sdk/ElixirSdkLibraryTreeStructureProvider.kt
@@ -1,0 +1,185 @@
+package org.elixir_lang.sdk
+
+import com.intellij.icons.AllIcons
+import com.intellij.ide.projectView.PresentationData
+import com.intellij.ide.projectView.ProjectViewNode
+import com.intellij.ide.projectView.TreeStructureProvider
+import com.intellij.ide.projectView.ViewSettings
+import com.intellij.ide.projectView.impl.nodes.ExternalLibrariesNode
+import com.intellij.ide.projectView.impl.nodes.NamedLibraryElementNode
+import com.intellij.ide.projectView.impl.nodes.PsiDirectoryNode
+import com.intellij.ide.util.treeView.AbstractTreeNode
+import com.intellij.openapi.project.DumbAware
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.roots.JdkOrderEntry
+import com.intellij.openapi.roots.LibraryOrderEntry
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.psi.PsiManager
+import org.elixir_lang.jps.shared.ElixirSdkTypeId
+import org.elixir_lang.jps.shared.ErlangSdkTypeId
+import org.elixir_lang.mix.library.CONSOLIDATED_LIBRARY_SUFFIX
+
+/**
+ * Replaces Elixir/Erlang SDK "ebin" class root nodes in External Libraries with the sibling "lib" source
+ * directory node when one exists.
+ *
+ * For OTP applications written in Elixir (e.g., `iex`, `elixir`, `logger`, `mix`, `ex_unit`), the
+ * SDK path layout is:
+ * ```
+ * lib/<app>/ebin/  ← beam files (CLASSES root)
+ * lib/<app>/lib/   ← .ex source files (SOURCES root)
+ * ```
+ *
+ * Without this provider, External Libraries shows only beam files (from the CLASSES roots).
+ * With this provider, External Libraries shows the .ex source directory instead - which is far more
+ * useful for code browsing.
+ *
+ * For Erlang-only OTP apps (no `lib/` sibling), the original `ebin` node is kept so beam files
+ * remain visible.
+ *
+ * Works in tandem with [ElixirSdkLibraryNodeDecorator] which renames the resulting "lib" (and
+ * remaining "ebin") nodes from their generic directory name to the parent application name.
+ *
+ * When a Mix dependency has roots compiled for multiple environments (e.g. `dev` and `test` both
+ * present under `_build/`), the duplicate `ebin` and `consolidated` roots are grouped under virtual
+ * subdirectory nodes named after the build environment so they can be distinguished.
+ */
+internal class ElixirSdkLibraryTreeStructureProvider : TreeStructureProvider, DumbAware {
+    override fun modify(
+        parent: AbstractTreeNode<*>,
+        children: Collection<AbstractTreeNode<*>>,
+        settings: ViewSettings,
+    ): Collection<AbstractTreeNode<*>> {
+        // Give nodes explicit weights so IntelliJ's tree sorter produces a stable order:
+        //   Elixir/Erlang SDKs (weight -2) → consolidated (weight -1) → all other deps (weight 0, alphabetical)
+        //
+        // This provider is registered application-wide (the treeStructureProvider extension point has no
+        // per-project filter), so scope the transformations to Elixir/Erlang content only: guard SDK nodes by
+        // their SDK type and consolidated nodes by the plugin-specific library-name suffix. Otherwise SDKs in
+        // unrelated (e.g. Java) projects would be re-weighted too.
+        if (parent is ExternalLibrariesNode) {
+            return children.map { node ->
+                if (node !is NamedLibraryElementNode) return@map node
+                when (val entry = node.value?.orderEntry) {
+                    is JdkOrderEntry ->
+                        if (entry.isElixirOrErlangSdk()) SdkLibraryNode(node, settings) else node
+                    is LibraryOrderEntry ->
+                        if (entry.libraryName?.endsWith(CONSOLIDATED_LIBRARY_SUFFIX) == true)
+                            ConsolidatedLibraryNode(node, settings)
+                        else node
+                    else -> node
+                }
+            }
+        }
+
+        // SDK ebin dirs are direct children of NamedLibraryElementNode; skip everything else cheaply.
+        if (parent !is NamedLibraryElementNode) return children
+        val project = parent.project ?: return children
+
+        // Apply ebin→lib replacement for SDK roots first, so replaced nodes get the right env detected.
+        val processed = children.map { child ->
+            tryReplaceEbinWithLib(child, project, settings) ?: child
+        }
+
+        // Group Mix build roots by their _build environment (e.g. "dev", "test").
+        // Roots not under _build (e.g. a deps/ SOURCES root) go in the null bucket.
+        val byEnv = LinkedHashMap<String?, MutableList<AbstractTreeNode<*>>>()
+        for (node in processed) {
+            val vFile = (node as? PsiDirectoryNode)?.value?.virtualFile
+            byEnv.getOrPut(buildEnv(vFile)) { mutableListOf() }.add(node)
+        }
+
+        val envKeys = byEnv.keys.filterNotNull()
+        if (envKeys.size < 2) return if (processed == children) children else processed
+
+        // Emit non-_build roots first (e.g. deps/ source roots), then one group per env.
+        val result = mutableListOf<AbstractTreeNode<*>>()
+        byEnv[null]?.let { result.addAll(it) }
+        for (env in envKeys) {
+            result.add(BuildEnvGroupNode(project, env, byEnv[env]!!, settings))
+        }
+        return result
+    }
+
+    private fun tryReplaceEbinWithLib(
+        node: AbstractTreeNode<*>,
+        project: Project,
+        settings: ViewSettings,
+    ): AbstractTreeNode<*>? {
+        if (node !is PsiDirectoryNode) return null
+        val ebinVFile = node.value?.virtualFile ?: return null
+        if (ebinVFile.name != "ebin") return null
+
+        // O(1) set lookup - avoids scanning all SDKs per child
+        if (ebinVFile !in ElixirSdkRootsCache.classRoots()) return null
+
+        // Replace ebin with the sibling lib directory when it exists (Elixir apps have .ex source there)
+        val libVFile = ebinVFile.parent?.findChild("lib")?.takeIf { it.isDirectory } ?: return null
+        val psiLibDir = PsiManager.getInstance(project).findDirectory(libVFile) ?: return null
+        return PsiDirectoryNode(project, psiLibDir, settings)
+    }
+}
+
+/**
+ * Whether this SDK order entry points at an Elixir or Erlang SDK, matching by SDK type id the same way
+ * [ElixirSdkRootsCache] does. Used to avoid re-weighting SDKs of unrelated projects (e.g. Java), since this
+ * provider is registered application-wide.
+ */
+private fun JdkOrderEntry.isElixirOrErlangSdk(): Boolean {
+    val typeName = jdk?.sdkType?.name ?: return false
+    return typeName == ElixirSdkTypeId.ELIXIR_SDK_TYPE_ID || typeName == ErlangSdkTypeId.ERLANG_SDK_TYPE_ID
+}
+
+/**
+ * Walks up the VFS hierarchy to find the direct child of `_build/`, returning its name (e.g. `"dev"`,
+ * `"test"`), or `null` if [vFile] is not under a `_build` directory.
+ */
+private fun buildEnv(vFile: VirtualFile?): String? {
+    var current = vFile ?: return null
+    while (true) {
+        val parent = current.parent ?: return null
+        if (parent.name == "_build") return current.name
+        current = parent
+    }
+}
+
+/**
+ * A virtual (non-PSI) tree node representing a Mix build environment (e.g. `dev` or `test`).
+ * Groups `ebin` and `consolidated` roots that would otherwise appear as indistinguishable duplicates.
+ */
+private class BuildEnvGroupNode(
+    project: Project,
+    envName: String,
+    private val envChildren: List<AbstractTreeNode<*>>,
+    settings: ViewSettings,
+) : ProjectViewNode<String>(project, envName, settings) {
+    override fun getChildren(): Collection<AbstractTreeNode<*>> = envChildren
+    override fun update(presentation: PresentationData) {
+        presentation.presentableText = value
+        presentation.setIcon(AllIcons.Nodes.Folder)
+    }
+    override fun contains(file: VirtualFile): Boolean =
+        envChildren.any { (it as? ProjectViewNode<*>)?.contains(file) == true }
+}
+
+/**
+ * Wraps an SDK [NamedLibraryElementNode] (names starting with `<`) with weight -2 so it sorts
+ * before consolidated libraries (weight -1) and all standard dep libraries (weight 0).
+ */
+private class SdkLibraryNode(
+    wrapped: NamedLibraryElementNode,
+    settings: ViewSettings,
+) : NamedLibraryElementNode(wrapped.project!!, wrapped.value!!, settings) {
+    override fun getWeight(): Int = -2
+}
+
+/**
+ * Wraps a consolidated [NamedLibraryElementNode] with weight -1 so IntelliJ's tree sorter places
+ * it after SDK nodes (weight -2) but before all standard dep nodes (weight 0).
+ */
+private class ConsolidatedLibraryNode(
+    wrapped: NamedLibraryElementNode,
+    settings: ViewSettings,
+) : NamedLibraryElementNode(wrapped.project!!, wrapped.value!!, settings) {
+    override fun getWeight(): Int = -1
+}

--- a/src/org/elixir_lang/sdk/ElixirSdkRootsCache.kt
+++ b/src/org/elixir_lang/sdk/ElixirSdkRootsCache.kt
@@ -1,0 +1,56 @@
+package org.elixir_lang.sdk
+
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.projectRoots.ProjectJdkTable
+import com.intellij.openapi.projectRoots.Sdk
+import com.intellij.openapi.roots.OrderRootType
+import com.intellij.openapi.vfs.VirtualFile
+import org.elixir_lang.jps.shared.ElixirSdkTypeId
+import org.elixir_lang.jps.shared.ErlangSdkTypeId
+
+/**
+ * Application-scoped cache of virtual-file roots belonging to Elixir and Erlang SDKs.
+ *
+ * Invalidated automatically via [ProjectJdkTable.JDK_TABLE_TOPIC] whenever an SDK is added,
+ * removed, or renamed, so callers always get a consistent view without polling.
+ */
+internal object ElixirSdkRootsCache {
+
+    @Volatile private var classRootsCache: Set<VirtualFile>? = null
+    @Volatile private var classAndSourceRootsCache: Set<VirtualFile>? = null
+
+    init {
+        ApplicationManager.getApplication().messageBus.connect()
+            .subscribe(ProjectJdkTable.JDK_TABLE_TOPIC, object : ProjectJdkTable.Listener {
+                override fun jdkAdded(jdk: Sdk) = invalidate()
+                override fun jdkRemoved(jdk: Sdk) = invalidate()
+                override fun jdkNameChanged(jdk: Sdk, previousName: String) = invalidate()
+            })
+    }
+
+    private fun invalidate() {
+        classRootsCache = null
+        classAndSourceRootsCache = null
+    }
+
+    private fun elixirSdks(): List<Sdk> =
+        ProjectJdkTable.getInstance().allJdks.filter {
+            it.sdkType.name == ElixirSdkTypeId.ELIXIR_SDK_TYPE_ID ||
+                it.sdkType.name == ErlangSdkTypeId.ERLANG_SDK_TYPE_ID
+        }
+
+    /** CLASSES roots of all registered Elixir/Erlang SDKs. */
+    fun classRoots(): Set<VirtualFile> =
+        classRootsCache ?: buildSet {
+            for (sdk in elixirSdks()) addAll(sdk.rootProvider.getFiles(OrderRootType.CLASSES))
+        }.also { classRootsCache = it }
+
+    /** CLASSES + SOURCES roots of all registered Elixir/Erlang SDKs. */
+    fun classAndSourceRoots(): Set<VirtualFile> =
+        classAndSourceRootsCache ?: buildSet {
+            for (sdk in elixirSdks()) {
+                addAll(sdk.rootProvider.getFiles(OrderRootType.CLASSES))
+                addAll(sdk.rootProvider.getFiles(OrderRootType.SOURCES))
+            }
+        }.also { classAndSourceRootsCache = it }
+}

--- a/src/org/elixir_lang/status_bar_widget/ElixirEditorBasedSdkWidget.kt
+++ b/src/org/elixir_lang/status_bar_widget/ElixirEditorBasedSdkWidget.kt
@@ -860,9 +860,9 @@ class ElixirEditorBasedSdkWidget(
     private fun configureSdkFromMise(project: Project, miseAssignments: Map<String, MiseVersions>) {
         runWithModalProgressBlocking(ModalTaskOwner.project(project), "Configuring Elixir SDK from mise") {
             // Collect content roots so Linux install paths returned by WSL-side mise
-            // (e.g. /home/steve/.local/share/mise/installs/erlang/23.3.4.20) can be
+            // (e.g. /home/user/.local/share/mise/installs/erlang/23.3.4.20) can be
             // converted to the Windows UNC form that SdkRegistrar and WslCompatService expect
-            // (e.g. \\wsl.localhost\ItronUbuntu\home\steve\.local\share\mise\installs\erlang\23.3.4.20).
+            // (e.g. \\wsl.localhost\Ubuntu\home\user\.local\share\mise\installs\erlang\23.3.4.20).
             val contentRootByModule: Map<String, Path?> = readAction {
                 miseAssignments.keys.associateWith { name ->
                     ModuleManager.getInstance(project).findModuleByName(name)
@@ -923,12 +923,12 @@ class ElixirEditorBasedSdkWidget(
     }
 
     /**
-     * Converts a Linux absolute path (e.g. `/home/steve/.local/share/mise/installs/elixir/1.11.3`)
+     * Converts a Linux absolute path (e.g. `/home/user/.local/share/mise/installs/elixir/1.11.3`)
      * to the Windows UNC form expected by [SdkRegistrar] and `wslCompat`
-     * (e.g. `\\wsl.localhost\ItronUbuntu\home\steve\.local\share\mise\installs\elixir\1.11.3`).
+     * (e.g. `\\wsl.localhost\Ubuntu\home\user\.local\share\mise\installs\elixir\1.11.3`).
      *
      * The WSL distribution is inferred from [contentRoot], which must be a Windows UNC path for
-     * a WSL filesystem (e.g. `\\wsl.localhost\ItronUbuntu\home\steve\workspace\intelliconnect`).
+     * a WSL filesystem (e.g. `\\wsl.localhost\Ubuntu\home\user\workspace\intelliconnect`).
      *
      * Returns [installPath] unchanged when:
      * - it is not a Linux absolute path (does not start with `/`),

--- a/tests/org/elixir_lang/DepsWatcherTest.kt
+++ b/tests/org/elixir_lang/DepsWatcherTest.kt
@@ -4,6 +4,7 @@ import com.intellij.openapi.application.WriteAction
 import com.intellij.openapi.progress.EmptyProgressIndicator
 import com.intellij.openapi.roots.OrderRootType
 import com.intellij.openapi.roots.libraries.LibraryTablesRegistrar
+import org.elixir_lang.mix.library.CONSOLIDATED_LIBRARY_SUFFIX
 
 class DepsWatcherTest : PlatformTestCase() {
     private val depName = "my_dep"
@@ -12,6 +13,7 @@ class DepsWatcherTest : PlatformTestCase() {
     override fun tearDown() {
         try {
             removeLibrariesIfPresent(depName, secondDepName)
+            removeConsolidatedLibraries()
         } finally {
             super.tearDown()
         }
@@ -34,7 +36,11 @@ class DepsWatcherTest : PlatformTestCase() {
 
         val firstSyncClassRootUrls = classRootUrls(depName)
         assertTrue(
-            "Expected dev consolidated root after first sync",
+            "Expected dev ebin class root after first sync",
+            firstSyncClassRootUrls.any { it.contains("/_build/dev/lib/$depName/ebin") }
+        )
+        assertFalse(
+            "Consolidated root must not be added to the per-dep library",
             firstSyncClassRootUrls.any { it.contains("/_build/dev/consolidated") }
         )
 
@@ -65,7 +71,11 @@ class DepsWatcherTest : PlatformTestCase() {
             secondSyncClassRootUrls.any { it.contains("/stale_classes/$depName") }
         )
         assertTrue(
-            "Expected dev consolidated root after re-sync",
+            "Expected dev ebin class root after re-sync",
+            secondSyncClassRootUrls.any { it.contains("/_build/dev/lib/$depName/ebin") }
+        )
+        assertFalse(
+            "Consolidated root must not be added to the per-dep library after re-sync",
             secondSyncClassRootUrls.any { it.contains("/_build/dev/consolidated") }
         )
     }
@@ -90,11 +100,19 @@ class DepsWatcherTest : PlatformTestCase() {
         }
 
         assertTrue(
-            "First dep should include dev consolidated root after first sync",
-            classRootUrls(depName).any { it.contains("/_build/dev/consolidated") }
+            "First dep should include its dev ebin class root after first sync",
+            classRootUrls(depName).any { it.contains("/_build/dev/lib/$depName/ebin") }
         )
         assertTrue(
-            "Second dep should include dev consolidated root after first sync",
+            "Second dep should include its dev ebin class root after first sync",
+            classRootUrls(secondDepName).any { it.contains("/_build/dev/lib/$secondDepName/ebin") }
+        )
+        assertFalse(
+            "First dep library must not include the shared consolidated root",
+            classRootUrls(depName).any { it.contains("/_build/dev/consolidated") }
+        )
+        assertFalse(
+            "Second dep library must not include the shared consolidated root",
             classRootUrls(secondDepName).any { it.contains("/_build/dev/consolidated") }
         )
 
@@ -143,11 +161,19 @@ class DepsWatcherTest : PlatformTestCase() {
             secondDepSecondSyncClassRootUrls.any { it.contains("/stale_classes/$secondDepName") }
         )
         assertTrue(
-            "First dep should still include dev consolidated root after re-sync",
-            firstDepSecondSyncClassRootUrls.any { it.contains("/_build/dev/consolidated") }
+            "First dep should still include its dev ebin class root after re-sync",
+            firstDepSecondSyncClassRootUrls.any { it.contains("/_build/dev/lib/$depName/ebin") }
         )
         assertTrue(
-            "Second dep should still include dev consolidated root after re-sync",
+            "Second dep should still include its dev ebin class root after re-sync",
+            secondDepSecondSyncClassRootUrls.any { it.contains("/_build/dev/lib/$secondDepName/ebin") }
+        )
+        assertFalse(
+            "First dep library must not include the shared consolidated root after re-sync",
+            firstDepSecondSyncClassRootUrls.any { it.contains("/_build/dev/consolidated") }
+        )
+        assertFalse(
+            "Second dep library must not include the shared consolidated root after re-sync",
             secondDepSecondSyncClassRootUrls.any { it.contains("/_build/dev/consolidated") }
         )
     }
@@ -205,6 +231,64 @@ class DepsWatcherTest : PlatformTestCase() {
         }
     }
 
+    fun testSyncConsolidatedLibraryCreatesSeparateSharedLibrary() {
+        myFixture.tempDirFixture.findOrCreateDir("deps/$depName/lib")
+        myFixture.tempDirFixture.findOrCreateDir("_build/dev/consolidated")
+        myFixture.tempDirFixture.findOrCreateDir("_build/test/consolidated")
+        myFixture.tempDirFixture.findOrCreateDir("_build/dev/lib/$depName/ebin")
+        val buildRoot = myFixture.tempDirFixture.findOrCreateDir("_build")
+
+        val watcher = DepsWatcher(project)
+        val indicator = EmptyProgressIndicator()
+
+        WriteAction.run<Throwable> {
+            watcher.syncConsolidatedLibrary(buildRoot, indicator)
+        }
+
+        val consolidatedLibraryName = "${buildRoot.parent!!.name} $CONSOLIDATED_LIBRARY_SUFFIX"
+        val consolidatedClassRoots = classRootUrls(consolidatedLibraryName)
+
+        assertTrue(
+            "Consolidated library should include the dev consolidated root",
+            consolidatedClassRoots.any { it.contains("/_build/dev/consolidated") }
+        )
+        assertTrue(
+            "Consolidated library should include the test consolidated root",
+            consolidatedClassRoots.any { it.contains("/_build/test/consolidated") }
+        )
+        assertFalse(
+            "Consolidated library must not include per-dep ebin roots",
+            consolidatedClassRoots.any { it.contains("/ebin") }
+        )
+    }
+
+    fun testDeleteAllLibrariesRemovesConsolidatedLibraryWithoutDepLibraries() {
+        val depsRoot = myFixture.tempDirFixture.findOrCreateDir("deps")
+        myFixture.tempDirFixture.findOrCreateDir("_build/dev/consolidated")
+        val buildRoot = myFixture.tempDirFixture.findOrCreateDir("_build")
+
+        val watcher = DepsWatcher(project)
+        val indicator = EmptyProgressIndicator()
+        val consolidatedLibraryName = "${buildRoot.parent!!.name} $CONSOLIDATED_LIBRARY_SUFFIX"
+
+        WriteAction.run<Throwable> {
+            watcher.syncConsolidatedLibrary(buildRoot, indicator)
+        }
+        assertNotNull(
+            "Expected consolidated library to exist before deleting all deps libraries",
+            LibraryTablesRegistrar.getInstance().getLibraryTable(project).getLibraryByName(consolidatedLibraryName)
+        )
+
+        val deleteAllLibraries = DepsWatcher::class.java.getDeclaredMethod("deleteAllLibraries", String::class.java)
+        deleteAllLibraries.isAccessible = true
+        deleteAllLibraries.invoke(watcher, depsRoot.url)
+
+        assertNull(
+            "Consolidated library should be removed even when there are no per-dep libraries",
+            LibraryTablesRegistrar.getInstance().getLibraryTable(project).getLibraryByName(consolidatedLibraryName)
+        )
+    }
+
     private fun classRootUrls(libraryName: String): kotlin.collections.List<String> {
         val library = LibraryTablesRegistrar.getInstance().getLibraryTable(project).getLibraryByName(libraryName)
         assertNotNull("Expected library '$libraryName' to exist", library)
@@ -229,6 +313,21 @@ class DepsWatcherTest : PlatformTestCase() {
 
         WriteAction.run<Throwable> {
             libraries.forEach { libraryTable.removeLibrary(it) }
+        }
+    }
+
+    private fun removeConsolidatedLibraries() {
+        val libraryTable = LibraryTablesRegistrar.getInstance().getLibraryTable(project)
+        val consolidatedLibraries = libraryTable.libraries.filter {
+            it.name?.endsWith(CONSOLIDATED_LIBRARY_SUFFIX) == true
+        }
+
+        if (consolidatedLibraries.isEmpty()) {
+            return
+        }
+
+        WriteAction.run<Throwable> {
+            consolidatedLibraries.forEach { libraryTable.removeLibrary(it) }
         }
     }
 


### PR DESCRIPTION
## Summary
This PR improves how Elixir SDK libraries appear in the IDE's **External Libraries** tree.

## Why this is needed
Today SDK entries can be confusing to read and may omit source roots, which makes navigation/discovery harder. This PR makes the nodes clearer and ensures sources are included.

## What changed
- Adds source file inclusion for Elixir SDK library presentation.
- Adds dedicated tree structure/provider and node decorator support for clearer SDK package naming.
- Updates plugin registration for the library tree customization.

Before:
Under the SDK, every single library is called `ebin`.
<img width="237" height="168" alt="image" src="https://github.com/user-attachments/assets/023bebea-98eb-4781-95e4-c7ab86b0d63c" />

After:
Under the SDK, the libraries have the correct names. 
<img width="240" height="211" alt="image" src="https://github.com/user-attachments/assets/254b9633-b10c-490d-a49c-7b8ab5a32967" />

Before:
Every dependency has all `_build/<env>/consolidated` folders, despite them being project-wide and not related to one particular dependency. Erlang dependencies have an `ebin` folder for each environment, despite there only being one folder which is in `deps/<depname>/ebin` that is sym-linked from the `_build/<env>/lib/` folders. Elixir dependencies have the same except these are real folders. There is no way to tell which folders are for each environment. There is no source code linked. 
<img width="321" height="342" alt="image" src="https://github.com/user-attachments/assets/528df115-8392-4004-bc48-ceb76f97c599" />

After:
The `consolidated` folders are moved to a `module (consolidated)` container and if there are multiple environments additionally moved under folders named for the environments. 
Erlang dependencies have only the single `ebin` folder present and additionally their `src` folder if available.
Elixir dependencies have separate environment folders for each of their `ebin` paths under `_build` and their `lib` and `priv` folders linked. 
<img width="321" height="391" alt="image" src="https://github.com/user-attachments/assets/b3427815-047b-439b-889c-e6444f408362" />
