### PR TITLE
Tool-manager abstraction and SDK checker integration

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -314,7 +314,6 @@
                           language="Elixir" level="ERROR"/>
         <projectService serviceInterface="org.elixir_lang.dialyzer.service.DialyzerService"
                         serviceImplementation="org.elixir_lang.dialyzer.service.DialyzerServiceImpl"/>
-        <projectService serviceImplementation="org.elixir_lang.tool_manager.ToolManagerSettings"/>
         <projectConfigurable id="language.elixir.dialyzer"
                              parentId="language.elixir"
                              instance="org.elixir_lang.dialyzer.service.Configurable"

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -51,6 +51,7 @@
 
         <editorNotificationProvider implementation="org.elixir_lang.notification.setup_sdk.Provider"/>
         <notificationGroup displayType="BALLOON" id="Elixir"/>
+        <notificationGroup displayType="STICKY_BALLOON" id="Elixir SDK"/>
         <notificationGroup displayType="STICKY_BALLOON" id="Elixir Mix Deps"/>
 
         <!-- Distillery -->
@@ -313,6 +314,7 @@
                           language="Elixir" level="ERROR"/>
         <projectService serviceInterface="org.elixir_lang.dialyzer.service.DialyzerService"
                         serviceImplementation="org.elixir_lang.dialyzer.service.DialyzerServiceImpl"/>
+        <projectService serviceImplementation="org.elixir_lang.tool_manager.ToolManagerSettings"/>
         <projectConfigurable id="language.elixir.dialyzer"
                              parentId="language.elixir"
                              instance="org.elixir_lang.dialyzer.service.Configurable"

--- a/resources/META-INF/rich-platform-plugin.xml
+++ b/resources/META-INF/rich-platform-plugin.xml
@@ -37,6 +37,20 @@
         <applicationService serviceInterface="org.elixir_lang.sdk.elixir.SdkSettingsOpener"
                             serviceImplementation="org.elixir_lang.sdk.elixir.ProjectStructureSdkSettingsOpener"
                             overrides="true"/>
+
+        <!-- Tool Manager settings and SDK checker - rich IDE only because SDK configuration
+             relies on Java-module APIs (ModuleRootManager modifiable model, SdkRegistrar, etc.) -->
+        <!--suppress LightServiceMigrationXML -->
+        <projectService serviceImplementation="org.elixir_lang.tool_manager.ToolManagerSettings"/>
+        <!--suppress LightServiceMigrationXML -->
+        <projectService serviceImplementation="org.elixir_lang.tool_manager.ToolManagerSdkCheckerService"/>
+        <!--suppress LightServiceMigrationXML -->
+        <projectService serviceImplementation="org.elixir_lang.tool_manager.ToolManagerSdkAnalyser"/>
+        <projectConfigurable id="language.elixir.tool_managers"
+                             parentId="language.elixir"
+                             displayName="Tool Managers"
+                             instance="org.elixir_lang.tool_manager.ToolManagerConfigurable"/>
+        <backgroundPostStartupActivity implementation="org.elixir_lang.tool_manager.ToolManagerSdkCheckerStartupActivity"/>
     </extensions>
     <actions>
         <!--suppress PluginXmlCapitalization -->

