### PR TITLE
Fixes for gutter icons

### DIFF
--- a/src/org/elixir_lang/exunit/TestLineMarkerProvider.kt
+++ b/src/org/elixir_lang/exunit/TestLineMarkerProvider.kt
@@ -2,9 +2,11 @@ package org.elixir_lang.exunit
 
 import com.intellij.execution.TestStateStorage
 import com.intellij.execution.lineMarker.RunLineMarkerContributor
+import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import com.intellij.psi.impl.source.tree.LeafPsiElement
+import com.intellij.psi.util.PsiTreeUtil
 import com.intellij.util.system.OS
 import org.elixir_lang.exunit.configuration.lineNumber
 import org.elixir_lang.mix.Test
@@ -17,6 +19,7 @@ import org.elixir_lang.sdk.wsl.wslCompat
  * Provides the gutter "run" icons for tests.
  */
 internal class ExUnitLineMarkerProvider : RunLineMarkerContributor() {
+    private val testMethodNames = setOf("test", "doctest")
 
     override fun getInfo(element: PsiElement): Info? {
 
@@ -63,20 +66,62 @@ internal class ExUnitLineMarkerProvider : RunLineMarkerContributor() {
         if (!TestFinder.isTestElement(element)) {
             return null
         }
+        val fileUrl = fileUrlAsExUnitSeesIt(containingFile)
+        val state = if (isClass) {
+            // describe/defmodule: aggregate states of all contained tests, since
+            // ExUnit never emits describe-level TC events with a locationHint, so
+            // TestStateStorage has no direct entry for the describe/module URL.
+            aggregateChildTestStates(parent, element.project, fileUrl, containingFile)
+        } else {
+            val url = appendLineNumber(fileUrl, element, containingFile)
+            TestStateStorage.getInstance(element.project)?.getState(url)
+        }
 
-        val number = lineNumber(element, containingFile)
-        val url = "file://${fileUrlAsExUnitSeesIt(containingFile)}:${number}"
-        val state = TestStateStorage.getInstance(element.project)?.getState(url)
         return withExecutorActions(getTestStateIcon(state, isClass))
     }
 
-    private fun fileUrlAsExUnitSeesIt(containingFile: PsiFile): String = if (OS.CURRENT == OS.Windows) {
-        // In Elixir, the drive letter is lowercase for some reason.
-        val fixedDriveLetter = containingFile.virtualFile.path.replaceFirstChar { it.lowercase() }
-        // On WSL, ExUnit reports the POSIX path, but IDEA references the file by the UNC path. We convert it to posix if
-        // it is UNC, otherwise return unchanged.
-        wslCompat.maybeParseWindowsUncPath(fixedDriveLetter)
-    } else {
-        containingFile.virtualFile.path
+    private fun fileUrlAsExUnitSeesIt(containingFile: PsiFile): String =
+            "file://" + if (OS.CURRENT == OS.Windows) {
+                // In Elixir, the drive letter is lowercase for some reason.
+                val fixedDriveLetter = containingFile.virtualFile.path.replaceFirstChar { it.lowercase() }
+                // On WSL, ExUnit reports the POSIX path, but IDEA references the file by the UNC path. We convert it to posix if
+                // it is UNC, otherwise return unchanged.
+                wslCompat.maybeParseWindowsUncPath(fixedDriveLetter)
+            } else {
+                containingFile.virtualFile.path
+            }
+
+    private fun appendLineNumber(fileUrl: String, element: PsiElement, containingFile: PsiFile): String =
+            "$fileUrl:${lineNumber(element, containingFile)}"
+
+    /**
+     * For describe/defmodule gutter icons: lazily iterate over all child test/doctest calls, looking up each
+     * test's state in turn from TestStateStorage. Returns a failure state as soon as one is found, returns the
+     * first good state if there are no bad states, or null if nothing is found.
+     *
+     * Priority: FAILED (6) or ERROR (8) > PASSED/COMPLETE (1) > null (no data).
+     */
+    private fun aggregateChildTestStates(
+        scopeCall: Call,
+        project: Project,
+        fileUrl: String,
+        containingFile: PsiFile
+    ): TestStateStorage.Record? {
+        val storage = TestStateStorage.getInstance(project) ?: return null
+        var goodState: TestStateStorage.Record? = null
+
+        val states = PsiTreeUtil.findChildrenOfType(scopeCall, Call::class.java)
+            .asSequence()
+            .filter { call -> call.functionName() in testMethodNames }
+            .mapNotNull { testCall -> storage.getState(appendLineNumber(fileUrl, testCall, containingFile)) }
+
+        for (state in states) {
+            when (state.magnitude) {
+                6, 8 -> return state                            // FAILED/ERROR → red icon, stop scanning
+                1 -> if (goodState == null) goodState = state   // PASSED/COMPLETE → remember first, keep looking
+            }
+        }
+
+        return goodState
     }
 }

--- a/src/org/elixir_lang/exunit/TestLineMarkerProvider.kt
+++ b/src/org/elixir_lang/exunit/TestLineMarkerProvider.kt
@@ -12,6 +12,7 @@ import org.elixir_lang.mix.TestFinder
 import org.elixir_lang.psi.ElixirFile
 import org.elixir_lang.psi.call.Call
 import org.elixir_lang.psi.operation.Match
+import org.elixir_lang.sdk.wsl.wslCompat
 
 /**
  * Provides the gutter "run" icons for tests.
@@ -55,14 +56,19 @@ class ExUnitLineMarkerProvider : RunLineMarkerContributor() {
         } ?: return null
 
         val number = lineNumber(element)
-        var url = "file://${element.containingFile.virtualFile.path}:${number}"
-        if (OS.CURRENT == OS.Windows) {
-            // In Elixir, the drive letter is lowercase for some reason.
-            val location = "file://".length
-            url = url.replaceRange(location, location + 1, url[location].lowercaseChar().toString())
-        }
+        val url = "file://${fileUrlAsExUnitSeesIt(element)}:${number}"
         val state = TestStateStorage.getInstance(element.project)?.getState(url)
         return withExecutorActions(getTestStateIcon(state, isClass))
+    }
+
+    private fun fileUrlAsExUnitSeesIt(element: PsiElement): String = if (OS.CURRENT == OS.Windows) {
+        // In Elixir, the drive letter is lowercase for some reason.
+        val fixedDriveLetter = element.containingFile.virtualFile.path.replaceFirstChar { it.lowercase() }
+        // On WSL, ExUnit reports the POSIX path, but IDEA references the file by the UNC path. We convert it to posix if
+        // it is UNC, otherwise return unchanged.
+        wslCompat.maybeParseWindowsUncPath(fixedDriveLetter)
+    } else {
+        element.containingFile.virtualFile.path
     }
 }
 

--- a/src/org/elixir_lang/exunit/TestLineMarkerProvider.kt
+++ b/src/org/elixir_lang/exunit/TestLineMarkerProvider.kt
@@ -2,14 +2,13 @@ package org.elixir_lang.exunit
 
 import com.intellij.execution.TestStateStorage
 import com.intellij.execution.lineMarker.RunLineMarkerContributor
-import com.intellij.openapi.roots.ProjectRootManager
 import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
 import com.intellij.psi.impl.source.tree.LeafPsiElement
 import com.intellij.util.system.OS
-import org.elixir_lang.exunit.configuration.SUFFIX
 import org.elixir_lang.exunit.configuration.lineNumber
+import org.elixir_lang.mix.Test
 import org.elixir_lang.mix.TestFinder
-import org.elixir_lang.psi.ElixirFile
 import org.elixir_lang.psi.call.Call
 import org.elixir_lang.psi.operation.Match
 import org.elixir_lang.sdk.wsl.wslCompat
@@ -17,16 +16,14 @@ import org.elixir_lang.sdk.wsl.wslCompat
 /**
  * Provides the gutter "run" icons for tests.
  */
-class ExUnitLineMarkerProvider : RunLineMarkerContributor() {
+internal class ExUnitLineMarkerProvider : RunLineMarkerContributor() {
 
     override fun getInfo(element: PsiElement): Info? {
 
-        // Speed things up by only looking at files inside the test directory.
-        if (!isUnderTestSources(element)) {
-            return null
-        }
-
-        if (!TestFinder.isTestElement(element) || element !is LeafPsiElement) {
+        // The platform calls getInfo for every element (leaf and composite) and recommends returning null as fast
+        // as possible, marking leaf elements only. Do the cheap, local AST checks before any file-system, index,
+        // or stub-resolution work.
+        if (element !is LeafPsiElement) {
             return null
         }
 
@@ -55,26 +52,31 @@ class ExUnitLineMarkerProvider : RunLineMarkerContributor() {
             else -> null
         } ?: return null
 
-        val number = lineNumber(element)
-        val url = "file://${fileUrlAsExUnitSeesIt(element)}:${number}"
+        // Only genuine test/describe/defmodule/doctest call-name leaves reach here; now pay for the file-level and
+        // stub-resolution checks. Resolve the containing file once (an AST walk) and reuse it below.
+        val containingFile = element.containingFile ?: return null
+
+        if (!Test.isUnderTestSources(containingFile)) {
+            return null
+        }
+
+        if (!TestFinder.isTestElement(element)) {
+            return null
+        }
+
+        val number = lineNumber(element, containingFile)
+        val url = "file://${fileUrlAsExUnitSeesIt(containingFile)}:${number}"
         val state = TestStateStorage.getInstance(element.project)?.getState(url)
         return withExecutorActions(getTestStateIcon(state, isClass))
     }
 
-    private fun fileUrlAsExUnitSeesIt(element: PsiElement): String = if (OS.CURRENT == OS.Windows) {
+    private fun fileUrlAsExUnitSeesIt(containingFile: PsiFile): String = if (OS.CURRENT == OS.Windows) {
         // In Elixir, the drive letter is lowercase for some reason.
-        val fixedDriveLetter = element.containingFile.virtualFile.path.replaceFirstChar { it.lowercase() }
+        val fixedDriveLetter = containingFile.virtualFile.path.replaceFirstChar { it.lowercase() }
         // On WSL, ExUnit reports the POSIX path, but IDEA references the file by the UNC path. We convert it to posix if
         // it is UNC, otherwise return unchanged.
         wslCompat.maybeParseWindowsUncPath(fixedDriveLetter)
     } else {
-        element.containingFile.virtualFile.path
+        containingFile.virtualFile.path
     }
-}
-
-fun isUnderTestSources(clazz: PsiElement): Boolean {
-    val psiFile = clazz.containingFile
-    val vFile = psiFile.virtualFile ?: return false
-    val isTest = psiFile is ElixirFile && psiFile.virtualFile.path.endsWith(SUFFIX)
-    return ProjectRootManager.getInstance(clazz.project).fileIndex.isInTestSourceContent(vFile) and isTest
 }

--- a/src/org/elixir_lang/exunit/configuration/Producer.kt
+++ b/src/org/elixir_lang/exunit/configuration/Producer.kt
@@ -9,14 +9,14 @@ import com.intellij.openapi.roots.ProjectRootManager
 import com.intellij.openapi.util.Ref
 import com.intellij.psi.*
 import org.elixir_lang.exunit.Configuration
-import org.elixir_lang.file.containsFileWithSuffix
 import org.elixir_lang.mix.Project
+import org.elixir_lang.mix.Test
 import org.elixir_lang.psi.ElixirFile
 import org.elixir_lang.sdk.elixir.Type
 import org.elixir_lang.sdk.elixir.ElixirSdkLookup.mostSpecificSdk
 import java.io.File
 
-class MixExUnitRunConfigurationProducer :
+internal class MixExUnitRunConfigurationProducer :
     LazyRunConfigurationProducer<Configuration>() {
     override fun getConfigurationFactory(): ConfigurationFactory = Factory
 
@@ -36,7 +36,6 @@ class MixExUnitRunConfigurationProducer :
         } == true
 }
 
-const val SUFFIX = "_test.exs"
 private const val UNKNOWN_LINE = -1
 
 private fun configurationName(
@@ -83,8 +82,9 @@ private fun isConfigurationFromContextImpl(configuration: Configuration, psiElem
             contextConfiguration.workingDirectory == configuration.workingDirectory
 }
 
-fun lineNumber(psiElement: PsiElement): Int {
-    val containingFile = psiElement.containingFile
+fun lineNumber(psiElement: PsiElement): Int = lineNumber(psiElement, psiElement.containingFile)
+
+fun lineNumber(psiElement: PsiElement, containingFile: PsiFile): Int {
     val documentLineNumber = PsiDocumentManager
         .getInstance(containingFile.project)
         .getDocument(containingFile)
@@ -137,7 +137,7 @@ private fun setupConfigurationFromContextImpl(
 
             if ((sdkTypeId == null || sdkTypeId == Type.instance) &&
                 ProjectRootsUtil.isInTestSource(psiElement.virtualFile, psiElement.project) &&
-                containsFileWithSuffix(psiElement, SUFFIX)
+                Test.containsTestFile(psiElement)
             ) {
                 val basePath = psiElement.getProject().basePath
                 val workingDirectory = workingDirectory(psiElement, basePath)
@@ -152,7 +152,7 @@ private fun setupConfigurationFromContextImpl(
             }
         }
         is ElixirFile -> {
-            if (psiElement.virtualFile?.path?.endsWith(SUFFIX) == true) {
+            if (Test.isTestFile(psiElement)) {
                 val basePath = psiElement.project.basePath
                 val workingDirectory = workingDirectory(psiElement, basePath)
                 val lineNumber = lineNumber(psiElement)
@@ -169,7 +169,7 @@ private fun setupConfigurationFromContextImpl(
         else -> {
             val containingFile = psiElement.containingFile
 
-            if (containingFile is ElixirFile && containingFile.virtualFile?.path?.endsWith(SUFFIX) == true) {
+            if (containingFile is ElixirFile && Test.isTestFile(containingFile)) {
                 val basePath = psiElement.project.basePath
                 val workingDirectory = workingDirectory(psiElement, basePath)
                 val lineNumber = lineNumber(psiElement)

--- a/src/org/elixir_lang/mix/Test.kt
+++ b/src/org/elixir_lang/mix/Test.kt
@@ -1,0 +1,167 @@
+package org.elixir_lang.mix
+
+import com.intellij.openapi.roots.ProjectRootManager
+import com.intellij.openapi.util.Key
+import com.intellij.psi.PsiDirectory
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import com.intellij.psi.PsiFileSystemItem
+import com.intellij.psi.PsiManager
+import com.intellij.psi.ResolveState
+import com.intellij.psi.util.CachedValue
+import com.intellij.psi.util.CachedValueProvider
+import com.intellij.psi.util.CachedValuesManager
+import com.intellij.util.concurrency.annotations.RequiresReadLock
+import org.elixir_lang.file.containsFileWithSuffix
+import org.elixir_lang.psi.CallDefinitionClause.isPublicFunction
+import org.elixir_lang.psi.CallDefinitionClause.nameArityInterval
+import org.elixir_lang.psi.ElixirAccessExpression
+import org.elixir_lang.psi.ElixirFile
+import org.elixir_lang.psi.ElixirLine
+import org.elixir_lang.psi.ElixirList
+import org.elixir_lang.psi.Quotable
+import org.elixir_lang.psi.QuotableKeywordList
+import org.elixir_lang.psi.call.Call
+import org.elixir_lang.psi.impl.call.finalArguments
+import org.elixir_lang.psi.impl.call.macroChildCallList
+import org.elixir_lang.psi.impl.keywordValue
+import org.elixir_lang.psi.impl.stripAccessExpression
+import org.elixir_lang.psi.operation.capture.NonNumeric
+
+/**
+ * Mix-level detection of test files and test sources.
+ *
+ * The `_test.exs` filename convention and test-file discovery are owned by Mix (the build tool), not by ExUnit
+ * (the framework): `mix test` finds files via `:test_paths`/`:test_pattern` and selects them with
+ * `:test_load_filters` (which defaults to `[&String.ends_with?(&1, "_test.exs")]`). ExUnit itself never looks at
+ * filenames; it runs whatever modules call `use ExUnit.Case`.
+ */
+object Test {
+    /**
+     * The default test file suffix, matching Mix's default `:test_load_filters` of
+     * `[&String.ends_with?(&1, "_test.exs")]`. Used as the fallback whenever a project's `mix.exs` does not
+     * specify a statically analyzable filter.
+     */
+    const val DEFAULT_TEST_SUFFIX = "_test.exs"
+
+    /**
+     * Whether [file] is an Elixir test file according to the governing `mix.exs`'s `:test_load_filters`, falling
+     * back to [DEFAULT_TEST_SUFFIX] when the filter is absent or not statically analyzable.
+     */
+    @RequiresReadLock
+    fun isTestFile(file: PsiFile): Boolean {
+        if (file !is ElixirFile) return false
+        val name = file.virtualFile?.name ?: return false
+
+        return testSuffixes(file).any { name.endsWith(it) }
+    }
+
+    /**
+     * Whether [directory] contains a test file (see [isTestFile]) at any depth, according to the governing
+     * `mix.exs`'s `:test_load_filters`.
+     */
+    @RequiresReadLock
+    fun containsTestFile(directory: PsiDirectory): Boolean =
+        testSuffixes(directory).any { containsFileWithSuffix(directory, it) }
+
+    /**
+     * Whether [file] is a test file (see [isTestFile]) in a test source root. Not a cheap per-element check - it
+     * queries the project file index and reads the governing `mix.exs` - so callers in hot paths (e.g. line
+     * markers) should apply cheaper structural checks first and resolve the [PsiFile] once.
+     */
+    @RequiresReadLock
+    fun isUnderTestSources(file: PsiFile): Boolean {
+        val vFile = file.virtualFile ?: return false
+
+        return ProjectRootManager.getInstance(file.project).fileIndex.isInTestSourceContent(vFile) &&
+                isTestFile(file)
+    }
+
+    /**
+     * The test file suffixes that apply to [context], read best-effort from its governing `mix.exs`. Always
+     * returns at least [DEFAULT_TEST_SUFFIX].
+     */
+    private fun testSuffixes(context: PsiFileSystemItem): List<String> =
+        governingMixExs(context)?.let { testSuffixesFor(it) } ?: listOf(DEFAULT_TEST_SUFFIX)
+
+    private val TEST_SUFFIXES: Key<CachedValue<List<String>>> = Key.create("ELIXIR_MIX_TEST_SUFFIXES")
+
+    private fun testSuffixesFor(mixExs: PsiFile): List<String> =
+        CachedValuesManager.getCachedValue(mixExs, TEST_SUFFIXES) {
+            val suffixes = (mixExs as? ElixirFile)?.let(::loadFilterSuffixes) ?: listOf(DEFAULT_TEST_SUFFIX)
+
+            CachedValueProvider.Result.create(suffixes, mixExs)
+        }
+
+    /**
+     * The nearest ancestor `mix.exs` of [context], or `null` if none. In umbrella projects this resolves to the
+     * child app's `mix.exs`, which is correct: Mix does not inherit `:test_load_filters` from the umbrella root.
+     */
+    private fun governingMixExs(context: PsiFileSystemItem): PsiFile? {
+        val psiManager = PsiManager.getInstance(context.project)
+        val virtualFile = context.virtualFile
+        var directory = if (virtualFile?.isDirectory == true) virtualFile else virtualFile?.parent
+
+        while (directory != null) {
+            directory.findChild(Project.MIX_EXS)?.let { return psiManager.findFile(it) }
+            directory = directory.parent
+        }
+
+        return null
+    }
+
+    /**
+     * The suffixes extracted from [mixExs]'s `:test_load_filters`, or `null` to fall back to the default when the
+     * key is absent or any entry is not the statically analyzable `&String.ends_with?(&1, "<suffix>")` shape.
+     */
+    private fun loadFilterSuffixes(mixExs: ElixirFile): List<String>? {
+        val keywords = projectKeywords(mixExs) ?: return null
+        val value = keywords.keywordValue("test_load_filters") ?: return null
+
+        return interpretLoadFilters(value)
+    }
+
+    /** The `:project` keyword list of the `def project do ... end` definition in [mixExs], if present. */
+    private fun projectKeywords(mixExs: ElixirFile): QuotableKeywordList? =
+        mixExs
+            .modulars()
+            .asSequence()
+            .flatMap { it.macroChildCallList().asSequence() }
+            .filter { call ->
+                isPublicFunction(call) && nameArityInterval(call, ResolveState.initial())?.let { (name, arityInterval) ->
+                    name == "project" && arityInterval.contains(0)
+                } == true
+            }
+            .flatMap { it.doBlock?.stab?.stabBody?.children?.asSequence() ?: emptySequence() }
+            .filterIsInstance<ElixirAccessExpression>()
+            .mapNotNull(ElixirAccessExpression::getList)
+            .mapNotNull(ElixirList::getKeywords)
+            .firstOrNull()
+
+    /**
+     * Interprets a `:test_load_filters` [value]. Returns the list of suffixes only when every entry is the
+     * reliably analyzable `&String.ends_with?(&1, "<suffix>")` capture; any regex, bare function capture, string,
+     * or otherwise unrecognized entry collapses the whole list to `null` so the caller falls back to the default.
+     *
+     * This is something that we might be able to improve in the future.
+     */
+    private fun interpretLoadFilters(value: Quotable): List<String>? {
+        val list = value.stripAccessExpression() as? ElixirList ?: return null
+        val suffixes = list.children.map { interpretLoadFilter(it.stripAccessExpression()) }
+
+        return if (suffixes.isNotEmpty() && suffixes.all { it != null }) suffixes.filterNotNull() else null
+    }
+
+    /** The suffix of a single `&String.ends_with?(&1, "<suffix>")` filter [entry], or `null` if not that shape. */
+    private fun interpretLoadFilter(entry: PsiElement): String? {
+        val capture = entry as? NonNumeric ?: return null
+        val call = capture.operand()?.stripAccessExpression() as? Call ?: return null
+
+        if (!call.isCalling("String", "ends_with?")) return null
+
+        val arguments = call.finalArguments() ?: return null
+        if (arguments.size != 2) return null
+
+        return (arguments[1].stripAccessExpression() as? ElixirLine)?.body?.text
+    }
+}

--- a/src/org/elixir_lang/mix/TestFinder.java
+++ b/src/org/elixir_lang/mix/TestFinder.java
@@ -22,7 +22,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Set;
 
-public class TestFinder implements com.intellij.testIntegration.TestFinder {
+public final class TestFinder implements com.intellij.testIntegration.TestFinder {
     private static final String TEST_SUFFIX = "Test";
 
     @NotNull
@@ -32,9 +32,7 @@ public class TestFinder implements com.intellij.testIntegration.TestFinder {
         Call sourceElement = sourceElement(element);
         Collection<PsiElement> correspondingCollection = new ArrayList<>();
 
-        if (sourceElement instanceof StubBased) {
-            @SuppressWarnings("rawtypes")
-            StubBased sourceStubBased = (StubBased) sourceElement;
+        if (sourceElement instanceof @SuppressWarnings("rawtypes")StubBased sourceStubBased) {
             Set<String> canonicalNameSet = sourceStubBased.canonicalNameSet();
 
             if (!canonicalNameSet.isEmpty()) {
@@ -54,9 +52,7 @@ public class TestFinder implements com.intellij.testIntegration.TestFinder {
                         );
 
                         for (NamedElement correspondingElement : correspondingElements) {
-                            if (correspondingElement instanceof Call) {
-                                Call correspondingCall = (Call) correspondingElement;
-
+                            if (correspondingElement instanceof Call correspondingCall) {
                                 if (correspondingCallCondition.value(correspondingCall)) {
                                     correspondingCollection.add(correspondingCall);
                                 }
@@ -159,9 +155,7 @@ public class TestFinder implements com.intellij.testIntegration.TestFinder {
         Call sourceElement = sourceElement(element);
         boolean isTest = false;
 
-        if (sourceElement instanceof StubBased) {
-            @SuppressWarnings("rawtypes")
-            StubBased sourceStubBased = (StubBased) sourceElement;
+        if (sourceElement instanceof StubBased sourceStubBased) {
             Set<String> canonicalNameSet = sourceStubBased.canonicalNameSet();
 
             if (!canonicalNameSet.isEmpty()) {

--- a/src/org/elixir_lang/sdk/wsl/WslCompatService.kt
+++ b/src/org/elixir_lang/sdk/wsl/WslCompatService.kt
@@ -173,6 +173,15 @@ interface WslCompatService {
     fun parseWindowsUncPath(windowsUncPath: String?): String?
 
     /**
+     * Converts a Windows UNC path (e.g., //wsl.localhost/Ubuntu/usr/lib) to a Linux path (e.g., /usr/lib) or just returns the input string.
+     *
+     * @param possibleWindowsUncPath the Windows UNC path to convert
+     * @return the Linux path, or the input if the path is not a Windows UNC path.
+     */
+    fun maybeParseWindowsUncPath(possibleWindowsUncPath: String): String =
+            parseWindowsUncPath(possibleWindowsUncPath) ?: possibleWindowsUncPath
+
+    /**
      * Gets a list of available WSL distributions installed on the system.
      *
      * @return list of available WSL distributions, empty list if none found or WSL not available

--- a/src/org/elixir_lang/sdk/wsl/WslCompatServiceImpl.kt
+++ b/src/org/elixir_lang/sdk/wsl/WslCompatServiceImpl.kt
@@ -10,7 +10,7 @@ import com.intellij.openapi.progress.ProgressManager
  * Default implementation of WslCompatService using the IntelliJ Platform WSL API.
  * Delegates to native IntelliJ APIs where possible to avoid redundancy.
  */
-class WslCompatServiceImpl : WslCompatService {
+internal class WslCompatServiceImpl : WslCompatService {
     override val log = Logger.getInstance(WslCompatServiceImpl::class.java)
 
     override fun isWslUncPath(path: String?): Boolean {
@@ -47,7 +47,8 @@ class WslCompatServiceImpl : WslCompatService {
         }
 
         return try {
-            // Delegate to native IntelliJ API
+            // Delegate to native IntelliJ API, this just returns null if
+            // running on a non-Windows system.
             val wslPath = WslPath.parseWindowsUncPath(windowsUncPath)
             wslPath?.linuxPath
         } catch (e: Exception) {

--- a/tests/org/elixir_lang/mix/MixTestFileDetectionTest.kt
+++ b/tests/org/elixir_lang/mix/MixTestFileDetectionTest.kt
@@ -1,0 +1,112 @@
+package org.elixir_lang.mix
+
+import com.intellij.openapi.command.WriteCommandAction
+import com.intellij.openapi.fileEditor.FileDocumentManager
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.psi.PsiDocumentManager
+import com.intellij.psi.PsiFile
+import com.intellij.psi.PsiManager
+import org.elixir_lang.PlatformTestCase
+
+/**
+ * Tests for [Test] - the Mix-level detection of test files, including reading `:test_load_filters` from the
+ * governing `mix.exs` and falling back to the default `_test.exs` suffix.
+ */
+class MixTestFileDetectionTest : PlatformTestCase() {
+    fun testDefaultSuffixWhenNoLoadFilters() {
+        mixExs("default", project = "[app: :default]")
+
+        assertTrue(isTestFile("default/test/foo_test.exs"))
+        assertFalse(isTestFile("default/test/foo.exs"))
+        assertFalse(isTestFile("default/lib/foo.ex"))
+    }
+
+    fun testCustomSuffixFromLoadFilters() {
+        mixExs("custom", project = """[app: :custom, test_load_filters: [&String.ends_with?(&1, "_spec.exs")]]""")
+
+        assertTrue(isTestFile("custom/test/foo_spec.exs"))
+        assertFalse("custom suffix replaces the default", isTestFile("custom/test/foo_test.exs"))
+    }
+
+    fun testMultipleLoadFilters() {
+        mixExs(
+            "multi",
+            project = """[
+              |  app: :multi,
+              |  test_load_filters: [&String.ends_with?(&1, "_test.exs"), &String.ends_with?(&1, "_spec.exs")]
+              |]""".trimMargin()
+        )
+
+        assertTrue(isTestFile("multi/test/foo_test.exs"))
+        assertTrue(isTestFile("multi/test/foo_spec.exs"))
+        assertFalse(isTestFile("multi/test/foo.exs"))
+    }
+
+    fun testUnanalyzableRegexFiltersFallBackToDefault() {
+        mixExs("regex", project = """[app: :regex, test_load_filters: [~r/_test\.exs$/]]""")
+
+        assertTrue("an unanalyzable regex filter must not narrow detection", isTestFile("regex/test/foo_test.exs"))
+    }
+
+    fun testUnanalyzableFunctionFiltersFallBackToDefault() {
+        mixExs("fn", project = """[app: :fn, test_load_filters: [&MyHelper.filter/1]]""")
+
+        assertTrue(isTestFile("fn/test/foo_test.exs"))
+    }
+
+    fun testNoGoverningMixExsFallsBackToDefault() {
+        myFixture.tempDirFixture.createFile("orphan/test/foo_test.exs", "")
+
+        assertTrue(isTestFile("orphan/test/foo_test.exs"))
+        assertFalse(isTestFile("orphan/test/foo.exs"))
+    }
+
+    fun testUmbrellaResolvesAgainstChildApp() {
+        mixExs("umbrella/apps/app_a", project = """[app: :app_a, test_load_filters: [&String.ends_with?(&1, "_spec.exs")]]""")
+        mixExs("umbrella/apps/app_b", project = "[app: :app_b]")
+
+        assertTrue(isTestFile("umbrella/apps/app_a/test/a_spec.exs"))
+        assertFalse("app_a's custom filter must not leak to its own _test.exs", isTestFile("umbrella/apps/app_a/test/a_test.exs"))
+        assertTrue("app_b inherits nothing from app_a and uses the default", isTestFile("umbrella/apps/app_b/test/b_test.exs"))
+    }
+
+    fun testReResolvesAfterMixExsEdit() {
+        val mixExs = mixExs("editable", project = "[app: :editable]")
+
+        assertTrue("default suffix before edit", isTestFile("editable/test/foo_test.exs"))
+        assertFalse("custom suffix not yet present", isTestFile("editable/test/foo_spec.exs"))
+
+        WriteCommandAction.runWriteCommandAction(project) {
+            val document = FileDocumentManager.getInstance().getDocument(mixExs)!!
+            document.setText(mixProjectText("""[app: :editable, test_load_filters: [&String.ends_with?(&1, "_spec.exs")]]"""))
+            PsiDocumentManager.getInstance(project).commitDocument(document)
+        }
+
+        assertTrue("cache invalidates so the new custom suffix applies", isTestFile("editable/test/foo_spec.exs"))
+        assertFalse("default no longer applies after the edit", isTestFile("editable/test/foo_test.exs"))
+    }
+
+    private fun isTestFile(path: String): Boolean = Test.isTestFile(psiFile(path))
+
+    private fun psiFile(path: String): PsiFile {
+        val virtualFile = myFixture.tempDirFixture.getFile(path)
+            ?: myFixture.tempDirFixture.createFile(path, "")
+
+        return PsiManager.getInstance(project).findFile(virtualFile)!!
+    }
+
+    /** Creates `<dir>/mix.exs` with a `project/0` returning [project], and returns the created [VirtualFile]. */
+    private fun mixExs(dir: String, project: String): VirtualFile =
+        myFixture.tempDirFixture.createFile("$dir/mix.exs", mixProjectText(project))
+
+    private fun mixProjectText(project: String): String =
+        """
+        |defmodule Sample.MixProject do
+        |  use Mix.Project
+        |
+        |  def project do
+        |    $project
+        |  end
+        |end
+        """.trimMargin()
+}


### PR DESCRIPTION
- WSL hosted projects now show status gutter icons after test run completion. 
- Minor refactor to align responsibilities of test file definitions with Elixir's own separation (mix filters files, not ExUnit)
- Test status results are now propagated to the `describe` and `defmodule` lines, matching other languages. 

Before fix: 
<img width="137" height="57" alt="image" src="https://github.com/user-attachments/assets/6f58db0b-53ad-4117-bf7c-75e7b4b96ede" />

After fix:
<img width="152" height="60" alt="image" src="https://github.com/user-attachments/assets/cf07e363-8195-4e6b-b0c7-ac5fc0b78043" />

Before fix
<img width="175" height="67" alt="image" src="https://github.com/user-attachments/assets/57b2f9f7-5d7e-454e-ad68-d59504f5919d" />

After fix:
<img width="182" height="75" alt="image" src="https://github.com/user-attachments/assets/51344cf1-37d4-493f-a8a2-58c9cc0acd16" />

