### PR TITLE
Threading hardening: require read-lock for commandLine factories

### DIFF
--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -126,9 +126,7 @@ runs:
     - name: Setup Elixir
       id: setup-elixir
       if: ${{ inputs.setup-elixir == 'true' }}
-      # Needed until https://github.com/erlef/setup-beam/pull/461 is merged/released or
-      # https://github.com/actions/runner-images/issues/14004 is resolved.
-      uses: sh41/setup-beam@fix-windows-2025
+      uses: erlef/setup-beam@v1
       with:
         otp-version: ${{ inputs.otp-version }}
         elixir-version: ${{ inputs.elixir-version }}

--- a/.github/workflows/shared-test.yml
+++ b/.github/workflows/shared-test.yml
@@ -66,7 +66,7 @@ jobs:
 
       - name: Run Tests
         id: test
-        run: ./gradlew --stacktrace check
+        run: ./gradlew -Dtestlogger.theme=standard -Dorg.gradle.console=plain --stacktrace check
 
       - name: Publish Test Results
         id: publish-test-results-linux
@@ -85,6 +85,58 @@ jobs:
           files: '**/build/test-results/**/*.xml'
           check_name: Test Results (${{ matrix.os }}, ${{ matrix.idea-version }})
           report_suite_logs: "error"