--- a/src/org/elixir_lang/mise/Mise.kt
+++ b/src/org/elixir_lang/mise/Mise.kt
@@ -261,7 +261,8 @@ object Mise {
      *
      * We match the second line to extract the untrusted config path.
      */
-    private fun parseTrustError(stderr: String): MiseResult.UntrustedConfig? {
+    @VisibleForTesting
+    internal fun parseTrustError(stderr: String): MiseResult.UntrustedConfig? {
         val match = Regex("""Config files in (.+) are not trusted\.""").find(stderr) ?: return null
         return MiseResult.UntrustedConfig(match.groupValues[1].trim())
     }

--- a/src/org/elixir_lang/mise/Mise.kt
+++ b/src/org/elixir_lang/mise/Mise.kt
@@ -12,6 +12,7 @@ import com.intellij.util.concurrency.annotations.RequiresBackgroundThread
 import org.elixir_lang.sdk.wsl.wslCompat
 import org.jetbrains.annotations.VisibleForTesting
 import java.nio.file.Path
+import java.nio.file.Paths
 
 private val LOG = logger<Mise>()
 
@@ -67,6 +68,15 @@ private data class RawMiseSource(
     val type: String?,
     val path: String?,
 )
+
+/** Raw Gson model for one entry from `mise config ls --json`. */
+private data class RawMiseConfigEntry(
+    val path: String?,
+)
+
+/** Raw Gson models for `mise doctor --json`. */
+private data class RawMiseDoctorDirs(val state: String?)
+private data class RawMiseDoctor(val dirs: RawMiseDoctorDirs?)
 
 /**
  * Integrates with [mise](https://mise.jdx.dev/) to resolve tool versions for the current project.
@@ -135,6 +145,112 @@ object Mise {
     }
 
     /**
+     * Invokes `mise config ls --json` in [workDir] and returns the list of config file paths
+     * that mise considers active for that directory.
+     *
+     * These are the files that, when modified, should trigger a re-scan.  The list typically
+     * includes both project-local files (`mise.toml`, `.tool-versions`) and user-global files
+     * (`~/.config/mise/config.toml`, `~/.tool-versions`).
+     *
+     * Returns `null` if mise is unavailable, times out, or the command fails.
+     *
+     * **Threading**: Must not be called on the EDT or under a read lock.
+     */
+    @RequiresBackgroundThread
+    fun configFiles(workDir: Path): List<Path>? {
+        ThreadingAssertions.assertBackgroundThread()
+        check(!ApplicationManager.getApplication().holdsReadLock()) {
+            "Mise.configFiles() must not be called under a read lock"
+        }
+        LOG.trace("configFiles: invoked for workDir=$workDir")
+        return try {
+            val commandLine = GeneralCommandLine("mise", "config", "ls", "--json")
+                .withWorkDirectory(workDir.toFile())
+            val handler = CapturingProcessHandler(commandLine)
+            val output = handler.runProcess(TIMEOUT_MS)
+            if (output.exitCode != 0) {
+                LOG.debug("mise config ls --json exited with ${output.exitCode} in $workDir")
+                return null
+            }
+            val gson = GsonBuilder().create()
+            val type = object : TypeToken<List<RawMiseConfigEntry>>() {}.type
+            @Suppress("UNCHECKED_CAST")
+            val entries = gson.fromJson(output.stdout, type) as? List<RawMiseConfigEntry>
+                ?: return null
+            val workDirString = workDir.toString()
+            entries.mapNotNull { entry ->
+                entry.path?.let { p ->
+                    // mise outputs Linux absolute paths (e.g. /home/user/.config/mise/config.toml)
+                    // when running inside WSL.  Convert to a Windows UNC path using the workDir as
+                    // context before handing the result to Paths.get(), because Paths.get("/...")
+                    // on Windows produces a drive-relative WindowsPath, not a Linux path.
+                    // maybeConvertLinuxPathToWindowsUncFromContext is a no-op on native Linux /
+                    // plain Windows, so this is safe everywhere.
+                    Paths.get(wslCompat.maybeConvertLinuxPathToWindowsUncFromContext(workDirString, p))
+                }
+            }
+                .also { LOG.trace("configFiles: found ${it.size} config file(s) for $workDir") }
+        } catch (e: Exception) {
+            LOG.debug("mise config ls --json failed in $workDir: ${e.message}")
+            null
+        }
+    }
+
+    /**
+     * Invokes `mise doctor --json` in [workDir] and returns the mise state directory path.
+     *
+     * The state directory contains the `trusted-configs` subdirectory, where mise records
+     * which config files have been trusted by the user (`mise trust`).  Watching this
+     * directory lets the plugin re-scan automatically when the user trusts a config.
+     *
+     * Returns `null` if mise is unavailable, times out, or the command fails.
+     *
+     * **Threading**: Must not be called on the EDT or under a read lock.
+     */
+    @RequiresBackgroundThread
+    fun stateDir(workDir: Path): Path? {
+        ThreadingAssertions.assertBackgroundThread()
+        ThreadingAssertions.assertNoReadAccess()
+        LOG.trace("stateDir: invoked for workDir=$workDir")
+        return try {
+            val commandLine = GeneralCommandLine("mise", "doctor", "--json")
+                .withWorkDirectory(workDir.toFile())
+            val handler = CapturingProcessHandler(commandLine)
+            val output = handler.runProcess(TIMEOUT_MS)
+            if (output.exitCode != 0) {
+                LOG.debug("mise doctor --json exited with ${output.exitCode} in $workDir")
+                return null
+            }
+            parseDoctorStateDir(output.stdout, workDir.toString())
+                .also { LOG.trace("stateDir: resolved to $it") }
+        } catch (e: Exception) {
+            LOG.debug("mise doctor --json failed in $workDir: ${e.message}")
+            null
+        }
+    }
+
+    /**
+     * Parses the JSON output of `mise doctor --json` and returns the `dirs.state` path.
+     *
+     * WSL Linux paths are converted to Windows UNC paths using [workDirString] as context
+     * (a no-op on native Linux / plain Windows).
+     *
+     * `internal` for testing - use [Mise.stateDir] in production code.
+     */
+    @VisibleForTesting
+    internal fun parseDoctorStateDir(json: String, workDirString: String): Path? {
+        return try {
+            val gson = GsonBuilder().create()
+            val parsed = gson.fromJson(json, RawMiseDoctor::class.java) ?: return null
+            val state = parsed.dirs?.state ?: return null
+            Paths.get(wslCompat.maybeConvertLinuxPathToWindowsUncFromContext(workDirString, state))
+        } catch (e: Exception) {
+            LOG.debug("parseDoctorStateDir: failed to parse: ${e.message}")
+            null
+        }
+    }
+
+    /**
      * Detects a `mise trust` error in [stderr].
      *
      * When mise encounters an untrusted config it prints two lines to stderr:
@@ -186,15 +302,18 @@ object Mise {
 
     private fun RawMiseEntry.toMiseToolEntry(workDir: Path): MiseToolEntry? {
         val v = version ?: return null
+        val workDirString = workDir.toString()
         val ip = install_path?.let {
-            wslCompat.maybeConvertLinuxPathToWindowsUncFromContext(workDir.toString(), it)
+            wslCompat.maybeConvertLinuxPathToWindowsUncFromContext(workDirString, it)
         } ?: return null
         return MiseToolEntry(
             version = v,
             requestedVersion = requested_version ?: v,
             installPath = ip,
             sourceType = source?.type,
-            sourcePath = source?.path,
+            sourcePath = source?.path?.let {
+                wslCompat.maybeConvertLinuxPathToWindowsUncFromContext(workDirString, it)
+            },
             installed = installed ?: false,
             active = active ?: false,
         )

--- a/src/org/elixir_lang/mise/Mise.kt
+++ b/src/org/elixir_lang/mise/Mise.kt
@@ -37,6 +37,20 @@ data class MiseVersions(
 )
 
 /**
+ * The result of a [Mise.resolveVersions] call.
+ *
+ * `null` from [Mise.resolveVersions] means mise is not on PATH or a transient failure occurred.
+ * A non-null result is one of:
+ * - [Success]          - mise ran successfully and returned version data.
+ * - [UntrustedConfig]  - mise exited non-zero because a config file in the project directory has
+ *   not been trusted yet.  The user must run `mise trust` in the directory to fix this.
+ */
+sealed interface MiseResult {
+    data class Success(val versions: MiseVersions) : MiseResult
+    data class UntrustedConfig(val configFilePath: String) : MiseResult
+}
+
+/**
  * Raw Gson model matching the snake_case JSON output of `mise ls --json`.
  * Converted to [MiseToolEntry] after parsing.
  */
@@ -70,8 +84,9 @@ object Mise {
     /**
      * Invokes `mise ls --current --json` in [workDir] and parses the result.
      *
-     * Returns `null` if mise is not on PATH, returns a non-zero exit code, times out, or
-     * produces output that cannot be parsed. Callers should treat `null` as "mise unavailable".
+     * Returns `null` if mise is not on PATH, times out, or fails in a way that is not
+     * otherwise classified.  Returns [MiseResult.UntrustedConfig] if mise exits non-zero because
+     * a config file has not been trusted.  Returns [MiseResult.Success] on a clean run.
      *
      * **Threading**: Must not be called on the EDT or under a read lock. This method spawns
      * a subprocess and blocks for up to [Mise.TIMEOUT_MS]ms. Callers must ensure they are running
@@ -79,7 +94,7 @@ object Mise {
      * after releasing any read lock).
      */
     @RequiresBackgroundThread
-    fun resolveVersions(workDir: Path): MiseVersions? {
+    fun resolveVersions(workDir: Path): MiseResult? {
         // `assertBackgroundThread()` only checks EDT, NOT holdsReadLock - both guards are needed.
         ThreadingAssertions.assertBackgroundThread()
         check(!ApplicationManager.getApplication().holdsReadLock()) {
@@ -96,6 +111,14 @@ object Mise {
 
             LOG.trace("resolveVersions: exit=${output.exitCode}, stdout.length=${output.stdout.length}, stderr.length=${output.stderr.length}")
             if (output.exitCode != 0) {
+                val trustError = parseTrustError(output.stderr)
+                if (trustError != null) {
+                    LOG.warn(
+                        "mise config not trusted in $workDir: '${trustError.configFilePath}'. " +
+                                "Run `mise trust` in the project directory to allow mise to read it."
+                    )
+                    return trustError
+                }
                 LOG.debug("mise ls --current --json exited with ${output.exitCode} in $workDir: ${output.stderr.take(200)}")
                 return null
             }
@@ -103,12 +126,28 @@ object Mise {
             LOG.trace("resolveVersions: stdout=${output.stdout.take(500)}")
             val result = parseOutput(output.stdout, workDir)
             LOG.trace("resolveVersions: parsed result=$result")
-            result
+            result?.let { MiseResult.Success(it) }
         } catch (e: Exception) {
             LOG.debug("mise ls --current --json failed in $workDir: ${e.message}")
             LOG.trace("resolveVersions: exception class=${e::class.simpleName} message=${e.message}")
             null
         }
+    }
+
+    /**
+     * Detects a `mise trust` error in [stderr].
+     *
+     * When mise encounters an untrusted config it prints two lines to stderr:
+     * ```
+     * mise ERROR error parsing config file: <path>
+     * mise ERROR Config files in <path> are not trusted.
+     * ```
+     *
+     * We match the second line to extract the untrusted config path.
+     */
+    private fun parseTrustError(stderr: String): MiseResult.UntrustedConfig? {
+        val match = Regex("""Config files in (.+) are not trusted\.""").find(stderr) ?: return null
+        return MiseResult.UntrustedConfig(match.groupValues[1].trim())
     }
 
     /**

--- a/src/org/elixir_lang/settings/ElixirSearchableOptionContributor.kt
+++ b/src/org/elixir_lang/settings/ElixirSearchableOptionContributor.kt
@@ -6,7 +6,7 @@ import com.intellij.ide.ui.search.SearchableOptionProcessor
 /**
  * Keeps Elixir settings discoverable in search without requiring Elixir-prefixed labels.
  */
-class ElixirSearchableOptionContributor : SearchableOptionContributor() {
+internal class ElixirSearchableOptionContributor : SearchableOptionContributor() {
     override fun processOptions(processor: SearchableOptionProcessor) {
         addAliases(
             processor = processor,
@@ -54,6 +54,14 @@ class ElixirSearchableOptionContributor : SearchableOptionContributor() {
             configurableDisplayName = "Internal Erlang SDKs",
             hit = "Internal Erlang SDKs",
             text = "elixir erlang sdk otp"
+        )
+
+        addAliases(
+            processor = processor,
+            configurableId = "language.elixir.tool_managers",
+            configurableDisplayName = "Tool Managers",
+            hit = "Tool Managers",
+            text = "elixir tool manager mise asdf sdk version automatic configure experimental"
         )
     }
 

--- a/src/org/elixir_lang/status_bar_widget/ElixirEditorBasedSdkWidget.kt
+++ b/src/org/elixir_lang/status_bar_widget/ElixirEditorBasedSdkWidget.kt
@@ -2,10 +2,9 @@ package org.elixir_lang.status_bar_widget
 
 import com.intellij.facet.FacetManager
 import com.intellij.icons.AllIcons
-import com.intellij.notification.NotificationGroupManager
 import com.intellij.notification.NotificationType
+import com.intellij.notification.impl.NotificationFullContent
 import com.intellij.openapi.actionSystem.*
-import com.intellij.openapi.application.edtWriteAction
 import com.intellij.openapi.application.readAction
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.module.ModuleManager
@@ -24,12 +23,13 @@ import com.intellij.openapi.ui.popup.ListPopup
 import com.intellij.openapi.util.Disposer
 import com.intellij.openapi.util.text.StringUtil
 import com.intellij.openapi.vfs.VirtualFile
-import com.intellij.openapi.vfs.toNioPathOrNull
+import com.intellij.openapi.vfs.VirtualFileManager
+import com.intellij.openapi.vfs.newvfs.BulkFileListener
+import com.intellij.openapi.vfs.newvfs.events.VFileEvent
 import com.intellij.openapi.wm.StatusBarWidget
 import com.intellij.openapi.wm.impl.status.EditorBasedStatusBarPopup
-import com.intellij.platform.ide.progress.ModalTaskOwner
-import com.intellij.platform.ide.progress.runWithModalProgressBlocking
-import com.intellij.ui.EditorNotifications
+import com.intellij.ui.ColorUtil
+import com.intellij.ui.JBColor
 import com.intellij.util.concurrency.ThreadingAssertions
 import com.intellij.util.concurrency.annotations.RequiresBackgroundThread
 import com.intellij.util.concurrency.annotations.RequiresReadLock
@@ -41,22 +41,24 @@ import kotlinx.coroutines.flow.debounce
 import org.elixir_lang.Facet
 import org.elixir_lang.Icons
 import org.elixir_lang.isElixirModule
-import org.elixir_lang.mise.Mise
-import org.elixir_lang.mise.MiseVersions
 import org.elixir_lang.mix.project.ProjectModuleSetupValidator
 import org.elixir_lang.mix.project.ProjectModuleSetupValidator.FolderMarkIssue
 import org.elixir_lang.sdk.SdkEbinPaths
-import org.elixir_lang.sdk.SdkRegistrar
+import org.elixir_lang.sdk.elixir.ElixirSdkLookup
 import org.elixir_lang.sdk.elixir.ElixirSdkMutation
 import org.elixir_lang.sdk.elixir.ElixirSdkValidation
-import org.elixir_lang.sdk.elixir.ElixirVersionDetector
+import org.elixir_lang.sdk.elixir.ElixirSdkValidation.detectOtpMismatch
 import org.elixir_lang.sdk.elixir.SdkSettingsOpener
-import org.elixir_lang.sdk.elixir.ElixirSdkLookup
-import org.elixir_lang.sdk.elixir.sdk
 import org.elixir_lang.sdk.elixir.Type
-import org.elixir_lang.sdk.erlang.ErlangVersionDetector
+import org.elixir_lang.sdk.elixir.sdk
 import org.elixir_lang.sdk.erlang_dependent.SdkAdditionalData
 import org.elixir_lang.sdk.wsl.wslCompat
+import org.elixir_lang.tool_manager.allBuiltInToolManagers
+import org.elixir_lang.tool_manager.ModuleSdkIssue
+import org.elixir_lang.tool_manager.SdkVersionTable
+import org.elixir_lang.tool_manager.ToolManagerSettings
+import org.elixir_lang.tool_manager.ToolManagerSdkChecker
+import org.elixir_lang.tool_manager.ToolManagerVersions
 import org.elixir_lang.util.WriteActions
 import java.nio.file.Path
 import java.util.concurrent.CancellationException
@@ -93,7 +95,8 @@ internal sealed interface SdkStatus {
     data class ModuleSdkError(
         val elixirSdk: Sdk?,
         val elixirVersion: String?,
-        val moduleSdkIssues: List<ModuleSdkIssue>
+        val moduleSdkIssues: List<ModuleSdkIssue>,
+        val sdkVersionTables: Map<String, SdkVersionTable> = emptyMap(),
     ) : SdkStatus
 
     data class FolderMarkWarning(
@@ -105,16 +108,16 @@ internal sealed interface SdkStatus {
     data object NotConfigured : SdkStatus
 
     /**
-     * No Elixir SDK is configured, but mise has an installed Elixir version for the module's
-     * content root. Surfaces a notification with a one-click "Configure from mise" action.
+     * No Elixir SDK is configured, but a tool manager has an installed Elixir version for the
+     * module's content root. Surfaces a notification with a one-click "Configure from <manager>"
+     * action.
      *
-     * [miseVersions] carries the full mise resolution result (used for configuration).
-     * [elixirCanonicalVersion] is the bare version string read from the mise install's
-     * `elixir.app` (e.g. `"1.15.7"`), pre-computed in the IO phase so Phase 3 display
-     * can use it without further file I/O or string parsing.
+     * [toolManagerVersions] carries the full tool-manager result (used for configuration).
+     * [elixirCanonicalVersion] is the bare version string read from the install's `elixir.app`,
+     * pre-computed so the notification can display it without further I/O.
      */
-    data class NotConfiguredMiseAvailable(
-        val miseVersions: MiseVersions,
+    data class NotConfiguredToolManagerAvailable(
+        val toolManagerVersions: ToolManagerVersions,
         val elixirCanonicalVersion: String?,
     ) : SdkStatus
 
@@ -136,8 +139,6 @@ internal sealed interface SdkStatus {
     ) : SdkStatus
 }
 
-internal data class ModuleSdkIssue(val moduleName: String, val issue: String, val isDangling: Boolean)
-
 @OptIn(FlowPreview::class)
 class ElixirEditorBasedSdkWidget(
     project: Project,
@@ -147,6 +148,12 @@ class ElixirEditorBasedSdkWidget(
     companion object {
         const val ID = "ElixirSdkStatus"
     }
+
+    private val checker = ToolManagerSdkChecker(
+        project = project,
+        toolManagers = allBuiltInToolManagers,
+        settings = ToolManagerSettings.getInstance(project),
+    )
 
     // Track last notified status to avoid spamming duplicate notifications
     @Volatile
@@ -224,28 +231,29 @@ class ElixirEditorBasedSdkWidget(
                     val modelData = readAction { collectNotificationScanModelData() }
                     val ioData = withContext(Dispatchers.IO) { collectNotificationScanIoData(modelData) }
 
-                    val miseIssues = detectMiseSdkMismatchIssues(
-                        modelData.moduleMiseCheckData,
-                        ioData.elixirVersionBySdk,
-                        ioData.miseByContentRoot,
-                        ioData.erlangOtpMajorByHomePath,
-                        ioData.elixirVersionByInstallPath,
+                    val (tmIssues, sdkVersionTables) = checker.detectMismatchIssues(
+                        moduleCheckData = modelData.moduleCheckData,
+                        toolManagerVersionsByRoot = ioData.toolManagerVersionsByRoot,
+                        elixirVersionBySdk = ioData.elixirVersionBySdk,
+                        erlangReleaseByHomePath = ioData.erlangReleaseByHomePath,
+                        elixirVersionByInstallPath = ioData.elixirVersionByInstallPath,
                     )
-                    // Build per-module mise assignments: module name → the MiseVersions that mise
-                    // resolves for that module's own content root.  Covers all modules with an
+                    // Build per-module tool manager assignments: module name → the ToolManagerVersions that are
+                    // resolved for that module's own content root.  Covers all modules with an
                     // installed elixir entry, regardless of whether they already have an SDK.
-                    val miseAssignments = buildMiseAssignments(
-                        modelData.moduleMiseCheckData,
-                        ioData.miseByContentRoot,
+                    val tmAssignments = checker.buildAssignments(
+                        moduleCheckData = modelData.moduleCheckData,
+                        toolManagerVersionsByRoot = ioData.toolManagerVersionsByRoot,
                     )
                     notifyIfNeeded(
-                        moduleSdkIssues = modelData.moduleSdkIssues + miseIssues,
+                        moduleSdkIssues = modelData.moduleSdkIssues + tmIssues,
                         folderMarkIssues = modelData.folderMarkIssues,
-                        miseAssignments = miseAssignments,
+                        tmAssignments = tmAssignments,
                         projectSdkSnapshot = modelData.projectSdkSnapshot,
                         classpathIssues = ioData.classpathIssues,
                         elixirVersionByInstallPath = ioData.elixirVersionByInstallPath,
                         projectSdkOtpMismatch = ioData.projectSdkOtpMismatch,
+                        sdkVersionTables = sdkVersionTables,
                     )
                 }
         }
@@ -342,7 +350,10 @@ class ElixirEditorBasedSdkWidget(
 
         // SDK refresh (from RefreshAllElixirSdksAction) - re-scan notifications since SDK
         // validity may have changed (e.g. Erlang SDK path restored).
+        // Clear lastNotifiedIssueKey so the scan re-notifies even if the same mismatch persists -
+        // the user explicitly requested a refresh and must see the current state.
         connection.subscribe(ElixirSdkRefreshListener.TOPIC, ElixirSdkRefreshListener {
+            lastNotifiedIssueKey = null
             update()
             notificationScanRequests.tryEmit(Unit)
         })
@@ -414,27 +425,99 @@ class ElixirEditorBasedSdkWidget(
     // Project-wide notification scan (triggered from rootsChanged background job)
     // -------------------------------------------------------------------------
 
-    /**
-     * Runs the project-wide notification scan. Called from the debounced collector -
-     * never from getWidgetState(). This is O(modules) for SDK resolution and should not run
-     * per-editor-switch.
-     *
-     * **Threading**: the [moduleSdkIssues] and [folderMarkIssues] parameters are pre-computed
-     * inside `readAction` by the caller. This method performs additional model access
-     * ([findModuleLevelElixirSdk], [getErlangSdk]) which also requires read access, so
-     * it wraps that access in its own `readAction` call.
-     */
+    private data class ProjectSdkSnapshot(
+        val elixirSdk: Sdk?,
+        val elixirVersion: String?,
+        val erlangSdk: Sdk?,
+    )
+
+    private data class NotificationScanModelData(
+        val moduleSdkIssues: List<ModuleSdkIssue>,
+        val folderMarkIssues: List<FolderMarkIssue>,
+        val moduleCheckData: List<ToolManagerSdkChecker.ModuleCheckData>,
+        val projectSdkSnapshot: ProjectSdkSnapshot,
+    )
+
+    private data class NotificationScanIoData(
+        val toolManagerVersionsByRoot: Map<Path, ToolManagerVersions?>,
+        val elixirVersionBySdk: Map<Sdk, String?>,
+        val erlangReleaseByHomePath: Map<String, org.elixir_lang.sdk.erlang.Release?>,
+        val projectSdkOtpMismatch: Pair<String, String>?,
+        val elixirVersionByInstallPath: Map<String, String?>,
+        val classpathIssues: List<String>,
+    )
+
+    @RequiresReadLock
+    private fun collectNotificationScanModelData(): NotificationScanModelData {
+        val moduleSdkIssues = detectModuleSdkIssues()
+        val folderMarkIssues = ProjectModuleSetupValidator.detectFolderMarkIssues(project)
+        val moduleCheckData = checker.collectModuleCheckData()
+        val projectSdkSnapshot = collectProjectSdkSnapshot()
+
+        return NotificationScanModelData(
+            moduleSdkIssues = moduleSdkIssues,
+            folderMarkIssues = folderMarkIssues,
+            moduleCheckData = moduleCheckData,
+            projectSdkSnapshot = projectSdkSnapshot,
+        )
+    }
+
+    @RequiresReadLock
+    private fun collectProjectSdkSnapshot(): ProjectSdkSnapshot {
+        val elixirSdk = findModuleLevelElixirSdk()
+        val elixirVersion = elixirSdk?.versionString?.let {
+            org.elixir_lang.sdk.Type.appendWslSuffix(it, elixirSdk.homePath)
+        }
+        val erlangSdk = elixirSdk?.let { getErlangSdk(it) }
+
+        return ProjectSdkSnapshot(
+            elixirSdk = elixirSdk,
+            elixirVersion = elixirVersion,
+            erlangSdk = erlangSdk,
+        )
+    }
+
+    private fun collectNotificationScanIoData(modelData: NotificationScanModelData): NotificationScanIoData {
+        val contentRoots = modelData.moduleCheckData.mapNotNull { it.contentRoot }.distinct()
+        LOG.trace("collectNotificationScanIoData: ${contentRoots.size} content root(s): $contentRoots")
+
+        val toolManagerVersionsByRoot = checker.resolveVersions(contentRoots)
+        val elixirVersionByInstallPath = checker.collectElixirVersionByInstallPath(toolManagerVersionsByRoot)
+        val erlangReleaseByHomePath = checker.collectErlangReleaseByHomePath(modelData.moduleCheckData)
+
+        val elixirVersionBySdk = modelData.moduleCheckData
+            .mapNotNull { it.elixirSdk }
+            .distinct()
+            .associateWith { sdk ->
+                Type.canonicalVersion(sdk).also { v ->
+                    LOG.trace("collectNotificationScanIoData: canonicalVersion('${sdk.name}') = $v")
+                }
+            }
+
+        val projectSdkOtpMismatch = modelData.projectSdkSnapshot.elixirSdk?.let { detectOtpMismatch(it) }
+
+        return NotificationScanIoData(
+            toolManagerVersionsByRoot = toolManagerVersionsByRoot,
+            elixirVersionBySdk = elixirVersionBySdk,
+            erlangReleaseByHomePath = erlangReleaseByHomePath,
+            projectSdkOtpMismatch = projectSdkOtpMismatch,
+            elixirVersionByInstallPath = elixirVersionByInstallPath,
+            classpathIssues = detectClasspathIssues(modelData.projectSdkSnapshot),
+        )
+    }
+
     private fun notifyIfNeeded(
         moduleSdkIssues: List<ModuleSdkIssue>,
         folderMarkIssues: List<FolderMarkIssue>,
-        /** Per-module mise assignments: module name → MiseVersions for that module's own content root. */
-        miseAssignments: Map<String, MiseVersions> = emptyMap(),
+        /** Per-module tool-manager assignments: module name → ToolManagerVersions for that module's content root. */
+        tmAssignments: Map<String, ToolManagerVersions> = emptyMap(),
         projectSdkSnapshot: ProjectSdkSnapshot,
         classpathIssues: List<String>,
         elixirVersionByInstallPath: Map<String, String?> = emptyMap(),
         /** Pre-computed OTP mismatch for the project's primary Elixir SDK, or `null` when there
          *  is no mismatch, when detection failed, or when the user suppressed warnings. */
         projectSdkOtpMismatch: Pair<String, String>? = null,
+        sdkVersionTables: Map<String, SdkVersionTable> = emptyMap(),
     ) {
         val elixirSdk = projectSdkSnapshot.elixirSdk
         val erlangSdk = projectSdkSnapshot.erlangSdk
@@ -442,15 +525,15 @@ class ElixirEditorBasedSdkWidget(
 
         val sdkStatus: SdkStatus = when {
             moduleSdkIssues.isNotEmpty() ->
-                SdkStatus.ModuleSdkError(elixirSdk, projectSdkSnapshot.elixirVersion, moduleSdkIssues)
+                SdkStatus.ModuleSdkError(elixirSdk, projectSdkSnapshot.elixirVersion, moduleSdkIssues, sdkVersionTables)
 
             folderMarkIssues.isNotEmpty() && elixirSdk != null ->
                 SdkStatus.FolderMarkWarning(elixirSdk, elixirVersion, folderMarkIssues)
 
-            elixirSdk == null && miseAssignments.isNotEmpty() -> {
-                val firstMise = miseAssignments.values.first()
-                val canonicalVersion = firstMise.elixir?.installPath?.let { elixirVersionByInstallPath[it] }
-                SdkStatus.NotConfiguredMiseAvailable(firstMise, canonicalVersion)
+            elixirSdk == null && tmAssignments.isNotEmpty() -> {
+                val firstVersions = tmAssignments.values.first()
+                val canonicalVersion = firstVersions.elixir?.installPath?.let { elixirVersionByInstallPath[it] }
+                SdkStatus.NotConfiguredToolManagerAvailable(firstVersions, canonicalVersion)
             }
 
             elixirSdk == null ->
@@ -493,25 +576,27 @@ class ElixirEditorBasedSdkWidget(
 
         val (title, message, type) = buildNotificationContent(sdkStatus) ?: return
 
-        val notification = NotificationGroupManager.getInstance()
-            .getNotificationGroup("Elixir")
-            .createNotification(title, message, type)
+        val notification = object : com.intellij.notification.Notification("Elixir SDK", title, message, type),
+            NotificationFullContent {}
 
-        // "Configure from Mise" is added first so it appears as the primary inline action.
-        // When any module SDK issue has a corresponding mise assignment (covering both dangling
+        // "Configure from <tool manager>" - for module SDK mismatches with a tool manager assignment.
+        // When any module SDK issue has a corresponding tool manager configured erlang or elixir SDK (covering both dangling
         // references and version mismatches), offer it.  Each affected module is assigned the
-        // SDK that mise resolves for *its own* content root - umbrella apps with different
-        // mise.toml entries get different SDKs rather than a shared one.
+        // SDK that the tool manager resolves for *its own* content root - umbrella apps with different
+        // configurations get different SDKs rather than a shared one.
         if (sdkStatus is SdkStatus.ModuleSdkError) {
             val affectedNames = sdkStatus.moduleSdkIssues.mapTo(HashSet()) { it.moduleName }
-            val relevantAssignments = miseAssignments.filterKeys { it in affectedNames }
+            val relevantAssignments = tmAssignments.filterKeys { it in affectedNames }
             if (relevantAssignments.isNotEmpty()) {
-                notification.addAction(object : AnAction("Configure from Mise") {
+                val toolName = sdkStatus.sdkVersionTables.values.firstOrNull()?.toolManagerName
+                    ?: relevantAssignments.values.firstOrNull()?.toolManagerName
+                    ?: "tool manager"
+                notification.addAction(object : AnAction("Configure from $toolName") {
                     override fun actionPerformed(e: AnActionEvent) {
                         notification.expire()
                         lastNotifiedIssueKey = null
                         activeNotification = null
-                        configureSdkFromMise(project, relevantAssignments)
+                        checker.configureSdks(relevantAssignments)
                     }
                 })
             }
@@ -534,19 +619,18 @@ class ElixirEditorBasedSdkWidget(
             })
         }
 
-        // For mise-available case (no SDK configured at all), offer one-click SDK configuration.
-        // Each module is assigned the SDK for its own content root.
-        if (sdkStatus is SdkStatus.NotConfiguredMiseAvailable) {
-            notification.addAction(object : AnAction("Configure from Mise") {
+        // "Configure from <tool manager>" - for unconfigured project with tool manager available.
+        if (sdkStatus is SdkStatus.NotConfiguredToolManagerAvailable) {
+            val toolName = sdkStatus.toolManagerVersions.toolManagerName
+            notification.addAction(object : AnAction("Configure from $toolName") {
                 override fun actionPerformed(e: AnActionEvent) {
                     notification.expire()
-                    configureSdkFromMise(project, miseAssignments)
+                    checker.configureSdks(tmAssignments)
                 }
             })
         }
 
-        // For module SDK errors or folder mark warnings, offer the reconfigure action as a
-        // secondary option (after "Configure from Mise" when both are present).
+        // "Reconfigure Now" - for module SDK errors and folder mark warnings.
         if (sdkStatus is SdkStatus.ModuleSdkError || sdkStatus is SdkStatus.FolderMarkWarning) {
             val reconfigureAction = ActionManager.getInstance().getAction("Elixir.ReconfigureModuleSetup")
             if (reconfigureAction != null) {
@@ -590,9 +674,8 @@ class ElixirEditorBasedSdkWidget(
         return when (status) {
             is SdkStatus.Configured -> null
             is SdkStatus.NotConfigured -> "not-configured"
-            is SdkStatus.NotConfiguredMiseAvailable ->
-                "not-configured-mise:${status.elixirCanonicalVersion ?: status.miseVersions.elixir?.version}"
-
+            is SdkStatus.NotConfiguredToolManagerAvailable ->
+                "not-configured-tm:${status.toolManagerVersions.toolManagerName}:${status.elixirCanonicalVersion ?: status.toolManagerVersions.elixir?.version}"
             is SdkStatus.InvalidSdk -> "partial:${status.issue}"
             is SdkStatus.ClasspathIssue -> "warning:${status.issues.sorted().joinToString(",")}"
             is SdkStatus.OtpMismatch ->
@@ -614,86 +697,105 @@ class ElixirEditorBasedSdkWidget(
 
     private data class NotificationContent(val title: String, val message: String, val type: NotificationType)
 
-    private fun buildNotificationContent(status: SdkStatus): NotificationContent? {
-        return when (status) {
+    private fun buildNotificationContent(status: SdkStatus): NotificationContent? = when (status) {
             is SdkStatus.Configured -> null
 
             is SdkStatus.NotConfigured -> NotificationContent(
+            "Elixir SDK Not Configured",
+            "No Elixir SDK is configured for this project. Code insight will not work.",
+            NotificationType.WARNING
+        )
+
+        is SdkStatus.NotConfiguredToolManagerAvailable -> {
+            val toolName = status.toolManagerVersions.toolManagerName
+            val displayVersion = status.elixirCanonicalVersion
+                ?: status.toolManagerVersions.elixir?.version
+                ?: "unknown"
+            NotificationContent(
                 "Elixir SDK Not Configured",
-                "No Elixir SDK is configured for this project. Code insight will not work.",
+                "No Elixir SDK configured, but Elixir $displayVersion is available via $toolName.",
                 NotificationType.WARNING
             )
+        }
 
-            is SdkStatus.NotConfiguredMiseAvailable -> {
-                val displayVersion = status.elixirCanonicalVersion
-                    ?: status.miseVersions.elixir?.version
-                    ?: "unknown"
+        is SdkStatus.InvalidSdk -> NotificationContent(
+            "Elixir SDK Issue",
+            "Elixir SDK: ${status.elixirVersion ?: "Unknown"} - ${status.issue}.",
+            NotificationType.WARNING
+        )
+
+        is SdkStatus.ClasspathIssue -> NotificationContent(
+            "Elixir SDK Warning",
+            "Elixir SDK ${status.elixirVersion}: ${status.issues.joinToString("; ")}.",
+            NotificationType.WARNING
+        )
+
+        is SdkStatus.OtpMismatch -> NotificationContent(
+            "Elixir SDK OTP Version Mismatch",
+            "Elixir ${status.elixirVersion} was compiled for OTP ${status.elixirOtpMajor} " +
+                    "but is paired with OTP ${status.erlangOtpMajor}. " +
+                    "This may cause runtime errors (e.g. {undef,[{elixir,start_cli,...}]}).",
+            NotificationType.WARNING
+        )
+
+        is SdkStatus.ModuleSdkError -> {
+            val hasDangling = status.moduleSdkIssues.any { it.isDangling }
+            if (hasDangling) {
+                val danglingIssues = status.moduleSdkIssues.filter { it.isDangling }
+                val moduleNames = danglingIssues.map { it.moduleName }.distinct()
+                val sdkNames = danglingIssues
+                    .map { it.issue.substringAfter("SDK '").substringBefore("'") }.distinct()
                 NotificationContent(
-                    "Elixir SDK Not Configured",
-                    "No Elixir SDK configured, but Elixir $displayVersion is available via mise.",
-                    NotificationType.WARNING
+                    "Elixir SDK Error: Module SDK ${StringUtil.pluralize("reference", moduleNames.size)} broken",
+                    formatDanglingMessage(moduleNames, sdkNames),
+                    NotificationType.ERROR
                 )
-            }
-
-            is SdkStatus.InvalidSdk -> NotificationContent(
-                "Elixir SDK Issue",
-                "Elixir SDK: ${status.elixirVersion ?: "Unknown"} - ${status.issue}.",
-                NotificationType.WARNING
-            )
-
-            is SdkStatus.ClasspathIssue -> NotificationContent(
-                "Elixir SDK Warning",
-                "Elixir SDK ${status.elixirVersion}: ${status.issues.joinToString("; ")}.",
-                NotificationType.WARNING
-            )
-
-            is SdkStatus.OtpMismatch -> NotificationContent(
-                "Elixir SDK OTP Version Mismatch",
-                "Elixir ${status.elixirVersion} was compiled for OTP ${status.elixirOtpMajor} " +
-                        "but is paired with OTP ${status.erlangOtpMajor}. " +
-                        "This may cause runtime errors (e.g. {undef,[{elixir,start_cli,...}]}).",
-                NotificationType.WARNING
-            )
-
-            is SdkStatus.ModuleSdkError -> {
-                val hasDangling = status.moduleSdkIssues.any { it.isDangling }
-                if (hasDangling) {
-                    val danglingIssues = status.moduleSdkIssues.filter { it.isDangling }
-                    val moduleNames = danglingIssues.map { it.moduleName }.distinct()
-                    val sdkNames =
-                            danglingIssues.map { it.issue.substringAfter("SDK '").substringBefore("'") }.distinct()
-                    NotificationContent(
-                        "Elixir SDK Error: Module SDK ${StringUtil.pluralize("reference", moduleNames.size)} broken",
-                        formatDanglingMessage(moduleNames, sdkNames),
-                        NotificationType.ERROR
-                    )
+            } else {
+                val distinctModules = status.moduleSdkIssues.map { it.moduleName }.distinct()
+                if (distinctModules.size == 1) {
+                    val moduleName = distinctModules.first()
+                    val table = status.sdkVersionTables[moduleName]
+                    if (table != null) {
+                        NotificationContent(
+                            "Elixir SDK: '$moduleName' Version Mismatch",
+                            buildSdkVersionTableHtml(table),
+                            NotificationType.WARNING
+                        )
+                    } else {
+                        val issueDescriptions = status.moduleSdkIssues.joinToString("; ") { it.issue }
+                        NotificationContent(
+                            "Elixir SDK: '$moduleName' Version Mismatch",
+                            "Mismatch detected: $issueDescriptions.",
+                            NotificationType.WARNING
+                        )
+                    }
                 } else {
                     val summary = status.moduleSdkIssues.joinToString("; ") { "'${it.moduleName}': ${it.issue}" }
                     NotificationContent(
-                        "Elixir SDK: Module SDK Mismatch",
-                        "Module SDK mismatch detected. $summary",
+                        "Elixir SDK: Module Version Mismatches",
+                        "Tool manager reports version mismatches. $summary.",
                         NotificationType.WARNING
                     )
                 }
             }
+        }
 
-            is SdkStatus.FolderMarkWarning -> {
-                val issueCount = status.folderMarkIssues.size
-                val moduleCount = status.folderMarkIssues.map { it.moduleName }.distinct().size
-                val summary = if (issueCount == 1) {
-                    val issue = status.folderMarkIssues.first()
-                    "${issue.folderRelativePath}/ is not marked as ${issue.folderMark.displayName} in module '${issue.moduleName}'"
-                } else {
+        is SdkStatus.FolderMarkWarning -> {
+            val issueCount = status.folderMarkIssues.size
+            val moduleCount = status.folderMarkIssues.map { it.moduleName }.distinct().size
+            val summary = if (issueCount == 1) {
+                val issue = status.folderMarkIssues.first()
+                "${issue.folderRelativePath}/ is not marked as ${issue.folderMark.displayName} in module '${issue.moduleName}'"
+            } else {
                     val issuesPlural=StringUtil.pluralize("issue", issueCount)
                     val modulesPlural=StringUtil.pluralize("module", moduleCount)
                     "$issueCount folder mark $issuesPlural across $moduleCount $modulesPlural"
                 }
-                NotificationContent(
-                    "Elixir: Project Structure Suboptimal",
-                    "$summary. Some code insight features may not work correctly.",
-                    NotificationType.WARNING
-                )
-            }
+            NotificationContent(
+                "Elixir: Project Structure Suboptimal",
+                "$summary. Some code insight features may not work correctly.",
+                NotificationType.WARNING
+            )
         }
     }
 
@@ -796,404 +898,14 @@ class ElixirEditorBasedSdkWidget(
         return issues
     }
 
-    // -------------------------------------------------------------------------
-    // Mise version mismatch detection
-    // -------------------------------------------------------------------------
-
-    /**
-     * Data gathered from the module model (requires a read lock) that is later used by
-     * [detectMiseSdkMismatchIssues] to compare against mise's resolved versions.
-     */
-    private data class ModuleMiseCheckData(
-        val moduleName: String,
-        /** Elixir SDK configured for the module (if any). */
-        val elixirSdk: Sdk?,
-        /** Home path of the Internal Erlang SDK (if any). Resolved to OTP major in IO phase. */
-        val erlangSdkHomePath: String?,
-        /** First content root of the module, used as the working directory for `mise ls`. */
-        val contentRoot: Path?,
-    )
-
-    private data class ProjectSdkSnapshot(
-        val elixirSdk: Sdk?,
-        val elixirVersion: String?,
-        val erlangSdk: Sdk?,
-    )
-
-    private data class NotificationScanModelData(
-        val moduleSdkIssues: List<ModuleSdkIssue>,
-        val folderMarkIssues: List<FolderMarkIssue>,
-        val moduleMiseCheckData: List<ModuleMiseCheckData>,
-        val projectSdkSnapshot: ProjectSdkSnapshot,
-    )
-
-    private data class NotificationScanIoData(
-        val miseByContentRoot: Map<Path, MiseVersions?>,
-        val elixirVersionBySdk: Map<Sdk, String?>,
-        /** OTP major (e.g. `"26"`) keyed by canonical Erlang SDK home path. Populated from
-         *  `releases/<N>/OTP_VERSION` - no subprocess. Used for OTP mismatch detection. */
-        val erlangOtpMajorByHomePath: Map<String, String?>,
-        /** OTP mismatch for the project's primary Elixir SDK, computed via [ElixirSdkValidation.detectOtpMismatch].
-         *  `null` when OTP majors match, when either side is undetermined, or when the user has
-         *  dismissed the warning - [ElixirSdkValidation.detectOtpMismatch] handles that internally. */
-        val projectSdkOtpMismatch: Pair<String, String>?,
-        /** Canonical Elixir version (e.g. `"1.15.7"`) keyed by install path, read from
-         *  `lib/elixir/ebin/elixir.app` inside each tool-manager install directory.
-         *  Works for mise, asdf, or any other manager that populates [org.elixir_lang.mise.MiseToolEntry.installPath]. */
-        val elixirVersionByInstallPath: Map<String, String?>,
-        val classpathIssues: List<String>,
-    )
-
-    @RequiresReadLock
-    private fun collectNotificationScanModelData(): NotificationScanModelData {
-        val moduleSdkIssues = detectModuleSdkIssues()
-        val folderMarkIssues = ProjectModuleSetupValidator.detectFolderMarkIssues(project)
-        val moduleMiseCheckData = collectModuleMiseCheckData()
-        val projectSdkSnapshot = collectProjectSdkSnapshot()
-
-        return NotificationScanModelData(
-            moduleSdkIssues = moduleSdkIssues,
-            folderMarkIssues = folderMarkIssues,
-            moduleMiseCheckData = moduleMiseCheckData,
-            projectSdkSnapshot = projectSdkSnapshot,
-        )
-    }
-
-    @RequiresReadLock
-    private fun collectProjectSdkSnapshot(): ProjectSdkSnapshot {
-        val elixirSdk = findModuleLevelElixirSdk()
-        val elixirVersion = elixirSdk?.versionString?.let {
-            org.elixir_lang.sdk.Type.appendWslSuffix(it, elixirSdk.homePath)
-        }
-        val erlangSdk = elixirSdk?.let { getErlangSdk(it) }
-
-        return ProjectSdkSnapshot(
-            elixirSdk = elixirSdk,
-            elixirVersion = elixirVersion,
-            erlangSdk = erlangSdk,
-        )
-    }
-
-    private suspend fun collectNotificationScanIoData(modelData: NotificationScanModelData): NotificationScanIoData {
-        val contentRoots = modelData.moduleMiseCheckData.mapNotNull { it.contentRoot }.distinct()
-        LOG.trace("collectNotificationScanIoData: ${contentRoots.size} content root(s) to check with mise: $contentRoots")
-
-        val miseByContentRoot = contentRoots
-            .associateWith { contentRoot ->
-                LOG.trace("collectNotificationScanIoData: calling Mise.resolveVersions for $contentRoot")
-                val result = Mise.resolveVersions(contentRoot)
-                LOG.trace("collectNotificationScanIoData: Mise.resolveVersions($contentRoot) = $result")
-                result
-            }
-
-        val elixirVersionBySdk = modelData.moduleMiseCheckData
-            .mapNotNull { it.elixirSdk }
-            .distinct()
-            .associateWith { sdk ->
-                val v = Type.canonicalVersion(sdk)
-                LOG.trace("collectNotificationScanIoData: canonicalVersion(sdk='${sdk.name}') = $v")
-                v
-            }
-
-        val erlangOtpMajorByHomePath = modelData.moduleMiseCheckData
-            .mapNotNull { it.erlangSdkHomePath }
-            .distinct()
-            .associateWith { homePath ->
-                ErlangVersionDetector.detectRelease(homePath)?.otpMajor
-            }
-
-        // Read the canonical Elixir version from each unique mise install's elixir.app.
-        // This avoids string-mangling the mise-reported version (e.g. "1.15.7-otp-26") and
-        // uses the same authoritative source as the SDK version detection.
-        val elixirVersionByInstallPath: Map<String, String?> = miseByContentRoot.values
-            .filterNotNull()
-            .mapNotNull { it.elixir?.installPath }
-            .distinct()
-            .associateWith { installPath ->
-                val v = ElixirVersionDetector.elixirVersion(installPath, null)
-                LOG.trace("collectNotificationScanIoData: ElixirVersionDetector.elixirVersion('$installPath') = $v")
-                v
-            }
-
-        // Detect OTP mismatch for the project's primary Elixir SDK.
-        // ElixirSdkValidation.detectOtpMismatch handles the suppress flag internally,
-        // returning null when the user has dismissed the warning for this SDK.
-        val projectSdkOtpMismatch: Pair<String, String>? =
-            modelData.projectSdkSnapshot.elixirSdk?.let { readAction { ElixirSdkValidation.detectOtpMismatch(it) } }
-
-        val classpathIssues = detectClasspathIssues(modelData.projectSdkSnapshot)
-
-        return NotificationScanIoData(
-            miseByContentRoot = miseByContentRoot,
-            elixirVersionBySdk = elixirVersionBySdk,
-            erlangOtpMajorByHomePath = erlangOtpMajorByHomePath,
-            projectSdkOtpMismatch = projectSdkOtpMismatch,
-            elixirVersionByInstallPath = elixirVersionByInstallPath,
-            classpathIssues = classpathIssues,
-        )
-    }
-
-    private fun detectClasspathIssues(projectSdkSnapshot: ProjectSdkSnapshot): List<String> {
-        val elixirSdk = projectSdkSnapshot.elixirSdk ?: return emptyList()
-        val erlangSdk = projectSdkSnapshot.erlangSdk ?: return emptyList()
-        val classpathIssues = mutableListOf<String>()
-
-        if (hasEbinPathIssues(elixirSdk)) {
-            classpathIssues.add("Missing Elixir ebin paths or classpath entries")
-        }
-        if (hasErlangSdkIssues(erlangSdk)) {
-            classpathIssues.add("Erlang SDK configuration issues")
-        }
-        if (!ElixirSdkValidation.hasErlangClasspathInElixirSdk(elixirSdk, erlangSdk)) {
-            classpathIssues.add("Erlang SDK classpath entries missing - reopen SDK settings to fix")
-        }
-
-        return classpathIssues
-    }
-
-    /**
-     * Gathers module SDK info needed for mise version-mismatch checks.
-     *
-     * Must be called inside a read action (accesses [ModuleRootManager]).
-     */
-    private fun collectModuleMiseCheckData(): List<ModuleMiseCheckData> {
-        return ModuleManager.getInstance(project).modules
-            .filter { it.isElixirModule() }
-            .map { module ->
-                val elixirSdk = ElixirSdkLookup.resolve(module).sdk
-                val erlangSdk = elixirSdk?.let { getErlangSdk(it) }
-                val contentRoot = ModuleRootManager.getInstance(module)
-                    .contentRoots
-                    .firstOrNull()
-                    ?.toNioPathOrNull()
-                LOG.trace("collectModuleMiseCheckData: module='${module.name}' elixirSdk='${elixirSdk?.name}' contentRoot=$contentRoot")
-                ModuleMiseCheckData(
-                    moduleName = module.name,
-                    elixirSdk = elixirSdk,
-                    erlangSdkHomePath = erlangSdk?.homePath,
-                    contentRoot = contentRoot,
-                )
-            }
-    }
-
-    /**
-     * Builds a map of module name → [MiseVersions] for every Elixir module whose content root
-     * has an installed mise Elixir version.
-     *
-     * Intentionally covers **all** modules - both those without a configured SDK (dangling /
-     * unconfigured) and those that already have one (for mismatch detection and correction).
-     * The caller decides which subset to act on.
-     *
-     * The value for each entry is the [MiseVersions] that mise resolves specifically for *that
-     * module's own content root*, so umbrella apps with per-app `mise.toml` entries each get
-     * their own versions rather than inheriting a single shared value.
-     *
-     * Must NOT be called under a read lock - [miseByContentRoot] was populated by calling
-     * [Mise.resolveVersions] (a subprocess) on a background thread.
-     */
-    private fun buildMiseAssignments(
-        moduleDataList: List<ModuleMiseCheckData>,
-        miseByContentRoot: Map<Path, MiseVersions?>,
-    ): Map<String, MiseVersions> {
-        val result = LinkedHashMap<String, MiseVersions>()
-        for (data in moduleDataList) {
-            val contentRoot = data.contentRoot ?: continue
-            val versions = miseByContentRoot[contentRoot] ?: continue
-            if (versions.elixir?.installed == true) {
-                result[data.moduleName] = versions
-            }
-        }
-        return result
-    }
-
-    private fun configureSdkFromMise(project: Project, miseAssignments: Map<String, MiseVersions>) {
-        LOG.trace("configureSdkFromMise: miseAssignments keys=${miseAssignments.keys}")
-        runWithModalProgressBlocking(ModalTaskOwner.project(project), "Configuring Elixir SDK from mise") {
-            // Collect content roots so Linux install paths returned by WSL-side mise
-            // (e.g. /home/user/.local/share/mise/installs/erlang/23.3.4.20) can be
-            // converted to the Windows UNC form that SdkRegistrar and WslCompatService expect
-            // (e.g. \\wsl.localhost\Ubuntu\home\user\.local\share\mise\installs\erlang\23.3.4.20).
-            val contentRootByModule: Map<String, Path?> = readAction {
-                miseAssignments.keys.associateWith { name ->
-                    ModuleManager.getInstance(project).findModuleByName(name)
-                        ?.let { ModuleRootManager.getInstance(it).contentRoots.firstOrNull()?.toNioPathOrNull() }
-                }
-            }
-
-            // Register unique (erlang, elixir) install-path combinations once each.
-            // Deduplication key = resolved elixir install path (post Linux→UNC conversion)
-            // so that multiple modules sharing the same mise config register the SDK only once.
-            val elixirSdkByInstallPath = mutableMapOf<String, Sdk>()
-
-            for ((moduleName, miseVersions) in miseAssignments) {
-                val elixirEntry = miseVersions.elixir ?: continue
-                val contentRoot = contentRootByModule[moduleName]
-                val resolvedElixirPath = resolveInstallPathForWsl(elixirEntry.installPath, contentRoot)
-                if (resolvedElixirPath in elixirSdkByInstallPath) continue
-
-                val erlangSdk = miseVersions.erlang?.let { erlang ->
-                    LOG.trace("configureSdkFromMise: registering Erlang SDK at '${erlang.installPath}'")
-                    SdkRegistrar.registerOrUpdateErlangSdk(erlang.installPath)
-                }
-                LOG.trace("configureSdkFromMise: registering Elixir SDK at '$resolvedElixirPath' (erlang='${erlangSdk?.name}')")
-                val elixirSdk = SdkRegistrar.registerOrUpdateElixirSdk(
-                    homePath = resolvedElixirPath,
-                    erlangSdk = erlangSdk,
-                    project = project,
-                )
-                if (elixirSdk == null) {
-                    LOG.warn("configureSdkFromMise: registerOrUpdateElixirSdk returned null for path '$resolvedElixirPath'")
-                    continue
-                }
-                LOG.trace("configureSdkFromMise: registered Elixir SDK '${elixirSdk.name}' for path '$resolvedElixirPath'")
-                elixirSdkByInstallPath[resolvedElixirPath] = elixirSdk
-            }
-
-            LOG.trace("configureSdkFromMise: elixirSdkByInstallPath keys=${elixirSdkByInstallPath.keys}")
-            if (elixirSdkByInstallPath.isEmpty()) {
-                LOG.warn("configureSdkFromMise: no SDKs registered, skipping module assignment")
-                return@runWithModalProgressBlocking
-            }
-
-            // Assign per-module SDKs in a single write action.
-            edtWriteAction {
-                for ((moduleName, miseVersions) in miseAssignments) {
-                    val elixirEntry = miseVersions.elixir ?: run {
-                        LOG.trace("configureSdkFromMise: skipping '$moduleName' - no elixir entry in miseVersions")
-                        continue
-                    }
-                    val elixirSdk = elixirSdkByInstallPath[elixirEntry.installPath] ?: run {
-                        LOG.warn("configureSdkFromMise: SDK not found in elixirSdkByInstallPath for installPath='${elixirEntry.installPath}' (module='$moduleName')")
-                        continue
-                    }
-                    val module = ModuleManager.getInstance(project).findModuleByName(moduleName)
-                        ?.takeIf { !it.isDisposed } ?: run {
-                        LOG.warn("configureSdkFromMise: module '$moduleName' not found or disposed")
-                        continue
-                    }
-
-                    LOG.trace("configureSdkFromMise: assigning SDK '${elixirSdk.name}' to module '$moduleName'")
-                    val modifiableModel = ModuleRootManager.getInstance(module).modifiableModel
-                    var committed = false
-                    try {
-                        modifiableModel.sdk = elixirSdk
-                        modifiableModel.commit()
-                        committed = true
-                        LOG.trace("configureSdkFromMise: committed SDK '${elixirSdk.name}' to module '$moduleName'")
-                    } catch (ex: Exception) {
-                        LOG.warn("configureSdkFromMise: failed to commit SDK '${elixirSdk.name}' to module '$moduleName'", ex)
-                    } finally {
-                        if (!committed) modifiableModel.dispose()
-                    }
-                }
-            }
-
-            EditorNotifications.getInstance(project).updateAllNotifications()
-        }
-    }
-
-    /**
-     * Converts a Linux absolute path (e.g. `/home/user/.local/share/mise/installs/elixir/1.11.3`)
-     * to the Windows UNC form expected by [SdkRegistrar] and `wslCompat`
-     * (e.g. `\\wsl.localhost\Ubuntu\home\user\.local\share\mise\installs\elixir\1.11.3`).
-     *
-     * The WSL distribution is inferred from [contentRoot], which must be a Windows UNC path for
-     * a WSL filesystem (e.g. `\\wsl.localhost\Ubuntu\home\user\workspace\intelliconnect`).
-     *
-     * Returns [installPath] unchanged when:
-     * - it is not a Linux absolute path (does not start with `/`),
-     * - [contentRoot] is null,
-     * - [contentRoot] is not a WSL UNC path, or
-     * - the distribution cannot be resolved or the conversion fails.
-     */
-    private fun resolveInstallPathForWsl(installPath: String, contentRoot: Path?): String {
-        if (!installPath.startsWith("/")) return installPath
-        val contentRootStr = contentRoot?.toString() ?: return installPath
-        if (!wslCompat.isWslUncPath(contentRootStr)) return installPath
-        val distribution = wslCompat.getDistributionByWindowsUncPath(contentRootStr) ?: return installPath
-        return wslCompat.convertLinuxPathToWindowsUnc(distribution, installPath) ?: installPath
-    }
-
-    /**
-     * Warns when the configured Elixir SDK version differs from the version mise resolves for
-     * the module directory, or when the Internal Erlang SDK OTP major release differs from the
-     * OTP major in the mise-resolved erlang version.
-     *
-     * Runs `mise ls --local --json` (a subprocess) for each module. Must NOT be called inside a
-     * read lock - use [collectModuleMiseCheckData] first to extract what you need, then call this.
-     */
-    private fun detectMiseSdkMismatchIssues(
-        moduleDataList: List<ModuleMiseCheckData>,
-        elixirVersionBySdk: Map<Sdk, String?>,
-        miseByContentRoot: Map<Path, MiseVersions?>,
-        erlangOtpMajorByHomePath: Map<String, String?>,
-        elixirVersionByInstallPath: Map<String, String?>,
-    ): List<ModuleSdkIssue> {
-        val issues = mutableListOf<ModuleSdkIssue>()
-
-        for (data in moduleDataList) {
-            val contentRoot = data.contentRoot ?: run {
-                LOG.trace("detectMiseSdkMismatchIssues: module='${data.moduleName}' skipped - no content root")
-                continue
-            }
-            val miseVersions = miseByContentRoot[contentRoot] ?: run {
-                LOG.trace("detectMiseSdkMismatchIssues: module='${data.moduleName}' skipped - no mise result for contentRoot=$contentRoot")
-                continue
-            }
-
-            // Elixir version mismatch: configured SDK vs mise-resolved version
-            val miseElixir = miseVersions.elixir
-            if (miseElixir != null) {
-                val configuredVersion = data.elixirSdk?.let { elixirVersionBySdk[it] }
-                // Use the canonical version read from elixir.app in the mise install directory.
-                // This is the same source as the SDK version, so both sides are bare strings
-                // (e.g. "1.15.7") with no OTP suffix manipulation.
-                val miseVersion = elixirVersionByInstallPath[miseElixir.installPath]
-                LOG.trace(
-                    "detectMiseSdkMismatchIssues: module='${data.moduleName}' " +
-                            "configuredVersion=$configuredVersion miseVersion=$miseVersion " +
-                            "miseInstallPath=${miseElixir.installPath}"
-                )
-                if (configuredVersion != null && miseVersion != null && configuredVersion != miseVersion) {
-                    LOG.info(
-                        "Mise version mismatch in module '${data.moduleName}': " +
-                                "SDK=$configuredVersion, mise=$miseVersion"
-                    )
-                    issues.add(
-                        ModuleSdkIssue(
-                            moduleName = data.moduleName,
-                            issue = "Module '${data.moduleName}' uses Elixir $configuredVersion " +
-                                    "but mise resolves ${miseElixir.version}. " +
-                                    "Run 'Refresh Active Elixir SDKs' or reconfigure.",
-                            isDangling = false,
-                        )
-                    )
-                }
-            }
-
-            // OTP version mismatch: Internal Erlang SDK vs mise-resolved erlang
-            val miseErlang = miseVersions.erlang
-            val erlangOtpMajor = data.erlangSdkHomePath?.let { erlangOtpMajorByHomePath[it] }
-            if (miseErlang != null && erlangOtpMajor != null) {
-                val miseErlangMajor = miseErlang.version.substringBefore(".")
-                if (miseErlangMajor != erlangOtpMajor) {
-                    LOG.info(
-                        "Mise OTP mismatch in module '${data.moduleName}': " +
-                                "SDK OTP=$erlangOtpMajor, mise=${miseErlang.version}"
-                    )
-                    issues.add(
-                        ModuleSdkIssue(
-                            moduleName = data.moduleName,
-                            issue = "Internal Erlang SDK OTP $erlangOtpMajor does not " +
-                                    "match mise (${miseErlang.version}). " +
-                                    "Run 'Refresh Active Elixir SDKs' or reconfigure.",
-                            isDangling = false,
-                        )
-                    )
-                }
-            }
-        }
-
+    private fun detectClasspathIssues(snapshot: ProjectSdkSnapshot): List<String> {
+        val elixirSdk = snapshot.elixirSdk ?: return emptyList()
+        val erlangSdk = snapshot.erlangSdk ?: return emptyList()
+        val issues = mutableListOf<String>()
+        if (hasEbinPathIssues(elixirSdk)) issues.add("Missing Elixir ebin paths or classpath entries")
+        if (hasErlangSdkIssues(erlangSdk)) issues.add("Erlang SDK configuration issues")
+        if (!ElixirSdkValidation.hasErlangClasspathInElixirSdk(elixirSdk, erlangSdk))
+            issues.add("Erlang SDK classpath entries missing - reopen SDK settings to fix")
         return issues
     }
 
@@ -1204,56 +916,70 @@ class ElixirEditorBasedSdkWidget(
         return sdkType.isValidSdkHome(homePath)
     }
 
-    private fun getErlangSdk(elixirSdk: Sdk): Sdk? {
-        val additionalData = elixirSdk.sdkAdditionalData as? SdkAdditionalData
-        return additionalData?.getErlangSdk()
-    }
+    private fun getErlangSdk(elixirSdk: Sdk): Sdk? =
+        (elixirSdk.sdkAdditionalData as? SdkAdditionalData)?.getErlangSdk()
 
     private fun hasEbinPathIssues(elixirSdk: Sdk): Boolean {
         val homePath = elixirSdk.homePath ?: return true
-
         // Check if Elixir SDK has proper ebin paths in lib directory
-        if (!SdkEbinPaths.hasEbinPath(homePath)) {
-            return true
-        }
-
+        if (!SdkEbinPaths.hasEbinPath(homePath)) return true
         // Check if SDK has proper classpath roots configured
-        val classRoots = elixirSdk.rootProvider.getFiles(com.intellij.openapi.roots.OrderRootType.CLASSES)
-        return classRoots.isEmpty()
+        return elixirSdk.rootProvider.getFiles(com.intellij.openapi.roots.OrderRootType.CLASSES).isEmpty()
     }
 
     private fun hasErlangSdkIssues(erlangSdk: Sdk): Boolean {
         val homePath = erlangSdk.homePath ?: return true
-
         // Check if Erlang SDK has proper ebin paths
-        if (!SdkEbinPaths.hasEbinPath(homePath)) {
-            return true
-        }
-
+        if (!SdkEbinPaths.hasEbinPath(homePath)) return true
         // Validate that this is a proper Erlang SDK type
         return !org.elixir_lang.sdk.erlang_dependent.Type.staticIsValidDependency(erlangSdk)
     }
 
-    private fun createAddSdkAction(): AnAction {
-        return object : AnAction("Configure Elixir SDKs...", "", AllIcons.General.Add) {
-            override fun actionPerformed(e: AnActionEvent) {
-                SdkSettingsOpener.getInstance().open(e)
-            }
+    // -------------------------------------------------------------------------
+    // UI helpers
+    // -------------------------------------------------------------------------
 
+    private fun createAddSdkAction(): AnAction =
+        object : AnAction("Configure Elixir SDKs...", "", AllIcons.General.Add) {
+            override fun actionPerformed(e: AnActionEvent) { SdkSettingsOpener.getInstance().open(e) }
             override fun getActionUpdateThread(): ActionUpdateThread = ActionUpdateThread.BGT
-
             override fun update(e: AnActionEvent) {
                 val isConfigured = findModuleLevelElixirSdk() != null
-                val text = if (isConfigured) "Configure Elixir SDKs..." else "Add Elixir SDK..."
                 val targetName = SdkSettingsOpener.getInstance().targetName()
-                val description = if (isConfigured) {
+                e.presentation.text = if (isConfigured) "Configure Elixir SDKs..." else "Add Elixir SDK..."
+                e.presentation.description = if (isConfigured)
                     "Configure Elixir SDKs in $targetName"
-                } else {
+                else
                     "Open $targetName to add an Elixir SDK"
-                }
-                e.presentation.text = text
-                e.presentation.description = description
             }
+        }
+
+    private fun buildSdkVersionTableHtml(table: SdkVersionTable): String {
+        val okColor   = ColorUtil.toHtmlColor(JBColor(0x388A34, 0x499C54))
+        val warnColor = ColorUtil.toHtmlColor(JBColor(0xBB8522, 0xC89B3C))
+        return buildString {
+            append("<table>")
+            append("<tr><td></td><td></td><td><b>SDK</b></td><td><b>${table.toolManagerName}</b></td></tr>")
+            for (row in table.rows) {
+                val configured = row.configuredVersion ?: "-"
+                val tm = row.toolManagerVersion ?: "-"
+                if (row.isMismatch) {
+                    append("<tr>")
+                    append("<td><font color=\"$warnColor\">&#x26A0;</font></td>")
+                    append("<td><b>${row.label}:</b></td>")
+                    append("<td><b>$configured</b></td>")
+                    append("<td><b>$tm</b></td>")
+                    append("</tr>")
+                } else {
+                    append("<tr>")
+                    append("<td><font color=\"$okColor\">&#x2713;</font></td>")
+                    append("<td>${row.label}:</td>")
+                    append("<td>$configured</td>")
+                    append("<td>$tm</td>")
+                    append("</tr>")
+                }
+            }
+            append("</table>")
         }
     }
 

--- a/src/org/elixir_lang/status_bar_widget/ElixirEditorBasedSdkWidget.kt
+++ b/src/org/elixir_lang/status_bar_widget/ElixirEditorBasedSdkWidget.kt
@@ -23,9 +23,6 @@ import com.intellij.openapi.ui.popup.ListPopup
 import com.intellij.openapi.util.Disposer
 import com.intellij.openapi.util.text.StringUtil
 import com.intellij.openapi.vfs.VirtualFile
-import com.intellij.openapi.vfs.VirtualFileManager
-import com.intellij.openapi.vfs.newvfs.BulkFileListener
-import com.intellij.openapi.vfs.newvfs.events.VFileEvent
 import com.intellij.openapi.wm.StatusBarWidget
 import com.intellij.openapi.wm.impl.status.EditorBasedStatusBarPopup
 import com.intellij.ui.ColorUtil
@@ -56,6 +53,7 @@ import org.elixir_lang.sdk.wsl.wslCompat
 import org.elixir_lang.tool_manager.allBuiltInToolManagers
 import org.elixir_lang.tool_manager.ModuleSdkIssue
 import org.elixir_lang.tool_manager.SdkVersionTable
+import org.elixir_lang.tool_manager.ToolManagerResult
 import org.elixir_lang.tool_manager.ToolManagerSettings
 import org.elixir_lang.tool_manager.ToolManagerSdkChecker
 import org.elixir_lang.tool_manager.ToolManagerVersions
@@ -233,7 +231,7 @@ class ElixirEditorBasedSdkWidget(
 
                     val (tmIssues, sdkVersionTables) = checker.detectMismatchIssues(
                         moduleCheckData = modelData.moduleCheckData,
-                        toolManagerVersionsByRoot = ioData.toolManagerVersionsByRoot,
+                        toolManagerResultsByRoot = ioData.toolManagerResultsByRoot,
                         elixirVersionBySdk = ioData.elixirVersionBySdk,
                         erlangReleaseByHomePath = ioData.erlangReleaseByHomePath,
                         elixirVersionByInstallPath = ioData.elixirVersionByInstallPath,
@@ -243,7 +241,7 @@ class ElixirEditorBasedSdkWidget(
                     // installed elixir entry, regardless of whether they already have an SDK.
                     val tmAssignments = checker.buildAssignments(
                         moduleCheckData = modelData.moduleCheckData,
-                        toolManagerVersionsByRoot = ioData.toolManagerVersionsByRoot,
+                        toolManagerResultsByRoot = ioData.toolManagerResultsByRoot,
                     )
                     notifyIfNeeded(
                         moduleSdkIssues = modelData.moduleSdkIssues + tmIssues,
@@ -254,6 +252,7 @@ class ElixirEditorBasedSdkWidget(
                         elixirVersionByInstallPath = ioData.elixirVersionByInstallPath,
                         projectSdkOtpMismatch = ioData.projectSdkOtpMismatch,
                         sdkVersionTables = sdkVersionTables,
+                        toolManagerErrors = ioData.toolManagerErrors,
                     )
                 }
         }
@@ -439,12 +438,13 @@ class ElixirEditorBasedSdkWidget(
     )
 
     private data class NotificationScanIoData(
-        val toolManagerVersionsByRoot: Map<Path, ToolManagerVersions?>,
+        val toolManagerResultsByRoot: Map<Path, ToolManagerResult?>,
         val elixirVersionBySdk: Map<Sdk, String?>,
         val erlangReleaseByHomePath: Map<String, org.elixir_lang.sdk.erlang.Release?>,
         val projectSdkOtpMismatch: Pair<String, String>?,
         val elixirVersionByInstallPath: Map<String, String?>,
         val classpathIssues: List<String>,
+        val toolManagerErrors: List<ToolManagerResult.Error>,
     )
 
     @RequiresReadLock
@@ -481,8 +481,9 @@ class ElixirEditorBasedSdkWidget(
         val contentRoots = modelData.moduleCheckData.mapNotNull { it.contentRoot }.distinct()
         LOG.trace("collectNotificationScanIoData: ${contentRoots.size} content root(s): $contentRoots")
 
-        val toolManagerVersionsByRoot = checker.resolveVersions(contentRoots)
-        val elixirVersionByInstallPath = checker.collectElixirVersionByInstallPath(toolManagerVersionsByRoot)
+        val toolManagerResultsByRoot = checker.resolveVersions(contentRoots)
+        val toolManagerErrors = checker.collectErrors(toolManagerResultsByRoot)
+        val elixirVersionByInstallPath = checker.collectElixirVersionByInstallPath(toolManagerResultsByRoot)
         val erlangReleaseByHomePath = checker.collectErlangReleaseByHomePath(modelData.moduleCheckData)
 
         val elixirVersionBySdk = modelData.moduleCheckData
@@ -497,12 +498,13 @@ class ElixirEditorBasedSdkWidget(
         val projectSdkOtpMismatch = modelData.projectSdkSnapshot.elixirSdk?.let { detectOtpMismatch(it) }
 
         return NotificationScanIoData(
-            toolManagerVersionsByRoot = toolManagerVersionsByRoot,
+            toolManagerResultsByRoot = toolManagerResultsByRoot,
             elixirVersionBySdk = elixirVersionBySdk,
             erlangReleaseByHomePath = erlangReleaseByHomePath,
             projectSdkOtpMismatch = projectSdkOtpMismatch,
             elixirVersionByInstallPath = elixirVersionByInstallPath,
             classpathIssues = detectClasspathIssues(modelData.projectSdkSnapshot),
+            toolManagerErrors = toolManagerErrors,
         )
     }
 
@@ -518,6 +520,8 @@ class ElixirEditorBasedSdkWidget(
          *  is no mismatch, when detection failed, or when the user suppressed warnings. */
         projectSdkOtpMismatch: Pair<String, String>? = null,
         sdkVersionTables: Map<String, SdkVersionTable> = emptyMap(),
+        /** Tool manager errors that prevented version resolution. */
+        toolManagerErrors: List<ToolManagerResult.Error> = emptyList(),
     ) {
         val elixirSdk = projectSdkSnapshot.elixirSdk
         val erlangSdk = projectSdkSnapshot.erlangSdk
@@ -536,6 +540,9 @@ class ElixirEditorBasedSdkWidget(
                 SdkStatus.NotConfiguredToolManagerAvailable(firstVersions, canonicalVersion)
             }
 
+            // No SDK and no tool-manager assignments.  If tool manager errors are present they
+            // likely prevented version resolution - treat as NotConfigured; the error descriptions
+            // are appended to the notification message below.
             elixirSdk == null ->
                 SdkStatus.NotConfigured
 
@@ -576,7 +583,17 @@ class ElixirEditorBasedSdkWidget(
 
         val (title, message, type) = buildNotificationContent(sdkStatus) ?: return
 
-        val notification = object : com.intellij.notification.Notification("Elixir SDK", title, message, type),
+        // Append tool-manager error descriptions when they prevented version resolution.
+        // Each concrete ElixirToolManager implementation provides a human-readable description
+        // and fix hint; the widget renders them verbatim without needing to know the error type.
+        val fullMessage = if (toolManagerErrors.isNotEmpty()) {
+            val errorLines = toolManagerErrors.joinToString("<br>") { "&#8226; [${it.toolManagerName}] ${it.description}" }
+            "$message<br><br><b>Tool manager errors:</b><br>$errorLines"
+        } else {
+            message
+        }
+
+        val notification = object : com.intellij.notification.Notification("Elixir SDK", title, fullMessage, type),
             NotificationFullContent {}
 
         // "Configure from <tool manager>" - for module SDK mismatches with a tool manager assignment.

--- a/src/org/elixir_lang/status_bar_widget/ElixirEditorBasedSdkWidget.kt
+++ b/src/org/elixir_lang/status_bar_widget/ElixirEditorBasedSdkWidget.kt
@@ -12,6 +12,7 @@ import com.intellij.openapi.module.ModuleManager
 import com.intellij.openapi.module.ModuleUtilCore
 import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.project.Project
+import com.intellij.workspaceModel.ide.JpsProjectLoadingManager
 import com.intellij.openapi.projectRoots.ProjectJdkTable
 import com.intellij.openapi.projectRoots.Sdk
 import com.intellij.openapi.roots.JdkOrderEntry
@@ -37,7 +38,6 @@ import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.debounce
-import kotlinx.coroutines.flow.onStart
 import org.elixir_lang.Facet
 import org.elixir_lang.Icons
 import org.elixir_lang.isElixirModule
@@ -180,17 +180,40 @@ class ElixirEditorBasedSdkWidget(
     )
 
     init {
-        // Cancel the notification scan collector when this widget instance is disposed.
-        // This mirrors the semantics of the platform's own debounce collector in
-        // EditorBasedStatusBarPopup (which uses @Internal cancelOnDispose).  Without this,
-        // multiframe widget instances would leave behind active collectors until project close.
+        // Trigger the initial notification scan only after the JPS project model sync completes.
+        //
+        // At startup the platform loads the workspace model from a cache, then runs the
+        // `DelayedProjectSynchronizer` project activity which reads the actual .iml and
+        // jdk.table.xml files from disk and applies them to the workspace model.  This sync
+        // takes several seconds (WSL projects: 5–13 s).  Any SDK assignment we commit before
+        // the sync completes is overwritten when the sync applies the persisted .iml state.
+        //
+        // `JpsProjectLoadingManager.jpsProjectLoaded` fires immediately if the JPS model is
+        // already loaded, or after `DelayedProjectSynchronizer` finishes otherwise.  This
+        // guarantees the workspace model is stable (reflects the on-disk .iml) before we show
+        // the notification or let the user click an action.
+        //
+        // `JpsProjectLoadingManager` is @ApiStatus.Internal + @Deprecated in favour of
+        // `WorkspaceModelInternal.awaitSynchronizationWithJpsModel`.  We cannot use the
+        // replacement because it is both @ApiStatus.Experimental *and* absent from the 2025.3
+        // platform (verified: not present in tag idea/253.28294.334).  Since pluginSinceBuild
+        // is 253, using it directly would throw NoSuchMethodError on 2025.3.
+        // JpsProjectLoadingManager works across all supported versions (253 through 261+)
+        // and is the documented mechanism for this use case ("add a missing SDK").
+        // The Python plugin (PySdkFromEnvironmentVariableConfigurator) uses it for the same
+        // purpose.
+        @Suppress("UnstableApiUsage", "DEPRECATION")
+        scope.launch {
+            suspendCancellableCoroutine<Unit> { cont ->
+                JpsProjectLoadingManager.getInstance(project).jpsProjectLoaded {
+                    cont.resumeWith(Result.success(Unit))
+                }
+            }
+            notificationScanRequests.tryEmit(Unit)
+        }
+
         val notificationScanJob = scope.launch {
             notificationScanRequests
-                // Emit a synthetic Unit on start so the initial scan fires ~500 ms after the
-                // coroutine starts (same debounce path as a rootsChanged event), without waiting
-                // for the first external trigger.  onStart { emit(Unit) } is safe here because
-                // we are already inside the subscribed collector, so the event is not dropped.
-                .onStart { emit(Unit) }
                 .debounce(500.milliseconds)  // slightly longer than widget debounce since notifications are less urgent
                 // Use `collect` (not `collectLatest`) deliberately: if events arrive while a scan
                 // is running, they queue in the debounce operator and trigger one follow-up scan
@@ -226,9 +249,10 @@ class ElixirEditorBasedSdkWidget(
                     )
                 }
         }
-        // Bind job lifecycle to widget disposal using only public Disposer API.
-        // When dispose() is called on this widget, the registered child cancels the job.
-        // When the job completes naturally, it disposes the child to avoid leaking Disposer entries.
+        // Cancel the notification scan collector when this widget instance is disposed.
+        // This mirrors the semantics of the platform's own debounce collector in
+        // EditorBasedStatusBarPopup (which uses @Internal cancelOnDispose).  Without this,
+        // multiframe widget instances would leave behind active collectors until project close.
         val jobDisposable = Disposer.newDisposable("ElixirEditorBasedSdkWidget.notificationScanJob")
         Disposer.register(this, jobDisposable)
         notificationScanJob.invokeOnCompletion { Disposer.dispose(jobDisposable) }

--- a/src/org/elixir_lang/status_bar_widget/ElixirEditorBasedSdkWidget.kt
+++ b/src/org/elixir_lang/status_bar_widget/ElixirEditorBasedSdkWidget.kt
@@ -49,16 +49,15 @@ import org.elixir_lang.sdk.elixir.SdkSettingsOpener
 import org.elixir_lang.sdk.elixir.Type
 import org.elixir_lang.sdk.elixir.sdk
 import org.elixir_lang.sdk.erlang_dependent.SdkAdditionalData
-import org.elixir_lang.sdk.wsl.wslCompat
-import org.elixir_lang.tool_manager.allBuiltInToolManagers
 import org.elixir_lang.tool_manager.ModuleSdkIssue
 import org.elixir_lang.tool_manager.SdkVersionTable
-import org.elixir_lang.tool_manager.ToolManagerResult
+import org.elixir_lang.tool_manager.ToolManagerAnalysisResult
+import org.elixir_lang.tool_manager.ToolManagerSdkAnalyser
+import org.elixir_lang.tool_manager.ToolManagerSdkCheckerService
 import org.elixir_lang.tool_manager.ToolManagerSettings
-import org.elixir_lang.tool_manager.ToolManagerSdkChecker
+import org.elixir_lang.tool_manager.ToolManagerSettingsListener
 import org.elixir_lang.tool_manager.ToolManagerVersions
 import org.elixir_lang.util.WriteActions
-import java.nio.file.Path
 import java.util.concurrent.CancellationException
 import kotlin.time.Duration.Companion.milliseconds
 
@@ -147,11 +146,11 @@ class ElixirEditorBasedSdkWidget(
         const val ID = "ElixirSdkStatus"
     }
 
-    private val checker = ToolManagerSdkChecker(
-        project = project,
-        toolManagers = allBuiltInToolManagers,
-        settings = ToolManagerSettings.getInstance(project),
-    )
+    // Latest tool-manager analysis result, updated whenever ToolManagerSdkAnalyser publishes.
+    // Null on small IDEs (where the analyser service is not registered) and before the first
+    // analysis completes on rich IDEs.
+    @Volatile
+    private var latestTmAnalysis: ToolManagerAnalysisResult? = null
 
     // Track last notified status to avoid spamming duplicate notifications
     @Volatile
@@ -217,6 +216,19 @@ class ElixirEditorBasedSdkWidget(
             notificationScanRequests.tryEmit(Unit)
         }
 
+        // Subscribe to tool-manager analysis results.  When the analyser publishes new results
+        // (after a scan completes or module SDKs change), cache them and trigger a notification
+        // scan so notifyIfNeeded() uses the latest TM data.
+        // On small IDEs the analyser service is absent; getInstanceIfRegistered returns null,
+        // so latestTmAnalysis stays null and notifyIfNeeded() skips all TM-specific logic.
+        ToolManagerSdkAnalyser.getInstanceIfRegistered(project)?.subscribeWithLatest(
+            parentDisposable = this,
+            onAnalysisCompleted = { result ->
+                latestTmAnalysis = result
+                notificationScanRequests.tryEmit(Unit)
+            }
+        )
+
         val notificationScanJob = scope.launch {
             notificationScanRequests
                 .debounce(500.milliseconds)  // slightly longer than widget debounce since notifications are less urgent
@@ -228,31 +240,15 @@ class ElixirEditorBasedSdkWidget(
                 .collect {
                     val modelData = readAction { collectNotificationScanModelData() }
                     val ioData = withContext(Dispatchers.IO) { collectNotificationScanIoData(modelData) }
+                    val tmAnalysis = latestTmAnalysis
 
-                    val (tmIssues, sdkVersionTables) = checker.detectMismatchIssues(
-                        moduleCheckData = modelData.moduleCheckData,
-                        toolManagerResultsByRoot = ioData.toolManagerResultsByRoot,
-                        elixirVersionBySdk = ioData.elixirVersionBySdk,
-                        erlangReleaseByHomePath = ioData.erlangReleaseByHomePath,
-                        elixirVersionByInstallPath = ioData.elixirVersionByInstallPath,
-                    )
-                    // Build per-module tool manager assignments: module name → the ToolManagerVersions that are
-                    // resolved for that module's own content root.  Covers all modules with an
-                    // installed elixir entry, regardless of whether they already have an SDK.
-                    val tmAssignments = checker.buildAssignments(
-                        moduleCheckData = modelData.moduleCheckData,
-                        toolManagerResultsByRoot = ioData.toolManagerResultsByRoot,
-                    )
                     notifyIfNeeded(
-                        moduleSdkIssues = modelData.moduleSdkIssues + tmIssues,
+                        moduleSdkIssues = modelData.moduleSdkIssues + (tmAnalysis?.tmIssues ?: emptyList()),
                         folderMarkIssues = modelData.folderMarkIssues,
-                        tmAssignments = tmAssignments,
+                        tmAnalysis = tmAnalysis,
                         projectSdkSnapshot = modelData.projectSdkSnapshot,
                         classpathIssues = ioData.classpathIssues,
-                        elixirVersionByInstallPath = ioData.elixirVersionByInstallPath,
                         projectSdkOtpMismatch = ioData.projectSdkOtpMismatch,
-                        sdkVersionTables = sdkVersionTables,
-                        toolManagerErrors = ioData.toolManagerErrors,
                     )
                 }
         }
@@ -356,6 +352,16 @@ class ElixirEditorBasedSdkWidget(
             update()
             notificationScanRequests.tryEmit(Unit)
         })
+
+        // Tool manager settings change (enable/disable a manager in Settings → Elixir → Tool Managers).
+        // The user explicitly changed which managers are active, so they must see the current state
+        // even if the overall SdkStatus category (e.g. NotConfigured) has not changed.  Without
+        // this reset the notification deduplication would suppress the updated message that includes
+        // tool-manager errors (e.g. "mise config not trusted") because the issue key is unchanged.
+        connection.subscribe(
+            ToolManagerSettings.SETTINGS_CHANGED_TOPIC,
+            ToolManagerSettingsListener { lastNotifiedIssueKey = null }
+        )
     }
 
     // -------------------------------------------------------------------------
@@ -433,31 +439,23 @@ class ElixirEditorBasedSdkWidget(
     private data class NotificationScanModelData(
         val moduleSdkIssues: List<ModuleSdkIssue>,
         val folderMarkIssues: List<FolderMarkIssue>,
-        val moduleCheckData: List<ToolManagerSdkChecker.ModuleCheckData>,
         val projectSdkSnapshot: ProjectSdkSnapshot,
     )
 
     private data class NotificationScanIoData(
-        val toolManagerResultsByRoot: Map<Path, ToolManagerResult?>,
-        val elixirVersionBySdk: Map<Sdk, String?>,
-        val erlangReleaseByHomePath: Map<String, org.elixir_lang.sdk.erlang.Release?>,
         val projectSdkOtpMismatch: Pair<String, String>?,
-        val elixirVersionByInstallPath: Map<String, String?>,
         val classpathIssues: List<String>,
-        val toolManagerErrors: List<ToolManagerResult.Error>,
     )
 
     @RequiresReadLock
     private fun collectNotificationScanModelData(): NotificationScanModelData {
         val moduleSdkIssues = detectModuleSdkIssues()
         val folderMarkIssues = ProjectModuleSetupValidator.detectFolderMarkIssues(project)
-        val moduleCheckData = checker.collectModuleCheckData()
         val projectSdkSnapshot = collectProjectSdkSnapshot()
 
         return NotificationScanModelData(
             moduleSdkIssues = moduleSdkIssues,
             folderMarkIssues = folderMarkIssues,
-            moduleCheckData = moduleCheckData,
             projectSdkSnapshot = projectSdkSnapshot,
         )
     }
@@ -478,54 +476,33 @@ class ElixirEditorBasedSdkWidget(
     }
 
     private fun collectNotificationScanIoData(modelData: NotificationScanModelData): NotificationScanIoData {
-        val contentRoots = modelData.moduleCheckData.mapNotNull { it.contentRoot }.distinct()
-        LOG.trace("collectNotificationScanIoData: ${contentRoots.size} content root(s): $contentRoots")
-
-        val toolManagerResultsByRoot = checker.resolveVersions(contentRoots)
-        val toolManagerErrors = checker.collectErrors(toolManagerResultsByRoot)
-        val elixirVersionByInstallPath = checker.collectElixirVersionByInstallPath(toolManagerResultsByRoot)
-        val erlangReleaseByHomePath = checker.collectErlangReleaseByHomePath(modelData.moduleCheckData)
-
-        val elixirVersionBySdk = modelData.moduleCheckData
-            .mapNotNull { it.elixirSdk }
-            .distinct()
-            .associateWith { sdk ->
-                Type.canonicalVersion(sdk).also { v ->
-                    LOG.trace("collectNotificationScanIoData: canonicalVersion('${sdk.name}') = $v")
-                }
-            }
-
-        val projectSdkOtpMismatch = modelData.projectSdkSnapshot.elixirSdk?.let { detectOtpMismatch(it) }
-
+        val snapshot = modelData.projectSdkSnapshot
+        val projectSdkOtpMismatch = snapshot.elixirSdk?.let { detectOtpMismatch(it) }
         return NotificationScanIoData(
-            toolManagerResultsByRoot = toolManagerResultsByRoot,
-            elixirVersionBySdk = elixirVersionBySdk,
-            erlangReleaseByHomePath = erlangReleaseByHomePath,
             projectSdkOtpMismatch = projectSdkOtpMismatch,
-            elixirVersionByInstallPath = elixirVersionByInstallPath,
-            classpathIssues = detectClasspathIssues(modelData.projectSdkSnapshot),
-            toolManagerErrors = toolManagerErrors,
+            classpathIssues = detectClasspathIssues(snapshot),
         )
     }
 
     private fun notifyIfNeeded(
         moduleSdkIssues: List<ModuleSdkIssue>,
         folderMarkIssues: List<FolderMarkIssue>,
-        /** Per-module tool-manager assignments: module name → ToolManagerVersions for that module's content root. */
-        tmAssignments: Map<String, ToolManagerVersions> = emptyMap(),
+        /** Tool-manager analysis result from [ToolManagerSdkAnalyser], or null if unavailable. */
+        tmAnalysis: ToolManagerAnalysisResult? = null,
         projectSdkSnapshot: ProjectSdkSnapshot,
         classpathIssues: List<String>,
-        elixirVersionByInstallPath: Map<String, String?> = emptyMap(),
         /** Pre-computed OTP mismatch for the project's primary Elixir SDK, or `null` when there
          *  is no mismatch, when detection failed, or when the user suppressed warnings. */
         projectSdkOtpMismatch: Pair<String, String>? = null,
-        sdkVersionTables: Map<String, SdkVersionTable> = emptyMap(),
-        /** Tool manager errors that prevented version resolution. */
-        toolManagerErrors: List<ToolManagerResult.Error> = emptyList(),
     ) {
         val elixirSdk = projectSdkSnapshot.elixirSdk
         val erlangSdk = projectSdkSnapshot.erlangSdk
         val elixirVersion = projectSdkSnapshot.elixirVersion ?: "Unknown"
+
+        val tmAssignments = tmAnalysis?.tmAssignments ?: emptyMap()
+        val sdkVersionTables = tmAnalysis?.sdkVersionTables ?: emptyMap()
+        val toolManagerErrors = tmAnalysis?.toolManagerErrors ?: emptyList()
+        val elixirVersionByInstallPath = tmAnalysis?.elixirVersionByInstallPath ?: emptyMap()
 
         val sdkStatus: SdkStatus = when {
             moduleSdkIssues.isNotEmpty() ->
@@ -613,7 +590,8 @@ class ElixirEditorBasedSdkWidget(
                         notification.expire()
                         lastNotifiedIssueKey = null
                         activeNotification = null
-                        checker.configureSdks(relevantAssignments)
+                        project.getServiceIfCreated(ToolManagerSdkCheckerService::class.java)
+                            ?.configureSdks(relevantAssignments)
                     }
                 })
             }
@@ -642,7 +620,8 @@ class ElixirEditorBasedSdkWidget(
             notification.addAction(object : AnAction("Configure from $toolName") {
                 override fun actionPerformed(e: AnActionEvent) {
                     notification.expire()
-                    checker.configureSdks(tmAssignments)
+                    project.getServiceIfCreated(ToolManagerSdkCheckerService::class.java)
+                        ?.configureSdks(tmAssignments)
                 }
             })
         }
@@ -851,7 +830,6 @@ class ElixirEditorBasedSdkWidget(
      * [ModuleRootManager] which requires read access; the caller must either hold a read lock
      * or call this inside a `readAction { }` block.
      */
-    @RequiresReadLock
     @RequiresBackgroundThread
     internal fun detectModuleSdkIssues(): List<ModuleSdkIssue> {
         ThreadingAssertions.assertBackgroundThread()

--- a/src/org/elixir_lang/tool_manager/ElixirToolManager.kt
+++ b/src/org/elixir_lang/tool_manager/ElixirToolManager.kt
@@ -35,4 +35,17 @@ interface ElixirToolManager {
      * Returns [ToolManagerResult.Success] when versions are successfully resolved.
      */
     fun resolveVersions(contentRoot: Path): ToolManagerResult?
+
+    /**
+     * Returns a [ToolManagerRefreshTrigger] that can detect when this tool manager's
+     * configuration has changed and a re-scan should occur, or `null` if this manager
+     * does not support automatic change detection.
+     *
+     * Called once per scan cycle to obtain a fresh trigger (so dynamically discovered watch
+     * targets stay up to date).  The default implementation returns `null`.
+     *
+     * The returned trigger's [ToolManagerRefreshTrigger.install] method is called on a
+     * background IO thread immediately after the scan completes.
+     */
+    fun createRefreshTrigger(): ToolManagerRefreshTrigger? = null
 }

--- a/src/org/elixir_lang/tool_manager/ElixirToolManager.kt
+++ b/src/org/elixir_lang/tool_manager/ElixirToolManager.kt
@@ -1,0 +1,33 @@
+package org.elixir_lang.tool_manager
+
+import java.nio.file.Path
+
+/**
+ * A tool manager that can resolve installed Elixir/Erlang versions for a project directory.
+ *
+ * Implementations (mise, asdf, …) must:
+ * - Return `null` from [resolveVersions] whenever the tool manager is not active for the given
+ *   directory (not installed, no config file, subprocess failure, etc.).  This is the normal
+ *   "not applicable" signal - callers do not distinguish "not installed" from "no config file".
+ * - Be stateless with respect to the project; all context is provided through [resolveVersions].
+ *
+ * [name] is the **stable persistence key** written to `elixir.xml` via [ToolManagerSettings].
+ * Do not change it after the first release that ships this tool manager.
+ */
+interface ElixirToolManager {
+    /** Stable persistence key. Used by [ToolManagerSettings] and as a fallback display label. */
+    val name: String
+
+    /** Human-readable label shown in the Settings UI (may be localised in the future). */
+    val displayName: String
+
+    /**
+     * Resolves tool versions for [contentRoot] by querying the tool manager.
+     *
+     * **Threading**: must NOT be called on the EDT or under a read lock - implementations
+     * may spawn subprocesses or perform file I/O. Call only from [kotlinx.coroutines.Dispatchers.IO].
+     *
+     * Returns `null` if this tool manager is not applicable for [contentRoot].
+     */
+    fun resolveVersions(contentRoot: Path): ToolManagerVersions?
+}

--- a/src/org/elixir_lang/tool_manager/ElixirToolManager.kt
+++ b/src/org/elixir_lang/tool_manager/ElixirToolManager.kt
@@ -6,9 +6,12 @@ import java.nio.file.Path
  * A tool manager that can resolve installed Elixir/Erlang versions for a project directory.
  *
  * Implementations (mise, asdf, …) must:
- * - Return `null` from [resolveVersions] whenever the tool manager is not active for the given
- *   directory (not installed, no config file, subprocess failure, etc.).  This is the normal
- *   "not applicable" signal - callers do not distinguish "not installed" from "no config file".
+ * - Return `null` from [resolveVersions] when the manager is not applicable for the given
+ *   directory (not installed, no config file, transient subprocess failure, etc.).
+ * - Return [ToolManagerResult.Error] when the manager is applicable but encountered an
+ *   actionable error.  The implementation is responsible for providing a human-readable
+ *   [ToolManagerResult.Error.description] that explains the problem and how to fix it.
+ * - Return [ToolManagerResult.Success] when versions were successfully resolved.
  * - Be stateless with respect to the project; all context is provided through [resolveVersions].
  *
  * [name] is the **stable persistence key** written to `elixir.xml` via [ToolManagerSettings].
@@ -28,6 +31,8 @@ interface ElixirToolManager {
      * may spawn subprocesses or perform file I/O. Call only from [kotlinx.coroutines.Dispatchers.IO].
      *
      * Returns `null` if this tool manager is not applicable for [contentRoot].
+     * Returns [ToolManagerResult.Error] when applicable but an actionable error occurred.
+     * Returns [ToolManagerResult.Success] when versions are successfully resolved.
      */
-    fun resolveVersions(contentRoot: Path): ToolManagerVersions?
+    fun resolveVersions(contentRoot: Path): ToolManagerResult?
 }

--- a/src/org/elixir_lang/tool_manager/ModuleSdkIssue.kt
+++ b/src/org/elixir_lang/tool_manager/ModuleSdkIssue.kt
@@ -1,0 +1,22 @@
+package org.elixir_lang.tool_manager
+
+/**
+ * A per-module SDK issue detected during the project-wide notification scan.
+ *
+ * Produced by both:
+ * - [ToolManagerSdkChecker.detectMismatchIssues] - tool-manager version mismatches.
+ * - `ElixirEditorBasedSdkWidget.detectModuleSdkIssues` - dangling SDK references and
+ *   module/project SDK disagreements (not tool-manager-specific).
+ *
+ * @param moduleName  IntelliJ module name.
+ * @param issue       Human-readable description of the problem (used in log output and
+ *                    as a fallback in multi-module notification text).
+ * @param isDangling  `true` when the module references an SDK name that no longer exists
+ *                    in the JDK table.  Dangling issues are displayed differently
+ *                    (error level, navigation hint) compared to version mismatches.
+ */
+data class ModuleSdkIssue(
+    val moduleName: String,
+    val issue: String,
+    val isDangling: Boolean,
+)

--- a/src/org/elixir_lang/tool_manager/SdkVersionTable.kt
+++ b/src/org/elixir_lang/tool_manager/SdkVersionTable.kt
@@ -1,0 +1,32 @@
+package org.elixir_lang.tool_manager
+
+/**
+ * A single row in an [SdkVersionTable], comparing the configured SDK version against the
+ * version a tool manager reports for the same module root.
+ *
+ * @param label             Display name for the tool, e.g. `"Elixir"` or `"Erlang"`.
+ * @param configuredVersion Version currently configured in the IDE SDK, or `null` if no SDK is set.
+ * @param toolManagerVersion Version reported by the tool manager, or `null` if unavailable.
+ * @param isMismatch        `true` when the two versions differ and a warning should be surfaced.
+ */
+data class SdkVersionRow(
+    val label: String,
+    val configuredVersion: String?,
+    val toolManagerVersion: String?,
+    val isMismatch: Boolean,
+)
+
+/**
+ * A per-module comparison table produced by [ToolManagerSdkChecker.detectMismatchIssues].
+ * Contains one [SdkVersionRow] for every tool (Elixir, Erlang) that the tool manager reported,
+ * including rows where the versions match (so the notification table shows the full picture).
+ *
+ * @param moduleName       Name of the IntelliJ module this table belongs to.
+ * @param toolManagerName  Stable name of the tool manager that produced this table (e.g. `"mise"`).
+ * @param rows             Comparison rows; at least one has [SdkVersionRow.isMismatch] == `true`.
+ */
+data class SdkVersionTable(
+    val moduleName: String,
+    val toolManagerName: String,
+    val rows: List<SdkVersionRow>,
+)

--- a/src/org/elixir_lang/tool_manager/ToolEntry.kt
+++ b/src/org/elixir_lang/tool_manager/ToolEntry.kt
@@ -1,0 +1,14 @@
+package org.elixir_lang.tool_manager
+
+/**
+ * A single tool version entry as resolved by a tool manager (mise, asdf, etc.).
+ *
+ * @param version      The version string as reported by the tool manager (e.g. `"1.17.3-otp-27"`).
+ * @param installPath  Absolute path to the tool manager's local install directory for this version.
+ * @param installed    Whether the tool is actually installed (vs. just configured but not downloaded).
+ */
+data class ToolEntry(
+    val version: String,
+    val installPath: String,
+    val installed: Boolean,
+)

--- a/src/org/elixir_lang/tool_manager/ToolManagerAnalysisResult.kt
+++ b/src/org/elixir_lang/tool_manager/ToolManagerAnalysisResult.kt
@@ -1,0 +1,48 @@
+package org.elixir_lang.tool_manager
+
+import java.nio.file.Path
+
+/**
+ * Listener notified when a new raw tool-manager scan completes.
+ * Published by [ToolManagerSdkCheckerService] on [ToolManagerSdkCheckerService.SCAN_TOPIC].
+ */
+fun interface ToolManagerScanListener {
+    /** Called with the raw scan results keyed by content root. */
+    fun scanCompleted(results: Map<Path, ToolManagerResult?>)
+}
+
+/**
+ * The fully-analysed output of a tool-manager scan cycle, ready for UI consumers.
+ *
+ * Produced by [ToolManagerSdkAnalyser] by comparing raw scan results against the currently
+ * configured module SDKs.  Published on [ToolManagerSdkAnalyser.ANALYSIS_TOPIC].
+ *
+ * All fields are immutable snapshots at the time of analysis - safe to consume from any thread.
+ *
+ * @param tmIssues                   Per-module version-mismatch issues for inclusion in
+ *                                   notification messages.
+ * @param tmAssignments              Module name → [ToolManagerVersions] for every module that
+ *                                   has an *installed* Elixir entry; used to populate the
+ *                                   "Configure from <tool manager>" action.
+ * @param sdkVersionTables           Per-module version comparison tables for rich notification
+ *                                   HTML rendering.
+ * @param toolManagerErrors          Actionable tool-manager errors (e.g. untrusted mise config)
+ *                                   that prevented version resolution.
+ * @param elixirVersionByInstallPath Canonical Elixir version (from `elixir.app`) per install
+ *                                   path; used to display the version in notification messages.
+ */
+data class ToolManagerAnalysisResult(
+    val tmIssues: List<ModuleSdkIssue>,
+    val tmAssignments: Map<String, ToolManagerVersions>,
+    val sdkVersionTables: Map<String, SdkVersionTable>,
+    val toolManagerErrors: List<ToolManagerResult.Error>,
+    val elixirVersionByInstallPath: Map<String, String?>,
+)
+
+/**
+ * Listener notified when a completed [ToolManagerAnalysisResult] is available.
+ * Published by [ToolManagerSdkAnalyser] on [ToolManagerSdkAnalyser.ANALYSIS_TOPIC].
+ */
+fun interface ToolManagerAnalysisListener {
+    fun analysisCompleted(result: ToolManagerAnalysisResult)
+}

--- a/src/org/elixir_lang/tool_manager/ToolManagerConfigurable.kt
+++ b/src/org/elixir_lang/tool_manager/ToolManagerConfigurable.kt
@@ -1,0 +1,67 @@
+package org.elixir_lang.tool_manager
+
+import com.intellij.openapi.options.Configurable
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.DialogPanel
+import com.intellij.ui.dsl.builder.bindSelected
+import com.intellij.ui.dsl.builder.panel
+import javax.swing.JComponent
+
+/**
+ * Project-level settings page for Tool Managers (under Settings → Elixir → Tool Managers).
+ *
+ * Only registered on rich IDEs (via `rich-platform-plugin.xml`), because the SDK
+ * configuration performed by tool managers relies on Java-module APIs unavailable on
+ * small IDEs.
+ *
+ * Renders one checkbox per registered tool manager so users can opt in to each experimental
+ * manager individually.  The list is driven by [allBuiltInToolManagers] so new managers
+ * registered there automatically appear here without any additional wiring.
+ */
+internal class ToolManagerConfigurable(private val project: Project) : Configurable {
+
+    private var panel: DialogPanel? = null
+    private val settings: ToolManagerSettings get() = ToolManagerSettings.getInstance(project)
+
+    override fun getDisplayName(): String = "Tool Managers"
+
+    override fun createComponent(): JComponent {
+        panel = panel {
+            group("Experimental Tool Manager Integrations") {
+                for (manager in allBuiltInToolManagers) {
+                    row {
+                        checkBox(manager.displayName)
+                            .comment(
+                                "When enabled, ${manager.displayName} is queried for Elixir/Erlang " +
+                                    "version information and the status-bar widget will compare it " +
+                                    "against the configured SDK."
+                            )
+                            .bindSelected(
+                                getter = { settings.isEnabled(manager) },
+                                setter = { settings.setEnabled(manager, it) }
+                            )
+                    }
+                }
+            }
+        }
+        return panel!!
+    }
+
+    override fun isModified(): Boolean = panel?.isModified() ?: false
+
+    override fun apply() {
+        panel?.apply()
+        // Notify listeners (e.g. ToolManagerSdkCheckerStartupActivity) so the status-bar widget
+        // visibility is refreshed and any pending SDK configuration scan is triggered.
+        project.messageBus.syncPublisher(ToolManagerSettings.SETTINGS_CHANGED_TOPIC)
+            .toolManagerSettingsChanged()
+    }
+
+    override fun reset() {
+        panel?.reset()
+    }
+
+    override fun disposeUIResources() {
+        panel = null
+    }
+}

--- a/src/org/elixir_lang/tool_manager/ToolManagerRefreshTrigger.kt
+++ b/src/org/elixir_lang/tool_manager/ToolManagerRefreshTrigger.kt
@@ -1,0 +1,48 @@
+package org.elixir_lang.tool_manager
+
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.project.Project
+import java.nio.file.Path
+
+/**
+ * A mechanism by which an [ElixirToolManager] can notify the system when its configuration
+ * state may have changed and a re-scan is needed.
+ *
+ * Each implementation is responsible for installing whatever listeners, watchers, or polling
+ * mechanisms it needs and calling `onChangeDetected` when a re-scan should occur.
+ *
+ * The trigger is re-installed after every completed scan cycle so that dynamically discovered
+ * watch targets (e.g. `mise config ls --json`) stay up to date.
+ *
+ * Implementations are **not** required to be stateless - [install] may perform IO to discover
+ * which files or resources to watch.  It is always called on a background thread.
+ *
+ * Examples of different trigger mechanisms:
+ * - **File-based** (mise, asdf, rtx): watch config files for modifications + content-root
+ *   directories for new files matching name patterns.
+ * - **Process-based**: listen for a specific CLI process to exit.
+ * - **Polling**: periodic background check for state changes.
+ * - **External service**: listen on a socket or HTTP endpoint.
+ */
+fun interface ToolManagerRefreshTrigger {
+
+    /**
+     * Installs the trigger for the given [contentRoots].
+     *
+     * Called on a **background IO thread** after each scan cycle completes.
+     * May perform IO (e.g. run a CLI command to discover watched files).
+     *
+     * @param project          The project this trigger belongs to.
+     * @param contentRoots     Content roots that were most recently scanned.
+     * @param onChangeDetected Called (on any thread) when a re-scan should be triggered.
+     *                         Implementations must call this at most once per logical change event;
+     *                         the scan service debounces multiple rapid calls automatically.
+     * @return A [Disposable] that tears down all listeners/watchers installed by this call.
+     *         Disposed either when a new trigger cycle begins or when the project closes.
+     */
+    fun install(
+        project: Project,
+        contentRoots: List<Path>,
+        onChangeDetected: () -> Unit,
+    ): Disposable
+}

--- a/src/org/elixir_lang/tool_manager/ToolManagerRegistry.kt
+++ b/src/org/elixir_lang/tool_manager/ToolManagerRegistry.kt
@@ -1,0 +1,16 @@
+package org.elixir_lang.tool_manager
+
+import com.intellij.openapi.projectRoots.impl.SdkConfigurationUtil
+import org.elixir_lang.tool_manager.mise.MiseToolManager
+
+/**
+ * Central list of all built-in [ElixirToolManager] implementations, in priority order.
+ *
+ * When multiple managers are enabled, [ToolManagerSdkChecker] queries them in this order
+ * and uses the first non-null result per content root.
+ *
+ * To add a new built-in tool manager, add it here. Nothing else needs to change.
+ */
+val allBuiltInToolManagers: List<ElixirToolManager> = listOf(
+    MiseToolManager(),
+)

--- a/src/org/elixir_lang/tool_manager/ToolManagerResult.kt
+++ b/src/org/elixir_lang/tool_manager/ToolManagerResult.kt
@@ -1,0 +1,38 @@
+package org.elixir_lang.tool_manager
+
+/**
+ * The result of querying a single tool manager for one content root.
+ *
+ * `null` from [ElixirToolManager.resolveVersions] means the manager is not applicable for that
+ * root (not installed, no config file, transient subprocess error, etc.).
+ *
+ * Non-null results are one of:
+ * - [Success] - the manager found installed versions for the root.
+ * - [Error]   - the manager is applicable for the root but encountered an actionable error
+ *   (e.g. a config file that needs to be trusted).  [Error.description] is a human-readable
+ *   explanation already formatted by the concrete manager implementation; the abstract layer and
+ *   the IDE widget render it verbatim without needing to know what kind of error it is.
+ */
+sealed interface ToolManagerResult {
+
+    /**
+     * The tool manager successfully resolved versions for the content root.
+     */
+    data class Success(val versions: ToolManagerVersions) : ToolManagerResult
+
+    /**
+     * The tool manager encountered an actionable error for the content root.
+     *
+     * The error is manager-specific (e.g. an untrusted mise config file, a missing asdf plugin,
+     * etc.).  Concrete [ElixirToolManager] implementations are responsible for producing a
+     * [description] that explains the problem and tells the user how to fix it.
+     *
+     * @param toolManagerName  The [ElixirToolManager.name] of the manager that reported this.
+     * @param description      Human-readable explanation and fix hint, already formatted by the
+     *                         concrete manager.  The widget renders this verbatim.
+     */
+    data class Error(
+        val toolManagerName: String,
+        val description: String,
+    ) : ToolManagerResult
+}

--- a/src/org/elixir_lang/tool_manager/ToolManagerSdkAnalyser.kt
+++ b/src/org/elixir_lang/tool_manager/ToolManagerSdkAnalyser.kt
@@ -1,0 +1,180 @@
+package org.elixir_lang.tool_manager
+
+import com.intellij.openapi.application.readAction
+import com.intellij.openapi.components.service
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.diagnostic.logger
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.projectRoots.Sdk
+import com.intellij.openapi.roots.ModuleRootListener
+import com.intellij.openapi.projectRoots.ProjectJdkTable
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import org.elixir_lang.sdk.elixir.Type
+import org.elixir_lang.util.ElixirCoroutineService
+import com.intellij.util.messages.Topic
+import java.nio.file.Path
+import kotlin.time.Duration.Companion.milliseconds
+
+private val LOG = logger<ToolManagerSdkAnalyser>()
+
+/**
+ * Project service (rich IDEs only, registered via `rich-platform-plugin.xml`) that analyses
+ * raw tool-manager scan results against the currently configured module SDKs.
+ *
+ * Responsibilities:
+ * - Subscribes to [ToolManagerSdkCheckerService.SCAN_TOPIC] and caches the latest scan results.
+ * - Re-runs analysis whenever new scan results arrive **or** when module SDKs change
+ *   ([ModuleRootListener], [ProjectJdkTable.JDK_TABLE_TOPIC]).
+ * - Produces a [ToolManagerAnalysisResult] and publishes it on [ANALYSIS_TOPIC].
+ *
+ * This service has **no knowledge of the UI** - it only produces analysis results.
+ * UI consumers (e.g. the status-bar widget) subscribe to [ANALYSIS_TOPIC] independently.
+ */
+@Suppress("LightServiceMigrationCode")
+@OptIn(FlowPreview::class)
+internal class ToolManagerSdkAnalyser(private val project: Project) : Disposable {
+
+    private val scope = project.service<ElixirCoroutineService>().supervisedChildScope(javaClass.simpleName)
+
+    private val checker = ToolManagerSdkChecker(
+        project = project,
+        toolManagers = allBuiltInToolManagers,
+        settings = ToolManagerSettings.getInstance(project),
+    )
+
+    @Volatile
+    private var latestScanResults: Map<Path, ToolManagerResult?> = emptyMap()
+
+    @Volatile
+    private var latestAnalysis: ToolManagerAnalysisResult? = null
+
+    private val analysisRequests = MutableSharedFlow<Unit>(
+        extraBufferCapacity = 1,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST,
+    )
+
+    init {
+        val connection = project.messageBus.connect(this)
+
+        // Trigger analysis when the scan service produces new results.
+        connection.subscribe(
+            ToolManagerSdkCheckerService.SCAN_TOPIC,
+            ToolManagerScanListener { results ->
+                LOG.debug("Received scan results for '${project.name}', scheduling analysis")
+                latestScanResults = results
+                analysisRequests.tryEmit(Unit)
+            }
+        )
+
+        // Re-analyse when module root changes alter SDK assignments.
+        connection.subscribe(ModuleRootListener.TOPIC, object : ModuleRootListener {
+            override fun rootsChanged(event: com.intellij.openapi.roots.ModuleRootEvent) {
+                analysisRequests.tryEmit(Unit)
+            }
+        })
+
+        // Re-analyse when SDKs are added/removed/renamed - changes the comparison baseline.
+        connection.subscribe(ProjectJdkTable.JDK_TABLE_TOPIC, object : ProjectJdkTable.Listener {
+            override fun jdkAdded(jdk: Sdk) = analysisRequests.tryEmit(Unit).let {}
+            override fun jdkRemoved(jdk: Sdk) = analysisRequests.tryEmit(Unit).let {}
+            override fun jdkNameChanged(jdk: Sdk, previousName: String) = analysisRequests.tryEmit(Unit).let {}
+        })
+
+        // Analysis collector - debounced so rapid SDK/module changes produce one analysis pass.
+        scope.launch {
+            analysisRequests
+                .debounce(200.milliseconds)
+                .collect {
+                    val scanResults = latestScanResults
+                    if (scanResults.isEmpty()) {
+                        LOG.trace("No scan results cached, skipping analysis for '${project.name}'")
+                        return@collect
+                    }
+                    LOG.debug("Running tool manager analysis for '${project.name}'")
+
+                    val moduleCheckData = readAction { checker.collectModuleCheckData() }
+
+                    val elixirVersionByInstallPath: Map<String, String?>
+                    val erlangReleaseByHomePath: Map<String, org.elixir_lang.sdk.erlang.Release?>
+                    val elixirVersionBySdk: Map<Sdk, String?>
+                    withContext(Dispatchers.IO) {
+                        elixirVersionByInstallPath = checker.collectElixirVersionByInstallPath(scanResults)
+                        erlangReleaseByHomePath = checker.collectErlangReleaseByHomePath(moduleCheckData)
+                        elixirVersionBySdk = moduleCheckData
+                            .mapNotNull { it.elixirSdk }
+                            .distinct()
+                            .associateWith { sdk ->
+                                Type.canonicalVersion(sdk).also { v ->
+                                    LOG.trace("analysis: canonicalVersion('${sdk.name}') = $v")
+                                }
+                            }
+                    }
+
+                    val (tmIssues, sdkVersionTables) = checker.detectMismatchIssues(
+                        moduleCheckData = moduleCheckData,
+                        toolManagerResultsByRoot = scanResults,
+                        elixirVersionBySdk = elixirVersionBySdk,
+                        erlangReleaseByHomePath = erlangReleaseByHomePath,
+                        elixirVersionByInstallPath = elixirVersionByInstallPath,
+                    )
+                    val tmAssignments = checker.buildAssignments(moduleCheckData, scanResults)
+                    val toolManagerErrors = checker.collectErrors(scanResults)
+
+                    val result = ToolManagerAnalysisResult(
+                        tmIssues = tmIssues,
+                        tmAssignments = tmAssignments,
+                        sdkVersionTables = sdkVersionTables,
+                        toolManagerErrors = toolManagerErrors,
+                        elixirVersionByInstallPath = elixirVersionByInstallPath,
+                    )
+                    latestAnalysis = result
+                    LOG.debug(
+                        "Analysis complete for '${project.name}': " +
+                            "${tmIssues.size} issue(s), ${tmAssignments.size} assignment(s)"
+                    )
+                    project.messageBus.syncPublisher(ANALYSIS_TOPIC).analysisCompleted(result)
+                }
+        }
+    }
+
+    /**
+     * Subscribes [onAnalysisCompleted] to [ANALYSIS_TOPIC] and immediately replays the latest
+     * completed analysis snapshot (if any) to avoid missing state when subscribers register late.
+     */
+    fun subscribeWithLatest(
+        parentDisposable: Disposable,
+        onAnalysisCompleted: (ToolManagerAnalysisResult) -> Unit,
+    ) {
+        project.messageBus.connect(parentDisposable).subscribe(
+            ANALYSIS_TOPIC,
+            ToolManagerAnalysisListener { result -> onAnalysisCompleted(result) }
+        )
+        latestAnalysis?.let(onAnalysisCompleted)
+    }
+
+    override fun dispose() {
+        scope.cancel()
+    }
+
+    companion object {
+        @JvmField
+        val ANALYSIS_TOPIC: Topic<ToolManagerAnalysisListener> = Topic.create(
+            "ToolManagerSdkAnalyser.analysisCompleted",
+            ToolManagerAnalysisListener::class.java,
+        )
+
+        fun getInstance(project: Project): ToolManagerSdkAnalyser =
+            project.getService(ToolManagerSdkAnalyser::class.java)
+                ?: error("ToolManagerSdkAnalyser not registered (not a rich IDE?)")
+
+        fun getInstanceIfRegistered(project: Project): ToolManagerSdkAnalyser? =
+            project.getService(ToolManagerSdkAnalyser::class.java)
+    }
+}

--- a/src/org/elixir_lang/tool_manager/ToolManagerSdkChecker.kt
+++ b/src/org/elixir_lang/tool_manager/ToolManagerSdkChecker.kt
@@ -1,0 +1,383 @@
+package org.elixir_lang.tool_manager
+
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.application.edtWriteAction
+import com.intellij.openapi.diagnostic.logger
+import com.intellij.openapi.module.ModuleManager
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.projectRoots.Sdk
+import com.intellij.openapi.roots.ModuleRootManager
+import com.intellij.openapi.vfs.toNioPathOrNull
+import com.intellij.platform.ide.progress.ModalTaskOwner
+import com.intellij.platform.ide.progress.runWithModalProgressBlocking
+import com.intellij.ui.EditorNotifications
+import com.intellij.util.concurrency.annotations.RequiresReadLock
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.elixir_lang.isElixirModule
+import org.elixir_lang.sdk.SdkRegistrar
+import org.elixir_lang.sdk.elixir.ElixirSdkLookup
+import org.elixir_lang.sdk.elixir.ElixirVersionDetector
+import org.elixir_lang.sdk.elixir.sdk
+import org.elixir_lang.sdk.erlang.ErlangVersionDetector
+import org.elixir_lang.sdk.erlang.Release
+import org.elixir_lang.sdk.erlang_dependent.SdkAdditionalData
+import java.nio.file.Path
+
+private val LOG = logger<ToolManagerSdkChecker>()
+
+/**
+ * Handles the tool-manager side of the SDK notification scan:
+ * collecting module data, resolving versions from all enabled tool managers, detecting
+ * version mismatches, building comparison tables, and configuring SDKs from tool-manager results.
+ *
+ * The widget is responsible for threading (readAction / Dispatchers.IO / EDT) and for
+ * combining the results here with its own non-tool-manager checks (dangling refs, classpath, etc.).
+ *
+ * @param project       The project this checker operates on.
+ * @param toolManagers  Ordered list of all registered tool managers.  The checker queries enabled
+ *                      managers in order and uses the first non-null result per content root.
+ * @param settings      Project-level enable/disable flags for each tool manager.
+ */
+class ToolManagerSdkChecker(
+    private val project: Project,
+    private val toolManagers: List<ElixirToolManager>,
+    private val settings: ToolManagerSettings,
+) {
+
+    // -------------------------------------------------------------------------
+    // Public data types
+    // -------------------------------------------------------------------------
+
+    /**
+     * Per-module snapshot of the data needed to compare configured SDK versions against
+     * tool-manager-resolved versions.  Collected inside a read action.
+     */
+    data class ModuleCheckData(
+        val moduleName: String,
+        /** Elixir SDK configured for the module (if any). */
+        val elixirSdk: Sdk?,
+        /** Home path of the Internal Erlang SDK paired with [elixirSdk] (if any).
+         *  Used in the IO phase to read the full OTP release version from `OTP_VERSION`. */
+        val erlangSdkHomePath: String?,
+        /** First content root of the module; used as the working directory for tool-manager queries. */
+        val contentRoot: Path?,
+    )
+
+    // -------------------------------------------------------------------------
+    // Phase 1 - model data (call inside readAction)
+    // -------------------------------------------------------------------------
+
+    /**
+     * Collects per-module data needed by the tool-manager scan.
+     * Must be called inside a `readAction { }` block.
+     */
+    @RequiresReadLock
+    fun collectModuleCheckData(): List<ModuleCheckData> {
+        return ModuleManager.getInstance(project).modules
+            .filter { it.isElixirModule() }
+            .map { module ->
+                val elixirSdk = ElixirSdkLookup.resolve(module).sdk
+                val erlangSdkHomePath = elixirSdk
+                    ?.let { (it.sdkAdditionalData as? SdkAdditionalData)?.getErlangSdk() }
+                    ?.homePath
+                val contentRoot = ModuleRootManager.getInstance(module)
+                    .contentRoots
+                    .firstOrNull()
+                    ?.toNioPathOrNull()
+                LOG.trace("collectModuleCheckData: module='${module.name}' elixirSdk='${elixirSdk?.name}' contentRoot=$contentRoot")
+                ModuleCheckData(
+                    moduleName = module.name,
+                    elixirSdk = elixirSdk,
+                    erlangSdkHomePath = erlangSdkHomePath,
+                    contentRoot = contentRoot,
+                )
+            }
+    }
+
+    // -------------------------------------------------------------------------
+    // Phase 2 - IO (call inside Dispatchers.IO, outside read lock)
+    // -------------------------------------------------------------------------
+
+    /**
+     * Queries all enabled tool managers for each path in [contentRoots], returning the first non-null
+     * result per content root (priority order matches [toolManagers]).
+     *
+     * Must NOT be called on the EDT or under a read lock - tool managers may spawn subprocesses.
+     */
+    fun resolveVersions(contentRoots: List<Path>): Map<Path, ToolManagerVersions?> {
+        val enabledManagers = toolManagers.filter { settings.isEnabled(it) }
+        return contentRoots.associateWith { contentRoot ->
+            enabledManagers.firstNotNullOfOrNull { manager ->
+                LOG.trace("resolveVersions: trying '${manager.name}' for $contentRoot")
+                manager.resolveVersions(contentRoot).also { result ->
+                    LOG.trace("resolveVersions: '${manager.name}' returned $result for $contentRoot")
+                }
+            }
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Phase 3 - pure analysis (no platform access needed)
+    // -------------------------------------------------------------------------
+
+    /**
+     * Detects version mismatches between configured SDKs and tool-manager-resolved versions.
+     *
+     * For each module that has tool-manager data, this builds an [SdkVersionTable] containing
+     * both matching and mismatching rows (so the notification table shows the full picture).
+     * A [ModuleSdkIssue] is also emitted for each mismatch (used for notification deduplication
+     * and the issue key).
+     *
+     * @param moduleCheckData              Collected in Phase 1.
+     * @param toolManagerVersionsByRoot    Collected in Phase 2.
+     * @param elixirVersionBySdk           Canonical Elixir version (from `elixir.app`) per SDK.
+     * @param erlangReleaseByHomePath      Full OTP [Release] per Erlang SDK home path.
+     * @param elixirVersionByInstallPath   Canonical Elixir version per tool-manager install path.
+     *
+     * @return Pair of (issues list, module-name → SdkVersionTable map).
+     */
+    fun detectMismatchIssues(
+        moduleCheckData: List<ModuleCheckData>,
+        toolManagerVersionsByRoot: Map<Path, ToolManagerVersions?>,
+        elixirVersionBySdk: Map<Sdk, String?>,
+        erlangReleaseByHomePath: Map<String, Release?>,
+        elixirVersionByInstallPath: Map<String, String?>,
+    ): Pair<List<ModuleSdkIssue>, Map<String, SdkVersionTable>> {
+        val issues = mutableListOf<ModuleSdkIssue>()
+        val tables = mutableMapOf<String, SdkVersionTable>()
+
+        for (data in moduleCheckData) {
+            val contentRoot = data.contentRoot ?: run {
+                LOG.trace("detectMismatchIssues: '${data.moduleName}' skipped - no content root")
+                continue
+            }
+            val tmVersions = toolManagerVersionsByRoot[contentRoot] ?: run {
+                LOG.trace("detectMismatchIssues: '${data.moduleName}' skipped - no tool manager result")
+                continue
+            }
+
+            val toolName = tmVersions.toolManagerName
+            val rows = mutableListOf<SdkVersionRow>()
+
+            // --- Elixir version ---
+            val tmElixir = tmVersions.elixir
+            if (tmElixir != null) {
+                val configuredVersion = data.elixirSdk?.let { elixirVersionBySdk[it] }
+                val tmVersion = elixirVersionByInstallPath[tmElixir.installPath]
+                LOG.trace(
+                    "detectMismatchIssues: '${data.moduleName}' Elixir " +
+                            "configured=$configuredVersion tm=$tmVersion installPath=${tmElixir.installPath}"
+                )
+                val isMismatch =
+                    configuredVersion != null && tmVersion != null && configuredVersion != tmVersion
+                if (isMismatch) {
+                    LOG.info("'${data.moduleName}': Elixir $configuredVersion ≠ $toolName ${tmElixir.version}")
+                    issues.add(
+                        ModuleSdkIssue(
+                            moduleName = data.moduleName,
+                            issue = "Elixir SDK is $configuredVersion but $toolName resolves ${tmElixir.version}",
+                            isDangling = false,
+                        )
+                    )
+                }
+                rows.add(SdkVersionRow("Elixir", configuredVersion, tmVersion ?: tmElixir.version, isMismatch))
+            }
+
+            // --- Erlang OTP version ---
+            val tmErlang = tmVersions.erlang
+            val erlangRelease = data.erlangSdkHomePath?.let { erlangReleaseByHomePath[it] }
+            if (tmErlang != null && erlangRelease != null) {
+                val tmMajor = tmErlang.version.substringBefore(".")
+                val isMismatch = tmMajor != erlangRelease.otpMajor
+                if (isMismatch) {
+                    LOG.info("'${data.moduleName}': Erlang OTP ${erlangRelease.otpMajor} ≠ $toolName ${tmErlang.version}")
+                    issues.add(
+                        ModuleSdkIssue(
+                            moduleName = data.moduleName,
+                            issue = "Internal Erlang SDK OTP ${erlangRelease.otpMajor} does not match $toolName (${tmErlang.version})",
+                            isDangling = false,
+                        )
+                    )
+                }
+                rows.add(SdkVersionRow("Erlang", erlangRelease.otpVersion, tmErlang.version, isMismatch))
+            }
+
+            if (rows.any { it.isMismatch }) {
+                tables[data.moduleName] = SdkVersionTable(data.moduleName, toolName, rows)
+            }
+        }
+
+        return Pair(issues, tables)
+    }
+
+    /**
+     * Builds the map of module name → [ToolManagerVersions] for every Elixir module whose
+     * content root has an *installed* tool-manager Elixir version.
+     *
+     * Used to populate the "Configure from <tool manager>" action in notifications.
+     */
+    fun buildAssignments(
+        moduleCheckData: List<ModuleCheckData>,
+        toolManagerVersionsByRoot: Map<Path, ToolManagerVersions?>,
+    ): Map<String, ToolManagerVersions> {
+        val result = LinkedHashMap<String, ToolManagerVersions>()
+        for (data in moduleCheckData) {
+            val contentRoot = data.contentRoot ?: continue
+            val versions = toolManagerVersionsByRoot[contentRoot] ?: continue
+            if (versions.elixir?.installed == true) {
+                result[data.moduleName] = versions
+            }
+        }
+        return result
+    }
+
+    // -------------------------------------------------------------------------
+    // IO data collected alongside resolveVersions (convenience helpers)
+    // -------------------------------------------------------------------------
+
+    /**
+     * Resolves the canonical Elixir version string (from `lib/elixir/ebin/elixir.app`) for every
+     * unique install path referenced by [toolManagerVersionsByRoot].
+     *
+     * Must be called on a background thread outside any read lock.
+     */
+    fun collectElixirVersionByInstallPath(
+        toolManagerVersionsByRoot: Map<Path, ToolManagerVersions?>,
+    ): Map<String, String?> {
+        return toolManagerVersionsByRoot.values
+            .filterNotNull()
+            .mapNotNull { it.elixir?.installPath }
+            .distinct()
+            .associateWith { installPath ->
+                ElixirVersionDetector.elixirVersion(installPath, null).also { v ->
+                    LOG.trace("collectElixirVersionByInstallPath: '$installPath' → $v")
+                }
+            }
+    }
+
+    /**
+     * Reads the full OTP [Release] (major + patch version) for every unique Erlang SDK home path
+     * referenced by [moduleCheckData].
+     *
+     * Must be called on a background thread outside any read lock.
+     */
+    fun collectErlangReleaseByHomePath(
+        moduleCheckData: List<ModuleCheckData>,
+    ): Map<String, Release?> {
+        return moduleCheckData
+            .mapNotNull { it.erlangSdkHomePath }
+            .distinct()
+            .associateWith { homePath -> ErlangVersionDetector.detectRelease(homePath) }
+    }
+
+    // -------------------------------------------------------------------------
+    // Phase 4 - SDK configuration (call from EDT action handler)
+    // -------------------------------------------------------------------------
+
+    /**
+     * Registers Elixir and Erlang SDKs from [assignments] and assigns them to their respective
+     * modules.  All work - SDK registration, classpath root setup, and module assignment - is
+     * performed inside a **single** write action with module assignment coming **last**.
+     *
+     * Root setup (`setupSdkPaths` equivalent) is moved inside the write action so that the
+     * `applyStateToProject` events fired by `sdkModificator.commitChanges()` (via
+     * `GlobalWorkspaceModel.onChanged`) happen *before* the module assignment rather than after
+     * it.  The VirtualFile lookups that would normally happen inside `setupSdkPaths` are
+     * pre-gathered on the background thread (off EDT) to avoid VFS refresh inside the write lock.
+     *
+     * Uses [runWithModalProgressBlocking] internally, so this must be called from a blocking
+     * context on the EDT (e.g. an `AnAction.actionPerformed` handler).
+     *
+     * @param assignments  Module name → [ToolManagerVersions] as built by [buildAssignments].
+     */
+    fun configureSdks(assignments: Map<String, ToolManagerVersions>) {
+        val toolName = assignments.values.firstOrNull()?.toolManagerName ?: "tool manager"
+        LOG.trace("configureSdks: assignments keys=${assignments.keys}")
+        runWithModalProgressBlocking(
+            ModalTaskOwner.project(project),
+            "Configuring Elixir SDK from $toolName"
+        ) {
+            // Register unique (erlang, elixir) install-path combinations once each.
+            // Deduplication key = elixir install path so that multiple modules sharing the same
+            // tool-manager config register the SDK only once.
+            val elixirSdkByInstallPath = mutableMapOf<String, Sdk>()
+
+            for (versions in assignments.values) {
+                val elixirEntry = versions.elixir ?: continue
+                val elixirPath = elixirEntry.installPath
+                if (elixirPath in elixirSdkByInstallPath) continue
+
+                val erlangSdk = versions.erlang?.let { erlang ->
+                    LOG.trace("configureSdks: registering Erlang SDK at '${erlang.installPath}'")
+                    SdkRegistrar.registerOrUpdateErlangSdk(erlang.installPath)
+                }
+                LOG.trace("configureSdks: registering Elixir SDK at '$elixirPath' erlang='${erlangSdk?.name}'")
+                val elixirSdk = SdkRegistrar.registerOrUpdateElixirSdk(
+                    homePath = elixirPath,
+                    erlangSdk = erlangSdk,
+                    project = project,
+                ) ?: run {
+                    LOG.warn("configureSdks: registerOrUpdateElixirSdk returned null for '$elixirPath'")
+                    continue
+                }
+                LOG.trace("configureSdks: registered Elixir SDK '${elixirSdk.name}' for '$elixirPath'")
+                elixirSdkByInstallPath[elixirPath] = elixirSdk
+            }
+
+            if (elixirSdkByInstallPath.isEmpty()) {
+                LOG.warn("configureSdks: no SDKs registered, skipping module assignment")
+                return@runWithModalProgressBlocking
+            }
+
+            // Force jdk.table.xml to disk before assigning module SDKs.
+            //
+            // setupSdkPaths → commitChanges() causes workspace model changes that trigger
+            // DelayedProjectSynchronizer to retry (Attempt 2). That retry reads jdk.table.xml
+            // to decide which SDKs to keep in the global model. Without this flush the new SDK
+            // is still only in memory, so Attempt 2 removes it - undoing the module assignment.
+            //
+            // Application.saveSettings() synchronously writes all dirty PersistentStateComponents
+            // (including ProjectJdkTable → jdk.table.xml) before this method returns, ensuring
+            // Attempt 2 finds the newly registered SDK on disk.
+            withContext(Dispatchers.IO) {
+                LOG.trace("configureSdks: flushing jdk.table.xml before module assignment")
+                ApplicationManager.getApplication().saveSettings()
+                LOG.trace("configureSdks: jdk.table.xml flush complete")
+            }
+
+            edtWriteAction {
+                for ((moduleName, versions) in assignments) {
+                    val elixirEntry = versions.elixir ?: run {
+                        LOG.trace("configureSdks: skipping '$moduleName' - no elixir entry")
+                        continue
+                    }
+                    val elixirSdk = elixirSdkByInstallPath[elixirEntry.installPath] ?: run {
+                        LOG.warn("configureSdks: SDK not found for installPath='${elixirEntry.installPath}' (module='$moduleName')")
+                        continue
+                    }
+                    val module = ModuleManager.getInstance(project)
+                        .findModuleByName(moduleName)
+                        ?.takeIf { !it.isDisposed } ?: run {
+                        LOG.warn("configureSdks: module '$moduleName' not found or disposed")
+                        continue
+                    }
+                    val modifiableModel = ModuleRootManager.getInstance(module).modifiableModel
+                    var committed = false
+                    try {
+                        modifiableModel.sdk = elixirSdk
+                        modifiableModel.commit()
+                        committed = true
+                        LOG.info("configureSdks: committed '${elixirSdk.name}' → '$moduleName'")
+                    } catch (ex: Exception) {
+                        LOG.warn("configureSdks: failed to commit '${elixirSdk.name}' → '$moduleName'", ex)
+                    } finally {
+                        if (!committed) modifiableModel.dispose()
+                    }
+                }
+            }
+
+            EditorNotifications.getInstance(project).updateAllNotifications()
+        }
+    }
+}

--- a/src/org/elixir_lang/tool_manager/ToolManagerSdkChecker.kt
+++ b/src/org/elixir_lang/tool_manager/ToolManagerSdkChecker.kt
@@ -100,12 +100,16 @@ class ToolManagerSdkChecker(
     // -------------------------------------------------------------------------
 
     /**
-     * Queries all enabled tool managers for each path in [contentRoots], returning the first non-null
-     * result per content root (priority order matches [toolManagers]).
+     * Queries all enabled tool managers for each path in [contentRoots].
+     *
+     * Returns the first non-null [ToolManagerResult] per content root in priority order.
+     * A [ToolManagerResult.Error] result is returned as-is (not skipped) so that
+     * callers can surface the error to the user rather than silently treating the manager
+     * as absent.
      *
      * Must NOT be called on the EDT or under a read lock - tool managers may spawn subprocesses.
      */
-    fun resolveVersions(contentRoots: List<Path>): Map<Path, ToolManagerVersions?> {
+    fun resolveVersions(contentRoots: List<Path>): Map<Path, ToolManagerResult?> {
         val enabledManagers = toolManagers.filter { settings.isEnabled(it) }
         return contentRoots.associateWith { contentRoot ->
             enabledManagers.firstNotNullOfOrNull { manager ->
@@ -117,6 +121,19 @@ class ToolManagerSdkChecker(
         }
     }
 
+    /**
+     * Extracts all [ToolManagerResult.Error] entries from [toolManagerResultsByRoot].
+     *
+     * Called from the widget's notification scan so the widget can append tool-manager error
+     * descriptions to the active notification rather than silently suppressing them.
+     */
+    fun collectErrors(
+        toolManagerResultsByRoot: Map<Path, ToolManagerResult?>,
+    ): List<ToolManagerResult.Error> =
+        toolManagerResultsByRoot.values
+            .filterIsInstance<ToolManagerResult.Error>()
+            .distinctBy { it.description }
+
     // -------------------------------------------------------------------------
     // Phase 3 - pure analysis (no platform access needed)
     // -------------------------------------------------------------------------
@@ -124,13 +141,11 @@ class ToolManagerSdkChecker(
     /**
      * Detects version mismatches between configured SDKs and tool-manager-resolved versions.
      *
-     * For each module that has tool-manager data, this builds an [SdkVersionTable] containing
-     * both matching and mismatching rows (so the notification table shows the full picture).
-     * A [ModuleSdkIssue] is also emitted for each mismatch (used for notification deduplication
-     * and the issue key).
+     * Only [ToolManagerResult.Success] entries in [toolManagerResultsByRoot] are examined;
+     * [ToolManagerResult.Error] entries are skipped (they carry no version data).
      *
      * @param moduleCheckData              Collected in Phase 1.
-     * @param toolManagerVersionsByRoot    Collected in Phase 2.
+     * @param toolManagerResultsByRoot     Collected in Phase 2.
      * @param elixirVersionBySdk           Canonical Elixir version (from `elixir.app`) per SDK.
      * @param erlangReleaseByHomePath      Full OTP [Release] per Erlang SDK home path.
      * @param elixirVersionByInstallPath   Canonical Elixir version per tool-manager install path.
@@ -139,7 +154,7 @@ class ToolManagerSdkChecker(
      */
     fun detectMismatchIssues(
         moduleCheckData: List<ModuleCheckData>,
-        toolManagerVersionsByRoot: Map<Path, ToolManagerVersions?>,
+        toolManagerResultsByRoot: Map<Path, ToolManagerResult?>,
         elixirVersionBySdk: Map<Sdk, String?>,
         erlangReleaseByHomePath: Map<String, Release?>,
         elixirVersionByInstallPath: Map<String, String?>,
@@ -152,8 +167,8 @@ class ToolManagerSdkChecker(
                 LOG.trace("detectMismatchIssues: '${data.moduleName}' skipped - no content root")
                 continue
             }
-            val tmVersions = toolManagerVersionsByRoot[contentRoot] ?: run {
-                LOG.trace("detectMismatchIssues: '${data.moduleName}' skipped - no tool manager result")
+            val tmVersions = (toolManagerResultsByRoot[contentRoot] as? ToolManagerResult.Success)?.versions ?: run {
+                LOG.trace("detectMismatchIssues: '${data.moduleName}' skipped - no successful tool manager result")
                 continue
             }
 
@@ -215,16 +230,19 @@ class ToolManagerSdkChecker(
      * Builds the map of module name → [ToolManagerVersions] for every Elixir module whose
      * content root has an *installed* tool-manager Elixir version.
      *
+     * Only [ToolManagerResult.Success] entries are considered; [ToolManagerResult.Error] entries
+     * are ignored here (the widget surfaces them through a separate notification path).
+     *
      * Used to populate the "Configure from <tool manager>" action in notifications.
      */
     fun buildAssignments(
         moduleCheckData: List<ModuleCheckData>,
-        toolManagerVersionsByRoot: Map<Path, ToolManagerVersions?>,
+        toolManagerResultsByRoot: Map<Path, ToolManagerResult?>,
     ): Map<String, ToolManagerVersions> {
         val result = LinkedHashMap<String, ToolManagerVersions>()
         for (data in moduleCheckData) {
             val contentRoot = data.contentRoot ?: continue
-            val versions = toolManagerVersionsByRoot[contentRoot] ?: continue
+            val versions = (toolManagerResultsByRoot[contentRoot] as? ToolManagerResult.Success)?.versions ?: continue
             if (versions.elixir?.installed == true) {
                 result[data.moduleName] = versions
             }
@@ -238,16 +256,16 @@ class ToolManagerSdkChecker(
 
     /**
      * Resolves the canonical Elixir version string (from `lib/elixir/ebin/elixir.app`) for every
-     * unique install path referenced by [toolManagerVersionsByRoot].
+     * unique install path referenced by successful results in [toolManagerResultsByRoot].
      *
      * Must be called on a background thread outside any read lock.
      */
     fun collectElixirVersionByInstallPath(
-        toolManagerVersionsByRoot: Map<Path, ToolManagerVersions?>,
+        toolManagerResultsByRoot: Map<Path, ToolManagerResult?>,
     ): Map<String, String?> {
-        return toolManagerVersionsByRoot.values
-            .filterNotNull()
-            .mapNotNull { it.elixir?.installPath }
+        return toolManagerResultsByRoot.values
+            .filterIsInstance<ToolManagerResult.Success>()
+            .mapNotNull { it.versions.elixir?.installPath }
             .distinct()
             .associateWith { installPath ->
                 ElixirVersionDetector.elixirVersion(installPath, null).also { v ->

--- a/src/org/elixir_lang/tool_manager/ToolManagerSdkChecker.kt
+++ b/src/org/elixir_lang/tool_manager/ToolManagerSdkChecker.kt
@@ -39,7 +39,7 @@ private val LOG = logger<ToolManagerSdkChecker>()
  *                      managers in order and uses the first non-null result per content root.
  * @param settings      Project-level enable/disable flags for each tool manager.
  */
-class ToolManagerSdkChecker(
+internal class ToolManagerSdkChecker(
     private val project: Project,
     private val toolManagers: List<ElixirToolManager>,
     private val settings: ToolManagerSettings,
@@ -67,6 +67,25 @@ class ToolManagerSdkChecker(
     // -------------------------------------------------------------------------
     // Phase 1 - model data (call inside readAction)
     // -------------------------------------------------------------------------
+
+    /**
+     * Collects the first content root path for every Elixir module in the project.
+     *
+     * Lighter than [collectModuleCheckData] - only returns paths, no SDK lookups.
+     * Used by [ToolManagerSdkCheckerService] to determine which roots to pass to tool managers.
+     * Must be called inside a `readAction { }` block.
+     */
+    @RequiresReadLock
+    fun collectContentRoots(): List<Path> =
+        ModuleManager.getInstance(project).modules
+            .filter { it.isElixirModule() }
+            .mapNotNull { module ->
+                ModuleRootManager.getInstance(module)
+                    .contentRoots
+                    .firstOrNull()
+                    ?.toNioPathOrNull()
+            }
+            .distinct()
 
     /**
      * Collects per-module data needed by the tool-manager scan.
@@ -295,14 +314,17 @@ class ToolManagerSdkChecker(
 
     /**
      * Registers Elixir and Erlang SDKs from [assignments] and assigns them to their respective
-     * modules.  All work - SDK registration, classpath root setup, and module assignment - is
-     * performed inside a **single** write action with module assignment coming **last**.
+     * modules.
      *
-     * Root setup (`setupSdkPaths` equivalent) is moved inside the write action so that the
-     * `applyStateToProject` events fired by `sdkModificator.commitChanges()` (via
-     * `GlobalWorkspaceModel.onChanged`) happen *before* the module assignment rather than after
-     * it.  The VirtualFile lookups that would normally happen inside `setupSdkPaths` are
-     * pre-gathered on the background thread (off EDT) to avoid VFS refresh inside the write lock.
+     * Performed in three ordered phases so that the global SDK table is durably persisted before
+     * any module is pointed at a newly registered SDK:
+     * 1. SDK registration (and classpath root setup) for every unique install-path combination,
+     *    via [SdkRegistrar]. The VirtualFile lookups that `setupSdkPaths` needs are pre-gathered
+     *    on the background thread (off EDT) to avoid VFS refresh inside the write lock.
+     * 2. A `jdk.table.xml` flush on [Dispatchers.IO] (see the inline comment below) so that
+     *    `DelayedProjectSynchronizer` Attempt 2 reads the newly registered SDKs from disk instead
+     *    of removing them as stale - which would undo the module assignment.
+     * 3. Module assignment **last**, inside a single [edtWriteAction].
      *
      * Uses [runWithModalProgressBlocking] internally, so this must be called from a blocking
      * context on the EDT (e.g. an `AnAction.actionPerformed` handler).

--- a/src/org/elixir_lang/tool_manager/ToolManagerSdkCheckerService.kt
+++ b/src/org/elixir_lang/tool_manager/ToolManagerSdkCheckerService.kt
@@ -1,0 +1,223 @@
+package org.elixir_lang.tool_manager
+
+import com.intellij.openapi.application.readAction
+import com.intellij.openapi.components.service
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.diagnostic.logger
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.roots.ModuleRootListener
+import com.intellij.openapi.util.Disposer
+import com.intellij.workspaceModel.ide.JpsProjectLoadingManager
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withContext
+import org.elixir_lang.util.ElixirCoroutineService
+import com.intellij.util.messages.Topic
+import java.nio.file.Path
+import kotlin.time.Duration.Companion.milliseconds
+
+private val LOG = logger<ToolManagerSdkCheckerService>()
+
+/**
+ * Project service (rich IDEs only, registered via `rich-platform-plugin.xml`) that owns the
+ * tool-manager scan lifecycle.
+ *
+ * Responsibilities:
+ * - Waits for the JPS project model to be fully loaded before the first scan.
+ * - Triggers a (debounced) scan when [ToolManagerSettings] change or module roots change.
+ * - Runs [ToolManagerSdkChecker.resolveVersions] on a background IO thread.
+ * - Publishes raw scan results on [SCAN_TOPIC] for downstream consumers (e.g. [ToolManagerSdkAnalyser]).
+ * - Exposes [configureSdks] for action buttons created by UI consumers.
+ *
+ * This service has **no knowledge of the UI** - it only produces scan results.
+ */
+@Suppress("LightServiceMigrationCode")
+internal class ToolManagerSdkCheckerService(private val project: Project) : Disposable {
+
+    private val scope = project.service<ElixirCoroutineService>().supervisedChildScope(javaClass.simpleName)
+
+    internal val checker = ToolManagerSdkChecker(
+        project = project,
+        toolManagers = allBuiltInToolManagers,
+        settings = ToolManagerSettings.getInstance(project),
+    )
+
+    private val scanRequests = MutableSharedFlow<Unit>(
+        extraBufferCapacity = 1,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST,
+    )
+
+    /**
+     * Disposable container for the currently active [ToolManagerRefreshTrigger] installations.
+     * Replaced (disposed + recreated) after every scan cycle (IO-dispatcher scan collector) and
+     * immediately when settings change (message-bus listener thread).
+     *
+     * Because it is touched from more than one thread, the dispose+recreate+reassign swap is
+     * confined to [triggerLock] (see [swapTriggerLifetime]); the lock guards only the cheap swap,
+     * never the trigger installation I/O.  [installRefreshTriggers] registers onto the lifetime
+     * reference returned by the swap rather than re-reading the field, so a concurrent reset cannot
+     * leave it registering onto an already-replaced container.
+     */
+    private val triggerLock = Any()
+
+    @Volatile
+    private var triggerLifetime: Disposable = Disposer.newDisposable("ToolManagerSdkCheckerService.triggers")
+
+    init {
+        // Dispose trigger lifetime when the service itself is disposed.
+        Disposer.register(this, triggerLifetime)
+
+        val connection = project.messageBus.connect(this)
+
+        // Re-scan when tool manager settings are toggled.  Also immediately dispose any active
+        // refresh triggers so we stop watching files for managers that were just disabled.
+        connection.subscribe(
+            ToolManagerSettings.SETTINGS_CHANGED_TOPIC,
+            ToolManagerSettingsListener {
+                LOG.debug("Tool manager settings changed, disposing triggers and scheduling scan for '${project.name}'")
+                disposeAndResetTriggers()
+                scanRequests.tryEmit(Unit)
+            }
+        )
+
+        // Re-scan when module roots change - new modules may introduce new content roots.
+        connection.subscribe(ModuleRootListener.TOPIC, object : ModuleRootListener {
+            override fun rootsChanged(event: com.intellij.openapi.roots.ModuleRootEvent) {
+                scanRequests.tryEmit(Unit)
+            }
+        })
+
+        // Wait for JPS project model sync before the initial scan so that module content roots
+        // and SDK assignments reflect the on-disk state rather than the workspace-model cache.
+        @Suppress("UnstableApiUsage", "DEPRECATION")
+        scope.launch {
+            suspendCancellableCoroutine<Unit> { cont ->
+                JpsProjectLoadingManager.getInstance(project).jpsProjectLoaded {
+                    cont.resumeWith(Result.success(Unit))
+                }
+            }
+            LOG.debug("JPS model loaded, emitting initial scan request for '${project.name}'")
+            scanRequests.tryEmit(Unit)
+        }
+
+        // Scan collector - debounced to avoid redundant work during bulk rootsChanged events.
+        @OptIn(FlowPreview::class)
+        scope.launch {
+            scanRequests
+                .debounce(500.milliseconds)
+                .collect {
+                    LOG.debug("Running tool manager scan for '${project.name}'")
+                    val contentRoots: List<Path> = readAction { checker.collectContentRoots() }
+                    if (contentRoots.isEmpty()) {
+                        LOG.trace("No Elixir content roots found, skipping scan")
+                        return@collect
+                    }
+                    val results = withContext(Dispatchers.IO) {
+                        checker.resolveVersions(contentRoots)
+                    }
+                    LOG.debug("Scan complete for '${project.name}', publishing ${results.size} result(s)")
+                    project.messageBus.syncPublisher(SCAN_TOPIC).scanCompleted(results)
+
+                    // Reinstall refresh triggers after each scan so dynamically discovered
+                    // file lists (e.g. from `mise config ls`) stay up to date.
+                    withContext(Dispatchers.IO) {
+                        installRefreshTriggers(contentRoots)
+                    }
+                }
+        }
+    }
+
+    /**
+     * Installs [ToolManagerRefreshTrigger]s for all currently enabled tool managers.
+     *
+     * Disposes any previously installed triggers first.  Must be called on a background IO thread
+     * (trigger implementations may run CLI commands to discover watched files).
+     */
+    private fun installRefreshTriggers(contentRoots: List<Path>) {
+        // Swap is atomic and returns the fresh lifetime; register onto that reference (not the
+        // field) so a concurrent settings-change reset cannot redirect our registrations.
+        val newLifetime = swapTriggerLifetime()
+
+        val settings = ToolManagerSettings.getInstance(project)
+
+        allBuiltInToolManagers
+            .filter { settings.isEnabled(it) }
+            .forEach { manager ->
+                val trigger = manager.createRefreshTrigger() ?: return@forEach
+                LOG.debug("Installing refresh trigger for '${manager.name}' in '${project.name}'")
+                val triggerDisposable = trigger.install(project, contentRoots) {
+                    LOG.debug("Refresh trigger fired for '${manager.name}', requesting scan of '${project.name}'")
+                    requestScan()
+                }
+                // tryRegister returns false (instead of throwing) if the lifetime was disposed by a
+                // concurrent settings change; in that case drop the just-installed trigger.
+                if (!Disposer.tryRegister(newLifetime, triggerDisposable)) {
+                    LOG.debug("Trigger lifetime disposed during install for '${manager.name}', disposing trigger")
+                    Disposer.dispose(triggerDisposable)
+                }
+            }
+    }
+
+    /** Disposes the current trigger lifetime and installs a fresh empty one, used by callers that
+     *  only need to stop watching (e.g. the settings-changed listener). */
+    private fun disposeAndResetTriggers() {
+        swapTriggerLifetime()
+    }
+
+    /**
+     * Atomically disposes the current trigger lifetime, creates a fresh empty one registered as a
+     * child of this service, stores it in [triggerLifetime], and returns it.
+     *
+     * The lock spans only this cheap swap (never trigger-install I/O), so the EDT settings listener
+     * is never blocked on background work.
+     */
+    private fun swapTriggerLifetime(): Disposable = synchronized(triggerLock) {
+        Disposer.dispose(triggerLifetime)
+        val newLifetime = Disposer.newDisposable("ToolManagerSdkCheckerService.triggers")
+        Disposer.register(this, newLifetime)
+        triggerLifetime = newLifetime
+        newLifetime
+    }
+
+    /**
+     * Requests an immediate (debounced) scan.  Safe to call from any thread.
+     * Exposed for [ToolManagerRefreshTrigger] implementations to call back into the service.
+     */
+    fun requestScan() {
+        scanRequests.tryEmit(Unit)
+    }
+
+    /**
+     * Configures module SDKs from the given [assignments].
+     *
+     * Delegates to [ToolManagerSdkChecker.configureSdks].  Called from notification action buttons
+     * created by UI consumers (e.g. [org.elixir_lang.status_bar_widget.ElixirEditorBasedSdkWidget]).
+     *
+     * Must be called from a blocking context on the EDT (e.g. `AnAction.actionPerformed`).
+     */
+    fun configureSdks(assignments: Map<String, ToolManagerVersions>) =
+        checker.configureSdks(assignments)
+
+    override fun dispose() {
+        scope.cancel()
+        // triggerLifetime is registered as a child of `this`, so Disposer handles it.
+    }
+
+    companion object {
+        @JvmField
+        val SCAN_TOPIC: Topic<ToolManagerScanListener> = Topic.create(
+            "ToolManagerSdkCheckerService.scanCompleted",
+            ToolManagerScanListener::class.java,
+        )
+
+        fun getInstance(project: Project): ToolManagerSdkCheckerService =
+            project.getService(ToolManagerSdkCheckerService::class.java)
+                ?: error("ToolManagerSdkCheckerService not registered (not a rich IDE?)")
+    }
+}

--- a/src/org/elixir_lang/tool_manager/ToolManagerSdkCheckerStartupActivity.kt
+++ b/src/org/elixir_lang/tool_manager/ToolManagerSdkCheckerStartupActivity.kt
@@ -1,0 +1,28 @@
+package org.elixir_lang.tool_manager
+
+import com.intellij.openapi.diagnostic.logger
+import com.intellij.openapi.project.DumbAware
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.startup.ProjectActivity
+
+private val LOG = logger<ToolManagerSdkCheckerStartupActivity>()
+
+/**
+ * Rich-IDE-only startup activity that eagerly initialises [ToolManagerSdkCheckerService] and
+ * [ToolManagerSdkAnalyser] at project open.
+ *
+ * Both services are lazy by default (created on first access). Accessing them here causes their
+ * `init` blocks to run, which subscribe to message-bus topics and schedule the initial scan.
+ * Without this activity the services would not activate until something else accessed them.
+ *
+ * Registered in `rich-platform-plugin.xml` so it only runs when `com.intellij.modules.java`
+ * is present.
+ */
+internal class ToolManagerSdkCheckerStartupActivity : ProjectActivity, DumbAware {
+
+    override suspend fun execute(project: Project) {
+        LOG.debug("Initialising tool manager services for project: ${project.name}")
+        ToolManagerSdkCheckerService.getInstance(project)
+        ToolManagerSdkAnalyser.getInstance(project)
+    }
+}

--- a/src/org/elixir_lang/tool_manager/ToolManagerSettings.kt
+++ b/src/org/elixir_lang/tool_manager/ToolManagerSettings.kt
@@ -1,0 +1,51 @@
+package org.elixir_lang.tool_manager
+
+import com.intellij.openapi.components.PersistentStateComponent
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.components.State
+import com.intellij.openapi.components.Storage
+import com.intellij.openapi.components.service
+import com.intellij.openapi.project.Project
+
+/**
+ * Project-level settings controlling which tool managers are active.
+ *
+ * Persisted in `.idea/elixir.xml` under the key `ElixirToolManagerSettings`.
+ *
+ * **Default behaviour**: all registered tool managers are enabled (opt-out model).
+ * An empty [State.disabledManagers] set means "check everything", which preserves
+ * the behaviour users had before this setting existed.
+ */
+@Service(Service.Level.PROJECT)
+@State(
+    name = "ElixirToolManagerSettings",
+    storages = [Storage("elixir.xml")]
+)
+class ToolManagerSettings : PersistentStateComponent<ToolManagerSettings.State> {
+
+    /** XML-serialisable state.  Fields must be `var` for IntelliJ's reflection-based serialiser. */
+    class State {
+        var disabledManagers: MutableSet<String> = mutableSetOf()
+    }
+
+    private var myState = State()
+
+    override fun getState(): State = myState
+
+    override fun loadState(state: State) {
+        myState = state
+    }
+
+    /** Returns `true` when [manager] should be consulted during the notification scan. */
+    fun isEnabled(manager: ElixirToolManager): Boolean =
+        manager.name !in myState.disabledManagers
+
+    fun setEnabled(manager: ElixirToolManager, enabled: Boolean) {
+        if (enabled) myState.disabledManagers.remove(manager.name)
+        else myState.disabledManagers.add(manager.name)
+    }
+
+    companion object {
+        fun getInstance(project: Project): ToolManagerSettings = project.service()
+    }
+}

--- a/src/org/elixir_lang/tool_manager/ToolManagerSettings.kt
+++ b/src/org/elixir_lang/tool_manager/ToolManagerSettings.kt
@@ -1,31 +1,43 @@
 package org.elixir_lang.tool_manager
 
 import com.intellij.openapi.components.PersistentStateComponent
-import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.State
 import com.intellij.openapi.components.Storage
 import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
+import com.intellij.util.messages.Topic
+
+/** Listener notified whenever a tool manager is enabled or disabled. */
+fun interface ToolManagerSettingsListener {
+    fun toolManagerSettingsChanged()
+}
 
 /**
  * Project-level settings controlling which tool managers are active.
  *
  * Persisted in `.idea/elixir.xml` under the key `ElixirToolManagerSettings`.
  *
- * **Default behaviour**: all registered tool managers are enabled (opt-out model).
- * An empty [State.disabledManagers] set means "check everything", which preserves
- * the behaviour users had before this setting existed.
+ * Registered only on rich IDEs (via `rich-platform-plugin.xml`) because the SDK
+ * configuration performed by tool managers relies on Java-module APIs.  No `@Service`
+ * annotation is present so the platform does not auto-register this class for all IDEs.
+ *
+ * **Default behaviour**: all tool managers are **disabled** (opt-in model).
+ * A tool manager must be explicitly enabled by the user before it is consulted
+ * during the SDK notification scan.  This ensures that experimental managers
+ * (such as mise) do not run without user consent.
+ *
+ * An empty [State.enabledManagers] set therefore means "no tool managers are active".
  */
-@Service(Service.Level.PROJECT)
+@Suppress("LightServiceMigrationCode")
 @State(
     name = "ElixirToolManagerSettings",
     storages = [Storage("elixir.xml")]
 )
-class ToolManagerSettings : PersistentStateComponent<ToolManagerSettings.State> {
+internal class ToolManagerSettings : PersistentStateComponent<ToolManagerSettings.State> {
 
     /** XML-serialisable state.  Fields must be `var` for IntelliJ's reflection-based serialiser. */
     class State {
-        var disabledManagers: MutableSet<String> = mutableSetOf()
+        var enabledManagers: MutableSet<String> = mutableSetOf()
     }
 
     private var myState = State()
@@ -36,16 +48,22 @@ class ToolManagerSettings : PersistentStateComponent<ToolManagerSettings.State> 
         myState = state
     }
 
-    /** Returns `true` when [manager] should be consulted during the notification scan. */
+    /** Returns `true` when [manager] has been explicitly enabled by the user. */
     fun isEnabled(manager: ElixirToolManager): Boolean =
-        manager.name !in myState.disabledManagers
+        manager.name in myState.enabledManagers
 
     fun setEnabled(manager: ElixirToolManager, enabled: Boolean) {
-        if (enabled) myState.disabledManagers.remove(manager.name)
-        else myState.disabledManagers.add(manager.name)
+        if (enabled) myState.enabledManagers.add(manager.name)
+        else myState.enabledManagers.remove(manager.name)
     }
 
     companion object {
+        @JvmField
+        val SETTINGS_CHANGED_TOPIC: Topic<ToolManagerSettingsListener> = Topic.create(
+            "ToolManagerSettings.changed",
+            ToolManagerSettingsListener::class.java
+        )
+
         fun getInstance(project: Project): ToolManagerSettings = project.service()
     }
 }

--- a/src/org/elixir_lang/tool_manager/ToolManagerVersions.kt
+++ b/src/org/elixir_lang/tool_manager/ToolManagerVersions.kt
@@ -1,0 +1,14 @@
+package org.elixir_lang.tool_manager
+
+/**
+ * Resolved tool versions for one module content root, as reported by a specific tool manager.
+ *
+ * [toolManagerName] is the stable identifier of the tool manager that produced this result
+ * (e.g. `"mise"`). It is used for display in notifications and for distinguishing results
+ * when multiple tool managers are active.
+ */
+interface ToolManagerVersions {
+    val toolManagerName: String
+    val elixir: ToolEntry?
+    val erlang: ToolEntry?
+}

--- a/src/org/elixir_lang/tool_manager/mise/MiseRefreshTrigger.kt
+++ b/src/org/elixir_lang/tool_manager/mise/MiseRefreshTrigger.kt
@@ -14,6 +14,7 @@ import com.intellij.openapi.vfs.newvfs.events.VFileDeleteEvent
 import com.intellij.openapi.vfs.newvfs.events.VFileEvent
 import org.elixir_lang.mise.Mise
 import org.elixir_lang.tool_manager.ToolManagerRefreshTrigger
+import org.jetbrains.annotations.VisibleForTesting
 import java.nio.file.Path
 
 private val LOG = logger<MiseRefreshTrigger>()
@@ -125,7 +126,8 @@ object MiseRefreshTrigger : ToolManagerRefreshTrigger {
         return lifetime
     }
 
-    private fun shouldTrigger(
+    @VisibleForTesting
+    internal fun shouldTrigger(
         event: VFileEvent,
         exactPaths: Set<String>,
         contentRootStrings: Set<String>,

--- a/src/org/elixir_lang/tool_manager/mise/MiseRefreshTrigger.kt
+++ b/src/org/elixir_lang/tool_manager/mise/MiseRefreshTrigger.kt
@@ -1,0 +1,159 @@
+package org.elixir_lang.tool_manager.mise
+
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.diagnostic.logger
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.Disposer
+import com.intellij.openapi.util.io.FileUtil
+import com.intellij.openapi.vfs.LocalFileSystem
+import com.intellij.openapi.vfs.newvfs.BulkFileListener
+import com.intellij.openapi.vfs.newvfs.events.VFileContentChangeEvent
+import com.intellij.openapi.vfs.newvfs.events.VFileCreateEvent
+import com.intellij.openapi.vfs.newvfs.events.VFileDeleteEvent
+import com.intellij.openapi.vfs.newvfs.events.VFileEvent
+import org.elixir_lang.mise.Mise
+import org.elixir_lang.tool_manager.ToolManagerRefreshTrigger
+import java.nio.file.Path
+
+private val LOG = logger<MiseRefreshTrigger>()
+
+/**
+ * File-name patterns to watch for in content root directories.
+ *
+ * These cover all standard mise config file names.  If a file matching any of these
+ * patterns is created in a content root directory, a re-scan is triggered even if the
+ * file was not previously known to mise.
+ */
+private val MISE_CONFIG_PATTERNS = listOf(
+    Regex("""^mise\.toml$"""),
+    Regex("""^mise\..+\.toml$"""),   // mise.local.toml, mise.test.toml, etc.
+    Regex("""^\.tool-versions$"""),
+)
+
+/**
+ * [ToolManagerRefreshTrigger] implementation for mise.
+ *
+ * On [install]:
+ * 1. Calls `mise config ls --json` for each content root to discover the exact set of
+ *    config files that mise is currently reading (including user-global config files such
+ *    as `~/.config/mise/config.toml`).
+ * 2. Registers [LocalFileSystem] watch roots for every discovered file so the VFS tracks
+ *    changes to files that may lie outside the project directory.
+ * 3. Subscribes a [BulkFileListener] that fires `onChangeDetected` when:
+ *    - Any watched exact file is modified or deleted.
+ *    - A file matching [MISE_CONFIG_PATTERNS] is created inside a content root directory
+ *      (handles the case where the user adds a new config file not yet known to mise).
+ */
+object MiseRefreshTrigger : ToolManagerRefreshTrigger {
+
+    override fun install(
+        project: Project,
+        contentRoots: List<Path>,
+        onChangeDetected: () -> Unit,
+    ): Disposable {
+        val lifetime = Disposer.newDisposable("MiseRefreshTrigger")
+
+        // --- 1. Discover exact config files from mise for each content root ---
+        // Mise.configFiles() already converts WSL Linux paths to Windows UNC paths (see Mise.kt),
+        // so Path objects here are always host-native absolute paths.
+        // Normalise to forward slashes so strings match VFileEvent.path values.
+        val exactPaths: Set<String> = contentRoots
+            .flatMap { root ->
+                Mise.configFiles(root)
+                    ?.map { FileUtil.toSystemIndependentName(it.toString()) }
+                    ?.also { LOG.trace("install: $root → ${it.size} config file(s)") }
+                    ?: emptyList()
+            }
+            .toSet()
+
+        LOG.debug("install: watching ${exactPaths.size} exact file(s) across ${contentRoots.size} content root(s)")
+
+        // --- 2. Discover the mise trusted-configs directory ---
+        // Watching this directory lets us detect when the user runs `mise trust`, which writes a
+        // file here but does not touch any of the watched config files themselves.
+        val trustedConfigsDirString: String = contentRoots.firstOrNull()
+            ?.let { Mise.stateDir(it) }
+            ?.resolve("trusted-configs")
+            ?.let { FileUtil.toSystemIndependentName(it.toString()) }
+            ?.also { LOG.debug("install: also watching trusted-configs dir: $it") }
+            ?: ""
+
+        // --- 3. Register LocalFileSystem watch roots ---
+        // Watch each exact file individually (handles files outside the project, e.g. ~/.config/mise/config.toml).
+        // Also watch each content root directory (non-recursive) so new files can be detected.
+        // Watch the trusted-configs directory so `mise trust` runs trigger a re-scan.
+        // Both exactPaths and content root strings are in system-independent (forward-slash) form,
+        // which LocalFileSystem normalises internally.
+        val watchPaths: Set<String> = exactPaths +
+                contentRoots.map { FileUtil.toSystemIndependentName(it.toString()) } +
+                listOfNotNull(trustedConfigsDirString.takeIf { it.isNotEmpty() })
+        val watchRequests = mutableSetOf<LocalFileSystem.WatchRequest>()
+        val lfs = LocalFileSystem.getInstance()
+        for (path in watchPaths) {
+            lfs.addRootToWatch(path, /* watchRecursively = */ false)
+                ?.let { watchRequests.add(it) }
+        }
+
+        // Unregister all watch requests when the trigger is disposed.
+        Disposer.register(lifetime) {
+            lfs.removeWatchedRoots(watchRequests)
+            LOG.trace("install: removed ${watchRequests.size} watch request(s)")
+        }
+
+        // Normalise content root strings to forward slashes to match VFileCreateEvent.parent.path.
+        val contentRootStrings: Set<String> = contentRoots.map { FileUtil.toSystemIndependentName(it.toString()) }.toSet()
+
+        // --- 4. Subscribe BulkFileListener for VFS change events ---
+        ApplicationManager.getApplication().messageBus
+            .connect(lifetime)
+            .subscribe(
+                com.intellij.openapi.vfs.VirtualFileManager.VFS_CHANGES,
+                object : BulkFileListener {
+                    override fun after(events: List<VFileEvent>) {
+                        for (event in events) {
+                            if (shouldTrigger(event, exactPaths, contentRootStrings, trustedConfigsDirString)) {
+                                LOG.debug("install: change detected via ${event::class.simpleName} on '${event.path}', triggering re-scan")
+                                onChangeDetected()
+                                return  // one call per batch is sufficient; scan is debounced
+                            }
+                        }
+                    }
+                }
+            )
+
+        return lifetime
+    }
+
+    private fun shouldTrigger(
+        event: VFileEvent,
+        exactPaths: Set<String>,
+        contentRootStrings: Set<String>,
+        trustedConfigsDirString: String,
+    ): Boolean = when (event) {
+        // Exact watched file was modified; or a trust-state file in the trusted-configs dir was
+        // updated (user re-ran `mise trust` on an already-trusted config).
+        is VFileContentChangeEvent ->
+            event.path in exactPaths ||
+                    (trustedConfigsDirString.isNotEmpty() && event.path.startsWith("$trustedConfigsDirString/"))
+
+        // Exact watched file was deleted - re-scan so mise can report absence.
+        // A trust-state file was deleted (user untrusted the config) - re-scan to surface the error.
+        is VFileDeleteEvent ->
+            event.path in exactPaths ||
+                    (trustedConfigsDirString.isNotEmpty() && event.path.startsWith("$trustedConfigsDirString/"))
+
+        // A new file was created: either a config file in a content root, or a trust-state file
+        // written by `mise trust` in the global trusted-configs directory.
+        is VFileCreateEvent -> {
+            val parentPath = event.parent.path
+            when {
+                trustedConfigsDirString.isNotEmpty() && parentPath == trustedConfigsDirString -> true
+                parentPath in contentRootStrings -> MISE_CONFIG_PATTERNS.any { it.matches(event.childName) }
+                else -> false
+            }
+        }
+
+        else -> false
+    }
+}

--- a/src/org/elixir_lang/tool_manager/mise/MiseToolManager.kt
+++ b/src/org/elixir_lang/tool_manager/mise/MiseToolManager.kt
@@ -3,6 +3,7 @@ package org.elixir_lang.tool_manager.mise
 import org.elixir_lang.mise.Mise
 import org.elixir_lang.mise.MiseResult
 import org.elixir_lang.tool_manager.ElixirToolManager
+import org.elixir_lang.tool_manager.ToolManagerRefreshTrigger
 import org.elixir_lang.tool_manager.ToolManagerResult
 import java.nio.file.Path
 
@@ -33,6 +34,12 @@ class MiseToolManager : ElixirToolManager {
             is MiseResult.Success ->
                 ToolManagerResult.Success(MiseToolManagerVersions(result.versions))
         }
+
+    /**
+     * Returns [MiseRefreshTrigger], which watches mise config files for changes and triggers
+     * a re-scan whenever a config file is modified, deleted, or a new one is created.
+     */
+    override fun createRefreshTrigger(): ToolManagerRefreshTrigger = MiseRefreshTrigger
 
     companion object {
         /** Stable persistence key - do not rename after first release. */

--- a/src/org/elixir_lang/tool_manager/mise/MiseToolManager.kt
+++ b/src/org/elixir_lang/tool_manager/mise/MiseToolManager.kt
@@ -1,0 +1,26 @@
+package org.elixir_lang.tool_manager.mise
+
+import org.elixir_lang.mise.Mise
+import org.elixir_lang.tool_manager.ElixirToolManager
+import org.elixir_lang.tool_manager.ToolManagerVersions
+import java.nio.file.Path
+
+/**
+ * [ElixirToolManager] implementation backed by [mise](https://mise.jdx.dev/).
+ *
+ * Delegates to [Mise.resolveVersions] and wraps the result in [MiseToolManagerVersions].
+ * All threading constraints of [Mise.resolveVersions] apply here - must not be called on
+ * the EDT or under a read lock.
+ */
+class MiseToolManager : ElixirToolManager {
+    override val name: String = NAME
+    override val displayName: String = "mise"
+
+    override fun resolveVersions(contentRoot: Path): ToolManagerVersions? =
+        Mise.resolveVersions(contentRoot)?.let { MiseToolManagerVersions(it) }
+
+    companion object {
+        /** Stable persistence key - do not rename after first release. */
+        const val NAME = "mise"
+    }
+}

--- a/src/org/elixir_lang/tool_manager/mise/MiseToolManager.kt
+++ b/src/org/elixir_lang/tool_manager/mise/MiseToolManager.kt
@@ -1,14 +1,19 @@
 package org.elixir_lang.tool_manager.mise
 
 import org.elixir_lang.mise.Mise
+import org.elixir_lang.mise.MiseResult
 import org.elixir_lang.tool_manager.ElixirToolManager
-import org.elixir_lang.tool_manager.ToolManagerVersions
+import org.elixir_lang.tool_manager.ToolManagerResult
 import java.nio.file.Path
 
 /**
  * [ElixirToolManager] implementation backed by [mise](https://mise.jdx.dev/).
  *
- * Delegates to [Mise.resolveVersions] and wraps the result in [MiseToolManagerVersions].
+ * Delegates to [Mise.resolveVersions] and maps the result to [ToolManagerResult]:
+ * - `null`                        → `null`        (mise unavailable for this root)
+ * - [MiseResult.UntrustedConfig]  → [ToolManagerResult.Error]
+ * - [MiseResult.Success]          → [ToolManagerResult.Success]
+ *
  * All threading constraints of [Mise.resolveVersions] apply here - must not be called on
  * the EDT or under a read lock.
  */
@@ -16,8 +21,18 @@ class MiseToolManager : ElixirToolManager {
     override val name: String = NAME
     override val displayName: String = "mise"
 
-    override fun resolveVersions(contentRoot: Path): ToolManagerVersions? =
-        Mise.resolveVersions(contentRoot)?.let { MiseToolManagerVersions(it) }
+    override fun resolveVersions(contentRoot: Path): ToolManagerResult? =
+        when (val result = Mise.resolveVersions(contentRoot)) {
+            null -> null
+            is MiseResult.UntrustedConfig ->
+                ToolManagerResult.Error(
+                    toolManagerName = NAME,
+                    description = "Config file '${result.configFilePath}' is not trusted. " +
+                        "Run <code>mise trust</code> in the project directory, then reload.",
+                )
+            is MiseResult.Success ->
+                ToolManagerResult.Success(MiseToolManagerVersions(result.versions))
+        }
 
     companion object {
         /** Stable persistence key - do not rename after first release. */

--- a/src/org/elixir_lang/tool_manager/mise/MiseToolManagerVersions.kt
+++ b/src/org/elixir_lang/tool_manager/mise/MiseToolManagerVersions.kt
@@ -1,0 +1,22 @@
+package org.elixir_lang.tool_manager.mise
+
+import org.elixir_lang.mise.MiseToolEntry
+import org.elixir_lang.mise.MiseVersions
+import org.elixir_lang.tool_manager.ToolEntry
+import org.elixir_lang.tool_manager.ToolManagerVersions
+
+/**
+ * Adapts a [MiseVersions] result (the internal mise wire type) to the generic
+ * [ToolManagerVersions] interface consumed by [ToolManagerSdkChecker][org.elixir_lang.tool_manager.ToolManagerSdkChecker].
+ */
+class MiseToolManagerVersions(miseVersions: MiseVersions) : ToolManagerVersions {
+    override val toolManagerName: String = "mise"
+    override val elixir: ToolEntry? = miseVersions.elixir?.toToolEntry()
+    override val erlang: ToolEntry? = miseVersions.erlang?.toToolEntry()
+}
+
+private fun MiseToolEntry.toToolEntry() = ToolEntry(
+    version = version,
+    installPath = installPath,
+    installed = installed,
+)

--- a/tests/org/elixir_lang/mise/MiseTest.kt
+++ b/tests/org/elixir_lang/mise/MiseTest.kt
@@ -190,4 +190,82 @@ class MiseTest : PlatformTestCase() {
         assertNull(result!!.elixir!!.sourceType)
         assertNull(result.elixir.sourcePath)
     }
+
+    // -------------------------------------------------------------------------
+    // parseTrustError
+    // -------------------------------------------------------------------------
+
+    fun testParseTrustError_documentedTwoLineStderr_extractsPath() {
+        // Mirrors the exact two-line output produced by mise when a config file is untrusted.
+        val stderr = """
+            mise ERROR error parsing config file: /home/user/proj/mise.toml
+            mise ERROR Config files in /home/user/proj/mise.toml are not trusted.
+        """.trimIndent()
+        val result = Mise.parseTrustError(stderr)
+        assertNotNull(result)
+        assertEquals("/home/user/proj/mise.toml", result!!.configFilePath)
+    }
+
+    fun testParseTrustError_singleMatchingLine_extractsPath() {
+        val stderr = "mise ERROR Config files in /my/project are not trusted."
+        val result = Mise.parseTrustError(stderr)
+        assertNotNull(result)
+        assertEquals("/my/project", result!!.configFilePath)
+    }
+
+    fun testParseTrustError_unrelatedStderr_returnsNull() {
+        assertNull(Mise.parseTrustError("mise ERROR command not found: elixir"))
+    }
+
+    fun testParseTrustError_emptyString_returnsNull() {
+        assertNull(Mise.parseTrustError(""))
+    }
+
+    fun testParseTrustError_pathWithSpaces_trimmedCorrectly() {
+        // Surrounding whitespace inside the captured group is trimmed via .trim().
+        val stderr = "mise ERROR Config files in   /home/user/my project/mise.toml   are not trusted."
+        val result = Mise.parseTrustError(stderr)
+        assertNotNull(result)
+        assertEquals("/home/user/my project/mise.toml", result!!.configFilePath)
+    }
+
+    fun testParseTrustError_patternEmbeddedInLongerStderr_stillMatched() {
+        // .find() scans the whole string; warnings/noise before and after must not prevent matching.
+        val stderr = """
+            mise WARN  some other warning
+            mise ERROR Config files in /proj/.mise.toml are not trusted.
+            mise INFO  continuing...
+        """.trimIndent()
+        val result = Mise.parseTrustError(stderr)
+        assertNotNull(result)
+        assertEquals("/proj/.mise.toml", result!!.configFilePath)
+    }
+
+    // -------------------------------------------------------------------------
+    // parseDoctorStateDir
+    // -------------------------------------------------------------------------
+
+    fun testParseDoctorStateDir_typicalJson_extractsStatePath() {
+        val json = """{"dirs":{"state":"/home/user/.local/state/mise","data":"/home/user/.local/share/mise"}}"""
+        val result = Mise.parseDoctorStateDir(json, "/home/user/project")
+        assertNotNull(result)
+        // Normalise to forward slashes so the assertion holds on both Windows and Linux.
+        assertEquals("/home/user/.local/state/mise", com.intellij.openapi.util.io.FileUtil.toSystemIndependentName(result!!.toString()))
+    }
+
+    fun testParseDoctorStateDir_missingDirs_returnsNull() {
+        assertNull(Mise.parseDoctorStateDir("""{"tools":{}}""", "/home/user/project"))
+    }
+
+    fun testParseDoctorStateDir_missingState_returnsNull() {
+        assertNull(Mise.parseDoctorStateDir("""{"dirs":{}}""", "/home/user/project"))
+    }
+
+    fun testParseDoctorStateDir_emptyObject_returnsNull() {
+        assertNull(Mise.parseDoctorStateDir("{}", "/home/user/project"))
+    }
+
+    fun testParseDoctorStateDir_malformedJson_returnsNull() {
+        assertNull(Mise.parseDoctorStateDir("not json at all {{{", "/home/user/project"))
+    }
 }

--- a/tests/org/elixir_lang/status_bar_widget/ElixirSdkStatusWidgetTest.kt
+++ b/tests/org/elixir_lang/status_bar_widget/ElixirSdkStatusWidgetTest.kt
@@ -4,6 +4,7 @@ import com.intellij.facet.FacetManager
 import com.intellij.facet.FacetType
 import com.intellij.facet.impl.FacetUtil
 import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.application.ReadAction
 import com.intellij.openapi.application.WriteAction
 import com.intellij.openapi.projectRoots.ProjectJdkTable
 import com.intellij.openapi.projectRoots.SimpleJavaSdkType
@@ -13,6 +14,7 @@ import com.intellij.openapi.roots.ModuleRootModificationUtil
 import com.intellij.openapi.roots.ProjectRootManager
 import com.intellij.util.concurrency.annotations.RequiresEdt
 import com.intellij.util.concurrency.annotations.RequiresReadLock
+import java.util.concurrent.Callable
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
@@ -20,6 +22,7 @@ import org.elixir_lang.Facet
 import org.elixir_lang.PlatformTestCase
 import org.elixir_lang.facet.Type
 import org.elixir_lang.sdk.elixir.Type as ElixirSdkType
+import org.elixir_lang.tool_manager.ModuleSdkIssue
 
 /**
  * Tests for [ElixirEditorBasedSdkWidget] detection logic (notification scan methods).
@@ -168,7 +171,7 @@ class ElixirSdkStatusWidgetTest : PlatformTestCase() {
         setModuleSdk(elixirSdk)
 
         val widget = createWidget()
-        val foundSdk = widget.findModuleLevelElixirSdk()
+        val foundSdk = ReadAction.nonBlocking(Callable<Sdk?> { widget.findModuleLevelElixirSdk() }).executeSynchronously()
 
         assertNotNull("Should find Elixir SDK from module even when project SDK is Java", foundSdk)
         assertEquals("Should return the module's Elixir SDK", elixirSdk, foundSdk)
@@ -202,7 +205,7 @@ class ElixirSdkStatusWidgetTest : PlatformTestCase() {
         setModuleSdk(elixirSdk)
 
         val widget = createWidget()
-        val foundSdk = widget.findModuleLevelElixirSdk()
+        val foundSdk = ReadAction.nonBlocking(Callable<Sdk?> { widget.findModuleLevelElixirSdk() }).executeSynchronously()
 
         assertNotNull("Should find Elixir SDK from module when project SDK is null", foundSdk)
         assertEquals(elixirSdk, foundSdk)

--- a/tests/org/elixir_lang/tool_manager/ToolManagerSdkCheckerTest.kt
+++ b/tests/org/elixir_lang/tool_manager/ToolManagerSdkCheckerTest.kt
@@ -1,0 +1,452 @@
+package org.elixir_lang.tool_manager
+
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.projectRoots.Sdk
+import org.elixir_lang.PlatformTestCase
+import org.elixir_lang.sdk.erlang.Release
+import org.mockito.Mockito.mock
+import java.nio.file.Path
+import java.nio.file.Paths
+
+/**
+ * Unit tests for the pure (Phase 2/3) methods of [ToolManagerSdkChecker]:
+ * [ToolManagerSdkChecker.detectMismatchIssues], [ToolManagerSdkChecker.buildAssignments],
+ * and [ToolManagerSdkChecker.collectErrors].
+ *
+ * These methods perform no platform I/O and require no read lock; all inputs are
+ * plain Kotlin data objects.  A [Project] mock is passed for construction only -
+ * none of the methods under test call through to it.
+ */
+class ToolManagerSdkCheckerTest : PlatformTestCase() {
+
+    private lateinit var checker: ToolManagerSdkChecker
+
+    override fun setUp() {
+        super.setUp()
+        checker = ToolManagerSdkChecker(
+            project = mock(Project::class.java),
+            toolManagers = emptyList(),
+            settings = ToolManagerSettings(),
+        )
+    }
+
+    // -------------------------------------------------------------------------
+    // Test-local helpers
+    // -------------------------------------------------------------------------
+
+    /** Minimal [ToolManagerVersions] backed by plain values (no platform needed). */
+    private fun versions(
+        toolManagerName: String = "mise",
+        elixir: ToolEntry? = null,
+        erlang: ToolEntry? = null,
+    ): ToolManagerVersions = object : ToolManagerVersions {
+        override val toolManagerName = toolManagerName
+        override val elixir = elixir
+        override val erlang = erlang
+    }
+
+    private fun elixirEntry(
+        version: String,
+        installPath: String,
+        installed: Boolean = true,
+    ) = ToolEntry(version, installPath, installed)
+
+    private fun erlangEntry(
+        version: String,
+        installPath: String = "/erlang-install",
+    ) = ToolEntry(version, installPath, installed = true)
+
+    private fun moduleData(
+        moduleName: String,
+        sdk: Sdk? = null,
+        erlangHome: String? = null,
+        contentRoot: Path? = Paths.get("/project"),
+    ) = ToolManagerSdkChecker.ModuleCheckData(moduleName, sdk, erlangHome, contentRoot)
+
+    private fun success(versions: ToolManagerVersions): ToolManagerResult.Success =
+        ToolManagerResult.Success(versions)
+
+    private fun error(
+        description: String = "an error",
+        toolManagerName: String = "mise",
+    ): ToolManagerResult.Error = ToolManagerResult.Error(toolManagerName, description)
+
+    // -------------------------------------------------------------------------
+    // collectErrors
+    // -------------------------------------------------------------------------
+
+    fun testCollectErrors_emptyInput_returnsEmpty() {
+        assertTrue(checker.collectErrors(emptyMap()).isEmpty())
+    }
+
+    fun testCollectErrors_onlySuccessAndNull_returnsEmpty() {
+        val roots = mapOf<Path, ToolManagerResult?>(
+            Paths.get("/a") to success(versions()),
+            Paths.get("/b") to null,
+        )
+        assertTrue(checker.collectErrors(roots).isEmpty())
+    }
+
+    fun testCollectErrors_mixedResults_returnsOnlyErrors() {
+        val roots = mapOf<Path, ToolManagerResult?>(
+            Paths.get("/a") to error("err1"),
+            Paths.get("/b") to success(versions()),
+            Paths.get("/c") to null,
+            Paths.get("/d") to error("err2"),
+        )
+        val errors = checker.collectErrors(roots)
+        assertEquals(2, errors.size)
+        assertTrue(errors.any { it.description == "err1" })
+        assertTrue(errors.any { it.description == "err2" })
+    }
+
+    fun testCollectErrors_deduplicatesByDescription() {
+        val roots = mapOf<Path, ToolManagerResult?>(
+            Paths.get("/a") to error("same error"),
+            Paths.get("/b") to error("same error"),  // duplicate
+            Paths.get("/c") to error("different error"),
+        )
+        val errors = checker.collectErrors(roots)
+        assertEquals(2, errors.size)
+        assertEquals(1, errors.count { it.description == "same error" })
+        assertEquals(1, errors.count { it.description == "different error" })
+    }
+
+    // -------------------------------------------------------------------------
+    // buildAssignments
+    // -------------------------------------------------------------------------
+
+    fun testBuildAssignments_elixirInstalled_included() {
+        val path = Paths.get("/project")
+        val v = versions(elixir = elixirEntry("1.17.3", "/elixir-1.17", installed = true))
+        val assignments = checker.buildAssignments(
+            listOf(moduleData("mod", contentRoot = path)),
+            mapOf(path to success(v)),
+        )
+        assertEquals(1, assignments.size)
+        assertNotNull(assignments["mod"])
+    }
+
+    fun testBuildAssignments_elixirNotInstalled_excluded() {
+        val path = Paths.get("/project")
+        val v = versions(elixir = elixirEntry("1.17.3", "/elixir-1.17", installed = false))
+        assertTrue(
+            checker.buildAssignments(
+                listOf(moduleData("mod", contentRoot = path)),
+                mapOf(path to success(v)),
+            ).isEmpty()
+        )
+    }
+
+    fun testBuildAssignments_noElixirEntry_excluded() {
+        val path = Paths.get("/project")
+        val v = versions(elixir = null, erlang = erlangEntry("27.3"))
+        assertTrue(
+            checker.buildAssignments(
+                listOf(moduleData("mod", contentRoot = path)),
+                mapOf(path to success(v)),
+            ).isEmpty()
+        )
+    }
+
+    fun testBuildAssignments_errorResult_excluded() {
+        val path = Paths.get("/project")
+        assertTrue(
+            checker.buildAssignments(
+                listOf(moduleData("mod", contentRoot = path)),
+                mapOf(path to error()),
+            ).isEmpty()
+        )
+    }
+
+    fun testBuildAssignments_nullResult_excluded() {
+        val path = Paths.get("/project")
+        assertTrue(
+            checker.buildAssignments(
+                listOf(moduleData("mod", contentRoot = path)),
+                mapOf(path to null),
+            ).isEmpty()
+        )
+    }
+
+    fun testBuildAssignments_nullContentRoot_excluded() {
+        assertTrue(
+            checker.buildAssignments(
+                listOf(moduleData("mod", contentRoot = null)),
+                emptyMap(),
+            ).isEmpty()
+        )
+    }
+
+    fun testBuildAssignments_preservesInsertionOrder() {
+        val pathA = Paths.get("/a")
+        val pathB = Paths.get("/b")
+        val pathC = Paths.get("/c")
+        val installed = { versions(elixir = elixirEntry("1.17", "/elixir", installed = true)) }
+        val assignments = checker.buildAssignments(
+            listOf(
+                moduleData("alpha", contentRoot = pathA),
+                moduleData("beta",  contentRoot = pathB),
+                moduleData("gamma", contentRoot = pathC),
+            ),
+            mapOf(
+                pathA to success(installed()),
+                pathB to success(installed()),
+                pathC to success(installed()),
+            ),
+        )
+        assertEquals(listOf("alpha", "beta", "gamma"), assignments.keys.toList())
+    }
+
+    // -------------------------------------------------------------------------
+    // detectMismatchIssues - Elixir cases
+    // -------------------------------------------------------------------------
+
+    fun testDetectMismatch_elixirVersionsMatch_noIssueNoTable() {
+        val sdk = mock(Sdk::class.java)
+        val path = Paths.get("/project")
+        val installPath = "/elixir-1.17"
+        val (issues, tables) = checker.detectMismatchIssues(
+            moduleCheckData = listOf(moduleData("mod", sdk = sdk, contentRoot = path)),
+            toolManagerResultsByRoot = mapOf(path to success(versions(elixir = elixirEntry("1.17.3", installPath)))),
+            elixirVersionBySdk = mapOf(sdk to "1.17.3"),
+            erlangReleaseByHomePath = emptyMap(),
+            elixirVersionByInstallPath = mapOf(installPath to "1.17.3"),
+        )
+        assertTrue("No issues when Elixir versions match", issues.isEmpty())
+        assertTrue("No table when Elixir versions match", tables.isEmpty())
+    }
+
+    fun testDetectMismatch_elixirVersionMismatch_producesIssueAndTable() {
+        val sdk = mock(Sdk::class.java)
+        val path = Paths.get("/project")
+        val installPath = "/elixir-1.18"
+        val (issues, tables) = checker.detectMismatchIssues(
+            moduleCheckData = listOf(moduleData("myModule", sdk = sdk, contentRoot = path)),
+            toolManagerResultsByRoot = mapOf(path to success(versions(elixir = elixirEntry("1.18.0", installPath)))),
+            elixirVersionBySdk = mapOf(sdk to "1.17.3"),
+            erlangReleaseByHomePath = emptyMap(),
+            elixirVersionByInstallPath = mapOf(installPath to "1.18.0"),
+        )
+        assertEquals(1, issues.size)
+        assertEquals("myModule", issues[0].moduleName)
+        assertFalse("Elixir mismatch is not a dangling reference", issues[0].isDangling)
+
+        val table = tables["myModule"]
+        assertNotNull("Table produced for mismatching module", table)
+        val row = table!!.rows.single()
+        assertEquals("Elixir", row.label)
+        assertTrue("Row marked as mismatch", row.isMismatch)
+        assertEquals("1.17.3", row.configuredVersion)
+        assertEquals("1.18.0", row.toolManagerVersion)
+    }
+
+    // -------------------------------------------------------------------------
+    // detectMismatchIssues - Erlang cases
+    // -------------------------------------------------------------------------
+
+    fun testDetectMismatch_erlangOtpMajorsMatch_noIssueNoTable() {
+        val path = Paths.get("/project")
+        val erlangHome = "/erlang-27"
+        val (issues, tables) = checker.detectMismatchIssues(
+            moduleCheckData = listOf(moduleData("mod", erlangHome = erlangHome, contentRoot = path)),
+            toolManagerResultsByRoot = mapOf(path to success(versions(erlang = erlangEntry("27.3.4")))),
+            elixirVersionBySdk = emptyMap(),
+            erlangReleaseByHomePath = mapOf(erlangHome to Release("27", "27.3.4")),
+            elixirVersionByInstallPath = emptyMap(),
+        )
+        assertTrue("No issues when Erlang OTP majors match", issues.isEmpty())
+        assertTrue("No table when Erlang OTP majors match", tables.isEmpty())
+    }
+
+    fun testDetectMismatch_erlangOtpMajorMismatch_producesIssueAndTable() {
+        val path = Paths.get("/project")
+        val erlangHome = "/erlang-26"
+        val (issues, tables) = checker.detectMismatchIssues(
+            moduleCheckData = listOf(moduleData("myModule", erlangHome = erlangHome, contentRoot = path)),
+            toolManagerResultsByRoot = mapOf(path to success(versions(erlang = erlangEntry("27.3.4")))),
+            elixirVersionBySdk = emptyMap(),
+            erlangReleaseByHomePath = mapOf(erlangHome to Release("26", "26.2.5")),
+            elixirVersionByInstallPath = emptyMap(),
+        )
+        assertEquals(1, issues.size)
+        assertEquals("myModule", issues[0].moduleName)
+        assertFalse("OTP mismatch is not a dangling reference", issues[0].isDangling)
+
+        val table = tables["myModule"]
+        assertNotNull("Table produced for mismatching module", table)
+        val row = table!!.rows.single()
+        assertEquals("Erlang", row.label)
+        assertTrue("Row marked as mismatch", row.isMismatch)
+        assertEquals("26.2.5", row.configuredVersion)   // Release.otpVersion → table's configuredVersion
+        assertEquals("27.3.4", row.toolManagerVersion)
+    }
+
+    // -------------------------------------------------------------------------
+    // detectMismatchIssues - combined and edge cases
+    // -------------------------------------------------------------------------
+
+    fun testDetectMismatch_bothElixirAndErlangMismatch_twoIssuesTwoRowTable() {
+        val sdk = mock(Sdk::class.java)
+        val path = Paths.get("/project")
+        val elixirInstall = "/elixir-1.18"
+        val erlangHome = "/erlang-26"
+        val (issues, tables) = checker.detectMismatchIssues(
+            moduleCheckData = listOf(moduleData("myModule", sdk = sdk, erlangHome = erlangHome, contentRoot = path)),
+            toolManagerResultsByRoot = mapOf(
+                path to success(versions(
+                    elixir = elixirEntry("1.18.0", elixirInstall),
+                    erlang = erlangEntry("27.3.4"),
+                ))
+            ),
+            elixirVersionBySdk = mapOf(sdk to "1.17.3"),
+            erlangReleaseByHomePath = mapOf(erlangHome to Release("26", "26.2.5")),
+            elixirVersionByInstallPath = mapOf(elixirInstall to "1.18.0"),
+        )
+        assertEquals("Two issues for two mismatches", 2, issues.size)
+        assertEquals("One table entry for the module", 1, tables.size)
+        val rows = tables["myModule"]!!.rows
+        assertEquals("Two rows in table (one per tool)", 2, rows.size)
+        assertTrue("All rows are mismatches", rows.all { it.isMismatch })
+        assertTrue(rows.any { it.label == "Elixir" })
+        assertTrue(rows.any { it.label == "Erlang" })
+    }
+
+    fun testDetectMismatch_allVersionsMatch_noIssueNoTable() {
+        // Both Elixir and Erlang present, both match → rows exist but none mismatch → no table.
+        val sdk = mock(Sdk::class.java)
+        val path = Paths.get("/project")
+        val elixirInstall = "/elixir-1.17"
+        val erlangHome = "/erlang-27"
+        val (issues, tables) = checker.detectMismatchIssues(
+            moduleCheckData = listOf(moduleData("mod", sdk = sdk, erlangHome = erlangHome, contentRoot = path)),
+            toolManagerResultsByRoot = mapOf(
+                path to success(versions(
+                    elixir = elixirEntry("1.17.3", elixirInstall),
+                    erlang = erlangEntry("27.3.4"),
+                ))
+            ),
+            elixirVersionBySdk = mapOf(sdk to "1.17.3"),
+            erlangReleaseByHomePath = mapOf(erlangHome to Release("27", "27.3.4")),
+            elixirVersionByInstallPath = mapOf(elixirInstall to "1.17.3"),
+        )
+        assertTrue("No issues when all versions match", issues.isEmpty())
+        assertTrue("No table when no row mismatches", tables.isEmpty())
+    }
+
+    fun testDetectMismatch_noConfiguredSdk_noIssue() {
+        // sdk = null → configuredVersion = null → isMismatch guard (both non-null) fails → no issue.
+        val path = Paths.get("/project")
+        val installPath = "/elixir-1.17"
+        val (issues, tables) = checker.detectMismatchIssues(
+            moduleCheckData = listOf(moduleData("mod", sdk = null, contentRoot = path)),
+            toolManagerResultsByRoot = mapOf(path to success(versions(elixir = elixirEntry("1.17.3", installPath)))),
+            elixirVersionBySdk = emptyMap(),
+            erlangReleaseByHomePath = emptyMap(),
+            elixirVersionByInstallPath = mapOf(installPath to "1.17.3"),
+        )
+        assertTrue("No issue when no SDK is configured", issues.isEmpty())
+        assertTrue("No table when no issue", tables.isEmpty())
+    }
+
+    fun testDetectMismatch_tmVersionNullInstallPathAbsent_noIssue_rowFallsBackToEntryVersion() {
+        // installPath not in elixirVersionByInstallPath → tmVersion = null → isMismatch = false.
+        // The row's toolManagerVersion falls back to tmElixir.version (the raw entry version string).
+        val sdk = mock(Sdk::class.java)
+        val path = Paths.get("/project")
+        val installPath = "/elixir-1.17"
+        val (issues, tables) = checker.detectMismatchIssues(
+            moduleCheckData = listOf(moduleData("mod", sdk = sdk, contentRoot = path)),
+            toolManagerResultsByRoot = mapOf(path to success(versions(elixir = elixirEntry("1.17.3", installPath)))),
+            elixirVersionBySdk = mapOf(sdk to "1.17.3"),
+            erlangReleaseByHomePath = emptyMap(),
+            elixirVersionByInstallPath = emptyMap(),   // install path absent
+        )
+        assertTrue("No issue when tmVersion is null", issues.isEmpty())
+        assertTrue("No table when tmVersion is null", tables.isEmpty())
+    }
+
+    fun testDetectMismatch_nullContentRoot_moduleSkipped() {
+        val sdk = mock(Sdk::class.java)
+        val (issues, tables) = checker.detectMismatchIssues(
+            moduleCheckData = listOf(moduleData("mod", sdk = sdk, contentRoot = null)),
+            toolManagerResultsByRoot = emptyMap(),
+            elixirVersionBySdk = mapOf(sdk to "1.17.3"),
+            erlangReleaseByHomePath = emptyMap(),
+            elixirVersionByInstallPath = emptyMap(),
+        )
+        assertTrue("Module skipped when contentRoot is null", issues.isEmpty())
+        assertTrue(tables.isEmpty())
+    }
+
+    fun testDetectMismatch_errorResult_moduleSkipped() {
+        val sdk = mock(Sdk::class.java)
+        val path = Paths.get("/project")
+        val (issues, tables) = checker.detectMismatchIssues(
+            moduleCheckData = listOf(moduleData("mod", sdk = sdk, contentRoot = path)),
+            toolManagerResultsByRoot = mapOf(path to error("config not trusted")),
+            elixirVersionBySdk = mapOf(sdk to "1.17.3"),
+            erlangReleaseByHomePath = emptyMap(),
+            elixirVersionByInstallPath = emptyMap(),
+        )
+        assertTrue("Module skipped when result is Error", issues.isEmpty())
+        assertTrue(tables.isEmpty())
+    }
+
+    fun testDetectMismatch_nullResult_moduleSkipped() {
+        val sdk = mock(Sdk::class.java)
+        val path = Paths.get("/project")
+        val (issues, tables) = checker.detectMismatchIssues(
+            moduleCheckData = listOf(moduleData("mod", sdk = sdk, contentRoot = path)),
+            toolManagerResultsByRoot = mapOf(path to null),
+            elixirVersionBySdk = mapOf(sdk to "1.17.3"),
+            erlangReleaseByHomePath = emptyMap(),
+            elixirVersionByInstallPath = emptyMap(),
+        )
+        assertTrue("Module skipped when result is null", issues.isEmpty())
+        assertTrue(tables.isEmpty())
+    }
+
+    fun testDetectMismatch_tableNameMatchesToolManagerName() {
+        val sdk = mock(Sdk::class.java)
+        val path = Paths.get("/project")
+        val installPath = "/elixir-1.18"
+        val (_, tables) = checker.detectMismatchIssues(
+            moduleCheckData = listOf(moduleData("mod", sdk = sdk, contentRoot = path)),
+            toolManagerResultsByRoot = mapOf(
+                path to success(versions(toolManagerName = "asdf", elixir = elixirEntry("1.18.0", installPath)))
+            ),
+            elixirVersionBySdk = mapOf(sdk to "1.17.3"),
+            erlangReleaseByHomePath = emptyMap(),
+            elixirVersionByInstallPath = mapOf(installPath to "1.18.0"),
+        )
+        assertEquals("asdf", tables["mod"]?.toolManagerName)
+    }
+
+    fun testDetectMismatch_multipleModules_independentlyEvaluated() {
+        val sdkA = mock(Sdk::class.java)
+        val sdkB = mock(Sdk::class.java)
+        val pathA = Paths.get("/a")
+        val pathB = Paths.get("/b")
+        val installA = "/elixir-1.18"
+        val installB = "/elixir-1.17"
+        // Module A mismatches; module B matches.
+        val (issues, tables) = checker.detectMismatchIssues(
+            moduleCheckData = listOf(
+                moduleData("modA", sdk = sdkA, contentRoot = pathA),
+                moduleData("modB", sdk = sdkB, contentRoot = pathB),
+            ),
+            toolManagerResultsByRoot = mapOf(
+                pathA to success(versions(elixir = elixirEntry("1.18.0", installA))),
+                pathB to success(versions(elixir = elixirEntry("1.17.3", installB))),
+            ),
+            elixirVersionBySdk = mapOf(sdkA to "1.17.3", sdkB to "1.17.3"),
+            erlangReleaseByHomePath = emptyMap(),
+            elixirVersionByInstallPath = mapOf(installA to "1.18.0", installB to "1.17.3"),
+        )
+        assertEquals("Only module A has a mismatch issue", 1, issues.size)
+        assertEquals("modA", issues[0].moduleName)
+        assertNotNull("Table for mismatching module A", tables["modA"])
+        assertTrue("No table for matching module B", !tables.containsKey("modB"))
+    }
+}

--- a/tests/org/elixir_lang/tool_manager/mise/MiseRefreshTriggerTest.kt
+++ b/tests/org/elixir_lang/tool_manager/mise/MiseRefreshTriggerTest.kt
@@ -1,0 +1,227 @@
+package org.elixir_lang.tool_manager.mise
+
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.openapi.vfs.newvfs.events.VFileContentChangeEvent
+import com.intellij.openapi.vfs.newvfs.events.VFileCreateEvent
+import com.intellij.openapi.vfs.newvfs.events.VFileDeleteEvent
+import com.intellij.openapi.vfs.newvfs.events.VFileEvent
+import org.elixir_lang.PlatformTestCase
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+
+/**
+ * Unit tests for [MiseRefreshTrigger.shouldTrigger] (internal).
+ *
+ * All three branching cases are covered:
+ * - [VFileContentChangeEvent] (exact-path match)
+ * - [VFileDeleteEvent]        (exact-path match)
+ * - [VFileCreateEvent]        (parent-in-contentRoots + child-name pattern match)
+ * - Unknown event subtype     (always false)
+ *
+ * The event subclasses are all `final`, so they are mocked via Mockito 5 + inline agent.
+ * Only the fields actually read by the function are stubbed; everything else is left at
+ * the Mockito default (null / false / 0).
+ */
+class MiseRefreshTriggerTest : PlatformTestCase() {
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private val exactPaths = setOf("/project/mise.toml", "/home/user/.config/mise/config.toml")
+    private val contentRoots = setOf("/project", "/another/project")
+
+    private fun contentChange(path: String): VFileContentChangeEvent =
+        mock(VFileContentChangeEvent::class.java).also { `when`(it.path).thenReturn(path) }
+
+    private fun delete(path: String): VFileDeleteEvent =
+        mock(VFileDeleteEvent::class.java).also { `when`(it.path).thenReturn(path) }
+
+    private fun create(parentPath: String, childName: String): VFileCreateEvent {
+        val parent = mock(VirtualFile::class.java)
+        `when`(parent.path).thenReturn(parentPath)
+        return mock(VFileCreateEvent::class.java).also {
+            `when`(it.parent).thenReturn(parent)
+            `when`(it.childName).thenReturn(childName)
+        }
+    }
+
+    /** A plain unknown subtype - not one of the three handled branches. */
+    private fun unknownEvent(): VFileEvent = mock(VFileEvent::class.java)
+
+    // -------------------------------------------------------------------------
+    // VFileContentChangeEvent
+    // -------------------------------------------------------------------------
+
+    fun testContentChange_pathInExactPaths_returnsTrue() {
+        assertTrue(
+            MiseRefreshTrigger.shouldTrigger(contentChange("/project/mise.toml"), exactPaths, contentRoots, "")
+        )
+    }
+
+    fun testContentChange_pathNotInExactPaths_returnsFalse() {
+        assertFalse(
+            MiseRefreshTrigger.shouldTrigger(contentChange("/project/README.md"), exactPaths, contentRoots, "")
+        )
+    }
+
+    // -------------------------------------------------------------------------
+    // VFileDeleteEvent
+    // -------------------------------------------------------------------------
+
+    fun testDelete_pathInExactPaths_returnsTrue() {
+        assertTrue(
+            MiseRefreshTrigger.shouldTrigger(delete("/project/mise.toml"), exactPaths, contentRoots, "")
+        )
+    }
+
+    fun testDelete_pathNotInExactPaths_returnsFalse() {
+        assertFalse(
+            MiseRefreshTrigger.shouldTrigger(delete("/project/mix.exs"), exactPaths, contentRoots, "")
+        )
+    }
+
+    // -------------------------------------------------------------------------
+    // VFileCreateEvent - pattern matching (^mise\.toml$)
+    // -------------------------------------------------------------------------
+
+    fun testCreate_miseToml_inContentRoot_returnsTrue() {
+        assertTrue(
+            MiseRefreshTrigger.shouldTrigger(create("/project", "mise.toml"), exactPaths, contentRoots, "")
+        )
+    }
+
+    fun testCreate_miseLocalToml_inContentRoot_returnsTrue() {
+        // Matches ^mise\..+\.toml$ (the "mise.<env>.toml" pattern)
+        assertTrue(
+            MiseRefreshTrigger.shouldTrigger(create("/project", "mise.local.toml"), exactPaths, contentRoots, "")
+        )
+    }
+
+    fun testCreate_miseCustomEnvToml_inContentRoot_returnsTrue() {
+        // Another variant of the ^mise\..+\.toml$ pattern
+        assertTrue(
+            MiseRefreshTrigger.shouldTrigger(create("/project", "mise.test.toml"), exactPaths, contentRoots, "")
+        )
+    }
+
+    fun testCreate_toolVersions_inContentRoot_returnsTrue() {
+        // Matches ^\.tool-versions$
+        assertTrue(
+            MiseRefreshTrigger.shouldTrigger(create("/project", ".tool-versions"), exactPaths, contentRoots, "")
+        )
+    }
+
+    fun testCreate_unrelatedFile_inContentRoot_returnsFalse() {
+        assertFalse(
+            MiseRefreshTrigger.shouldTrigger(create("/project", "README.md"), exactPaths, contentRoots, "")
+        )
+    }
+
+    fun testCreate_miseToml_parentNotContentRoot_returnsFalse() {
+        // The file name matches, but the parent directory is not a watched content root.
+        assertFalse(
+            MiseRefreshTrigger.shouldTrigger(create("/some/other/dir", "mise.toml"), exactPaths, contentRoots, "")
+        )
+    }
+
+    fun testCreate_miseTomlBak_trailingChars_returnsFalse() {
+        // Trailing ".bak" must not match due to the $ anchor in ^mise\.toml$
+        assertFalse(
+            MiseRefreshTrigger.shouldTrigger(create("/project", "mise.toml.bak"), exactPaths, contentRoots, "")
+        )
+    }
+
+    fun testCreate_notMiseToml_leadingChars_returnsFalse() {
+        // Leading chars must not match due to the ^ anchor in ^mise\.toml$
+        assertFalse(
+            MiseRefreshTrigger.shouldTrigger(create("/project", "notmise.toml"), exactPaths, contentRoots, "")
+        )
+    }
+
+    // -------------------------------------------------------------------------
+    // Unknown event type
+    // -------------------------------------------------------------------------
+
+    fun testUnknownEventType_returnsFalse() {
+        assertFalse(
+            MiseRefreshTrigger.shouldTrigger(unknownEvent(), exactPaths, contentRoots, "")
+        )
+    }
+
+    // -------------------------------------------------------------------------
+    // VFileCreateEvent - trusted-configs directory
+    // -------------------------------------------------------------------------
+
+    fun testCreate_anyFile_inTrustedConfigsDir_returnsTrue() {
+        // `mise trust` creates a file named with an opaque hash in the trusted-configs dir.
+        assertTrue(
+            MiseRefreshTrigger.shouldTrigger(
+                create("/home/user/.local/state/mise/trusted-configs", "IdeaProjects-myproject-abc123"),
+                exactPaths, contentRoots,
+                "/home/user/.local/state/mise/trusted-configs"
+            )
+        )
+    }
+
+    fun testCreate_anyFile_trustedConfigsDirEmpty_doesNotTrigger() {
+        // When trustedConfigsDirString is empty (stateDir unavailable), do not trigger.
+        assertFalse(
+            MiseRefreshTrigger.shouldTrigger(
+                create("/home/user/.local/state/mise/trusted-configs", "IdeaProjects-myproject-abc123"),
+                exactPaths, contentRoots,
+                ""
+            )
+        )
+    }
+
+    // -------------------------------------------------------------------------
+    // VFileContentChangeEvent - trusted-configs directory
+    // -------------------------------------------------------------------------
+
+    fun testContentChange_pathInTrustedConfigsDir_returnsTrue() {
+        // User re-ran `mise trust` on an already-trusted config - file is updated, not created.
+        assertTrue(
+            MiseRefreshTrigger.shouldTrigger(
+                contentChange("/home/user/.local/state/mise/trusted-configs/IdeaProjects-myproject-abc123"),
+                exactPaths, contentRoots,
+                "/home/user/.local/state/mise/trusted-configs"
+            )
+        )
+    }
+
+    fun testContentChange_pathInTrustedConfigsDir_trustedConfigsDirEmpty_returnsFalse() {
+        assertFalse(
+            MiseRefreshTrigger.shouldTrigger(
+                contentChange("/home/user/.local/state/mise/trusted-configs/IdeaProjects-myproject-abc123"),
+                exactPaths, contentRoots,
+                ""
+            )
+        )
+    }
+
+    // -------------------------------------------------------------------------
+    // VFileDeleteEvent - trusted-configs directory
+    // -------------------------------------------------------------------------
+
+    fun testDelete_pathInTrustedConfigsDir_returnsTrue() {
+        // User untrusted the config - the trust file is removed; re-scan to surface the error.
+        assertTrue(
+            MiseRefreshTrigger.shouldTrigger(
+                delete("/home/user/.local/state/mise/trusted-configs/IdeaProjects-myproject-abc123"),
+                exactPaths, contentRoots,
+                "/home/user/.local/state/mise/trusted-configs"
+            )
+        )
+    }
+
+    fun testDelete_pathInTrustedConfigsDir_trustedConfigsDirEmpty_returnsFalse() {
+        assertFalse(
+            MiseRefreshTrigger.shouldTrigger(
+                delete("/home/user/.local/state/mise/trusted-configs/IdeaProjects-myproject-abc123"),
+                exactPaths, contentRoots,
+                ""
+            )
+        )
+    }
+}

--- a/tests/org/elixir_lang/tool_manager/mise/MiseToolManagerVersionsTest.kt
+++ b/tests/org/elixir_lang/tool_manager/mise/MiseToolManagerVersionsTest.kt
@@ -1,0 +1,157 @@
+package org.elixir_lang.tool_manager.mise
+
+import org.elixir_lang.PlatformTestCase
+import org.elixir_lang.mise.MiseToolEntry
+import org.elixir_lang.mise.MiseVersions
+
+/**
+ * Unit tests for [MiseToolManagerVersions].
+ *
+ * Verifies that the adapter correctly maps the three [MiseToolEntry] fields that
+ * [org.elixir_lang.tool_manager.ToolManagerSdkChecker] actually uses
+ * ([version][org.elixir_lang.tool_manager.ToolEntry.version],
+ * [installPath][org.elixir_lang.tool_manager.ToolEntry.installPath],
+ * [installed][org.elixir_lang.tool_manager.ToolEntry.installed]) and that the other
+ * mise-specific fields are silently dropped at the adapter boundary.
+ */
+class MiseToolManagerVersionsTest : PlatformTestCase() {
+
+    // -------------------------------------------------------------------------
+    // Helper
+    // -------------------------------------------------------------------------
+
+    /**
+     * Constructs a [MiseToolEntry] with only the three fields that survive into [MiseToolManagerVersions].
+     * The remaining fields ([MiseToolEntry.requestedVersion], [MiseToolEntry.sourceType],
+     * [MiseToolEntry.sourcePath], [MiseToolEntry.active]) are filled with stable placeholders so the
+     * intent of each test stays focused on the mapped fields.
+     */
+    private fun miseEntry(
+        version: String,
+        installPath: String,
+        installed: Boolean = true,
+    ) = MiseToolEntry(
+        version = version,
+        requestedVersion = "latest",
+        installPath = installPath,
+        sourceType = "tool-versions",
+        sourcePath = "/project/.tool-versions",
+        installed = installed,
+        active = true,
+    )
+
+    // -------------------------------------------------------------------------
+    // toolManagerName
+    // -------------------------------------------------------------------------
+
+    fun testToolManagerName_isAlwaysMise() {
+        val adapted = MiseToolManagerVersions(MiseVersions(elixir = null, erlang = null))
+        assertEquals("mise", adapted.toolManagerName)
+    }
+
+    // -------------------------------------------------------------------------
+    // Both entries present - field mapping
+    // -------------------------------------------------------------------------
+
+    fun testBothEntries_versionMappedVerbatim() {
+        val adapted = MiseToolManagerVersions(
+            MiseVersions(
+                elixir = miseEntry("1.17.3", "/i/elixir-1.17"),
+                erlang = miseEntry("27.3.4", "/i/erlang-27"),
+            )
+        )
+        assertEquals("1.17.3", adapted.elixir!!.version)
+        assertEquals("27.3.4", adapted.erlang!!.version)
+    }
+
+    fun testBothEntries_installPathMappedVerbatim() {
+        val adapted = MiseToolManagerVersions(
+            MiseVersions(
+                elixir = miseEntry("1.17.3", "/i/elixir-1.17"),
+                erlang = miseEntry("27.3.4", "/i/erlang-27"),
+            )
+        )
+        assertEquals("/i/elixir-1.17", adapted.elixir!!.installPath)
+        assertEquals("/i/erlang-27",   adapted.erlang!!.installPath)
+    }
+
+    fun testBothEntries_installedTruePreserved() {
+        val adapted = MiseToolManagerVersions(
+            MiseVersions(
+                elixir = miseEntry("1.17.3", "/i/elixir", installed = true),
+                erlang = miseEntry("27.3.4",  "/i/erlang", installed = true),
+            )
+        )
+        assertTrue("elixir.installed should be true",  adapted.elixir!!.installed)
+        assertTrue("erlang.installed should be true",  adapted.erlang!!.installed)
+    }
+
+    fun testBothEntries_installedFalsePreserved() {
+        // Verifies the flag is propagated, not assumed/defaulted to true.
+        val adapted = MiseToolManagerVersions(
+            MiseVersions(
+                elixir = miseEntry("1.17.3", "/i/elixir", installed = false),
+                erlang = miseEntry("27.3.4",  "/i/erlang", installed = false),
+            )
+        )
+        assertFalse("elixir.installed should be false", adapted.elixir!!.installed)
+        assertFalse("erlang.installed should be false", adapted.erlang!!.installed)
+    }
+
+    // -------------------------------------------------------------------------
+    // Null propagation
+    // -------------------------------------------------------------------------
+
+    fun testElixirNull_erlangPresent() {
+        val adapted = MiseToolManagerVersions(
+            MiseVersions(
+                elixir = null,
+                erlang = miseEntry("27.3.4", "/i/erlang-27"),
+            )
+        )
+        assertNull("elixir should be null", adapted.elixir)
+        assertNotNull("erlang should not be null", adapted.erlang)
+        assertEquals("27.3.4", adapted.erlang!!.version)
+    }
+
+    fun testElixirPresent_erlangNull() {
+        val adapted = MiseToolManagerVersions(
+            MiseVersions(
+                elixir = miseEntry("1.17.3", "/i/elixir-1.17"),
+                erlang = null,
+            )
+        )
+        assertNotNull("elixir should not be null", adapted.elixir)
+        assertNull("erlang should be null", adapted.erlang)
+        assertEquals("1.17.3", adapted.elixir!!.version)
+    }
+
+    fun testBothNull_toolManagerNameStillMise() {
+        val adapted = MiseToolManagerVersions(MiseVersions(elixir = null, erlang = null))
+        assertNull(adapted.elixir)
+        assertNull(adapted.erlang)
+        assertEquals("mise", adapted.toolManagerName)
+    }
+
+    // -------------------------------------------------------------------------
+    // Unconventional version strings - no parsing or normalisation
+    // -------------------------------------------------------------------------
+
+    fun testUnconventionalVersionStrings_copiedVerbatim() {
+        // The adapter must not parse, normalise, or strip any part of the version string.
+        val versions = listOf("", "1.17.3-otp-27", "main", "ref:abc1234")
+        for (v in versions) {
+            val adapted = MiseToolManagerVersions(
+                MiseVersions(
+                    elixir = miseEntry(v, "/i/elixir"),
+                    erlang = null,
+                )
+            )
+            assertEquals(
+                "version '$v' should be copied verbatim without normalisation",
+                v,
+                adapted.elixir!!.version,
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Overview

Introduces a **tool-manager abstraction** for Elixir/Erlang SDK detection and wires it into the SDK status notification pipeline. A tool manager (currently **mise**, with room for asdf and others) is queried for the Elixir/Erlang versions installed for each module's content root; the results drive SDK registration, module SDK assignment, version-mismatch notifications, and one-click "Configure from &lt;tool manager&gt;" actions.

The feature is **opt-in** and **rich-IDE only**. Nothing runs until the user explicitly enables a tool manager, and the services are registered only where the Java module APIs required for SDK configuration are available.

## Architecture

A three-stage, message-bus-decoupled pipeline replaces the previous mise-coupled logic in the status-bar widget:

```
ToolManagerSdkCheckerService   (scan)      →  SCAN_TOPIC      (raw Map<Path, ToolManagerResult?>)
        ↓
ToolManagerSdkAnalyser         (analyse)   →  ANALYSIS_TOPIC  (ToolManagerAnalysisResult snapshot)
        ↓
ElixirEditorBasedSdkWidget     (UI)        →  renders notification, no CLI/comparison logic
```

- **`ToolManagerSdkCheckerService`** — owns the scan lifecycle. Waits for JPS project-model load before the first scan, debounces re-scans triggered by settings changes / `rootsChanged` / file-watch triggers, runs resolution on `Dispatchers.IO`, and publishes raw results. No UI knowledge.
- **`ToolManagerSdkAnalyser`** — compares raw scan results against the currently configured module SDKs and publishes a fully-analysed, immutable `ToolManagerAnalysisResult`. Re-analyses on new scans or when module SDKs change (`ModuleRootListener`, `ProjectJdkTable.JDK_TABLE_TOPIC`). Replays the latest snapshot to late subscribers so the widget always gets a result on first registration.
- **`ElixirEditorBasedSdkWidget`** — now a pure consumer of `ANALYSIS_TOPIC`. Runs no mise CLI calls or SDK comparison itself; it only renders notifications and combines tool-manager issues with its own non-tool-manager checks (dangling SDK refs, module/project SDK disagreements). This is a large rewrite (net reduction) of the widget.

## Tool-manager abstraction

- **`ElixirToolManager`** — stateless interface: `resolveVersions(contentRoot)`, optional `createRefreshTrigger()`, a stable persistence `name`, and a `displayName`.
- **`ToolManagerResult`** — sealed: `Success(versions)` / `Error(toolManagerName, description)`; `null` means "not applicable". Error descriptions are pre-formatted by the concrete manager; the abstract layer and widget render them verbatim.
- **`ToolManagerVersions` / `ToolEntry`** — parsed `(tool, version, installPath, installed)` data.
- **`ModuleSdkIssue`** — data class describing a per-module issue (version mismatch or dangling SDK reference).
- **`SdkVersionTable`** — per-module install-path → SDK map for fast lookup and rich notification tables.
- **`ToolManagerRegistry`** (`allBuiltInToolManagers`) — priority-ordered list of built-in managers; adding a manager is a one-line change.
- **`ToolManagerSdkChecker`** — the pure logic core: collects module data under a read action, resolves versions on IO, detects mismatches, builds comparison tables, and configures SDKs (`SdkRegistrar` + module modifiable model).

## mise implementation

- **`MiseToolManager` / `MiseToolManagerVersions`** — map mise output onto the abstraction.
- **`Mise.resolveVersions()`** now returns a sealed `MiseResult` (`Success` | `UntrustedConfig`). A non-zero exit is inspected for the "Config files … are not trusted" stderr pattern; when matched it surfaces as a `ToolManagerResult.Error` with the `mise trust` fix command instead of being silently swallowed.
- **File watching** — `MiseRefreshTrigger` registers `LocalFileSystem` watch roots for the exact active config files (`mise config ls --json`, incl. user-global files), content-root directories, and the global trusted-configs directory (`mise doctor --json` → state dir, WSL-path-converted). A re-scan fires on content-change/delete of watched files, pattern-matched creates (`mise.toml`, `mise.*.toml`, `.tool-versions`) in content roots, and any change in trusted-configs — so `mise trust` triggers a re-scan without editing a config file. Triggers are reinstalled after each scan so dynamically discovered file lists stay current.

## Settings & registration

- **`ToolManagerSettings`** — project-level, opt-in (`enabledManagers` set), persisted in `.idea/elixir.xml`. Deliberately **not** a light `@Service` so it is not auto-registered on non-rich IDEs. Publishes `SETTINGS_CHANGED_TOPIC`.
- **`ToolManagerConfigurable`** — new **Settings → Languages & Frameworks → Elixir → Tool Managers** page.
- **`ElixirSearchableOptionContributor`** — adds search aliases so the page is discoverable in Settings search.
- **Registration** — all tool-manager services, the configurable, and the startup activity (`ToolManagerSdkCheckerStartupActivity`) are declared in `rich-platform-plugin.xml` (guarded by `com.intellij.modules.java`). `plugin.xml` only adds the new `Elixir SDK` sticky notification group.

## Threading & startup correctness

- Initial scan is deferred until `JpsProjectLoadingManager.jpsProjectLoaded` so module content roots and SDK assignments reflect on-disk state rather than the stale workspace-model cache (fixes a race where a newly-registered SDK could be removed by `DelayedProjectSynchronizer`).
- `configureSdks` flushes `jdk.table.xml` via `Application.saveSettings()` on IO before the module-assignment write action, preventing the synchronizer from reverting the assignment.
- Scans run off-EDT on `Dispatchers.IO`; model reads use `readAction`; SDK writes use `edtWriteAction` / `runWithModalProgressBlocking`. Refresh-trigger lifetimes are swapped under a short lock that never spans install I/O.

## Tests

- **`ToolManagerSdkCheckerTest`** — the pure phase-3 logic: `detectMismatchIssues` (match / single- and dual-mismatch / all-match guard / null short-circuits / error-and-null skips / multi-module independence), `buildAssignments` (installed filtering, null skips, insertion-order preservation), and `collectErrors` (empty / success-only / mixed / distinct-by-description).
- **`MiseRefreshTriggerTest`** — branch coverage of `shouldTrigger`: exact-path content/delete matches, create-pattern regexes in content roots, trusted-configs create/change/delete (incl. unavailable-state-dir sentinel), and negative/anchor cases. Uses the Mockito 5 inline agent to mock the final `VFile*Event` classes.
- **`MiseToolManagerVersionsTest`** — verbatim `ToolEntry` field mapping, null propagation, and no normalisation of unconventional version strings.
- **`MiseTest`** — extended with `parseTrustError` and `parseDoctorStateDir` cases.
- **`ElixirSdkStatusWidgetTest`** — updated for the refactored widget.

## Scope

28 files, ~+2,935 / −587. New `org.elixir_lang.tool_manager` package (production + tests), a large `ElixirEditorBasedSdkWidget` rewrite, mise changes in `Mise.kt`, and the two `plugin.xml` registration edits.
