### PR TITLE
feat(beam): support OTP 26 map-comprehension AST nodes

### DIFF
--- a/src/org/elixir_lang/beam/chunk/debug_info/v1/erl_abstract_code/abstract_code_compiler_options/abstract_code/Comprehension.kt
+++ b/src/org/elixir_lang/beam/chunk/debug_info/v1/erl_abstract_code/abstract_code_compiler_options/abstract_code/Comprehension.kt
@@ -9,7 +9,8 @@ import org.elixir_lang.beam.chunk.debug_info.v1.erl_abstract_code.abstract_code_
 object Comprehension {
     fun ifToMacroStringDeclaredScope(term: OtpErlangObject, scope: Scope): MacroStringDeclaredScope? =
             ifTag(term, "bc") { toMacroStringDeclaredScope(it, scope) } ?:
-            ifTag(term, "lc") { toMacroStringDeclaredScope(it, scope) }
+            ifTag(term, "lc") { toMacroStringDeclaredScope(it, scope) } ?:
+            ifTag(term, "mc") { toMacroStringDeclaredScope(it, scope) }
 
     fun toMacroStringDeclaredScope(term: OtpErlangTuple, scope: Scope): MacroStringDeclaredScope {
         val (qualifiersMacroString, qualifiersDeclaredScope) = qualifiersMacroStringDeclaredScope(term, scope)

--- a/src/org/elixir_lang/beam/chunk/debug_info/v1/erl_abstract_code/abstract_code_compiler_options/abstract_code/comprehension/Qualifier.kt
+++ b/src/org/elixir_lang/beam/chunk/debug_info/v1/erl_abstract_code/abstract_code_compiler_options/abstract_code/comprehension/Qualifier.kt
@@ -6,10 +6,12 @@ import org.elixir_lang.beam.chunk.debug_info.v1.erl_abstract_code.abstract_code_
 import org.elixir_lang.beam.chunk.debug_info.v1.erl_abstract_code.abstract_code_compiler_options.abstract_code.Scope
 import org.elixir_lang.beam.chunk.debug_info.v1.erl_abstract_code.abstract_code_compiler_options.abstract_code.comprehension.qualifier.BitstringGenerate
 import org.elixir_lang.beam.chunk.debug_info.v1.erl_abstract_code.abstract_code_compiler_options.abstract_code.comprehension.qualifier.Generate
+import org.elixir_lang.beam.chunk.debug_info.v1.erl_abstract_code.abstract_code_compiler_options.abstract_code.comprehension.qualifier.MapGenerate
 
 object Qualifier {
     fun toMacroStringDeclaredScope(term: OtpErlangObject, scope: Scope): MacroStringDeclaredScope =
             Generate.ifToMacroStringDeclaredScope(term, scope) ?:
             BitstringGenerate.ifToMacroStringDeclaredScope(term, scope) ?:
+            MapGenerate.ifToMacroStringDeclaredScope(term, scope) ?:
             AbstractCode.toMacroStringDeclaredScope(term, scope)
 }

--- a/src/org/elixir_lang/beam/chunk/debug_info/v1/erl_abstract_code/abstract_code_compiler_options/abstract_code/comprehension/qualifier/MapGenerate.kt
+++ b/src/org/elixir_lang/beam/chunk/debug_info/v1/erl_abstract_code/abstract_code_compiler_options/abstract_code/comprehension/qualifier/MapGenerate.kt
@@ -1,0 +1,48 @@
+package org.elixir_lang.beam.chunk.debug_info.v1.erl_abstract_code.abstract_code_compiler_options.abstract_code.comprehension.qualifier
+
+import com.ericsson.otp.erlang.OtpErlangObject
+import com.ericsson.otp.erlang.OtpErlangTuple
+import org.elixir_lang.beam.chunk.debug_info.v1.erl_abstract_code.abstract_code_compiler_options.AbstractCode
+import org.elixir_lang.beam.chunk.debug_info.v1.erl_abstract_code.abstract_code_compiler_options.AbstractCode.ifTag
+import org.elixir_lang.beam.chunk.debug_info.v1.erl_abstract_code.abstract_code_compiler_options.abstract_code.MacroStringDeclaredScope
+import org.elixir_lang.beam.chunk.debug_info.v1.erl_abstract_code.abstract_code_compiler_options.abstract_code.Scope
+
+/**
+ * Handles the `m_generate` abstract code node introduced in OTP 26 for map comprehension
+ * generators: `Key := Value <- MapExpression`.
+ *
+ * Structure: `{m_generate, Anno, Pattern, Expression}`
+ * - Pattern  (element 2): a `map_field_exact` or `map_field_assoc` pattern
+ * - Expression (element 3): the source map expression
+ *
+ * Rendered as `pattern <- expression`, consistent with list and bitstring generators.
+ */
+object MapGenerate {
+    fun ifToMacroStringDeclaredScope(term: OtpErlangObject, scope: Scope): MacroStringDeclaredScope? =
+            ifTag(term, TAG) { toMacroStringDeclaredScope(it, scope) }
+
+    fun toMacroStringDeclaredScope(term: OtpErlangTuple, scope: Scope): MacroStringDeclaredScope {
+        val (expressionMacroString, expressionDeclaredScope) = expressionMacroStringDeclaredScope(term, scope)
+        val patternScope = scope.union(expressionDeclaredScope)
+        val (patternMacroString, patternDeclaredScope) = patternMacroStringDeclaredScope(term, patternScope)
+        val macroString = "${patternMacroString.string} <- ${expressionMacroString.group().string}"
+        val declaredScope = patternScope.union(patternDeclaredScope)
+
+        return MacroStringDeclaredScope(macroString, doBlock = false, declaredScope)
+    }
+
+    private const val TAG = "m_generate"
+
+    private fun expressionMacroStringDeclaredScope(term: OtpErlangTuple, scope: Scope) =
+            toExpression(term)
+                    ?.let { AbstractCode.toMacroStringDeclaredScope(it, scope) }
+                    ?: MacroStringDeclaredScope.missing("expression", scope, "map generate expression", term)
+
+    private fun patternMacroStringDeclaredScope(term: OtpErlangTuple, scope: Scope) =
+            toPattern(term)
+                    ?.let { AbstractCode.toMacroStringDeclaredScope(it, scope) }
+                    ?: MacroStringDeclaredScope.missing("pattern", scope, "map generate pattern", term)
+
+    private fun toExpression(term: OtpErlangTuple): OtpErlangObject? = term.elementAt(3)
+    private fun toPattern(term: OtpErlangTuple): OtpErlangObject? = term.elementAt(2)
+}

--- a/tests/org/elixir_lang/beam/chunk/debug_info/v1/erl_abstract_code/abstract_code_compiler_options/abstract_code/ComprehensionTest.kt
+++ b/tests/org/elixir_lang/beam/chunk/debug_info/v1/erl_abstract_code/abstract_code_compiler_options/abstract_code/ComprehensionTest.kt
@@ -1,0 +1,117 @@
+package org.elixir_lang.beam.chunk.debug_info.v1.erl_abstract_code.abstract_code_compiler_options.abstract_code
+
+import com.ericsson.otp.erlang.OtpErlangAtom
+import com.ericsson.otp.erlang.OtpErlangList
+import com.ericsson.otp.erlang.OtpErlangLong
+import com.ericsson.otp.erlang.OtpErlangObject
+import com.ericsson.otp.erlang.OtpErlangTuple
+import junit.framework.TestCase
+
+class ComprehensionTest : TestCase() {
+
+    /**
+     * Smoke-test: `lc` (list comprehension) is recognised.
+     *
+     * Erlang: `[X || X <- List]`
+     * AST: `{lc, 1, {var,1,'X'}, [{generate,1,{var,1,'X'},{var,1,'List'}}]}`
+     */
+    fun testLcIsRecognised() {
+        val lc = buildComprehension("lc",
+            body = tuple(OtpErlangAtom("var"), line, OtpErlangAtom("X")),
+            qualifiers = listOf(
+                tuple(OtpErlangAtom("generate"), line,
+                    tuple(OtpErlangAtom("var"), line, OtpErlangAtom("X")),
+                    tuple(OtpErlangAtom("var"), line, OtpErlangAtom("List")))
+            )
+        )
+
+        val result = Comprehension.ifToMacroStringDeclaredScope(lc, Scope.EMPTY)
+        assertNotNull("lc should be recognised", result)
+        assertTrue("lc result should contain 'for'", result!!.macroString.string.contains("for"))
+    }
+
+    /**
+     * Smoke-test: `bc` (bitstring comprehension) is recognised.
+     *
+     * Erlang: `<< <<X>> || X <- List >>`
+     */
+    fun testBcIsRecognised() {
+        val body = tuple(
+            OtpErlangAtom("bin"), line,
+            OtpErlangList(arrayOf<OtpErlangObject>(
+                tuple(OtpErlangAtom("bin_element"), line,
+                    tuple(OtpErlangAtom("var"), line, OtpErlangAtom("X")),
+                    OtpErlangAtom("default"),
+                    OtpErlangAtom("default"))
+            ))
+        )
+        val bc = buildComprehension("bc",
+            body = body,
+            qualifiers = listOf(
+                tuple(OtpErlangAtom("generate"), line,
+                    tuple(OtpErlangAtom("var"), line, OtpErlangAtom("X")),
+                    tuple(OtpErlangAtom("var"), line, OtpErlangAtom("List")))
+            )
+        )
+
+        val result = Comprehension.ifToMacroStringDeclaredScope(bc, Scope.EMPTY)
+        assertNotNull("bc should be recognised", result)
+    }
+
+    /**
+     * Verifies that `mc` (OTP 26 map comprehension) is recognised and does not fall
+     * through to the unknown-handler.
+     *
+     * Erlang: `#{K => V || K := V <- Map}`
+     * AST: `{mc, 1, {map_field_assoc,1,{var,1,'K'},{var,1,'V'}},
+     *              [{m_generate,1,{map_field_exact,1,{var,1,'K'},{var,1,'V'}},{var,1,'Map'}}]}`
+     */
+    fun testMcIsRecognised() {
+        val body = tuple(
+            OtpErlangAtom("map_field_assoc"), line,
+            tuple(OtpErlangAtom("var"), line, OtpErlangAtom("K")),
+            tuple(OtpErlangAtom("var"), line, OtpErlangAtom("V"))
+        )
+        val mc = buildComprehension("mc",
+            body = body,
+            qualifiers = listOf(
+                tuple(OtpErlangAtom("m_generate"), line,
+                    tuple(OtpErlangAtom("map_field_exact"), line,
+                        tuple(OtpErlangAtom("var"), line, OtpErlangAtom("K")),
+                        tuple(OtpErlangAtom("var"), line, OtpErlangAtom("V"))),
+                    tuple(OtpErlangAtom("var"), line, OtpErlangAtom("Map")))
+            )
+        )
+
+        val result = Comprehension.ifToMacroStringDeclaredScope(mc, Scope.EMPTY)
+        assertNotNull("mc (OTP 26 map comprehension) should be recognised, not fall through to unknown", result)
+        assertTrue("mc result should contain 'for'", result!!.macroString.string.contains("for"))
+    }
+
+    /**
+     * Verifies that an unknown tag returns null.
+     */
+    fun testUnknownTagReturnsNull() {
+        val unknown = buildComprehension("xc",
+            body = tuple(OtpErlangAtom("var"), line, OtpErlangAtom("X")),
+            qualifiers = emptyList()
+        )
+
+        val result = Comprehension.ifToMacroStringDeclaredScope(unknown, Scope.EMPTY)
+        assertNull("Unknown comprehension tag should return null", result)
+    }
+
+    // ---- helpers ----
+
+    private val line = OtpErlangLong(1)
+
+    private fun buildComprehension(tag: String, body: OtpErlangTuple, qualifiers: List<OtpErlangTuple>): OtpErlangTuple =
+        tuple(
+            OtpErlangAtom(tag),
+            line,
+            body,
+            OtpErlangList(qualifiers.toTypedArray<OtpErlangObject>())
+        )
+
+    private fun tuple(vararg elements: OtpErlangObject): OtpErlangTuple = OtpErlangTuple(elements)
+}

--- a/tests/org/elixir_lang/beam/chunk/debug_info/v1/erl_abstract_code/abstract_code_compiler_options/abstract_code/comprehension/qualifier/MapGenerateTest.kt
+++ b/tests/org/elixir_lang/beam/chunk/debug_info/v1/erl_abstract_code/abstract_code_compiler_options/abstract_code/comprehension/qualifier/MapGenerateTest.kt
@@ -1,0 +1,76 @@
+package org.elixir_lang.beam.chunk.debug_info.v1.erl_abstract_code.abstract_code_compiler_options.abstract_code.comprehension.qualifier
+
+import com.ericsson.otp.erlang.OtpErlangAtom
+import com.ericsson.otp.erlang.OtpErlangLong
+import com.ericsson.otp.erlang.OtpErlangObject
+import com.ericsson.otp.erlang.OtpErlangTuple
+import junit.framework.TestCase
+import org.elixir_lang.beam.chunk.debug_info.v1.erl_abstract_code.abstract_code_compiler_options.abstract_code.Scope
+
+class MapGenerateTest : TestCase() {
+
+    /**
+     * Verifies that [MapGenerate] is recognised for an `m_generate` term (OTP 26 map generator)
+     * and not routed to the unknown-handler.
+     *
+     * Erlang source equivalent: `TimeoutType := {_TimerRef, TimeoutMsg} <- Timers`
+     * (from `gen_statem` internals)
+     *
+     * AST: `{m_generate, {5412,49},
+     *         {map_field_exact, {5412,22}, {var,{5412,10},'TimeoutType'}, {var,{5412,25},'Value'}},
+     *         {var, {5412,52}, 'Timers'}}`
+     */
+    fun testIfToMacroStringDeclaredScopeReturnsNonNullForMGenerate() {
+        val line = OtpErlangLong(1)
+
+        val key = tuple(OtpErlangAtom("var"), line, OtpErlangAtom("TimeoutType"))
+        val value = tuple(OtpErlangAtom("var"), line, OtpErlangAtom("Value"))
+        val pattern = tuple(OtpErlangAtom("map_field_exact"), line, key, value)
+        val expression = tuple(OtpErlangAtom("var"), line, OtpErlangAtom("Timers"))
+        val mGenerate = tuple(OtpErlangAtom("m_generate"), line, pattern, expression)
+
+        val result = MapGenerate.ifToMacroStringDeclaredScope(mGenerate, Scope.EMPTY)
+
+        assertNotNull("m_generate should be handled, not fall through to unknown", result)
+    }
+
+    /**
+     * Verifies that the rendered string contains the `<-` generator arrow and
+     * references to both the pattern and the expression variable.
+     *
+     * A variable-key `map_field_exact` pattern like `K := V` renders as something
+     * containing `<-` (generator arrow) and the expression variable name lowercased.
+     */
+    fun testToMacroStringDeclaredScopeContainsArrowAndExpression() {
+        val line = OtpErlangLong(1)
+
+        val key = tuple(OtpErlangAtom("var"), line, OtpErlangAtom("K"))
+        val value = tuple(OtpErlangAtom("var"), line, OtpErlangAtom("V"))
+        val pattern = tuple(OtpErlangAtom("map_field_exact"), line, key, value)
+        val expression = tuple(OtpErlangAtom("var"), line, OtpErlangAtom("MyMap"))
+        val mGenerate = tuple(OtpErlangAtom("m_generate"), line, pattern, expression)
+
+        val result = MapGenerate.toMacroStringDeclaredScope(mGenerate, Scope.EMPTY)
+        val string = result.macroString.string
+
+        assertTrue("Result should contain <- generator arrow, got: $string", string.contains("<-"))
+        assertTrue("Result should reference expression variable, got: $string", string.contains("myMap"))
+    }
+
+    /**
+     * Verifies that a non-`m_generate` tag returns null from [MapGenerate.ifToMacroStringDeclaredScope],
+     * so it does not intercept terms meant for other handlers.
+     */
+    fun testIfToMacroStringDeclaredScopeReturnsNullForOtherTags() {
+        val line = OtpErlangLong(1)
+        val generate = tuple(OtpErlangAtom("generate"), line,
+            tuple(OtpErlangAtom("var"), line, OtpErlangAtom("X")),
+            tuple(OtpErlangAtom("var"), line, OtpErlangAtom("List")))
+
+        val result = MapGenerate.ifToMacroStringDeclaredScope(generate, Scope.EMPTY)
+
+        assertNull("Non-m_generate tag should return null", result)
+    }
+
+    private fun tuple(vararg elements: OtpErlangObject): OtpErlangTuple = OtpErlangTuple(elements)
+}


### PR DESCRIPTION
## Summary
This PR adds BEAM decompiler support for OTP 26 map-comprehension AST nodes.

## Why this is needed
Without this node support, decompilation of newer OTP-generated abstract code can fail or produce incomplete output when map comprehensions are present.

## What changed
- Adds `MapGenerate` qualifier support in comprehension AST handling.
- Wires qualifier parsing in comprehension model classes.
- Adds focused tests for comprehension and map-generate parsing behavior.

## Notes for reviewers
- This PR is intentionally scoped to BEAM abstract-code parsing.
- It does not include lexer/parser fixes, SDK mismatch UI, or resolver/navigation changes.

## Suggested review order
1. `.../comprehension/qualifier/MapGenerate.kt`
2. `.../Comprehension.kt`
3. `.../Qualifier.kt`
4. `ComprehensionTest.kt` and `MapGenerateTest.kt`

I will add screenshots in follow-up comments where visual output comparison helps.