+
+      - name: Summarize first failed tests
+        id: summarize-failed-tests
+        if: always()
+        run: |
+          PYTHON_BIN="$(command -v python3 || command -v python || true)"
+          [ -n "$PYTHON_BIN" ] || exit 0
+
+          "$PYTHON_BIN" - <<'PY'
+          import glob
+          import os
+          import xml.etree.ElementTree as ET
+
+          MAX_FAILURES = 10
+          seen = set()
+          failed = []
+
+          files = glob.glob("**/build/test-results/**/*.xml", recursive=True)
+          if not files:
+              raise SystemExit(0)
+
+          for path in files:
+              try:
+                  root = ET.parse(path).getroot()
+              except Exception:
+                  continue
+
+              for tc in root.iter("testcase"):
+                  if tc.find("failure") is None and tc.find("error") is None:
+                      continue
+
+                  classname = " ".join(tc.get("classname", "<unknown>").split())
+                  testname = " ".join(tc.get("name", "<unknown>").split())
+                  item = (classname, testname)
+                  if item in seen:
+                      continue
+
+                  seen.add(item)
+                  failed.append(item)
+                  if len(failed) >= MAX_FAILURES:
+                      break
+
+              if len(failed) >= MAX_FAILURES:
+                  break
+
+          if not failed:
+              raise SystemExit(0)
+
+          with open(os.environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as s:
+              s.write("### Failed tests (max 10)\n\n")
+              s.writelines(f"- `{cls}.{name}`\n" for cls, name in failed)
+          PY
 
       - name: Upload Test Reports (on failure or when requested)
         id: upload-test-reports

--- a/src/org/elixir_lang/Elixir.kt
+++ b/src/org/elixir_lang/Elixir.kt
@@ -3,6 +3,7 @@ package org.elixir_lang
 import com.intellij.execution.configurations.GeneralCommandLine
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.projectRoots.Sdk
+import com.intellij.util.concurrency.annotations.RequiresReadLock
 import org.elixir_lang.cli.CliArguments
 import org.elixir_lang.jps.shared.cli.CliArgs
 import org.elixir_lang.jps.shared.cli.CliTool
@@ -13,6 +14,7 @@ object Elixir {
     /**
      * Keep in-sync with [org.elixir_lang.jps.Builder.elixirCommandLine]
      */
+    @RequiresReadLock
     fun commandLine(
         environment: Map<String, String>,
         workingDirectory: String?,

--- a/src/org/elixir_lang/IEx.kt
+++ b/src/org/elixir_lang/IEx.kt
@@ -3,12 +3,14 @@ package org.elixir_lang
 import com.intellij.execution.configurations.GeneralCommandLine
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.projectRoots.Sdk
+import com.intellij.util.concurrency.annotations.RequiresReadLock
 import org.elixir_lang.cli.CliArguments
 import org.elixir_lang.jps.shared.cli.CliArgs
 import org.elixir_lang.jps.shared.cli.CliTool
 import org.elixir_lang.run.baseCommandLine
 
 object IEx {
+    @RequiresReadLock
     fun commandLine(
         environment: Map<String, String>,
         workingDirectory: String?,

--- a/src/org/elixir_lang/Mix.kt
+++ b/src/org/elixir_lang/Mix.kt
@@ -3,6 +3,7 @@ package org.elixir_lang
 import com.intellij.execution.configurations.GeneralCommandLine
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.projectRoots.Sdk
+import com.intellij.util.concurrency.annotations.RequiresReadLock
 import org.elixir_lang.cli.CliArguments
 import org.elixir_lang.jps.shared.cli.CliArgs
 import org.elixir_lang.jps.shared.cli.CliTool
@@ -11,6 +12,7 @@ import org.elixir_lang.run.baseCommandLine
 
 object Mix {
     @JvmStatic
+    @RequiresReadLock
     fun commandLine(
         environment: Map<String, String>,
         workingDirectory: String?,

--- a/src/org/elixir_lang/cli/CliArguments.kt
+++ b/src/org/elixir_lang/cli/CliArguments.kt
@@ -4,6 +4,7 @@ import com.intellij.execution.ExecutionException
 import com.intellij.execution.wsl.WslPath
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.projectRoots.Sdk
+import com.intellij.util.concurrency.annotations.RequiresReadLock
 import com.intellij.util.system.OS
 import org.elixir_lang.jps.shared.cli.CliArgs
 import org.elixir_lang.jps.shared.cli.CliTool
@@ -32,6 +33,7 @@ object CliArguments {
         )
     }
 
+    @RequiresReadLock
     fun argsOrThrow(
         elixirSdk: Sdk,
         tool: CliTool,

--- a/src/org/elixir_lang/mix/PackageManager.kt
+++ b/src/org/elixir_lang/mix/PackageManager.kt
@@ -2,6 +2,7 @@ package org.elixir_lang.mix
 
 import com.intellij.execution.ExecutionException
 import com.intellij.execution.util.ExecUtil
+import com.intellij.openapi.application.ReadAction
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.projectRoots.Sdk
@@ -9,6 +10,7 @@ import com.intellij.openapi.vfs.VirtualFile
 import org.elixir_lang.Mix
 import org.elixir_lang.package_manager.DepGatherer
 import org.elixir_lang.package_manager.DepsStatusResult
+import java.util.concurrent.Callable
 
 private val LOG = logger<PackageManager>()
 private val ANSI_REGEX = Regex("\u001B\\[[;\\d]*m")
@@ -27,7 +29,17 @@ class PackageManager : org.elixir_lang.PackageManager {
         val workingDirectory = packageVirtualFile.parent?.path
             ?: return DepsStatusResult.Error("Missing working directory for ${packageVirtualFile.path}")
 
-        val commandLine = Mix.commandLine(emptyMap(), workingDirectory, sdk)
+        // Mix.commandLine() -> CliArguments.argsOrThrow() -> requireErlangSdkOrNotifyAndThrow()
+        // -> resolveErlangSdkResult() -> findErlangSdkByHomePath() which asserts a read lock.
+        // Build the command line under a cancellable read action, then run the process outside it.
+        val commandLine = try {
+            ReadAction.nonBlocking(Callable { Mix.commandLine(emptyMap(), workingDirectory, sdk) })
+                .executeSynchronously()
+        } catch (e: ExecutionException) {
+            // Erlang SDK missing or misconfigured (CantRunException extends ExecutionException);
+            // the notifier was already invoked by requireErlangSdkOrNotifyAndThrow.
+            return DepsStatusResult.Error(e.message ?: "Erlang SDK not configured for ${sdk.name}")
+        }
         commandLine.addParameters("deps")
 
         return try {

--- a/src/org/elixir_lang/mix/runner/MixTaskRunner.kt
+++ b/src/org/elixir_lang/mix/runner/MixTaskRunner.kt
@@ -5,6 +5,7 @@ import com.intellij.execution.process.ProcessEvent
 import com.intellij.execution.process.ProcessHandlerFactory
 import com.intellij.execution.process.ProcessListener
 import com.intellij.execution.process.ProcessTerminatedListener
+import com.intellij.openapi.application.ReadAction
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.progress.Task
@@ -14,6 +15,7 @@ import com.intellij.openapi.util.Key
 import com.intellij.platform.ide.progress.ModalTaskOwner
 import com.intellij.platform.ide.progress.runWithModalProgressBlocking
 import org.elixir_lang.Mix
+import java.util.concurrent.Callable
 
 private val LOG = logger<MixTaskRunner>()
 
@@ -85,14 +87,11 @@ object MixTaskRunner {
         val indicator = ProgressManager.getInstance().progressIndicator
         indicator?.isIndeterminate = true
 
-        val commandLine = Mix.commandLine(
-            emptyMap(),
-            workingDirectory,
-            sdk,
-            emptyList(),
-            emptyList(),
-            project = project,
-        )
+        // Mix.commandLine() -> argsOrThrow() -> requireErlangSdkOrNotifyAndThrow()
+        // -> findErlangSdkByHomePath() asserts a read lock; acquire one here.
+        val commandLine = ReadAction.nonBlocking(Callable {
+            Mix.commandLine(emptyMap(), workingDirectory, sdk, emptyList(), emptyList(), project = project)
+        }).executeSynchronously()
         commandLine.addParameter(task)
         commandLine.addParameters(*taskParameters)
 

--- a/src/org/elixir_lang/new_project_wizard/Step.kt
+++ b/src/org/elixir_lang/new_project_wizard/Step.kt
@@ -41,6 +41,8 @@ import org.elixir_lang.sdk.elixir.Type
 import org.elixir_lang.sdk.erlang_dependent.ErlangSdkResolver
 import java.io.IOException
 import java.nio.file.Paths
+import com.intellij.openapi.application.ReadAction
+import java.util.concurrent.Callable
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
 
@@ -146,7 +148,11 @@ class Step(parent: NewProjectWizardStep) : AbstractNewProjectWizardStep(parent),
             }
             erlangSdkForSetup = null  // Clear after use; Step is wizard-scoped so no leak, but signals intent
 
-            val commandLine = Mix.commandLine(emptyMap(), workingDirectory, sdk, project = project)
+            // Mix.commandLine() -> argsOrThrow() -> requireErlangSdkOrNotifyAndThrow()
+            // -> findErlangSdkByHomePath() asserts a read lock; acquire one here.
+            val commandLine = ReadAction.nonBlocking(Callable {
+                Mix.commandLine(emptyMap(), workingDirectory, sdk, project = project)
+            }).executeSynchronously()
             commandLine.addParameters("new", projectDirectory)
 
             if (mixNewApp.isNotBlank()) {

--- a/src/org/elixir_lang/run/WslSafeCommandLineState.kt
+++ b/src/org/elixir_lang/run/WslSafeCommandLineState.kt
@@ -5,7 +5,9 @@ import com.intellij.execution.configurations.CommandLineState
 import com.intellij.execution.configurations.GeneralCommandLine
 import com.intellij.execution.process.ProcessHandler
 import com.intellij.execution.runners.ExecutionEnvironment
+import com.intellij.openapi.application.ReadAction
 import com.intellij.platform.ide.progress.runWithModalProgressBlocking
+import java.util.concurrent.Callable
 
 abstract class WslSafeCommandLineState<T>(
     environment: ExecutionEnvironment,
@@ -16,9 +18,13 @@ abstract class WslSafeCommandLineState<T>(
 
     @Throws(ExecutionException::class)
     override fun startProcess(): ProcessHandler {
+        // configuration.commandLine() -> Mix/Elixir/IEx.commandLine() -> CliArguments.argsOrThrow()
+        // -> requireErlangSdkOrNotifyAndThrow() -> findErlangSdkByHomePath() which asserts a read
+        // lock. startProcess() is called by the execution infrastructure without a read lock, so
+        // we must acquire one here.
         val commandLine =
             try {
-                configuration.commandLine()
+                ReadAction.nonBlocking(Callable { configuration.commandLine() }).executeSynchronously()
             } catch (e: ExecutionException) {
                 handleExecutionException(e)
                 throw e

--- a/src/org/elixir_lang/sdk/erlang_dependent/ErlangSdkResolver.kt
+++ b/src/org/elixir_lang/sdk/erlang_dependent/ErlangSdkResolver.kt
@@ -6,6 +6,8 @@ import com.intellij.openapi.diagnostic.debug
 import com.intellij.openapi.projectRoots.ProjectJdkTable
 import com.intellij.openapi.projectRoots.Sdk
 import com.intellij.openapi.projectRoots.SdkModel
+import com.intellij.util.concurrency.ThreadingAssertions
+import com.intellij.util.concurrency.annotations.RequiresReadLock
 import org.elixir_lang.sdk.wsl.wslCompat
 
 
@@ -51,6 +53,7 @@ interface ErlangSdkResolver {
  * 3. Both absent → NOT_CONFIGURED
  */
 class DefaultErlangSdkResolver : ErlangSdkResolver {
+    @RequiresReadLock
     override fun resolveErlangSdkResult(elixirSdk: Sdk, sdkModel: SdkModel?): ErlangSdkResult {
         val elixirName = elixirSdk.name
         val additionalData = elixirSdk.elixirAdditionalData
@@ -138,7 +141,9 @@ class DefaultErlangSdkResolver : ErlangSdkResolver {
             || (jdkTable.findJdk(name) != null)
     }
 
+    @RequiresReadLock
     private fun findErlangSdkByHomePath(homePath: String, sdkModel: SdkModel?): Sdk? {
+        ThreadingAssertions.assertReadAccess()
         val fromModel = sdkModel?.sdks?.find { sdk ->
             Type.staticIsValidDependency(sdk) && wslCompat.pathsEqualWslAware(sdk.homePath, homePath)
         }


### PR DESCRIPTION
## Summary
This PR splits out threading/read-lock contract hardening from `multi-module` into a focused review unit.

## What is included
- Adds explicit `@RequiresReadLock` contracts to command-line construction paths that rely on model access.
- Updates call sites to acquire read access before invoking those APIs.
- Adds runtime read-access assertion where SDK table traversal requires lock safety.

## Why this is split
This is mechanical reliability hardening and reviews cleanly on its own.

## Stack context
Current stack for this PR: **#3839 -> #3845 -> #3846 -> (this PR)**.

- Preferred review diff (this PR only): [main...this PR](https://github.com/KronicDeth/intellij-elixir/compare/main...sh41:split/threading-readlock-commandline)
